### PR TITLE
Assultborg bug fix

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -325,22 +325,6 @@
       noMindState: synd_sec
     - type: Construction
       node: syndicateassault
-    - type: MobThresholds   # Goobstation Assult borg buff HP upped by 100%
-      thresholds:
-        0: Alive
-        200: Critical
-        300: Dead
-    - type: Destructible  #  Goobstation Assult borg buff alarm goes of at 75% health
-      thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 150
-        behaviors:
-        - !type:PlaySoundBehavior
-          sound:
-            path: /Audio/Machines/warning_buzzer.ogg
-            params:
-              volume: 5
 
 - type: entity
   id: BorgChassisSyndicateMedical

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -325,6 +325,22 @@
       noMindState: synd_sec
     - type: Construction
       node: syndicateassault
+    - type: MobThresholds   # Goobstation Assult borg buff HP upped by 100%
+      thresholds:
+        0: Alive
+        200: Critical
+        300: Dead
+    - type: Destructible  #  Goobstation Assult borg buff alarm goes of at 75% health
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 150
+        behaviors:
+        - !type:PlaySoundBehavior
+          sound:
+            path: /Audio/Machines/warning_buzzer.ogg
+            params:
+              volume: 5
 
 - type: entity
   id: BorgChassisSyndicateMedical

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -528,7 +528,7 @@
   id: BorgModuleEsword
   parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule ]
   name: energy sword cyborg module
-  description: A module that comes with a double energy sword.
+  description: A module that comes with a energy sword. #Goobstation
   components:
     - type: Sprite
       layers:
@@ -536,7 +536,7 @@
       - state: icon-syndicate
     - type: ItemBorgModule
       items:
-      - EnergySwordDouble
+      - EnergySword     #Goobstation - bug
       - PinpointerSyndicateNuclear
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -536,7 +536,7 @@
       - state: icon-syndicate
     - type: ItemBorgModule
       items:
-      - EnergySwordDoubleBorg
+      - EnergySword
       - PinpointerSyndicateNuclear
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -536,7 +536,7 @@
       - state: icon-syndicate
     - type: ItemBorgModule
       items:
-      - EnergySword   # Goobstation - changed becuse of bug
+      - EnergySwordBorg   # Goobstation - changed becuse of bug
       - PinpointerSyndicateNuclear
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -528,7 +528,7 @@
   id: BorgModuleEsword
   parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule ]
   name: energy sword cyborg module
-  description: A module that comes with a energy sword. #Goobstation
+  description: A module that comes with a energy sword.
   components:
     - type: Sprite
       layers:
@@ -536,7 +536,7 @@
       - state: icon-syndicate
     - type: ItemBorgModule
       items:
-      - EnergySword     #Goobstation - bug
+      - EnergySwordDoubleBorg
       - PinpointerSyndicateNuclear
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -528,7 +528,7 @@
   id: BorgModuleEsword
   parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule ]
   name: energy sword cyborg module
-  description: A module that comes with a energy sword.
+  description: A module that comes with a energy sword.   # Goobstation
   components:
     - type: Sprite
       layers:
@@ -536,7 +536,7 @@
       - state: icon-syndicate
     - type: ItemBorgModule
       items:
-      - EnergySword
+      - EnergySword   # Goobstation - changed becuse of bug
       - PinpointerSyndicateNuclear
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -528,7 +528,7 @@
   id: BorgModuleEsword
   parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule ]
   name: energy sword cyborg module
-  description: A module that comes with a energy sword. #Goobstation
+  description: A module that comes with a double energy sword.
   components:
     - type: Sprite
       layers:
@@ -536,7 +536,7 @@
       - state: icon-syndicate
     - type: ItemBorgModule
       items:
-      - EnergySword     #Goobstation - bug
+      - EnergySwordDouble
       - PinpointerSyndicateNuclear
 
 - type: entity

--- a/Resources/Prototypes/Goobstation/Entities/Weapons/e_sword.yml
+++ b/Resources/Prototypes/Goobstation/Entities/Weapons/e_sword.yml
@@ -1,0 +1,19 @@
+- type: entity
+  name: energy sword
+  parent: EnergySword
+  id: EnergySwordBorg
+  suffix: Borg only
+  description: A very loud & dangerous sword with a beam made of pure, concentrated plasma. Cuts through unarmored targets like butter.
+  components:
+  - type: Reflect
+    reflectProb: .75
+    spread: 75
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/e_sword.rsi
+    layers:
+      - state: e_sword
+      - state: e_sword_blade
+        color: "#FFFFFF"
+        visible: false
+        shader: unshaded
+        map: [ "blade" ]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
replaces assultboirgs double energysword whit a  normal e -sword

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
sword is bugged

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!

- fix: Fixed fun!
-->
:cl:
- tweak: Syndicate Assult borg now has a one handed e-sword