### PR TITLE
Make Emote Wheel useful again

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/harpy.yml
@@ -127,6 +127,12 @@
     speciesId: harpy
     templateId: digitigrade
   - type: HarpyVisuals
+  - type: Tag
+    tags:
+    - CanPilot
+    - FootstepSound
+    - DoorBumpOpener
+    - HarpyEmotes
 
 - type: entity
   save: false

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
@@ -96,6 +96,12 @@
       Male: MaleVulpkanin
       Female: FemaleVulpkanin
       Unsexed: MaleVulpkanin
+  - type: Tag
+    tags:
+    - CanPilot
+    - FootstepSound
+    - DoorBumpOpener
+    - VulpEmotes
 
 - type: entity
   save: false

--- a/Resources/Prototypes/DeltaV/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/DeltaV/Voice/speech_emotes.yml
@@ -3,6 +3,12 @@
   id: Ring
   name: Ring
   category: Vocal
+  whitelist:
+    tags:
+    - HarpyEmotes
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [rings.]
   chatTriggers:
     - ring.
@@ -15,6 +21,12 @@
   id: Pew
   name: Pew
   category: Vocal
+  whitelist:
+    tags:
+    - HarpyEmotes
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [pews.]
   chatTriggers:
     - pew.
@@ -25,6 +37,12 @@
   id: Bang
   name: Bang
   category: Vocal
+  whitelist:
+    tags:
+    - HarpyEmotes
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [bangs.]
   chatTriggers:
     - bangs.
@@ -48,6 +66,12 @@
   id: Rev
   name: Rev
   category: Vocal
+  whitelist:
+    tags:
+    - HarpyEmotes
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [revs.]
   chatTriggers:
     - revs.
@@ -71,6 +95,12 @@
   id: Caw
   name: Caw
   category: Vocal
+  whitelist:
+    tags:
+    - HarpyEmotes
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [caws.]
   chatTriggers:
     - caws.
@@ -84,6 +114,13 @@
   id: Bark
   name: Bark
   category: Vocal
+  whitelist:
+    tags:
+    - VulpEmotes
+    - HarpyEmotes
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [barks.]
   chatTriggers:
     - bark.
@@ -98,6 +135,13 @@
   id: Snarl
   name: Snarl
   category: Vocal
+  whitelist:
+    tags:
+    - VulpEmotes
+    - HarpyEmotes
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [snarls.]
   chatTriggers:
     - snarl.
@@ -112,6 +156,13 @@
   id: Whine
   name: Whine
   category: Vocal
+  whitelist:
+    tags:
+    - VulpEmotes
+    - HarpyEmotes
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [whines.]
   chatTriggers:
     - whine.
@@ -126,6 +177,13 @@
   id: Howl
   name: Howl
   category: Vocal
+  whitelist:
+    tags:
+    - VulpEmotes
+    - HarpyEmotes
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [howls.]
   chatTriggers:
     - howl.
@@ -139,6 +197,13 @@
   id: Awoo
   name: Awoo
   category: Vocal
+  whitelist:
+    tags:
+    - VulpEmotes
+    - HarpyEmotes
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [awoos.]
   chatTriggers:
     - awoo.

--- a/Resources/Prototypes/Goobstation/tags.yml
+++ b/Resources/Prototypes/Goobstation/tags.yml
@@ -1,5 +1,14 @@
 - type: Tag
-  id: SnapPop
+  id: BreathMask
+
+- type: Tag
+  id: ClownEmergencyOxygenTank
+
+- type: Tag
+  id: EmergencyMedipen
+
+- type: Tag
+  id: EmergencyNitrogenTank
 
 - type: Tag
   id: EmergencyOxygenTank
@@ -8,13 +17,10 @@
   id: ExtendedEmergencyOxygenTank
 
 - type: Tag
-  id: ClownEmergencyOxygenTank
+  id: FelinidEmotes
 
 - type: Tag
-  id: EmergencyNitrogenTank
-
-- type: Tag
-  id: BreathMask
+  id: HarpyEmotes
 
 - type: Tag
   id: MedicalPatch
@@ -23,10 +29,7 @@
   id: SecurityBreathMask
 
 - type: Tag
-  id: SyndicateBreathMask
-
-- type: Tag
-  id: EmergencyMedipen
+  id: SnapPop
 
 - type: Tag
   id: SpaceMedipen
@@ -36,4 +39,9 @@
   
 - type: Tag
   id: StasisCage
- 
+
+- type: Tag
+  id: SyndicateBreathMask
+
+- type: Tag
+  id: VulpEmotes

--- a/Resources/Prototypes/Goobstation/tags.yml
+++ b/Resources/Prototypes/Goobstation/tags.yml
@@ -45,3 +45,4 @@
 
 - type: Tag
   id: VulpEmotes
+  

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -65,6 +65,12 @@
       Unsexed: MaleFelinid
   - type: Felinid
   - type: NoShoesSilentFootsteps
+  - type: Tag
+    tags:
+    - CanPilot
+    - FootstepSound
+    - DoorBumpOpener
+    - FelinidEmotes
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Nyanotrasen/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Nyanotrasen/Voice/speech_emotes.yml
@@ -1,8 +1,15 @@
 # vocal emotes
 - type: emote
   id: Hiss
-  name: /Audio/Nyanotrasen/Voice/Felinid/cat_hiss1.ogg
+  name: Hiss
   category: Vocal
+  whitelist:
+    tags:
+    - FelinidEmotes
+    - HarpyEmotes
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [hisses.]
   chatTriggers:
     - hiss.
@@ -15,6 +22,13 @@
   id: Meow
   name: Meow
   category: Vocal
+  whitelist:
+    tags:
+    - FelinidEmotes
+    - HarpyEmotes
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [meows.]
   chatTriggers:
     - meow.
@@ -41,6 +55,13 @@
   id: Mew
   name: Mew
   category: Vocal
+  whitelist:
+    tags:
+    - FelinidEmotes
+    - HarpyEmotes
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [mews.]
   chatTriggers:
     - mew.
@@ -54,8 +75,15 @@
 
 - type: emote
   id: Growl
-  name: growls.
+  name: Growl
   category: Vocal
+  whitelist:
+    tags:
+    - FelinidEmotes
+    - HarpyEmotes
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [growls.]
   chatTriggers:
     - growl.
@@ -68,6 +96,13 @@
   id: Purr
   name: Purr
   category: Vocal
+  whitelist:
+    tags:
+    - FelinidEmotes
+    - HarpyEmotes
+  blacklist:
+    components:
+    - BorgChassis
   chatMessages: [purrs.]
   chatTriggers:
     - purr.


### PR DESCRIPTION
## About the PR
Now emote wheel will be filled with emotes your species can soundplay.

## Why / Balance
It was hell to find emote in this wheel.

## Technical details
Added 3 new tags for species to determine emotions they can use.

## Media
![image](https://github.com/user-attachments/assets/ee87a83d-7d67-45aa-af13-5435892a3faa)
![image](https://github.com/user-attachments/assets/afb10184-8eed-41bf-8794-865d3433d5ef)
![image](https://github.com/user-attachments/assets/bd68a23c-f02e-4a9a-8a7a-87afa9c558b3)

- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

:cl:
- fix: Emotes wheel will contain only your species emotions.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced capabilities for Harpy, Vulpkanin, and Felinid entities with new tags for improved interactions, including `CanPilot`, `FootstepSound`, `DoorBumpOpener`, and specific emotes.
	- Introduced whitelists and blacklists for vocal emotes to refine usage and restrict certain entities.
	- Added new tags in the system to improve organization and clarity.

- **Bug Fixes**
	- Standardized naming conventions for vocal emotes to enhance consistency.

- **Chores**
	- Renamed and reorganized various tags to improve clarity and functionality within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->