### PR TITLE
Siouxcide

### DIFF
--- a/Resources/Prototypes/Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -13,6 +13,12 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 90000 # 25 hours
+    - !type:AgeRequirement
+      requiredAge: 21
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Felinid
   weight: 20
   startingGear: BlueshieldOfficerGear
   icon: "JobIconNanotrasen"

--- a/Resources/Prototypes/Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
+++ b/Resources/Prototypes/Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
@@ -7,6 +7,12 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 180000  #50 hours
+    - !type:AgeRequirement
+      requiredAge: 21
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Felinid
   weight: 20
   startingGear: NanotrasenRepresentativeGear
   icon: "JobIconNanotrasenRepresentative"

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -25,10 +25,11 @@
     prototype: Felinid
   - type: Damageable
     damageModifierSet: Felinid
-  - type: SlowOnDamage
-    speedModifierThresholds:
-      60: 0.85  # 0.7 is base speed.
-      80: 0.75  # 0.5 is base speed.
+  # Goobstation - Siouxcide, felinids have standard slow on damage numbers
+# - type: SlowOnDamage
+#   speedModifierThresholds:
+#     60: 0.85  # 0.7 is base speed.
+#     80: 0.75  # 0.5 is base speed.
   - type: MeleeWeapon
     soundHit:
       collection: Punch
@@ -47,7 +48,7 @@
       types:
         Blunt: 1
   - type: Stamina
-    critThreshold: 85
+    critThreshold: 75 # Goobstation - Siouxcide, felinids take 3 disabler shots to down
   - type: TypingIndicator
     proto: felinid
   - type: PseudoItem

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -17,6 +17,7 @@
       time: 144000 #40 hrs
     - !type:AgeRequirement
       requiredAge: 21
+    # Goobstation - Siouxcide, prevent felinids from playing command
     - !type:SpeciesRequirement
       inverted: true
       species:

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -17,6 +17,10 @@
       time: 144000 #40 hrs
     - !type:AgeRequirement
       requiredAge: 21
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Felinid
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -18,6 +18,10 @@
       time: 54000 # 15 hours
     - !type:AgeRequirement
       requiredAge: 21
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Felinid
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -18,6 +18,7 @@
       time: 54000 # 15 hours
     - !type:AgeRequirement
       requiredAge: 21
+    # Goobstation - Siouxcide, prevent felinids from playing command
     - !type:SpeciesRequirement
       inverted: true
       species:

--- a/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
@@ -8,6 +8,13 @@
   icon: "JobIconNanotrasen"
   supervisors: job-supervisors-hos
   canBeAntag: false
+  requirements:
+  - !type:AgeRequirement
+    requiredAge: 21
+  - !type:SpeciesRequirement
+    inverted: true
+    species:
+    - Felinid
   accessGroups:
   - AllAccess
   access:

--- a/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
@@ -8,6 +8,7 @@
   icon: "JobIconNanotrasen"
   supervisors: job-supervisors-hos
   canBeAntag: false
+  # Goobstation - Siouxcide, prevent felinids from playing command
   requirements:
   - !type:AgeRequirement
     requiredAge: 21

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -18,6 +18,7 @@
       time: 36000 # 10 hours
     - !type:AgeRequirement
       requiredAge: 21
+    # Goobstation - Siouxcide, prevent felinids from playing command
     - !type:SpeciesRequirement
       inverted: true
       species:

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -18,6 +18,10 @@
       time: 36000 # 10 hours
     - !type:AgeRequirement
       requiredAge: 21
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Felinid
   weight: 20
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -17,6 +17,7 @@
       time: 144000 #40 hrs
     - !type:AgeRequirement
       requiredAge: 21
+    # Goobstation - Siouxcide, prevent felinids from playing command
     - !type:SpeciesRequirement
       inverted: true
       species:

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -17,6 +17,10 @@
       time: 144000 #40 hrs
     - !type:AgeRequirement
       requiredAge: 21
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Felinid
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -19,6 +19,10 @@
       time: 144000 #40 hrs
     - !type:AgeRequirement
       requiredAge: 21
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Felinid
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -19,6 +19,7 @@
       time: 144000 #40 hrs
     - !type:AgeRequirement
       requiredAge: 21
+    # Goobstation - Siouxcide, prevent felinids from playing command
     - !type:SpeciesRequirement
       inverted: true
       species:

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -11,6 +11,10 @@
       time: 144000 #40 hrs
     - !type:AgeRequirement
       requiredAge: 21
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Felinid
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -11,6 +11,7 @@
       time: 144000 #40 hrs
     - !type:AgeRequirement
       requiredAge: 21
+    # Goobstation - Siouxcide, prevent felinids from playing command
     - !type:SpeciesRequirement
       inverted: true
       species:

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -17,6 +17,7 @@
       time: 144000 #40 hrs
     - !type:AgeRequirement
       requiredAge: 21
+    # Goobstation - Siouxcide, prevent felinids from playing command
     - !type:SpeciesRequirement
       inverted: true
       species:

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -17,6 +17,10 @@
       time: 144000 #40 hrs
     - !type:AgeRequirement
       requiredAge: 21
+    - !type:SpeciesRequirement
+      inverted: true
+      species:
+      - Felinid
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
![image](https://github.com/user-attachments/assets/4c7b23de-6391-46e3-9eb2-d545cbc43084)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Maintenance of average round-to-round quality.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
NT, BSO now have the 21 age lower limit enforced in line with other command.
Felinids are barred from playing command, have their stamina threshold reduced from 85 to 75 and lose their slow on damage advantage over other species.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
![image](https://github.com/user-attachments/assets/5079db79-8231-448d-97d9-483760627816)

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- tweak: Lowered stamina crit threshold for felinids (85 -> 75)
- remove: Felinids lose their slow on damage advantage over other species
- fix: NT and BSO missing the minimum age threshold
- tweak: Felinids are no longer eligible for command roles