### PR TITLE
Revert "Automated changelog update (#587)"

### DIFF
--- a/Resources/Changelog/GoobChangelog.yml
+++ b/Resources/Changelog/GoobChangelog.yml
@@ -890,7 +890,3 @@ Entries:
       message: Added crawling. Toggleable on R by default
   id: 113
   time: '2024-09-02T14:41:45.0000000+00:00'
-- author: Icepicked
-  changes: []
-  id: 114
-  time: '2024-09-03T16:28:27.0000000+00:00'


### PR DESCRIPTION
Nothing happened in Goobstation changelogs 3 sep 2024

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed an outdated entry from the changelog to enhance clarity and streamline the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->