### PR TITLE
action bar PageButtons relocation

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/Widgets/ActionsBar.xaml
+++ b/Content.Client/UserInterface/Systems/Actions/Widgets/ActionsBar.xaml
@@ -8,12 +8,12 @@
     HorizontalExpand="False"
 >
     <BoxContainer Orientation="Vertical">
+        <controls:ActionPageButtons Name="PageButtons" Access="Public"/> <!-- goobstation -->
         <controls:ActionButtonContainer
             HorizontalAlignment="Center"
             VerticalAlignment="Center"
             MaxSize="64 9999"
             Name="ActionsContainer"
             Access="Public"/>
-        <controls:ActionPageButtons Name="PageButtons" Access="Public"/> <!-- goobstation -->
     </BoxContainer>
 </widgets:ActionsBar>


### PR DESCRIPTION
## Why / Balance
It looks better

## Media
https://discord.com/channels/1202734573247795300/1202734573247795303/1272097080617340989

**Changelog**
:cl:
- tweak: The button for pages has been moved to the top of the UI.