### PR TITLE
End Rev Round when command dies instead of calling shuttle

### DIFF
--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -79,8 +79,10 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
 
             if (CheckCommandLose())
             {
-                _roundEnd.DoRoundEndBehavior(RoundEndBehavior.ShuttleCall, component.ShuttleCallTime);
+               // _roundEnd.DoRoundEndBehavior(RoundEndBehavior.ShuttleCall, component.ShuttleCallTime);
+                _roundEnd.EndRound();
                 GameTicker.EndGameRule(uid, gameRule);
+                //Immediately Ends Round if all of command dies 
             }
         }
     }

--- a/Resources/Changelog/GoobChangelog.yml
+++ b/Resources/Changelog/GoobChangelog.yml
@@ -703,9 +703,3 @@ Entries:
       message: The Syndicate has updated their drip to match the new fashion standart
   id: 91
   time: '2024-08-15T08:45:17.0000000+00:00'
-- author: ComradeSilver
-  changes:
-    - type: Tweak
-      message: Rev gamemode ends immediately instead of calling shuttle
-  id: 92
-  time: '2024-08-15T20:54:17.0000000+00:00'

--- a/Resources/Changelog/GoobChangelog.yml
+++ b/Resources/Changelog/GoobChangelog.yml
@@ -414,7 +414,7 @@ Entries:
     - type: Add
       message: >-
         Added gamemodes to secret with two antags at once, but have less of one
-        type and need 30+ Players ready to start. 
+        type and need 30+ Players ready to start.
     - type: Tweak
       message: >-
         Weights have been slightly tweaked. Lings are rarer, and ops/revs are
@@ -422,7 +422,7 @@ Entries:
     - type: Tweak
       message: >-
         Changeling now rolls with the same delay as traitors, and changeling max
-        has been lessened to 5. 
+        has been lessened to 5.
   id: 53
   time: '2024-07-18T17:39:51.0000000+00:00'
 - author: Aidenkrz
@@ -703,3 +703,9 @@ Entries:
       message: The Syndicate has updated their drip to match the new fashion standart
   id: 91
   time: '2024-08-15T08:45:17.0000000+00:00'
+- author: ComradeSilver
+  changes:
+    - type: Tweak
+      message: Rev gamemode ends immediately instead of calling shuttle
+  id: 92
+  time: '2024-08-15T20:54:17.0000000+00:00'


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Simple fix to Change the Rev Gamemode so that it immediately ends when all of command dies
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
https://github.com/Goob-Station/Goob-Station/issues/372
Saw this issue easy fix
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Very simple rewrites the existing logic so instead of calling the shuttle when command dies, it ends the game


## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase




:cl:
- tweak: Rev victory ends game instead of calling shuttle


