### PR TITLE
zombies thing

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/ZombieRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/ZombieRuleComponent.cs
@@ -25,4 +25,7 @@ public sealed partial class ZombieRuleComponent : Component
     /// </summary>
     [DataField]
     public float ZombieShuttleCallPercentage = 0.7f;
+
+    // goob edit
+    public bool StartAnnounced = false;
 }

--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Zombies;
+using Robust.Shared.Audio;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
 using System.Globalization;
@@ -116,6 +117,18 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
         var healthy = GetHealthyHumans();
         if (healthy.Count == 1) // Only one human left. spooky
             _popup.PopupEntity(Loc.GetString("zombie-alone"), healthy[0], healthy[0]);
+
+        // goob edit
+        if (GetInfectedFraction(false) > zombieRuleComponent.ZombieShuttleCallPercentage / 5f && !zombieRuleComponent.StartAnnounced)
+        {
+            zombieRuleComponent.StartAnnounced = true;
+
+            foreach (var station in _station.GetStations())
+                _chat.DispatchStationAnnouncement(station,
+                    Loc.GetString("zombie-start-announcement"),
+                    colorOverride: Color.Pink,
+                    announcementSound: new SoundPathSpecifier("/Audio/Announcements/outbreak7.ogg"));
+        }
 
         if (GetInfectedFraction(false) > zombieRuleComponent.ZombieShuttleCallPercentage && !_roundEnd.IsRoundEndRequested())
         {

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-zombies.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-zombies.ftl
@@ -12,6 +12,9 @@ zombie-healing = You feel a stirring in your flesh
 zombie-infection-warning = You feel the zombie virus take hold
 zombie-infection-underway = Your blood begins to thicken
 
+## goob edit
+zombie-start-announcement = Confirmed outbreak of level 7 biological hazard aboard the station. All personnel must contain the outbreak.
+
 zombie-alone = You feel entirely alone.
 
 zombie-shuttle-call = We have detected that the undead have overtaken the station. Dispatching an emergency shuttle to collect remaining personnel.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
when zeds take over one fifth of the required crew members needed to call the shuttle the fun announcement will play

## Media
![image](https://github.com/user-attachments/assets/109a8561-5055-403f-97e3-8c615879b6e1)

:cl:
- add: Centcom has learned the difference between a zombie outbreak and flu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new announcement system for the start of the zombie outbreak, enhancing player awareness and interactivity.
	- Added a localization entry for the start announcement, improving the game's narrative context.

- **Bug Fixes**
	- Resolved issues with the announcement logic to ensure accurate triggering based on game state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->