### PR TITLE
Guns dual wielding

### DIFF
--- a/Content.Shared/Goobstation/Weapons/Multishot/MultishotComponent.cs
+++ b/Content.Shared/Goobstation/Weapons/Multishot/MultishotComponent.cs
@@ -20,10 +20,4 @@ public sealed partial class MultishotComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public EntityUid? RelatedWeapon = default!;
-
-    /// <summary>
-    /// How many hands this weapon required to allow multishot. Just to prevent nukeops borg shoot everything he have.
-    /// </summary>
-    [DataField]
-    public byte RequiredHandsCount = 2;
 }

--- a/Content.Shared/Goobstation/Weapons/Multishot/MultishotComponent.cs
+++ b/Content.Shared/Goobstation/Weapons/Multishot/MultishotComponent.cs
@@ -1,0 +1,29 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Goobstation.Weapons.Multishot;
+
+/// <summary>
+/// Component that allows guns to be shooted with another weapon by holding it in second hand
+/// </summary>
+[RegisterComponent]
+[NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class MultishotComponent : Component
+{
+    /// <summary>
+    /// Increasing spread when shooting with multiple hands
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float SpreadMultiplier = 1.5f;
+
+    /// <summary>
+    /// Uid of related weapon
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid? RelatedWeapon = default!;
+
+    /// <summary>
+    /// How many hands this weapon required to allow multishot. Just to prevent nukeops borg shoot everything he have.
+    /// </summary>
+    [DataField]
+    public byte RequiredHandsCount = 2;
+}

--- a/Content.Shared/Goobstation/Weapons/Multishot/SharedMultishotSystem.cs
+++ b/Content.Shared/Goobstation/Weapons/Multishot/SharedMultishotSystem.cs
@@ -1,0 +1,116 @@
+using Content.Shared.Hands;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Weapons.Ranged.Systems;
+
+namespace Content.Shared.Goobstation.Weapons.Multishot;
+
+public sealed partial class SharedMultishotSystem : EntitySystem
+{
+    [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
+    [Dependency] private readonly SharedGunSystem _gunSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MultishotComponent, GotEquippedHandEvent>(OnEquipWeapon);
+        SubscribeLocalEvent<MultishotComponent, GotUnequippedHandEvent>(OnUnequipWeapon);
+        SubscribeLocalEvent<MultishotComponent, GunRefreshModifiersEvent>(OnRefreshModifiers);
+        SubscribeLocalEvent<MultishotComponent, GunShotEvent>(OnShotAttempt);
+    }
+
+    private void OnShotAttempt(Entity<MultishotComponent> multishotWeapon, ref GunShotEvent args)
+    {
+        var comp = multishotWeapon.Comp;
+
+        if (comp.RelatedWeapon == null)
+            return;
+
+        // Need to prevent recursive shoot attempting
+        if (_handsSystem.GetActiveItem(args.User) != multishotWeapon)
+            return;
+
+        if (!TryComp<GunComponent>(comp.RelatedWeapon, out var relatedGun) || !TryComp<GunComponent>(multishotWeapon, out var gun))
+            return;
+
+        if (gun.ShootCoordinates == null)
+            return;
+
+        _gunSystem.AttemptShoot(args.User, comp.RelatedWeapon.Value, relatedGun, gun.ShootCoordinates.Value);
+
+        // Synchronizing reload timer
+        var reloadDelta = relatedGun.LastFire - gun.LastFire;
+        relatedGun.NextFire -= reloadDelta.Duration();
+    }
+
+    private void OnRefreshModifiers(Entity<MultishotComponent> multishotWeapon, ref GunRefreshModifiersEvent args)
+    {
+        var comp = multishotWeapon.Comp;
+
+        if (comp.RelatedWeapon == null)
+            return;
+
+        args.MaxAngle *= comp.SpreadMultiplier;
+        args.MinAngle *= comp.SpreadMultiplier;
+    }
+
+    private void OnEquipWeapon(Entity<MultishotComponent> multishotWeapon, ref GotEquippedHandEvent args)
+    {
+        var comp = multishotWeapon.Comp;
+
+        if (!TryComp<HandsComponent>(args.User, out var handsComp))
+            return;
+
+        if (handsComp.Count < 2 || handsComp.Count != comp.RequiredHandsCount)
+            return;
+
+        // Find first suitable weapon
+        foreach (var held in _handsSystem.EnumerateHeld(args.User, handsComp))
+        {
+            if (held == multishotWeapon.Owner)
+                continue;
+
+            if (!TryComp<MultishotComponent>(held, out var multishotHeld))
+                continue;
+
+            comp.RelatedWeapon = held;
+            multishotHeld.RelatedWeapon = multishotWeapon;
+
+            Dirty(held, multishotHeld);
+            Dirty(multishotWeapon, comp);
+
+            _gunSystem.RefreshModifiers(multishotWeapon.Owner);
+            _gunSystem.RefreshModifiers(held);
+
+            break;
+        }
+    }
+
+    private void OnUnequipWeapon(Entity<MultishotComponent> multishotWeapon, ref GotUnequippedHandEvent args)
+    {
+        var comp = multishotWeapon.Comp;
+
+        if (comp.RelatedWeapon == null)
+            return;
+
+        if (!TryComp<MultishotComponent>(comp.RelatedWeapon.Value, out var relatedMultishot))
+        {
+            comp.RelatedWeapon = null;
+            return;
+        }
+
+        var tempRelated = comp.RelatedWeapon.Value;
+
+        relatedMultishot.RelatedWeapon = null;
+        comp.RelatedWeapon = null;
+
+        _gunSystem.RefreshModifiers(tempRelated);
+        _gunSystem.RefreshModifiers(multishotWeapon.Owner);
+
+        Dirty(tempRelated, relatedMultishot);
+        Dirty(multishotWeapon, comp);
+    }
+}

--- a/Content.Shared/Goobstation/Weapons/Multishot/SharedMultishotSystem.cs
+++ b/Content.Shared/Goobstation/Weapons/Multishot/SharedMultishotSystem.cs
@@ -55,6 +55,7 @@ public sealed partial class SharedMultishotSystem : EntitySystem
 
         args.MaxAngle *= comp.SpreadMultiplier;
         args.MinAngle *= comp.SpreadMultiplier;
+        args.FireRate /= comp.SpreadMultiplier;
     }
 
     private void OnEquipWeapon(Entity<MultishotComponent> multishotWeapon, ref GotEquippedHandEvent args)

--- a/Content.Shared/Goobstation/Weapons/Multishot/SharedMultishotSystem.cs
+++ b/Content.Shared/Goobstation/Weapons/Multishot/SharedMultishotSystem.cs
@@ -64,7 +64,7 @@ public sealed partial class SharedMultishotSystem : EntitySystem
         if (!TryComp<HandsComponent>(args.User, out var handsComp))
             return;
 
-        if (handsComp.Count < 2 || handsComp.Count != comp.RequiredHandsCount)
+        if (handsComp.Count != 2)
             return;
 
         // Find first suitable weapon

--- a/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Goobstation.Weapons.Multishot;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Audio;
@@ -8,7 +9,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 namespace Content.Shared.Weapons.Ranged.Components;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
-[Access(typeof(SharedGunSystem))]
+[Access(typeof(SharedGunSystem), typeof(SharedMultishotSystem))] // GoobStation - Multishot v
 public sealed partial class GunComponent : Component
 {
     #region Sound

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -361,6 +361,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         }
 
         Dirty(gunUid, gun);
+        UpdateAmmoCount(gunUid); //GoobStation - Multishot
     }
 
     public void Shoot(

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -122,6 +122,7 @@
     magState: mag
     steps: 5
     zeroVisible: true
+  - type: Multishot # Goobstation
 
 - type: entity
   name: retro laser blaster
@@ -145,6 +146,7 @@
     steps: 5
     zeroVisible: true
   - type: Appearance
+  - type: Multishot # Goobstation
 
 - type: entity
   name: makeshift laser pistol
@@ -168,6 +170,7 @@
   - type: Battery
     maxCharge: 500
     startingCharge: 500
+  - type: Multishot # Goobstation
 
 - type: entity
   name: tesla gun
@@ -264,6 +267,7 @@
   - type: Battery
     maxCharge: 2000
     startingCharge: 2000
+  - type: Multishot # Goobstation
 
 - type: entity
   name: pulse carbine
@@ -588,6 +592,7 @@
     flavorKind: station-event-random-sentience-flavor-inanimate
     weight: 0.0002 # 5,000 times less likely than 1 regular animal
     # not putting a BlockMovement component here cause that's funny.
+  - type: Multishot # Goobstation
 
 - type: entity
   name: advanced laser pistol
@@ -623,6 +628,7 @@
   - type: Appearance
   - type: StaticPrice
     price: 63
+  - type: Multishot # Goobstation
 
 - type: entity
   name: C.H.I.M.P. handcannon
@@ -669,6 +675,7 @@
     node: start
   - type: StaticPrice
     price: 100
+  - type: Multishot # Goobstation
 
 - type: entity
   name: experimental C.H.I.M.P. handcannon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -62,7 +62,7 @@
   - type: UseDelay
     delay: 1
   - type: Multishot # Goobstation
-    spreadMultiplier: 1.85 # Try not to hit teammates challenge :godo:
+    spreadMultiplier: 1.4
 
 - type: entity
   name: L6 SAW

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -61,6 +61,8 @@
     price: 500
   - type: UseDelay
     delay: 1
+  - type: Multishot # Goobstation
+    spreadMultiplier: 1.85 # Try not to hit teammates challenge :godo:
 
 - type: entity
   name: L6 SAW

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -19,6 +19,7 @@
     containers:
       ballistic-ammo: !type:Container
         ents: []
+  - type: Multishot # Goobstation
 
 - type: entity
   name: china lake

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -67,6 +67,8 @@
   - type: Appearance
   - type: StaticPrice
     price: 500
+  - type: Multishot # Goobstation
+    spreadMultiplier: 1.25
 
 - type: entity
   name: viper
@@ -251,3 +253,5 @@
         whitelist:
           tags:
             - CartridgeMagnum
+  - type: Multishot # Goobstation
+    spreadMultiplier: 1.25

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -49,6 +49,8 @@
       path: /Audio/Weapons/Guns/MagIn/revolver_magin.ogg
   - type: StaticPrice
     price: 500
+  - type: Multishot # Goobstation
+    spreadMultiplier: 1.2
 
 - type: entity
   name: Deckard

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -50,6 +50,8 @@
       gun_chamber: !type:ContainerSlot
   - type: StaticPrice
     price: 500
+  - type: Multishot # Goobstation
+    spreadMultiplier: 1.6
 
 - type: entity
   name: AKMS

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -55,6 +55,8 @@
       gun_chamber: !type:ContainerSlot
   - type: StaticPrice
     price: 500
+  - type: Multishot # Goobstation
+    spreadMultiplier: 1.4
 
 - type: entity
   name: Atreides

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -201,7 +201,6 @@
     node: shotgunsawn
     deconstructionTarget: null
   - type: Multishot # Goobstation
-    spreadMultiplier: 1.8
 
 - type: entity
   name: sawn-off shotgun
@@ -241,7 +240,6 @@
   - type: StaticPrice
     price: 0
   - type: Multishot # Goobstation
-    spreadMultiplier: 1.8
 
 - type: entity
   name: blunderbuss

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -200,6 +200,8 @@
     graph: ShotgunSawn
     node: shotgunsawn
     deconstructionTarget: null
+  - type: Multishot # Goobstation
+    spreadMultiplier: 1.8
 
 - type: entity
   name: sawn-off shotgun
@@ -238,6 +240,8 @@
     deconstructionTarget: null
   - type: StaticPrice
     price: 0
+  - type: Multishot # Goobstation
+    spreadMultiplier: 1.8
 
 - type: entity
   name: blunderbuss

--- a/Resources/Prototypes/Goobstation/Entities/Objects/Weapons/Guns/Basic/plasma_cutter.yml
+++ b/Resources/Prototypes/Goobstation/Entities/Objects/Weapons/Guns/Basic/plasma_cutter.yml
@@ -24,6 +24,8 @@
     proto: BulletPlasmaCutter
     fireCost: 100
   - type: Appearance
+  - type: Multishot
+    spreadMultiplier: 1.2
 
 - type: entity
   parent: WeaponPlasmaCutter

--- a/Resources/Prototypes/Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -24,3 +24,5 @@
     magState: mag
     steps: 2
     zeroVisible: true
+  - type: Multishot
+    spreadMultiplier: 1.2


### PR DESCRIPTION
## About the PR
Most guns can be shoot from both hands now with lower accuracy

## Why / Balance
Funny SS13 TG mechanic (i like dual berettas from cs 1.6)

## Media

https://github.com/user-attachments/assets/97fef649-0ccd-475d-b7a5-7aaa3fd7a3ed

:cl:
- tweak: Dual welding for guns! Now you can shoot from most weapons with both hands!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a multishot capability for various weapons, allowing players to fire multiple projectiles simultaneously.
	- Added a `SpreadMultiplier` property to adjust projectile spread for enhanced tactical gameplay.
	- New entity types for multishot functionality added across multiple weapon categories including pistols, rifles, shotguns, and more.

- **Bug Fixes**
	- Improved ammunition management for multishot weapons to ensure accurate ammo counts after shooting.

- **Chores**
	- Updated weapon configuration files to include new multishot types and properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->