### PR TITLE
making tesla coils and radiation collectors craftable

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1253,3 +1253,31 @@
       Steel: 2
       Glass: 5
       Cable: 2
+
+- type: entity # Goobstation - making tesla coils and radiation collectors craftable
+  parent: BaseMachineCircuitboard
+  id: RadiationCollectorCircuitboard
+  name: radiation collector board
+  description: A machine printed circuit board for a radiation collector.
+  components:
+  - type: MachineBoard
+    prototype: RadiationCollector
+    stackRequirements:
+      Capacitor: 5
+      Steel: 5
+      CableHV: 10
+      Uranium: 5
+
+- type: entity # Goobstation - making tesla coils and radiation collectors craftable
+  parent: BaseMachineCircuitboard
+  id: TeslaCoilCircuitboard
+  name: tesla coil board
+  description: A machine printed circuit board for a tesla coil.
+  components:
+  - type: MachineBoard
+    prototype: TeslaCoil
+    stackRequirements:
+      Capacitor: 5
+      Steel: 5
+      CableHV: 10
+      Uranium: 5

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1253,31 +1253,3 @@
       Steel: 2
       Glass: 5
       Cable: 2
-
-- type: entity # Goobstation - making tesla coils and radiation collectors craftable
-  parent: BaseMachineCircuitboard
-  id: RadiationCollectorCircuitboard
-  name: radiation collector board
-  description: A machine printed circuit board for a radiation collector.
-  components:
-  - type: MachineBoard
-    prototype: RadiationCollector
-    stackRequirements:
-      Capacitor: 5
-      Steel: 5
-      CableHV: 10
-      Uranium: 5
-
-- type: entity # Goobstation - making tesla coils and radiation collectors craftable
-  parent: BaseMachineCircuitboard
-  id: TeslaCoilCircuitboard
-  name: tesla coil board
-  description: A machine printed circuit board for a tesla coil.
-  components:
-  - type: MachineBoard
-    prototype: TeslaCoil
-    stackRequirements:
-      Capacitor: 5
-      Steel: 5
-      CableHV: 10
-      Uranium: 5

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
@@ -81,6 +81,8 @@
           - GasTank
   - type: UseDelay
     delay: 1
+  - type: Machine # Goobstation - making tesla coils and radiation collectors craftable
+    board: RadiationCollectorCircuitboard
 
 - type: entity
   id: RadiationCollectorNoTank

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -101,6 +101,8 @@
               SheetSteel1:
                 min: 2
                 max: 4
+  - type: Machine # Goobstation - making tesla coils and radiation collectors craftable
+    board: TeslaCoilCircuitboard
   #- type: GuideHelp #   To Do - add Tesla Guide
 
 - type: entity

--- a/Resources/Prototypes/Goobstation/Entities/objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Goobstation/Entities/objects/Devices/Circuitboards/Machine/production.yml
@@ -1,0 +1,31 @@
+- type: entity # Goobstation - making tesla coils and radiation collectors craftable
+  parent: BaseMachineCircuitboard
+  id: RadiationCollectorCircuitboard
+  name: radiation collector board
+  description: A machine printed circuit board for a radiation collector.
+  components:
+  - type: Sprite
+    state: engineering
+  - type: MachineBoard
+    prototype: RadiationCollector
+    stackRequirements:
+      Capacitor: 5
+      Steel: 5
+      CableHV: 10
+      Uranium: 5
+
+- type: entity # Goobstation - making tesla coils and radiation collectors craftable
+  parent: BaseMachineCircuitboard
+  id: TeslaCoilCircuitboard
+  name: tesla coil board
+  description: A machine printed circuit board for a tesla coil.
+  components:
+  - type: Sprite
+    state: engineering
+  - type: MachineBoard
+    prototype: TeslaCoil
+    stackRequirements:
+      Capacitor: 5
+      Steel: 5
+      CableHV: 10
+      Uranium: 5

--- a/Resources/Prototypes/Goobstation/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Goobstation/Recipes/Lathes/electronics.yml
@@ -1,0 +1,19 @@
+- type: latheRecipe # Goobstation - making tesla coils and radiation collectors craftable
+  id: TeslaCoilCircuitboard
+  result: TeslaCoilCircuitboard
+  category: Circuitry
+  completetime: 7
+  materials:
+    Steel: 100
+    Glass: 500
+    Gold: 100
+
+- type: latheRecipe # Goobstation - making tesla coils and radiation collectors craftable
+  id: RadiationCollectorCircuitboard
+  result: RadiationCollectorCircuitboard
+  category: Circuitry
+  completetime: 7
+  materials:
+    Steel: 100
+    Glass: 500
+    Gold: 100

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -975,3 +975,22 @@
   materials:
     Steel: 100
     Glass: 500
+- type: latheRecipe # Goobstation - making tesla coils and radiation collectors craftable
+  id: TeslaCoilCircuitboard
+  result: TeslaCoilCircuitboard
+  category: Circuitry
+  completetime: 7
+  materials:
+    Steel: 100
+    Glass: 500
+    Gold: 100
+
+- type: latheRecipe # Goobstation - making tesla coils and radiation collectors craftable
+  id: RadiationCollectorCircuitboard
+  result: RadiationCollectorCircuitboard
+  category: Circuitry
+  completetime: 7
+  materials:
+    Steel: 100
+    Glass: 500
+    Gold: 100

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -975,22 +975,3 @@
   materials:
     Steel: 100
     Glass: 500
-- type: latheRecipe # Goobstation - making tesla coils and radiation collectors craftable
-  id: TeslaCoilCircuitboard
-  result: TeslaCoilCircuitboard
-  category: Circuitry
-  completetime: 7
-  materials:
-    Steel: 100
-    Glass: 500
-    Gold: 100
-
-- type: latheRecipe # Goobstation - making tesla coils and radiation collectors craftable
-  id: RadiationCollectorCircuitboard
-  result: RadiationCollectorCircuitboard
-  category: Circuitry
-  completetime: 7
-  materials:
-    Steel: 100
-    Glass: 500
-    Gold: 100

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -73,6 +73,8 @@
   - SolarControlComputerCircuitboard
   - SolarTrackerElectronics
   - EmitterCircuitboard
+  - TeslaCoilCircuitboard # Goobstation - making tesla coils and radiation collectors craftable
+  - RadiationCollectorCircuitboard # Goobstation - making tesla coils and radiation collectors craftable
 
 - type: technology
   id: AtmosphericTech


### PR DESCRIPTION
## About the PR
This PR makes tesla coils and radiation collectors craftable and researchable.
## Why / Balance
Solves #308 
This should be added because it will help engineering generate the power needed for bitcoin miners (#286) as well as provide more power to the station at a balanced cost.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: tesla coils and radiation collectors are craftable and researchable

dont merge this PR yet, it doesnt work properly.