### PR TITLE
Gives AGhosts feet for ghost socks

### DIFF
--- a/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
@@ -41,3 +41,11 @@
       uiWindowPos: 1,0
       strippingWindowPos: 1,3
       displayName: Shoes
+    
+    # Durk wants ghost gloves    
+    - name: gloves
+      slotTexture: gloves
+      slotFlags: GLOVES
+      uiWindowPos: 2,1
+      strippingWindowPos: 2,2
+      displayName: Gloves  

--- a/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
@@ -32,3 +32,12 @@
       uiWindowPos: 0,1
       strippingWindowPos: 1,1
       displayName: Mask
+      
+    # Kira wants ghost socks
+    - name: shoes
+      slotTexture: shoes
+      slotFlags: FEET
+      stripTime: 3
+      uiWindowPos: 1,0
+      strippingWindowPos: 1,3
+      displayName: Shoes


### PR DESCRIPTION
## About the PR
Adds feet slots for AGhosts

## Why / Balance
Neptune wants to add socks for AGhosts so they need this

## Technical details
I went into the afterlife and broke the ghosts legs so they can fit into them

## Media
![image](https://github.com/Goob-Station/Goob-Station/assets/166929042/f732526e-dea0-40c8-9fbe-81f0fa2267cb)

## Breaking changes
Theres no whitelist for what can go on AGhosts feet, i might get around to it at somepoint but since its an admin only thing its not that big

**Changelog**
Added: Admin Ghost Feet!
