### PR TITLE
Ling Status Fix

### DIFF
--- a/Content.Shared/Goobstation/Changeling/ChangelingComponent.cs
+++ b/Content.Shared/Goobstation/Changeling/ChangelingComponent.cs
@@ -42,7 +42,7 @@ public sealed partial class ChangelingComponent : Component
     /// </summary>
 
     [DataField, ViewVariables(VVAccess.ReadOnly)]
-    public ProtoId<StatusIconPrototype> StatusIcon { get; set; } = "HivemindFaction";
+    public ProtoId<FactionIconPrototype> StatusIcon { get; set; } = "HivemindFaction";
 
     #endregion
 


### PR DESCRIPTION
## About the PR
Quick fix for the ling status icon, didn't realize i had to update it inside of the changeling component when upstream changed statusicons to factionicons, oops!

:cl:
- fix: Changeling hivemind status icon fixed
