### PR TITLE
Readding stuff. (Train, Spacepen in Emergency Box, and Maps to the rotation.)

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -9,7 +9,7 @@
       - id: ClothingMaskBreath
       - id: EmergencyOxygenTankFilled
       - id: EmergencyMedipen
-      - id: Flare
+      - id: SpaceMedipen
       - id: FoodSnackNutribrick
       - id: DrinkWaterBottleFull
   - type: Sprite

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -15,4 +15,4 @@
   - Saltern
   - Packed
   - Reach
-  #- Train
+  - Train

--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -2,8 +2,8 @@
   id: Bagel
   mapName: 'Bagel Station'
   mapPath: /Maps/bagel.yml
-  minPlayers: 40
-  maxPlayers: 76
+  minPlayers: 0
+  maxPlayers: 100
   stations:
     Bagel:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -2,7 +2,7 @@
   id: Box
   mapName: 'Box Station'
   mapPath: /Maps/box.yml
-  minPlayers: 50
+  minPlayers: 0
   stations:
     Boxstation:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/cluster.yml
+++ b/Resources/Prototypes/Maps/cluster.yml
@@ -2,8 +2,8 @@
   id: Cluster
   mapName: 'Cluster'
   mapPath: /Maps/cluster.yml
-  minPlayers: 10
-  maxPlayers: 35
+  minPlayers: 0
+  maxPlayers: 100
   stations:
     Cluster:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -2,7 +2,7 @@
   id: Core
   mapName: 'Core'
   mapPath: /Maps/core.yml
-  minPlayers: 30
+  minPlayers: 0
   maxPlayers: 60
   stations:
     Core:

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -2,7 +2,7 @@
   id: Fland
   mapName: 'Fland Installation'
   mapPath: /Maps/fland.yml
-  minPlayers: 70
+  minPlayers: 0
   stations:
     Fland:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -2,7 +2,7 @@
   id: Meta
   mapName: 'Meta Station'
   mapPath: /Maps/meta.yml
-  minPlayers: 50
+  minPlayers: 0
   stations:
     Meta:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -2,7 +2,7 @@
   id: Oasis
   mapName: 'Oasis'
   mapPath: /Maps/oasis.yml
-  minPlayers: 70
+  minPlayers: 0
   stations:
     Oasis:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/origin.yml
+++ b/Resources/Prototypes/Maps/origin.yml
@@ -2,7 +2,7 @@
   id: Origin
   mapName: 'Origin'
   mapPath: /Maps/origin.yml
-  minPlayers: 50
+  minPlayers: 0
   stations:
     Origin:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -2,8 +2,8 @@
   id: Packed
   mapName: 'Packed'
   mapPath: /Maps/packed.yml
-  minPlayers: 5
-  maxPlayers: 40
+  minPlayers: 0
+  maxPlayers: 100
   stations:
     Packed:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/train.yml
+++ b/Resources/Prototypes/Maps/train.yml
@@ -2,7 +2,7 @@
   id: Train
   mapName: 'Why would you fucking want this map at all?'
   mapPath: /Maps/train.yml
-  minPlayers: 0
+  minPlayers: 90
   maxPlayers: 100
   stations:
     Train:

--- a/Resources/Prototypes/Maps/train.yml
+++ b/Resources/Prototypes/Maps/train.yml
@@ -1,8 +1,8 @@
 - type: gameMap
   id: Train
-  mapName: 'Train'
+  mapName: 'Why would you fucking want this map at all?'
   mapPath: /Maps/train.yml
-  minPlayers: 90
+  minPlayers: 0
   maxPlayers: 100
   stations:
     Train:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Train is back in selection temporarily for now.

Certain stations should be available again even when there's a low amount of players on the server.

Spacepens are back in the Emergency Box.

## Why / Balance
It was here before the refactor but didn't come out with it being done, so I'm redoing it back again. Plus, Train is just going to exist for a singular day until then since it's atmos is being redone.

## Technical details
Changes the minimum and maximum number of players that will allow the map to be available in the map rotation.

The flare has instead been replaced with the Spacepen due to storage limitation.

Train was readded to the Map rotation but still requires it's atmos redone.



## Media
No media.


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None?

**Changelog**

Added back Train, the Spacepen in the Emergency Box, and certain Space Stations to the rotation.