### PR TITLE
little SM fixes

### DIFF
--- a/Content.Server/Goobstation/Supermatter/Systems/SupermatterSystem.cs
+++ b/Content.Server/Goobstation/Supermatter/Systems/SupermatterSystem.cs
@@ -91,7 +91,7 @@ public sealed class SupermatterSystem : SharedSupermatterSystem
         foreach (var sm in EntityManager.EntityQuery<SupermatterComponent>())
         {
             if (!sm.Activated)
-                return;
+                continue;
 
             var uid = sm.Owner;
             sm.UpdateAccumulator += frameTime;
@@ -444,13 +444,14 @@ public sealed class SupermatterSystem : SharedSupermatterSystem
 
         if (mix is { })
         {
-            var absorbedGas = mix.Remove(sm.GasEfficiency * mix.TotalMoles);
-            var moles = absorbedGas.TotalMoles;
+            // var absorbedGas = mix.Remove(sm.GasEfficiency * mix.TotalMoles);
+            var moles = mix.TotalMoles;
 
             if (moles >= sm.MolePenaltyThreshold)
                 return DelamType.Singulo;
         }
-        if (sm.Power >= sm.PowerPenaltyThreshold)
+
+        if (sm.Power >= sm.PowerPenaltyThreshold) 
             return DelamType.Tesla;
 
         // TODO: add resonance cascade when there's crazy conditions, or a destabilizing crystal :godo:
@@ -480,7 +481,7 @@ public sealed class SupermatterSystem : SharedSupermatterSystem
 
         sm.DelamTimerAccumulator++;
 
-        if (sm.DelamTimerAccumulator < sm.DelamTimer)
+        if (sm.DelamTimer > sm.DelamTimerAccumulator)
             return;
 
         switch (_delamType)
@@ -613,7 +614,8 @@ public sealed class SupermatterSystem : SharedSupermatterSystem
 
         Spawn(sm.SliverPrototypeId, _transform.GetMapCoordinates(args.User));
 
-        sm.DelamTimer /= 2;
+        if (sm.DelamTimer > 30f)
+            sm.DelamTimer -= 10f;
     }
 
     private void OnExamine(EntityUid uid, SupermatterComponent sm, ref ExaminedEvent args)

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -100,3 +100,4 @@
             sprite: Structures/Power/Generation/Singularity/singularity_6.rsi
             state: singularity_6
             scale: .9,.9
+  - type: SupermatterImmune # Goobstation

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/energyball.yml
@@ -104,6 +104,7 @@
     interactSuccessString: petting-success-tesla
     interactFailureString: petting-failure-tesla
     interactSuccessSpawn: EffectHearts
+  - type: SupermatterImmune # Goobstation
 
 - type: entity
   id: TeslaMiniEnergyBall


### PR DESCRIPTION
## About the PR
Singularity/tesla wont delete itself when collided with SM.
You can actually make singularity out of SM.
You cant lower delamation timer below 30 seconds.
It there is more then one SM code will work correctly.

## Technical details
plain text.

## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**

:cl:
- fix: SM.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `SupermatterImmune` type for the singularity structure, enhancing its interaction with supermatter.
	- Added `SupermatterImmune` type to the Tesla energy ball, allowing it to function without being affected by supermatter mechanics.

- **Gameplay Changes**
	- Adjusted logic in the Supermatter system for better handling of component states and delamination events, potentially altering gameplay dynamics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->