### PR TITLE
Fix mime survival kit

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
@@ -700,6 +700,10 @@
     damage:
       types:
         Blunt: 1 # bonk
+  - type: Tag #Goobstation
+    tags:
+    - BreadEmergency 
+
 # Tastes like France.
 
 - type: entity

--- a/Resources/Prototypes/Goobstation/Entities/Objects/Misc/emergencybox.yml
+++ b/Resources/Prototypes/Goobstation/Entities/Objects/Misc/emergencybox.yml
@@ -42,6 +42,7 @@
         whitelist:
           tags:
           - FoodSnack
+          - BreadEmergency
       flare:
         ejectOnInteract: false
         whitelist:
@@ -94,6 +95,7 @@
         whitelist:
           tags:
           - FoodSnack
+          - BreadEmergency
       flare:
         whitelist:
           tags:
@@ -426,3 +428,49 @@
     currentLabel: reagent-name-nitrogen
   - type: Sprite
     state: box_syndie
+
+- type: entity
+  parent: BoxSurvivalSlots
+  id: BoxMimeSlots
+  suffix: Mime, Emergency
+  components:
+  - type: ContainerFill
+    containers:
+      water:
+      - DrinkWaterBottleFull
+      nutriblock:
+      - FoodBreadBaguette
+      flare:
+      - Flare
+      tank:
+      - EmergencyOxygenTankFilled
+      mask:
+      - ClothingMaskBreath
+      emergencypen:
+      - EmergencyMedipen
+      spacepen:
+      - SpaceMedipen
+
+- type: entity
+  parent: BoxSurvivalSlots
+  id: BoxMimeSlotsNitrogen
+  suffix: Mime, Emergency N2
+  components:
+  - type: ContainerFill
+    containers:
+      water:
+      - DrinkWaterBottleFull
+      nutriblock:
+      - FoodBreadBaguette
+      flare:
+      - Flare
+      tank:
+      - EmergencyNitrogenTankFilled
+      mask:
+      - ClothingMaskBreath
+      emergencypen:
+      - EmergencyMedipen
+      spacepen:
+      - SpaceMedipen
+  - type: Label
+    currentLabel: reagent-name-nitrogen

--- a/Resources/Prototypes/Goobstation/tags.yml
+++ b/Resources/Prototypes/Goobstation/tags.yml
@@ -1,4 +1,7 @@
 - type: Tag
+  id: BreadEmergency
+
+- type: Tag
   id: BreathMask
 
 - type: Tag

--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -59,7 +59,7 @@
     proto: OxygenBreather
   storage:
     back:
-    - BoxHugSlots
+    - BoxHugSlots # Goobstation - Slots Based Survival Boxes
 
 - type: loadout
   id: EmergencyNitrogenClown
@@ -68,7 +68,7 @@
     proto: NitrogenBreather
   storage:
     back:
-    - BoxHugSlotsNitrogen
+    - BoxHugSlotsNitrogen # Goobstation - Slots Based Survival Boxes
 
 # Mime
 - type: loadout
@@ -78,7 +78,7 @@
     proto: OxygenBreather
   storage:
     back:
-    - BoxMime
+    - BoxMimeSlots # Goobstation - Slots Based Survival Boxes
 
 - type: loadout
   id: EmergencyNitrogenMime
@@ -87,7 +87,7 @@
     proto: NitrogenBreather
   storage:
     back:
-    - BoxMimeNitrogen
+    - BoxMimeSlotsNitrogen # Goobstation - Slots Based Survival Boxes
 
 
 # Engineering / Extended


### PR DESCRIPTION
## About the PR
return slot based survival kit to mime



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new tag "BreadEmergency" for enhanced categorization of the bread entity.
  - Added new emergency supply entities, `BoxMimeSlots` and `BoxMimeSlotsNitrogen`, to improve organization of emergency items.
  
- **Bug Fixes**
  - Updated the whitelist for the `flare` component to recognize the new "BreadEmergency" tag.

- **Documentation**
  - Enhanced comments in loadout configurations for clarity regarding survival box features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->