### PR TITLE
Make Felinids Mew Again.

### DIFF
--- a/Resources/Prototypes/DeltaV/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/DeltaV/Voice/speech_emotes.yml
@@ -12,11 +12,10 @@
     - BorgChassis
   chatMessages: [rings.]
   chatTriggers:
-    - ring.
-    - rings.
-    - rings!
-    - ringing.
-    - ringed.
+    - ring
+    - rings
+    - ringing
+    - ringed
 
 - type: emote
   id: Pew
@@ -31,9 +30,8 @@
     - BorgChassis
   chatMessages: [pews.]
   chatTriggers:
-    - pew.
-    - pews.
-    - pew!
+    - pew
+    - pews
 
 - type: emote
   id: Bang
@@ -48,22 +46,20 @@
     - BorgChassis
   chatMessages: [bangs.]
   chatTriggers:
-    - bangs.
-    - bang.
-    - bang!
-    - banging.
-    - banged.
+    - bangs
+    - bang
+    - banging
+    - banged
 
 #- type: emote
 #  id: Beep
 #  category: Vocal
 #  chatMessages: [beeps.]
 #  chatTriggers:
-#    - beeps.
-#    - beep.
-#    - beep!
-#    - beeping.
-#    - beeped.
+#    - beeps
+#    - beep
+#    - beeping
+#    - beeped
 
 - type: emote
   id: Rev
@@ -78,9 +74,8 @@
     - BorgChassis
   chatMessages: [revs.]
   chatTriggers:
-    - revs.
-    - rev.
-    - rev!
+    - revs
+    - rev
     - revving
     - revved
 
@@ -89,11 +84,10 @@
 #  category: Vocal
 #  chatMessages: [clicks.]
 #  chatTriggers:
-#    - clicks.
-#    - click.
-#    - click!
-#    - clicking.
-#    - clicked.
+#    - clicks
+#    - click
+#    - clicking
+#    - clicked
 
 - type: emote
   id: Caw
@@ -108,9 +102,8 @@
     - BorgChassis
   chatMessages: [caws.]
   chatTriggers:
-    - caws.
-    - caw.
-    - caw!
+    - caws
+    - caw
     - cawing
     - cawed
 
@@ -129,13 +122,10 @@
     - BorgChassis
   chatMessages: [barks.]
   chatTriggers:
-    - bark.
-    - bark!
-    - barks.
-    - barks!
-    - barked.
-    - barked!
-    - barking.
+    - bark
+    - barks
+    - barked
+    - barking
 
 - type: emote
   id: Snarl
@@ -151,13 +141,10 @@
     - BorgChassis
   chatMessages: [snarls.]
   chatTriggers:
-    - snarl.
-    - snarl!
-    - snarls.
-    - snarls!
-    - snarled.
-    - snarled!
-    - snarling.
+    - snarl
+    - snarls
+    - snarled
+    - snarling
 
 - type: emote
   id: Whine
@@ -173,13 +160,10 @@
     - BorgChassis
   chatMessages: [whines.]
   chatTriggers:
-    - whine.
-    - whine!
-    - whines.
-    - whines!
-    - whined.
-    - whined!
-    - whining.
+    - whine
+    - whines
+    - whined
+    - whining
 
 - type: emote
   id: Howl
@@ -195,12 +179,10 @@
     - BorgChassis
   chatMessages: [howls.]
   chatTriggers:
-    - howl.
-    - howl!
-    - howls.
-    - howls!
-    - howling.
-    - howled.
+    - howl
+    - howls
+    - howling
+    - howled
 
 - type: emote
   id: Awoo
@@ -216,9 +198,7 @@
     - BorgChassis
   chatMessages: [awoos.]
   chatTriggers:
-    - awoo.
-    - awoo!
-    - awoos.
-    - awoos!
-    - awooing.
-    - awooed.
+    - awoo
+    - awoos
+    - awooing
+    - awooed

--- a/Resources/Prototypes/Nyanotrasen/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Nyanotrasen/Voice/speech_emotes.yml
@@ -13,11 +13,10 @@
     - BorgChassis
   chatMessages: [hisses.]
   chatTriggers:
-    - hiss.
-    - hisses.
-    - hisses!
-    - hissing.
-    - hissed.
+    - hiss
+    - hisses
+    - hissing
+    - hissed
 
 - type: emote
   id: Meow
@@ -33,25 +32,16 @@
     - BorgChassis
   chatMessages: [meows.]
   chatTriggers:
-    - meow.
-    - meow!
-    - meows.
-    - meows~
-    - meows!
-    - meowing.
-    - meowed.
-    - miau.
-    - miaus.
-    - miaus!
-    - nya.
-    - nyas.
-    - nyas!
-    - mraow.
-    - mraow!
-    - mraow~
-    - mraows.
-    - mraows!
-    - mraows~
+    - meow
+    - meows
+    - meowing
+    - meowed
+    - miau
+    - miaus
+    - nya
+    - nyas
+    - mraow
+    - mraows
 
 - type: emote
   id: Mew
@@ -67,14 +57,10 @@
     - BorgChassis
   chatMessages: [mews.]
   chatTriggers:
-    - mew.
-    - mew!
-    - mew~
-    - mews.
-    - mews!
-    - mews~
-    - mewing.
-    - mewed.
+    - mew
+    - mews
+    - mewing
+    - mewed
 
 - type: emote
   id: Growl
@@ -90,11 +76,10 @@
     - BorgChassis
   chatMessages: [growls.]
   chatTriggers:
-    - growl.
-    - growls.
-    - growls!
-    - growling.
-    - growled.
+    - growl
+    - growls
+    - growling
+    - growled
 
 - type: emote
   id: Purr
@@ -110,9 +95,7 @@
     - BorgChassis
   chatMessages: [purrs.]
   chatTriggers:
-    - purr.
-    - purrs.
-    - purrs~
-    - purrs!
-    - purring.
-    - purred.
+    - purr
+    - purrs
+    - purring
+    - purred


### PR DESCRIPTION
And other assorted formerly-broken emote sounds.

## About the PR
Fixed some species not producing noises when emoting via chat inputs.

## Why / Balance
Because I want to mew without the emote wheel god dammit

## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Felinids, Vulps, and Harpies can type some of their their noisiest emotes again. Mew! Purr! Growl! Rev!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Standardized trigger phrases for various emotes by removing punctuation for improved consistency and recognition.
  
- **Bug Fixes**
	- Enhanced parsing logic by simplifying chat triggers, potentially reducing input errors.

- **Documentation**
	- Improved clarity in the documentation regarding the emote triggers and their intended usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->