### PR TITLE
Emag works as laws board for syndicate lawset on AI

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/emag.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/emag.yml
@@ -12,6 +12,8 @@
   - type: Item
     sprite: Objects/Tools/emag.rsi
     storedRotation: -90
+  - type: SiliconLawProvider #Goobstation
+    laws: SyndicateStatic
 
 - type: entity
   parent: EmagUnlimited


### PR DESCRIPTION
## About the PR
Title ↑
Don't provide syndicate comms for AI

**Changelog**
:cl:
- tweak: Emag can be inserted to AI upload to change AI lawset to syndicate one.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new entity type, `SiliconLawProvider`, enhancing the functionality of the emag tool by allowing interaction with specific legal frameworks.
  
- **Improvements**
	- Expanded capabilities of existing tools without altering their fundamental properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->