### PR TITLE
turn off scream action

### DIFF
--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -28,23 +28,24 @@ public sealed class VocalSystem : EntitySystem
         SubscribeLocalEvent<VocalComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<VocalComponent, SexChangedEvent>(OnSexChanged);
         SubscribeLocalEvent<VocalComponent, EmoteEvent>(OnEmote);
-        SubscribeLocalEvent<VocalComponent, ScreamActionEvent>(OnScreamAction);
+        // SubscribeLocalEvent<VocalComponent, ScreamActionEvent>(OnScreamAction); // Goobstation - turn off scream action
     }
+
 
     private void OnMapInit(EntityUid uid, VocalComponent component, MapInitEvent args)
     {
         // try to add scream action when vocal comp added
-        _actions.AddAction(uid, ref component.ScreamActionEntity, component.ScreamAction);
+        //_actions.AddAction(uid, ref component.ScreamActionEntity, component.ScreamAction); // Goobstation - turn off scream action
         LoadSounds(uid, component);
     }
 
     private void OnShutdown(EntityUid uid, VocalComponent component, ComponentShutdown args)
     {
         // remove scream action when component removed
-        if (component.ScreamActionEntity != null)
-        {
-            _actions.RemoveAction(uid, component.ScreamActionEntity);
-        }
+        // if (component.ScreamActionEntity != null)    // Goobstation - turn off scream action
+        // {
+        //     _actions.RemoveAction(uid, component.ScreamActionEntity);
+        // }
     }
 
     private void OnSexChanged(EntityUid uid, VocalComponent component, SexChangedEvent args)
@@ -68,14 +69,15 @@ public sealed class VocalSystem : EntitySystem
         args.Handled = _chat.TryPlayEmoteSound(uid, component.EmoteSounds, args.Emote);
     }
 
-    private void OnScreamAction(EntityUid uid, VocalComponent component, ScreamActionEvent args)
-    {
-        if (args.Handled)
-            return;
+    //// Goobstation - turn off scream action
+    // private void OnScreamAction(EntityUid uid, VocalComponent component, ScreamActionEvent args)
+    // {
+    //     if (args.Handled)
+    //         return;
 
-        _chat.TryEmoteWithChat(uid, component.ScreamId);
-        args.Handled = true;
-    }
+    //     _chat.TryEmoteWithChat(uid, component.ScreamId);
+    //     args.Handled = true;
+    // }
 
     private bool TryPlayScreamSound(EntityUid uid, VocalComponent component)
     {

--- a/Content.Server/Speech/Muting/MutingSystem.cs
+++ b/Content.Server/Speech/Muting/MutingSystem.cs
@@ -18,7 +18,7 @@ namespace Content.Server.Speech.Muting
             base.Initialize();
             SubscribeLocalEvent<MutedComponent, SpeakAttemptEvent>(OnSpeakAttempt);
             SubscribeLocalEvent<MutedComponent, EmoteEvent>(OnEmote, before: new[] { typeof(VocalSystem) });
-            SubscribeLocalEvent<MutedComponent, ScreamActionEvent>(OnScreamAction, before: new[] { typeof(VocalSystem) });
+            //SubscribeLocalEvent<MutedComponent, ScreamActionEvent>(OnScreamAction, before: new[] { typeof(VocalSystem) }); // Goobstation - turn off scream action
         }
 
         private void OnEmote(EntityUid uid, MutedComponent component, ref EmoteEvent args)
@@ -31,18 +31,19 @@ namespace Content.Server.Speech.Muting
                 args.Handled = true;
         }
 
-        private void OnScreamAction(EntityUid uid, MutedComponent component, ScreamActionEvent args)
-        {
-            if (args.Handled)
-                return;
+        //// Goobstation - turn off scream action
+        // private void OnScreamAction(EntityUid uid, MutedComponent component, ScreamActionEvent args)
+        // {
+        //     if (args.Handled)
+        //         return;
 
-            if (HasComp<MimePowersComponent>(uid))
-                _popupSystem.PopupEntity(Loc.GetString("mime-cant-speak"), uid, uid);
+        //     if (HasComp<MimePowersComponent>(uid))
+        //         _popupSystem.PopupEntity(Loc.GetString("mime-cant-speak"), uid, uid);
 
-            else
-                _popupSystem.PopupEntity(Loc.GetString("speech-muted"), uid, uid);
-            args.Handled = true;
-        }
+        //     else
+        //         _popupSystem.PopupEntity(Loc.GetString("speech-muted"), uid, uid);
+        //     args.Handled = true;
+        // }
 
 
         private void OnSpeakAttempt(EntityUid uid, MutedComponent component, SpeakAttemptEvent args)

--- a/Content.Shared/Speech/Components/VocalComponent.cs
+++ b/Content.Shared/Speech/Components/VocalComponent.cs
@@ -35,13 +35,14 @@ public sealed partial class VocalComponent : Component
     [AutoNetworkedField]
     public float WilhelmProbability = 0.0002f;
 
-    [DataField("screamAction", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-    [AutoNetworkedField]
-    public string ScreamAction = "ActionScream";
+    ////// Goobstation - turn off scream action
+    // [DataField("screamAction", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    // [AutoNetworkedField]
+    // public string ScreamAction = "ActionScream";
 
-    [DataField("screamActionEntity")]
-    [AutoNetworkedField]
-    public EntityUid? ScreamActionEntity;
+    // [DataField("screamActionEntity")]
+    // [AutoNetworkedField]
+    // public EntityUid? ScreamActionEntity;
 
     /// <summary>
     ///     Currently loaded emote sounds prototype, based on entity sex.

--- a/Content.Shared/Speech/ScreamActionEvent.cs
+++ b/Content.Shared/Speech/ScreamActionEvent.cs
@@ -1,7 +1,9 @@
-﻿using Content.Shared.Actions;
+﻿// using Content.Shared.Actions;
 
-namespace Content.Shared.Speech;
+// namespace Content.Shared.Speech;
 
-public sealed partial class ScreamActionEvent : InstantActionEvent
-{
-}
+// public sealed partial class ScreamActionEvent : InstantActionEvent
+// {
+// }
+
+////// Goobstation - turn off scream action

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -9,16 +9,17 @@
 
 # actions
 
-- type: entity
-  id: ActionScream
-  name: Scream
-  description: AAAAAAAAAAAAAAAAAAAAAAAAA
-  components:
-  - type: InstantAction
-    useDelay: 10
-    icon: Interface/Actions/scream.png
-    event: !type:ScreamActionEvent
-    checkCanInteract: false
+## Goobstation - turn off scream action
+# - type: entity
+#   id: ActionScream
+#   name: Scream
+#   description: AAAAAAAAAAAAAAAAAAAAAAAAA
+#   components:
+#   - type: InstantAction
+#     useDelay: 10
+#     icon: Interface/Actions/scream.png
+#     event: !type:ScreamActionEvent
+#     checkCanInteract: false
 
 - type: entity
   id: ActionTurnUndead

--- a/Resources/Prototypes/Catalog/catalog.yml
+++ b/Resources/Prototypes/Catalog/catalog.yml
@@ -24,15 +24,16 @@
   categories:
     - Debug
 
-- type: listing
-  id: DebugListing4
-  name: debug name 4
-  description: debug desc 4
-  productAction: ActionScream
-  categories:
-    - Debug
-  cost:
-    DebugDollar: 1
+## Goobstation - turn off scream action
+# - type: listing
+#   id: DebugListing4
+#   name: debug name 4
+#   description: debug desc 4
+#   productAction: ActionScream
+#   categories:
+#     - Debug
+#   cost:
+#     DebugDollar: 1
 
 - type: listing
   id: DebugListing2


### PR DESCRIPTION
## About the PR
Turns off scream action.
You still can scream via chat emote or emote wheel.

## Why / Balance
Players use it as a funny button with funny sound.

## Media
![Screenshot from 2024-08-28 20-26-09](https://github.com/user-attachments/assets/272fedd8-ff1d-4835-9d1d-cd2860fe200d)


## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
:cl:
- remove: You have no action but you must scream.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- The scream action has been fully disabled across the game, impacting character vocal interactions.

- **Bug Fixes**
	- Resolved issues related to unwanted scream actions during gameplay.

- **Chores**
	- Cleaned up code by commenting out unused scream action definitions across multiple components and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->