### PR TITLE
remove cog from map pool

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -3,7 +3,7 @@
   maps:
   - Bagel
   - Box
-  - Cog
+  #- Cog # Goobstation - cog is broken
   - Core
   - Fland
   - Marathon


### PR DESCRIPTION
## About the PR
remove cog from map pool

## Why / Balance
cog is broken. 

**Changelog**

:cl:
- remove: Cog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Temporarily removed the "Cog" map from the list of available maps to prevent gameplay issues.
  
- **Bug Fixes**
	- Addressed issues related to the broken state of the "Cog" map in the Goobstation context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->