### PR TITLE
Slightly Updates Roleplay Rule #4

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
@@ -13,6 +13,7 @@
   - Events you experienced as a different character.
   - All information related to the player of a character rather than the character itself. (See "Metafriending and Metagrudging" below.)
   - All information gained while dead or a ghost.
+  - All information gained while in critical condition or unconscious.
   - The fact that a round will end.
 
   This does not prevent knowing that a shift will end, but does prohibit things like preparing to kill people at central command when roleplay rules stop being enforced on LRP.
@@ -66,12 +67,6 @@
   - seeing the item used for its hidden purpose
   - experiencing a situation where absolutely no other explanation is possible
   - discovering an unlocked uplink
-
-  ## MRP Amendment 1
-  A shield prevents your character from remembering anything that happened while unconscious. This shield is never revealed IC.
-
-  ## MRP Amendment 2
-  There is a "New Life Rule" shield. It prevents you from remembering anything that lead to your death, even if you are put into an MMI. If you are cloned, it also prevents you from remembering everything from that round. This shield is never revealed IC.
 
   ## Metafriending and Metagrudging
   This section provides additional information on a concept that is prohibited by multiple metashield items that are never revealed IC. Giving a person or character preferential treatment based on something that your character should not know is considered metafriending. Treating a person or character negatively based on something that your character should not know is considered metagrudging.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Changes roleplay rule 4 to remove the MRP amendments and to explicitly prevent metagaming information while crit/unconscious.

## Why / Balance
Constant confusion from this rule due to the MRP amendments have made it a rule which commonly creates problems. This should fix that. Not to mention that we were already handling this rule in this way.

## Technical details
Just changes some lines in the XML file.

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Updated roleplay rule 4 to explicitly deny metagaming while crit/unconscious.
