### PR TITLE
Remove inappropriate names from skeletons and ninjas.

### DIFF
--- a/Resources/Prototypes/Datasets/Names/ninja.yml
+++ b/Resources/Prototypes/Datasets/Names/ninja.yml
@@ -31,7 +31,6 @@
   - Daemon
   - Goemon
   - McAwesome
-  - Throat
   - Death
   - Aria
   - Bro

--- a/Resources/Prototypes/Datasets/Names/ninja_title.yml
+++ b/Resources/Prototypes/Datasets/Names/ninja_title.yml
@@ -33,7 +33,6 @@
   - Grappler
   - Ulimate
   - Remorseless
-  - Deep
   - Dragon
   - Cruel
   - Nightshade

--- a/Resources/Prototypes/Datasets/Names/skeleton_first.yml
+++ b/Resources/Prototypes/Datasets/Names/skeleton_first.yml
@@ -21,7 +21,6 @@
   - Tarsals
   - Patella
   - Tailbone
-  - Boner
   - Rib
   - Hyoid
   - Coccyx


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Removed a Ninja name and title along with a Skeleton first name. (Boner, Throat, Deep.)

## Why / Balance
There's no way in hell you don't know where I'm going with this. "Boner" come on. I'm not staring at my monitor watching a Ninja named "Deep Throat" bro.

## Technical details
Removed "Boner" from the Skeleton first name file. I also remove the "Deep" name along with "Throat" from the Ninja Titles file.

## Media


- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None?

**Changelog**
Removed certain Skeleton and Ninja names.


:cl:
- removed: Inappropriate names.

