### PR TITLE
Adding Nitrogen tank to Trinket

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -206,3 +206,13 @@
   storage:
     back:
     - ClothingNeckAutismPin
+
+- type: loadout
+  id: EmergencyNitrogenTank
+  equipment: EmergencyNitrogenTank
+
+- type: startingGear
+  id: EmergencyNitrogenTank
+  storage:
+    back:
+    - EmergencyNitrogenTank


### PR DESCRIPTION
Vox and slimes dont have nitrogen round start.
addding it as a trinket item gives them some more life time.

 Emergency Nitrogen Tank, not a full size tank
