### PR TITLE
 Headrevs now have syndicate encryption keys, Revs and survival chances swapped

### DIFF
--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -20,3 +20,4 @@
     back:
     - Flash
     - ClothingEyesGlassesSunglasses
+    - EncryptionKeySyndie # Goobstation

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -4,5 +4,6 @@
     Nukeops: 0.20
     Traitor: 0.60
     Zombie: 0.05
-    Survival: 0.10
-    Revolutionary: 0.05
+    Survival: 0.05 # Goobstation
+    Revolutionary: 0.10 # Goobstation
+  # Wizard: 0.05


### PR DESCRIPTION
Literally just an unfucked, scaled down version of the rev changes PR- by that, VERY scaled down. Might add the midround revs later or some of the other changes when i'm less shitty at PRs. Reopened to not be master branch.

**Changelog**
:cl:
- add: Headrevs now have syndicate encryption keys. Coordinate and plan a strategy!
- tweak: Revs and survival chances have been swapped. Revs at a 10%, and survival at 5%.