### PR TITLE
Removing the Removal of the Throngler

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
@@ -110,6 +110,9 @@
     - id: WeaponRifleAk
       prob: 0.0001
       orGroup: Weapons
+      - id: Throngler
+      prob: 0.0001
+      orGroup: Weapons
     - id: WeaponLauncherPirateCannon
       prob: 0.001
       orGroup: Weapons


### PR DESCRIPTION
removing the removal of the throngler, cargo mains rejoyce!

## About the PR
- Removed the removal of the throngler from the grand lottery

## Why / Balance
- The throngler should have never been removed in the first place, its a fun item and belongs on goob station.

## Media

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
:cl:
- tweak: Added the Throngler back to the grand lottery

