### PR TITLE
Jukeboxes now activate artifacts

### DIFF
--- a/Content.Server/Audio/Jukebox/JukeboxSystem.cs
+++ b/Content.Server/Audio/Jukebox/JukeboxSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Instruments;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Shared.Audio.Jukebox;
@@ -44,6 +45,7 @@ public sealed class JukeboxSystem : SharedJukeboxSystem
         if (Exists(component.AudioStream))
         {
             Audio.SetState(component.AudioStream, AudioState.Playing);
+            EnsureComp<ActiveInstrumentComponent>(uid);
         }
         else
         {
@@ -56,6 +58,7 @@ public sealed class JukeboxSystem : SharedJukeboxSystem
             }
 
             component.AudioStream = Audio.PlayPvs(jukeboxProto.Path, uid, AudioParams.Default.WithMaxDistance(10f))?.Entity;
+            EnsureComp<ActiveInstrumentComponent>(uid);
             Dirty(uid, component);
         }
     }
@@ -63,6 +66,7 @@ public sealed class JukeboxSystem : SharedJukeboxSystem
     private void OnJukeboxPause(Entity<JukeboxComponent> ent, ref JukeboxPauseMessage args)
     {
         Audio.SetState(ent.Comp.AudioStream, AudioState.Paused);
+        RemComp<ActiveInstrumentComponent>(ent.Owner);
     }
 
     private void OnJukeboxSetTime(EntityUid uid, JukeboxComponent component, JukeboxSetTimeMessage args)
@@ -92,6 +96,7 @@ public sealed class JukeboxSystem : SharedJukeboxSystem
     private void Stop(Entity<JukeboxComponent> entity)
     {
         Audio.SetState(entity.Comp.AudioStream, AudioState.Stopped);
+        RemComp<ActiveInstrumentComponent>(entity.Owner);
         Dirty(entity);
     }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Jukeboxes can now activate artifacts when a song is played through an ActiveInstrument component.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I raged about it in LOOC once that Jukeboxes don't activate artifacts.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
An ActiveInstrument component is added when the jukebox is playing music. The component is then removed when power is cutoff to the jukebox, when the jukebox is paused, or the jukebox is stopped. Players can't join a band with jukeboxes either.

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
None from what I can see.

**Changelog**
:cl:
- add: Jukeboxes now activate artifacts