### PR TITLE
Cryo/Bluespace syringe buff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -435,14 +435,14 @@
   - type: SolutionContainerManager
     solutions:
       injector:
-        maxVol: 10
+        maxVol: 20
         canReact: false
   - type: Injector
-    delay: 1.5
+    delay: 1
     injectOnly: false
     minTransferAmount: 5
-    maxTransferAmount: 25
-    transferAmount: 25
+    maxTransferAmount: 20
+    transferAmount: 20
   - type: Tag
     tags:
     - Syringe

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -406,7 +406,7 @@
       injector:
         maxVol: 100
   - type: Injector
-    delay: 2.5
+    delay: 0.5
     injectOnly: false
   - type: SolutionContainerVisuals
     maxFillLevels: 2
@@ -420,7 +420,7 @@
   id: SyringeCryostasis
   parent: BaseSyringe
   name: cryostasis syringe
-  description: A syringe used to contain chemicals or solutions without reactions.
+  description: An improved syringe used to contain chemicals or solutions without reactions.
   components:
   - type: Sprite
     layers:
@@ -438,10 +438,11 @@
         maxVol: 10
         canReact: false
   - type: Injector
+    delay: 1
     injectOnly: false
     minTransferAmount: 5
-    maxTransferAmount: 10
-    transferAmount: 10
+    maxTransferAmount: 20
+    transferAmount: 20
   - type: Tag
     tags:
     - Syringe

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -406,7 +406,7 @@
       injector:
         maxVol: 100
   - type: Injector
-    delay: 0.5
+    delay: 2
     injectOnly: false
   - type: SolutionContainerVisuals
     maxFillLevels: 2
@@ -438,11 +438,11 @@
         maxVol: 10
         canReact: false
   - type: Injector
-    delay: 1
+    delay: 1.5
     injectOnly: false
     minTransferAmount: 5
-    maxTransferAmount: 20
-    transferAmount: 20
+    maxTransferAmount: 25
+    transferAmount: 25
   - type: Tag
     tags:
     - Syringe

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -406,7 +406,7 @@
       injector:
         maxVol: 100
   - type: Injector
-    delay: 1
+    delay: 1 # Goobstation - buffing cryo syringe cause its currently pointless and buffing bluespace syringe to make it more useful.
     injectOnly: false
   - type: SolutionContainerVisuals
     maxFillLevels: 2
@@ -435,14 +435,14 @@
   - type: SolutionContainerManager
     solutions:
       injector:
-        maxVol: 20
+        maxVol: 20 # Goobstation - buffing cryo syringe cause its currently pointless and buffing bluespace syringe to make it more useful.
         canReact: false
   - type: Injector
     delay: 2
     injectOnly: false
     minTransferAmount: 5
     maxTransferAmount: 20
-    transferAmount: 20
+    transferAmount: 20 # Goobstation - buffing cryo syringe cause its currently pointless and buffing bluespace syringe to make it more useful.
   - type: Tag
     tags:
     - Syringe

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -406,7 +406,7 @@
       injector:
         maxVol: 100
   - type: Injector
-    delay: 2
+    delay: 1
     injectOnly: false
   - type: SolutionContainerVisuals
     maxFillLevels: 2
@@ -420,7 +420,7 @@
   id: SyringeCryostasis
   parent: BaseSyringe
   name: cryostasis syringe
-  description: An improved syringe used to contain chemicals or solutions without reactions.
+  description: An improved syringe used to contain chemicals or solutions without reactions. # Goobstation - buffing cryo syringe cause its currently pointless and buffing bluespace syringe to make it more useful.
   components:
   - type: Sprite
     layers:
@@ -438,7 +438,7 @@
         maxVol: 20
         canReact: false
   - type: Injector
-    delay: 1
+    delay: 2
     injectOnly: false
     minTransferAmount: 5
     maxTransferAmount: 20


### PR DESCRIPTION
## About the PR
buff to cryo and bluespace syringes.

## Why / Balance
have you ever seen a cryo syringe used ever? they are literally pointless right now, this buff makes it so they are slightly better than regular syringes for capacity and gives them a faster injection speed. they are now a complete upgrade to normal syringes, considering they are behind a T2 civ tech i think this is acceptable.
improved syringes will help a lot when med is overwhelmed and it still requires science to do their job, research civ and make the syringes for med.
i may have overdone the injection speed, if you feel i have then let me know and i will change it.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## **Changelog**
:cl: 
- buffed cryo syringe to 20u capacity
- buffed cryo syringe to inject faster
- buffed bluespace syringe to inject faster