### PR TITLE
int32 burger

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -45,7 +45,7 @@
     - map: ["foodSequenceLayers"]
   - type: FoodSequenceStartPoint
     key: burger
-    maxLayers: 10
+    maxLayers: 2147483647 # Goobstation
     startPosition: 0, 0
     offset: 0, 0.1
     minLayerOffset: -0.05, 0


### PR DESCRIPTION
## About the PR
Burger max size is set to int32 limit.

## Why / Balance
It's funny and [whateverusername0](https://github.com/whateverusername0) asked for it.

## Media
![image](https://github.com/user-attachments/assets/c21af00b-0a33-4c5e-9d71-e896ae9e4e92)

:cl:
- tweak: Burger size knows no bounds.
