### PR TITLE
No more antag ghostbar people:)

### DIFF
--- a/Content.Server/Goobstation/Ghostbar/GhostBarSystem.cs
+++ b/Content.Server/Goobstation/Ghostbar/GhostBarSystem.cs
@@ -16,6 +16,8 @@ using Content.Shared.Mind.Components;
 using Content.Shared.Roles.Jobs;
 using Content.Shared.Roles;
 using Content.Shared.Inventory;
+using Content.Server.Antag.Components;
+using Content.Shared.Mindshield.Components;
 
 namespace Content.Server.Goobstation.Ghostbar;
 

--- a/Content.Server/Goobstation/Ghostbar/GhostBarSystem.cs
+++ b/Content.Server/Goobstation/Ghostbar/GhostBarSystem.cs
@@ -83,6 +83,8 @@ public sealed class GhostBarSystem : EntitySystem
         var mobUid = _spawningSystem.SpawnPlayerMob(randomSpawnPoint, randomJob, profile, null);
 
         _entityManager.EnsureComponent<GhostBarPlayerComponent>(mobUid);
+        _entityManager.EnsureComponent<MindShieldComponent>(mobUid);
+        _entityManager.EnsureComponent<AntagImmuneComponent>(mobUid);
 
         var targetMind = _mindSystem.GetMind(args.SenderSession.UserId);
 


### PR DESCRIPTION
## About the PR
People can't roll midround antags in the ghostbar anymore.

## Why / Balance
We don't need people in ghostbar rolling syndie.

## Technical details
Just gives the players the antagimmune and mindshield components.

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Ghost bar goers can no longer roll midround antag.

