### PR TITLE
Add optional time strings to playtime commands

### DIFF
--- a/Content.Server/Administration/Commands/PlayTimeCommands.cs
+++ b/Content.Server/Administration/Commands/PlayTimeCommands.cs
@@ -1,10 +1,94 @@
-﻿using Content.Server.Players.PlayTimeTracking;
+using Content.Server.Players.PlayTimeTracking;
 using Content.Shared.Administration;
 using Content.Shared.Players.PlayTimeTracking;
 using Robust.Server.Player;
 using Robust.Shared.Console;
+using System.Text.RegularExpressions;
 
 namespace Content.Server.Administration.Commands;
+
+public sealed class PlayTimeCommandUtilities
+{
+    private readonly static Dictionary<string, int> Units = new() {
+        { "y", 525960 },
+        { "mo", 43800 },
+        { "w", 10080 },
+        { "d", 1440 },
+        { "h", 60 },
+        { "m", 1 },
+    };
+
+    public struct TimeUnit
+    {
+        public int TimeValue { get; }
+        public string Unit { get; }
+
+        public TimeUnit(int timeValue)
+        {
+            TimeValue = timeValue;
+            Unit = "m";
+        }
+
+        public TimeUnit(int timeValue, string unit)
+        {
+            TimeValue = timeValue;
+            Unit = unit;
+        }
+        public int ToMinutes()
+        {
+            var unitExists = Units.TryGetValue(Unit, out int minutes);
+
+            if (!unitExists)
+                return TimeValue;
+
+            return TimeValue * minutes;
+        }
+    }
+
+    public static List<TimeUnit> ConvertToTimeUnits(string timeString)
+    {
+        // Searching for something similar to 365d24h, etc.
+        List<TimeUnit> result = new();
+
+        // We want to support plain numbers as a translation to just minutes, just in case people don't know things like 30d or 1d are an option.
+        if (int.TryParse(timeString, out int timeValue))
+        {
+            result.Add(new TimeUnit(timeValue, "m"));
+            return result;
+        }
+
+        MatchCollection timeRegex = Regex.Matches(timeString, "(\\d+)([A-Za-z]+)");
+
+        foreach (Match match in timeRegex)
+        {
+            bool isTimeAmountNumber = int.TryParse(match.Groups[1].Value, out int amountOfTime);
+            string timeUnit = match.Groups[2].Value;
+
+            if (!isTimeAmountNumber)
+                continue;
+
+            if (!Units.ContainsKey(timeUnit))
+                continue;
+
+            result.Add(new TimeUnit(amountOfTime, timeUnit));
+        }
+
+        return result;
+    }
+
+    public static int CountMinutes(string timeString)
+    {
+        List<TimeUnit> timeUnits = ConvertToTimeUnits(timeString);
+        int total = 0;
+
+        foreach (var timeUnit in timeUnits)
+        {
+            total += timeUnit.ToMinutes();
+        }
+
+        return total;
+    }
+}
 
 [AdminCommand(AdminFlags.Moderator)]
 public sealed class PlayTimeAddOverallCommand : IConsoleCommand
@@ -24,11 +108,7 @@ public sealed class PlayTimeAddOverallCommand : IConsoleCommand
             return;
         }
 
-        if (!int.TryParse(args[1], out var minutes))
-        {
-            shell.WriteError(Loc.GetString("parse-minutes-fail", ("minutes", args[1])));
-            return;
-        }
+        var minutes = PlayTimeCommandUtilities.CountMinutes(args[1]);
 
         if (!_playerManager.TryGetSessionByUsername(args[0], out var player))
         {
@@ -85,14 +165,9 @@ public sealed class PlayTimeAddRoleCommand : IConsoleCommand
 
         var role = args[1];
 
-        var m = args[2];
-        if (!int.TryParse(m, out var minutes))
-        {
-            shell.WriteError(Loc.GetString("parse-minutes-fail", ("minutes", minutes)));
-            return;
-        }
+        var m = PlayTimeCommandUtilities.CountMinutes(args[2]);
 
-        _playTimeTracking.AddTimeToTracker(player, role, TimeSpan.FromMinutes(minutes));
+        _playTimeTracking.AddTimeToTracker(player, role, TimeSpan.FromMinutes(m));
         var time = _playTimeTracking.GetPlayTimeForTracker(player, role);
         shell.WriteLine(Loc.GetString("cmd-playtime_addrole-succeed",
             ("username", userName),


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changed the playtime commands to allow the minutes argument to take a time string instead of just a number of minutes. This can be done like this: 1y1mo1w1d1h1m, but the order and the number you put in **does not matter whatsoever.** If an invalid time unit is specified, it is counted as 0 minutes. This is a fully optional change; you can still do the number of minutes without issue, but this is here to automate hour-to-minute or any other time unit translation with 0 effort on an admins' part.

Here's the list of all possible units:
- 1y - translates to 1 year in minutes
- 1mo - translates to 1 month in minutes
- 1w - translates to 1 week in minutes
- 1d - translates to 1 day in minutes
- 1h - translates to 1 hour in minutes
- 1m - translates to 1 minute in... minutes?

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
An issue was brought to my attention in the general chat about how annoying it is to do playtime transfer tickets. With this, I hope to make it even slightly easier on the admin team to do so.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Most of this was changing a single line inside the commands classes to count up the minutes that were specified. Additionally, I added a new PlaytimeCommandUtilities at the top of the PlaytimeCommands.cs file to make all of this functional.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/user-attachments/assets/3a6d30f8-493d-4b1c-86e8-e7e847906850)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Playtime commands can now use time strings (such as 3d30m) for the minutes argument.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->