### PR TITLE
Introduce balanced pipe stacking

### DIFF
--- a/Content.Server/Atmos/EntitySystems/PipeRestrictOverlapSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/PipeRestrictOverlapSystem.cs
@@ -4,9 +4,11 @@ using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.Nodes;
 using Content.Server.Popups;
 using Content.Shared.Atmos;
+using Content.Shared.CCVar;
 using Content.Shared.Construction.Components;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
+using Robust.Shared.Configuration;
 using Robust.Shared.Map.Components;
 
 namespace Content.Server.Atmos.EntitySystems;
@@ -16,18 +18,21 @@ namespace Content.Server.Atmos.EntitySystems;
 /// </summary>
 public sealed class PipeRestrictOverlapSystem : EntitySystem
 {
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly MapSystem _map = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly TransformSystem _xform = default!;
 
     private readonly List<EntityUid> _anchoredEntities = new();
     private EntityQuery<NodeContainerComponent> _nodeContainerQuery;
+    public bool StrictPipeStacking = false;
 
     /// <inheritdoc/>
     public override void Initialize()
     {
         SubscribeLocalEvent<PipeRestrictOverlapComponent, AnchorStateChangedEvent>(OnAnchorStateChanged);
         SubscribeLocalEvent<PipeRestrictOverlapComponent, AnchorAttemptEvent>(OnAnchorAttempt);
+        Subs.CVar(_cfg, CCVars.StrictPipeStacking, (bool val) => {StrictPipeStacking = val;}, false);
 
         _nodeContainerQuery = GetEntityQuery<NodeContainerComponent>();
     }
@@ -78,6 +83,9 @@ public sealed class PipeRestrictOverlapSystem : EntitySystem
         _anchoredEntities.Clear();
         _map.GetAnchoredEntities((grid, gridComp), indices, _anchoredEntities);
 
+        // ATMOS: change to long if you add more pipe layers than 5 + z levels
+        var takenDirs = PipeDirection.None;
+
         foreach (var otherEnt in _anchoredEntities)
         {
             // this should never actually happen but just for safety
@@ -87,28 +95,40 @@ public sealed class PipeRestrictOverlapSystem : EntitySystem
             if (!_nodeContainerQuery.TryComp(otherEnt, out var otherComp))
                 continue;
 
-            if (PipeNodesOverlap(ent, (otherEnt, otherComp, Transform(otherEnt))))
+            var (overlapping, which) = PipeNodesOverlap(ent, (otherEnt, otherComp, Transform(otherEnt)), takenDirs);
+            takenDirs |= which;
+
+            if (overlapping)
                 return true;
         }
 
         return false;
     }
 
-    public bool PipeNodesOverlap(Entity<NodeContainerComponent, TransformComponent> ent, Entity<NodeContainerComponent, TransformComponent> other)
+    public (bool, PipeDirection) PipeNodesOverlap(Entity<NodeContainerComponent, TransformComponent> ent, Entity<NodeContainerComponent, TransformComponent> other, PipeDirection takenDirs)
     {
         var entDirs = GetAllDirections(ent).ToList();
         var otherDirs = GetAllDirections(other).ToList();
+        var entDirsCollapsed = PipeDirection.None;
 
         foreach (var dir in entDirs)
         {
+            entDirsCollapsed |= dir;
             foreach (var otherDir in otherDirs)
             {
-                if ((dir & otherDir) != 0)
-                    return true;
+                takenDirs |= otherDir;
+                if (StrictPipeStacking)
+                    if ((dir & otherDir) != 0)
+                        return (true, takenDirs);
+                else
+                    if ((dir ^ otherDir) != 0)
+                        break;
             }
         }
 
-        return false;
+        // If no strict pipe stacking, then output ("are all entDirs occupied", takenDirs)
+
+        return (StrictPipeStacking ? false : ((takenDirs & entDirsCollapsed) == entDirsCollapsed), takenDirs);
 
         IEnumerable<PipeDirection> GetAllDirections(Entity<NodeContainerComponent, TransformComponent> pipe)
         {

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1100,6 +1100,13 @@ namespace Content.Shared.CCVar
             CVarDef.Create("atmos.space_wind", true, CVar.SERVERONLY);
 
         /// <summary>
+        ///     Whether pipes will unanchor on ANY conflicting connection. May break maps.
+        ///     If false, allows you to stack pipes as long as new directions are added (i.e. in a new pipe rotation, layer or multi-Z link), otherwise unanchoring them.
+        /// </summary>
+        public static readonly CVarDef<bool> StrictPipeStacking =
+            CVarDef.Create("atmos.strict_pipe_stacking", false, CVar.SERVERONLY);
+
+        /// <summary>
         ///     Divisor from maxForce (pressureDifference * 2.25f) to force applied on objects.
         /// </summary>
         public static readonly CVarDef<float> SpaceWindPressureForceDivisorThrow =


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Readded pipe stacking, but good.  
Pipes only anchor if they add a new pipe direction to the tile. This means not only are we limited to 4 (for now, pipe layers/multiZ just a week away) devices per tile, but they also MUST necessarily provide value to the Atmos Tech at hand. Not to mention the immense readability increase since now you can just rightclick and mouse over pipes, though a future PR (i.e. making context-menu-highlighted pipe outlines overlay green over all entities) might alleviate this issue.

## Why / Balance
It has become increasingly harder to make clean and readable Atmos and SM setups for anything complicated, such as a hybrid SM+TEG setup on Oasis - let alone running a frezon setup in parallel. Modern atmos setups are in some ways more spaghetti than pre-stacking change setups; although those can be reverted to be available on demand with a CVar change.
Consequently, it is also impossible to stack an infinite amount of gas this way.
The absolute highest volume a tile can hold is 1600L + canister + air tile. However, it would still take an experienced atmosian to push to effective use of at least 1200L.

<details>
<summary>Small rant on readability</summary><br>
Back in April2023mos days readability was a big issue since every setup was so goddamn convoluted you needed to either BE THERE to understand it, or be one of the few people to notice the shitty green outline that at the time was inconsistent.  
Since then, spray painters had a feature added to them that allowed pipes to be painted over with a color. I haven't seen Atmos use this, but it also doesn't take an atmos to use it and figure out which pipes go where. 
 
Gas analyzers can also be used to identify pipes in-tile by comparison, which is far easier to teach, and in a pinch could be used to identify pipe bends. However, outline code has been changed a bit since, and all three of these can be used for atmos debugging.

Personally, I'd make spray painters smaller/integrated into an RPD or be almost instant for pipes, for now, I think it's Atmos's own fault for not making their own builds readable.
</details>

## Technical details
If `atmos.strict_pipe_stacking` is disabled (by default), use AND logic for unanchoring. Otherwise, use OR logic.

## Media
Can't add any because github 2FA is broken and uploading is made egregiously difficult. Oh well.

Picture two pipe bends on each other with strict pipe stacking off. They're stable and anchored.

Video of same thing, but with strict pipe stacking turned on through console (`sudo cvar atmos.strict_pipe_stacking true`). Second pipe doesn't fit when built or anchored.

Video of pipe stacking off, showing a canister port, pipe bend and two mixers being placed in Sandbox.  
"Technically" the highest storage setup for a single tile.

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No.

**Changelog**
:cl: router
- tweak: Reintroduced limited pipe stacking. Beware of placement order, as you can't place smaller pipes overlaying large pipes doing the same thing - each new pipe must add a new flow direction to get anchored on.
