### PR TITLE
Heavy hit people heads

### DIFF
--- a/Content.Shared/Execution/SharedExecutionSystem.cs
+++ b/Content.Shared/Execution/SharedExecutionSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Mind;
 using Robust.Shared.Player;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Execution;
 

--- a/Content.Shared/Goobstation/Execution/HitHeadComponent.cs
+++ b/Content.Shared/Goobstation/Execution/HitHeadComponent.cs
@@ -1,0 +1,40 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Goobstation.Execution;
+
+/// <summary>
+/// Component that allow weapon to stun people for minute after doafter. Like Execution
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class HitHeadComponent : Component
+{
+    /// <summary>
+    /// Multiply duration of weapon cooldown
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float DoAfterDurationMultiplier = 2f;
+
+    /// <summary>
+    /// Chance that head hit will apply sleep
+    /// </summary>
+    [DataField]
+    public float SleepChance = 0.25f;
+
+    /// <summary>
+    /// Multiplier of hit damage
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float DamageMultiplier = 2f;
+
+    /// <summary>
+    /// Sleep duration in seconds
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan SleepDuration = TimeSpan.FromSeconds(45);
+
+    /// <summary>
+    /// For multiplying damage only on doafter
+    /// </summary>
+    [DataField]
+    public bool HitProccess = false;
+}

--- a/Content.Shared/Goobstation/Execution/HitHeadProtectionComponent.cs
+++ b/Content.Shared/Goobstation/Execution/HitHeadProtectionComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Goobstation.Execution;
+
+/// <summary>
+/// Makes the headgear protect against sleep hit
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class HitHeadProtectionComponent : Component
+{
+}

--- a/Content.Shared/Goobstation/Execution/SharedHitHeadSystem.cs
+++ b/Content.Shared/Goobstation/Execution/SharedHitHeadSystem.cs
@@ -1,0 +1,189 @@
+using Content.Shared.ActionBlocker;
+using Content.Shared.Bed.Sleep;
+using Content.Shared.CombatMode;
+using Content.Shared.Database;
+using Content.Shared.DoAfter;
+using Content.Shared.Inventory;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Popups;
+using Content.Shared.StatusEffect;
+using Content.Shared.Verbs;
+using Content.Shared.Weapons.Melee;
+using Content.Shared.Weapons.Melee.Events;
+using Robust.Shared.Random;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Goobstation.Execution;
+
+/// <summary>
+/// System for make people sleeping without killing them for easier marooning
+/// </summary>
+public sealed class SharedHitHeadSystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+    [Dependency] private readonly InventorySystem _inventorySystem = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly SharedCombatModeSystem _combatSystem = default!;
+    [Dependency] private readonly SharedMeleeWeaponSystem _meleeSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<HitHeadComponent, GetVerbsEvent<UtilityVerb>>(OnGetVerbs);
+        SubscribeLocalEvent<HitHeadComponent, HitUnconsciousDoAfterEvent>(OnHitDoAfter);
+        SubscribeLocalEvent<HitHeadComponent, GetMeleeDamageEvent>(OnGetMeleeDamage);
+    }
+
+    private void OnGetVerbs(Entity<HitHeadComponent> weapon, ref GetVerbsEvent<UtilityVerb> args)
+    {
+        if (args.Using == null || !args.CanAccess || !args.CanInteract)
+            return;
+
+        var attacker = args.User;
+        var target = args.Target;
+
+        if (!CanBeHit(target, attacker))
+            return;
+
+        UtilityVerb verb = new()
+        {
+            Act = () => TryStartHitDoAfter(weapon, target, attacker),
+            Impact = LogImpact.High,
+            IconEntity = GetNetEntity(weapon),
+            Text = Loc.GetString("hit-head-verb-name"),
+            Message = Loc.GetString("hit-head-verb-message"),
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    private bool TryStartHitDoAfter(Entity<HitHeadComponent> weapon, EntityUid target, EntityUid attacker)
+    {
+        if (!CanBeHit(target, attacker))
+            return false;
+
+        _popupSystem.PopupPredicted(Loc.GetString("hit-head-popup-trying-to-hit", ("attacker", attacker), ("target", target)),
+            attacker,
+            null,
+            PopupType.SmallCaution);
+
+        if (!TryComp<MeleeWeaponComponent>(weapon, out var meleeWeapon))
+            return false;
+
+        // Dividng one second to attack rate and multiplying with multiplier to get do after time
+        var doAfterTime = (1 / meleeWeapon.AttackRate) * weapon.Comp.DoAfterDurationMultiplier;
+
+        var ev = new HitUnconsciousDoAfterEvent();
+        var doAfterArgs = new DoAfterArgs(EntityManager, attacker, doAfterTime, ev, weapon, target, weapon)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = true,
+            NeedHand = true
+        };
+
+        if (!_doAfter.TryStartDoAfter(doAfterArgs))
+            return false;
+
+        return true;
+    }
+
+    private void OnHitDoAfter(Entity<HitHeadComponent> weapon, ref HitUnconsciousDoAfterEvent args)
+    {
+        if (args.Handled || args.Cancelled || args.Used == null || args.Target == null)
+            return;
+
+        if (!TryComp<MeleeWeaponComponent>(weapon, out var meleeWeaponComp))
+            return;
+
+        var attacker = args.User;
+        var target = args.Target.Value;
+        var comp = weapon.Comp;
+
+        if (!CanBeHit(target, attacker))
+            return;
+
+        // Changing attacker combat mode to make hit
+        var previousCombatMode = _combatSystem.IsInCombatMode(attacker);
+        _combatSystem.SetInCombatMode(attacker, true);
+        comp.HitProccess = true;
+
+        if (_meleeSystem.AttemptLightAttack(attacker, weapon, meleeWeaponComp, target))
+        {
+            // Calculating change to apply sleep
+            if (_random.Prob(comp.SleepChance))
+                _statusEffects.TryAddStatusEffect<ForcedSleepingComponent>(target, "ForcedSleep", comp.SleepDuration, true);
+
+            _popupSystem.PopupPredicted(
+                Loc.GetString("hit-head-popup-on-hit", ("attacker", attacker), ("target", target)),
+                target,
+                null,
+                PopupType.MediumCaution
+                );
+        }
+
+        _combatSystem.SetInCombatMode(attacker, previousCombatMode);
+        comp.HitProccess = false;
+        args.Handled = true;
+    }
+
+    private void OnGetMeleeDamage(Entity<HitHeadComponent> weapon, ref GetMeleeDamageEvent args)
+    {
+        var comp = weapon.Comp;
+
+        if (!TryComp<MeleeWeaponComponent>(weapon, out var meleeWeapon) || !comp.HitProccess)
+            return;
+
+        var damage = meleeWeapon.Damage * comp.DamageMultiplier;
+        args.Damage = damage;
+        args.ResistanceBypass = true;
+    }
+
+    private bool CanBeHit(EntityUid target, EntityUid attacker, string protectionSlot = "head")
+    {
+        // Stupid to hit yourself
+        if (target == attacker)
+            return false;
+
+        // If it don't have mob state it can't sleep
+        if (!TryComp<MobStateComponent>(target, out var mobState))
+            return false;
+
+        // If target is dead or in crit we don't need to make it sleep
+        if (_mobState.IsCritical(target, mobState) || _mobState.IsDead(target, mobState))
+            return false;
+
+        // If it can't get sleep 
+        if (!HasComp<StatusEffectsComponent>(target))
+            return false;
+
+        // Attacker can't hit target if he can't attack
+        if (!_actionBlocker.CanAttack(attacker))
+            return false;
+
+        // If target is sleeping already we don't need to stack the effect
+        if (HasComp<SleepingComponent>(target))
+            return false;
+
+        // check if target has something on head
+        if (!_inventorySystem.TryGetSlotEntity(target, protectionSlot, out var protectionEntity))
+            return true;
+
+        // check if headgear have protection
+        if (HasComp<HitHeadProtectionComponent>(protectionEntity))
+            return false;
+
+        return true;
+    }
+}
+
+
+[Serializable, NetSerializable]
+public sealed partial class HitUnconsciousDoAfterEvent : SimpleDoAfterEvent
+{
+}

--- a/Resources/Locale/en-US/Goobstation/execution/excecution.ftl
+++ b/Resources/Locale/en-US/Goobstation/execution/excecution.ftl
@@ -1,0 +1,5 @@
+hit-head-verb-name = Heavy hit the head
+hit-head-verb-message = Heavy hit the head with small chance target lose it's consciousness.
+
+hit-head-popup-trying-to-hit = {$attacker} swings a heavy object toward the {$target}.
+hit-head-popup-on-hit = {$attacker} takes a heavy blow to the head of {$target}.

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -145,6 +145,7 @@
     - Snout
     - HeadTop
     - HeadSide
+  - type: HitHeadProtection # GoobStation
 
 - type: entity
   abstract: true
@@ -189,6 +190,7 @@
     - Snout
     - HeadTop
     - HeadSide
+  - type: HitHeadProtection # GoobStation
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -65,6 +65,7 @@
   - type: Tag
     tags:
     - WhitelistChameleon
+  - type: HitHeadProtection # GoobStation
 
 - type: entity
   parent: ClothingHeadHatHardhatBase

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -203,6 +203,7 @@
     - ClothMade
     - HamsterWearable
     - WhitelistChameleon
+  - type: HitHeadProtection # GoobStation
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -26,6 +26,7 @@
     slots:
     - HeadTop
     - HeadSide
+  - type: HitHeadProtection # GoobStation
 
 #Mercenary Helmet
 - type: entity

--- a/Resources/Prototypes/Entities/Debugging/debug_sweps.yml
+++ b/Resources/Prototypes/Entities/Debugging/debug_sweps.yml
@@ -103,7 +103,8 @@
   - type: Item
     size: Tiny
     sprite: Objects/Weapons/Melee/debug.rsi
-
+  - type: HitHead #GoobStation
+  
 - type: entity
   name: bang stick 100dmg
   parent: MeleeDebugGib

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -168,6 +168,7 @@
   - type: Produce
     seedId: towercap
   - type: Log
+  - type: HitHead #GoobStation
 
 - type: entity
   name: steel-cap log
@@ -187,6 +188,7 @@
   - type: Log
     spawnedPrototype: SheetSteel1
     spawnCount: 1
+  - type: HitHead #GoobStation
 
 - type: entity
   name: nettle

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
@@ -157,6 +157,7 @@
     damage:
       types:
         Blunt: 15
+  - type: HitHead #GoobStation
 
 - type: entity
   parent: BaseHandheldInstrument

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -1389,6 +1389,7 @@
       damage:
         types:
           Blunt: 0
+    - type: HitHead #GoobStation >:)
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fire_extinguisher.yml
@@ -71,6 +71,7 @@
   - type: PhysicalComposition
     materialComposition:
       Steel: 100
+  - type: HitHead #GoobStation
 
 - type: entity
   name: extinguisher spray

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -584,7 +584,8 @@
         Blunt: 10
   - type: StealTarget
     stealGroup: BoxFolderQmClipboard
-
+  - type: HitHead #GoobStation
+  
 - type: entity
   parent: [Paper, BaseSyndicateContraband] # eat or burn your damn piece of paper damn thieves
   id: TraitorCodePaper

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -112,6 +112,7 @@
     sprite: Objects/Tools/Hydroponics/spade.rsi
   - type: Shovel
     speedModifier: 0.75 # slower at digging than a full-sized shovel
+  - type: HitHead #GoobStation
 
 - type: entity
   name: plant bag

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -51,6 +51,7 @@
     guides:
     - Janitorial
   - type: DnaSubstanceTrace
+  - type: HitHead #GoobStation
 
 - type: entity
   parent: BaseItem
@@ -111,6 +112,7 @@
         - Mop
         - MopAdv
     - type: DnaSubstanceTrace
+    - type: HitHead #GoobStation
 
 - type: entity
   name: wet floor sign

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -105,6 +105,7 @@
         node: start
       - !type:DoActsBehavior
         acts: ["Destruction"]
+  - type: HitHead #GoobStation
 
 - type: entity
   id: MechRipley

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
@@ -156,3 +156,4 @@
         Cold: 100
         Radiation: 100
     slots: NONE
+  - type: HitHead #GoobStation

--- a/Resources/Prototypes/Entities/Objects/Tools/crowbars.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/crowbars.yml
@@ -41,6 +41,7 @@
     size: Normal
     shape:
     - 0,0,0,1
+  - type: HitHead #GoobStation
 
 # Standard (grey) Crowbar
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -45,6 +45,7 @@
       Steel: 185
   - type: StaticPrice
     price: 30
+  - type: HitHead #GoobStation
 
 - type: entity
   abstract: true
@@ -113,6 +114,7 @@
   - type: Tag # Goobstation - For survival boxes
     tags:
     - EmergencyOxygenTank
+  - type: HitHead #GoobStation
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -49,6 +49,7 @@
         Blunt: 10
     soundHit:
       collection: MetalThud
+  - type: HitHead #GoobStation
 
 - type: entity
   name: syndicate jaws of life

--- a/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/toolbox.yml
@@ -32,6 +32,7 @@
           True: { state: icon-open }
           False: { state: icon }
   - type: Appearance
+  - type: HitHead #GoobStation
 
 - type: entity
   name: emergency toolbox

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -480,6 +480,7 @@
   - type: StaticPrice
     price: 25
   - type: Shovel
+  - type: HitHead #GoobStation
 
 - type: entity
   parent: BaseItem
@@ -514,3 +515,4 @@
   - type: Tag
     tags:
     - RollingPin
+  - type: HitHead #GoobStation

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
@@ -42,6 +42,7 @@
   - type: Tag
     tags:
     - BaseballBat
+  - type: HitHead #GoobStation
 
 - type: entity
   name: incomplete baseball bat

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cult.yml
@@ -85,3 +85,4 @@
     - back
   - type: UseDelay
     delay: 1
+  - type: HitHead #GoobStation

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -151,6 +151,7 @@
     size: Ginormous
   - type: DisarmMalus
   - type: Prying
+  - type: HitHead #GoobStation
 
 - type: entity
   parent: [ BaseWeaponCrusher, BaseSecurityCargoContraband]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sledgehammer.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sledgehammer.yml
@@ -23,3 +23,4 @@
         Structural: 10
   - type: Item
     size: Large
+  - type: HitHead #GoobStation

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -190,3 +190,4 @@
     - type: Grammar
       attributes:
         proper: true
+    - type: HitHead #GoobStation

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -88,6 +88,7 @@
     guides:
     - Security
     - Antagonists
+  - type: HitHead #GoobStation
 
 - type: entity
   name: truncheon
@@ -125,6 +126,7 @@
     guides:
     - Security
     - Antagonists
+  - type: HitHead #GoobStation
 
 - type: entity
   name: flash

--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -350,6 +350,7 @@
     graph: Seat
     node: chairFolding
   - type: DamageExaminable
+  - type: HitHead #GoobStation
 
 - type: entity
   parent: ChairFolding

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -127,6 +127,7 @@
         Blunt: 8
     soundHit:
       collection: MetalThud # this NEEDS to changed to the metal pipe falling sound effect on april first every year
+  - type: HitHead #GoobStation
 
 - type: entity
   # Goobstation - Allow device-on-pipe stacking
@@ -168,6 +169,7 @@
     damage:
       types:
         Blunt: 8 # Woe, pipe be upon ye!
+  - type: HitHead #GoobStation
 
 - type: entity
   # Goobstation - Allow device-on-pipe stacking
@@ -205,6 +207,7 @@
         Blunt: 10
     soundHit:
       collection: MetalThud
+  - type: HitHead #GoobStation
 
 - type: entity
   # Goobstation - Allow device-on-pipe stacking
@@ -241,6 +244,7 @@
         Blunt: 10
     soundHit:
       collection: MetalThud
+  - type: HitHead #GoobStation
 
 - type: entity
   id: GasPipeBroken

--- a/Resources/Prototypes/Goobstation/Entities/Objects/Weapons/Melee/cane.yml
+++ b/Resources/Prototypes/Goobstation/Entities/Objects/Weapons/Melee/cane.yml
@@ -24,6 +24,7 @@
     tags:
       - CaneBlade
   - type: DisarmMalus
+  - type: Execution
 
 - type: entity
   id: CaneSheathFilledNanotrasen


### PR DESCRIPTION
## About the PR
Now you'll be able to heavy hit people head's with blunt damage melee weapons with special verb.
The hit have x2 of weapons attack rate doafter (1 sec /attack rate actually) and will make x2 damage. Also it'll have 25% chance to force target sleep for 45 seconds. When you trying to make heavy hit you'll make red popup that everyone will be able to see.

You won't be able to hit the target if it's equipped with hard hats (helmets, hardhats, space suit helmets and etc.)

## Why / Balance
Kidnapping someone is very hard task right now. Much easier to just kill and gib someone, instead of kill and move body in bodybag or trying to move body without killing because target will scream all the way.

On other hand, obtaining sleepy reagent is hard task if you're not syndie agent (chloral hydrate works much worse now) and you still need to use TC for it, when you can kill target without using TC.

With this update you'll be able to cuff and force sleep target, making it much easier to move it.

## Media

https://github.com/user-attachments/assets/771f2110-8842-45c4-995a-027d961a2d23

- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

- add: Now you can make heavy hit with almost all blunt melee weapon with chance to force sleep the target.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `HitHeadComponent` for weapons to stun targets after a delay.
	- Added `HitHeadProtectionComponent` to provide protective headgear against stun effects.
	- Implemented `SharedHitHeadSystem` for managing head-hitting mechanics and interactions.
	- Added localization strings for head-hitting actions to enhance player feedback.
	- Expanded item types to include `HitHead` across various entities, enhancing gameplay interactions.

- **Bug Fixes**
	- None reported.

- **Documentation**
	- Updated localization files to include new action descriptions.

- **Chores**
	- Added new entity types and configurations across multiple YAML files to support new gameplay mechanics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->