### PR TITLE
added Department comunication computer

### DIFF
--- a/Resources/Locale/en-US/Goobstation/Computer/department-announcement/department-announcement.ftl
+++ b/Resources/Locale/en-US/Goobstation/Computer/department-announcement/department-announcement.ftl
@@ -1,0 +1,7 @@
+comms-console-announcement-title-department-rd  = Research Directors Desk
+comms-console-announcement-title-department-qm  = Quartermasters Desk
+comms-console-announcement-title-department-cmo = Chief Medical Officers Desk
+comms-console-announcement-title-department-ce  = Chief Engineers Desk
+comms-console-announcement-title-department-hop = Head of Personnels Desk
+comms-console-announcement-title-department-hos = Head of Securitys Desk
+comms-console-announcement-title-department-cap = Captains Desk

--- a/Resources/Prototypes/Goobstation/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Goobstation/Entities/Structures/Machines/Computers/computers.yml
@@ -90,7 +90,7 @@
 
 - type: entity
   parent: ComputerCommsNoEvac
-  id: ComputerCommsNoEvacHos
+  id: ComputerCommsNoEvacCaptain
   suffix: Captain
   components:
   - type: CommunicationsConsole

--- a/Resources/Prototypes/Goobstation/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Goobstation/Entities/Structures/Machines/Computers/computers.yml
@@ -28,21 +28,21 @@
   suffix: RD
   components:
   - type: CommunicationsConsole
-    title: "Research Director"
+    title: "Research Director's Desk"
     canShuttle: false
   - type: AccessReader
     access: [[ "ResearchDirector" ]]
 
 - type: entity
   parent: ComputerCommsNoEvac
-  id: ComputerCommsNoEvacHop
-  suffix: Hop
+  id: ComputerCommsNoEvacHoP
+  suffix: HoP
   components:
   - type: CommunicationsConsole
-    title: "Head Of Personell"
+    title: "Head Of Personell's Desk"
     canShuttle: false
   - type: AccessReader
-    access: [[ "HeadOfPersonnel" ]]
+    access: [[ "HeadOfPersonell" ]]
 
 - type: entity
   parent: ComputerCommsNoEvac
@@ -50,7 +50,7 @@
   suffix: QM
   components:
   - type: CommunicationsConsole
-    title: "Quarter Master"
+    title: "Quartermaster's Desk"
     canShuttle: false
   - type: AccessReader
     access: [[ "Quartermaster" ]]
@@ -61,7 +61,7 @@
   suffix: CE
   components:
   - type: CommunicationsConsole
-    title: "Chief Engineer"
+    title: "Chief Engineer's Desk"
     canShuttle: false
   - type: AccessReader
     access: [[ "ChiefEngineer" ]]
@@ -72,7 +72,7 @@
   suffix: CMO
   components:
   - type: CommunicationsConsole
-    title: "Chief Medical Officer"
+    title: "Chief Medical Officer's Desk"
     canShuttle: false
   - type: AccessReader
     access: [[ "ChiefMedicalOfficer" ]]
@@ -80,10 +80,10 @@
 - type: entity
   parent: ComputerCommsNoEvac
   id: ComputerCommsNoEvacHos
-  suffix: Hos
+  suffix: HoS
   components:
   - type: CommunicationsConsole
-    title: "Head Of Security"
+    title: "Head Of Security's Desk"
     canShuttle: false
   - type: AccessReader
     access: [[ "HeadOfSecurity" ]]
@@ -91,10 +91,10 @@
 - type: entity
   parent: ComputerCommsNoEvac
   id: ComputerCommsNoEvacHos
-  suffix: warden
+  suffix: Captain
   components:
   - type: CommunicationsConsole
-    title: "Warden"
+    title: "Captain's Desk"
     canShuttle: false
   - type: AccessReader
-    access: [[ "Armory" ]]
+    access: [[ "Captain" ]]

--- a/Resources/Prototypes/Goobstation/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Goobstation/Entities/Structures/Machines/Computers/computers.yml
@@ -1,0 +1,50 @@
+- type: entity
+  parent: BaseComputerCircuitboard
+  id: CommsComputerCircuitboardNoEvac
+  name: department communications computer board
+  description: A computer printed circuit board for a Department communications console.
+  components:
+    - type: Sprite
+      state: cpu_command
+    - type: ComputerBoard
+      prototype: ComputerCommsNoEvac
+
+- type: entity
+  parent: BaseComputer
+  id: ComputerCommsNoEvac
+  name: department communications computer
+  suffix: Evac Disabled
+  description: A computer used to make station wide announcements via keyboard, set the appropriate alert level.
+  components:
+  - type: Sprite
+    layers:
+    - map: ["computerLayerBody"]
+      state: computer
+    - map: ["computerLayerKeyboard"]
+      state: generic_keyboard
+    - map: ["computerLayerScreen"]
+      state: comm
+    - map: ["computerLayerKeys"]
+      state: generic_keys
+  - type: AccessReader
+    access: [[ "Command" ]]
+  - type: CommunicationsConsole
+    title: comms-console-announcement-title-station
+    canShuttle: false
+  - type: DeviceNetwork
+    transmitFrequencyId: ShuttleTimer
+  - type: ActivatableUI
+    key: enum.CommunicationsConsoleUiKey.Key
+  - type: UserInterface
+    interfaces:
+      enum.CommunicationsConsoleUiKey.Key:
+        type: CommunicationsConsoleBoundUserInterface
+  - type: Computer
+    board: CommsComputerCircuitboardNoEvac
+  - type: PointLight
+    radius: 1.5
+    energy: 1.6
+    color: "#3c5eb5"
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: StrongMetallic

--- a/Resources/Prototypes/Goobstation/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Goobstation/Entities/Structures/Machines/Computers/computers.yml
@@ -28,7 +28,7 @@
   suffix: RD
   components:
   - type: CommunicationsConsole
-    title: "Research Director's Desk"
+    title: comms-console-announcement-title-department-rd
     canShuttle: false
   - type: AccessReader
     access: [[ "ResearchDirector" ]]
@@ -39,7 +39,7 @@
   suffix: HoP
   components:
   - type: CommunicationsConsole
-    title: "Head Of Personnel's Desk"
+    title: comms-console-announcement-title-department-hop
     canShuttle: false
   - type: AccessReader
     access: [[ "HeadOfPersonnel" ]]
@@ -50,7 +50,7 @@
   suffix: QM
   components:
   - type: CommunicationsConsole
-    title: "Quartermaster Desk"
+    title: comms-console-announcement-title-department-qm
     canShuttle: false
   - type: AccessReader
     access: [[ "Quartermaster" ]]
@@ -61,7 +61,7 @@
   suffix: CE
   components:
   - type: CommunicationsConsole
-    title: "Chief Engineer's Desk"
+    title: comms-console-announcement-title-department-ce
     canShuttle: false
   - type: AccessReader
     access: [[ "ChiefEngineer" ]]
@@ -72,7 +72,7 @@
   suffix: CMO
   components:
   - type: CommunicationsConsole
-    title: "Chief Medical Officer's Desk"
+    title: comms-console-announcement-title-department-cmo
     canShuttle: false
   - type: AccessReader
     access: [[ "ChiefMedicalOfficer" ]]
@@ -83,7 +83,7 @@
   suffix: HoS
   components:
   - type: CommunicationsConsole
-    title: "Head Of Security Desk"
+    title: comms-console-announcement-title-department-hos
     canShuttle: false
   - type: AccessReader
     access: [[ "HeadOfSecurity" ], ["Armory"]]
@@ -94,7 +94,7 @@
   suffix: Captain
   components:
   - type: CommunicationsConsole
-    title: "Captain's Desk"
+    title: comms-console-announcement-title-department-cap
     canShuttle: false
   - type: AccessReader
     access: [[ "Captain" ]]

--- a/Resources/Prototypes/Goobstation/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Goobstation/Entities/Structures/Machines/Computers/computers.yml
@@ -24,7 +24,7 @@
 
 - type: entity
   parent: ComputerCommsNoEvac
-  id: ComputerCommsNoEvacRD
+  id: ComputerCommsNoEvacRd
   suffix: RD
   components:
   - type: CommunicationsConsole
@@ -35,18 +35,18 @@
 
 - type: entity
   parent: ComputerCommsNoEvac
-  id: ComputerCommsNoEvacHoP
+  id: ComputerCommsNoEvacHop
   suffix: HoP
   components:
   - type: CommunicationsConsole
-    title: "Head Of Personell's Desk"
+    title: "Head Of Personnel's Desk"
     canShuttle: false
   - type: AccessReader
-    access: [[ "HeadOfPersonell" ]]
+    access: [[ "HeadOfPersonnel" ]]
 
 - type: entity
   parent: ComputerCommsNoEvac
-  id: ComputerCommsNoEvacQM
+  id: ComputerCommsNoEvacQm
   suffix: QM
   components:
   - type: CommunicationsConsole
@@ -57,7 +57,7 @@
 
 - type: entity
   parent: ComputerCommsNoEvac
-  id: ComputerCommsNoEvacCE
+  id: ComputerCommsNoEvacCe
   suffix: CE
   components:
   - type: CommunicationsConsole
@@ -68,7 +68,7 @@
 
 - type: entity
   parent: ComputerCommsNoEvac
-  id: ComputerCommsNoEvacCMO
+  id: ComputerCommsNoEvacCmo
   suffix: CMO
   components:
   - type: CommunicationsConsole

--- a/Resources/Prototypes/Goobstation/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Goobstation/Entities/Structures/Machines/Computers/computers.yml
@@ -10,41 +10,91 @@
       prototype: ComputerCommsNoEvac
 
 - type: entity
-  parent: BaseComputer
+  parent: ComputerComms
   id: ComputerCommsNoEvac
   name: department communications computer
   suffix: Evac Disabled
   description: A computer used to make station wide announcements via keyboard, set the appropriate alert level.
   components:
-  - type: Sprite
-    layers:
-    - map: ["computerLayerBody"]
-      state: computer
-    - map: ["computerLayerKeyboard"]
-      state: generic_keyboard
-    - map: ["computerLayerScreen"]
-      state: comm
-    - map: ["computerLayerKeys"]
-      state: generic_keys
   - type: AccessReader
     access: [[ "Command" ]]
   - type: CommunicationsConsole
     title: comms-console-announcement-title-station
     canShuttle: false
-  - type: DeviceNetwork
-    transmitFrequencyId: ShuttleTimer
-  - type: ActivatableUI
-    key: enum.CommunicationsConsoleUiKey.Key
-  - type: UserInterface
-    interfaces:
-      enum.CommunicationsConsoleUiKey.Key:
-        type: CommunicationsConsoleBoundUserInterface
-  - type: Computer
-    board: CommsComputerCircuitboardNoEvac
-  - type: PointLight
-    radius: 1.5
-    energy: 1.6
-    color: "#3c5eb5"
-  - type: Damageable
-    damageContainer: Inorganic
-    damageModifierSet: StrongMetallic
+
+- type: entity
+  parent: ComputerCommsNoEvac
+  id: ComputerCommsNoEvacRD
+  suffix: RD
+  components:
+  - type: CommunicationsConsole
+    title: "Research Director"
+    canShuttle: false
+  - type: AccessReader
+    access: [[ "ResearchDirector" ]]
+
+- type: entity
+  parent: ComputerCommsNoEvac
+  id: ComputerCommsNoEvacHop
+  suffix: Hop
+  components:
+  - type: CommunicationsConsole
+    title: "Head Of Personell"
+    canShuttle: false
+  - type: AccessReader
+    access: [[ "HeadOfPersonnel" ]]
+
+- type: entity
+  parent: ComputerCommsNoEvac
+  id: ComputerCommsNoEvacQM
+  suffix: QM
+  components:
+  - type: CommunicationsConsole
+    title: "Quarter Master"
+    canShuttle: false
+  - type: AccessReader
+    access: [[ "Quartermaster" ]]
+
+- type: entity
+  parent: ComputerCommsNoEvac
+  id: ComputerCommsNoEvacCE
+  suffix: CE
+  components:
+  - type: CommunicationsConsole
+    title: "Chief Engineer"
+    canShuttle: false
+  - type: AccessReader
+    access: [[ "ChiefEngineer" ]]
+
+- type: entity
+  parent: ComputerCommsNoEvac
+  id: ComputerCommsNoEvacCMO
+  suffix: CMO
+  components:
+  - type: CommunicationsConsole
+    title: "Chief Medical Officer"
+    canShuttle: false
+  - type: AccessReader
+    access: [[ "ChiefMedicalOfficer" ]]
+
+- type: entity
+  parent: ComputerCommsNoEvac
+  id: ComputerCommsNoEvacHos
+  suffix: Hos
+  components:
+  - type: CommunicationsConsole
+    title: "Head Of Security"
+    canShuttle: false
+  - type: AccessReader
+    access: [[ "HeadOfSecurity" ]]
+
+- type: entity
+  parent: ComputerCommsNoEvac
+  id: ComputerCommsNoEvacHos
+  suffix: warden
+  components:
+  - type: CommunicationsConsole
+    title: "Warden"
+    canShuttle: false
+  - type: AccessReader
+    access: [[ "Armory" ]]

--- a/Resources/Prototypes/Goobstation/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Goobstation/Entities/Structures/Machines/Computers/computers.yml
@@ -50,7 +50,7 @@
   suffix: QM
   components:
   - type: CommunicationsConsole
-    title: "Quartermaster's Desk"
+    title: "Quartermaster Desk"
     canShuttle: false
   - type: AccessReader
     access: [[ "Quartermaster" ]]
@@ -83,10 +83,10 @@
   suffix: HoS
   components:
   - type: CommunicationsConsole
-    title: "Head Of Security's Desk"
+    title: "Head Of Security Desk"
     canShuttle: false
   - type: AccessReader
-    access: [[ "HeadOfSecurity" ]]
+    access: [[ "HeadOfSecurity" ], ["Armory"]]
 
 - type: entity
   parent: ComputerCommsNoEvac


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
adds communications computer for department heads
can only make annoucments not evac , 
one for eatch head and warden. not captain. captain can use the bridge.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
https://discord.com/channels/1202734573247795300/1236697829171527841/1274338638909673494
will make the Ninja Broadcast Objective simpler, (its already simple)

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
if you start dismanteling it you get the base  vac 
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
![image](https://github.com/user-attachments/assets/d0f503c4-6549-49d8-aaa3-d5a71cb9a347)
## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new communication system with dedicated computers for various roles within the station, enhancing communication capabilities.
	- Added role-specific communication consoles allowing authorized personnel to make station-wide announcements while ensuring security protocols are maintained.
	- Implemented a new localization framework for departmental announcements, improving user interface clarity and accessibility.
- **Improvements**
	- Improved structure for accessibility of communication consoles to streamline operations for designated roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->