### PR TITLE
tweak: Added t-ray scanner to Station Engineer belt round start fill.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -25,6 +25,8 @@
       - id: Wirecutter
       - id: Welder
       - id: Multitool
+      #Goob-Station - edit by Jellygato 7/13/24
+      - id: trayScanner
 
 - type: entity
   id: ClothingBeltChiefEngineerFilled


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Added t-ray scanner to Station Engineer belt round start fill.

## Why / Balance
I changed this because I was tired of having to find a t-ray scanner as part of my engineer pre-shift setup. T-ray scanners are immensely important to round start work for engineers and should not have to be hunted down. I did not add this to Chief Engineer or Technical Assistant belts. CE has additional items on their belt and I don't want to overfill it, and I don't want to give TAs this tool by default to avoid abuse.

## Technical details
Added the t-ray scanner to the prefill settings YAML.

## Media
![image](https://github.com/user-attachments/assets/1cb65720-01b7-4adb-b074-e90b09558a1d)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None known at this time.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Added t-ray scanner to Station Engineer belt round start.