### PR TITLE
Update publish_github_artifact.py

### DIFF
--- a/Tools/publish_github_artifact.py
+++ b/Tools/publish_github_artifact.py
@@ -14,8 +14,8 @@ VERSION = os.environ['GITHUB_SHA']
 # CONFIGURATION PARAMETERS
 # Forks should change these to publish to their own infrastructure.
 #
-ROBUST_CDN_URL = "https://wizards.cdn.spacestation14.com/"
-FORK_ID = "wizards"
+ROBUST_CDN_URL = "https://cdn.networkgamez.com/"
+FORK_ID = "goobstation"
 
 def main():
     print("Fetching artifact URL from API...")


### PR DESCRIPTION

## About the PR

adds CDN
## Why / Balance

cause you fuckers have been complaining about CDN and replays for ages
## Technical details

points publish_github_artifact.py to cdn.networkgamez.com and names the fork "goobstation"
