### PR TITLE
Nukie planet update

### DIFF
--- a/Resources/Maps/Goobstation/Nonstations/nukieplanet.yml
+++ b/Resources/Maps/Goobstation/Nonstations/nukieplanet.yml
@@ -71,7 +71,7 @@ entities:
   - uid: 2
     components:
     - type: MetaData
-      name: Nukieplanet
+      name: Syndicate Outpost
     - type: Transform
       pos: -4.024322,5.604384
       parent: 1
@@ -4310,29 +4310,56 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 14.5,-21.5
       parent: 2
-- proto: FireAxeFlaming
+- proto: FireAxeCabinetOpen
   entities:
-  - uid: 661
+  - uid: 2395
     components:
     - type: Transform
-      pos: -2.2713957,-20.14453
+      rot: 3.141592653589793 rad
+      pos: -5.5,-9.5
       parent: 2
+    - type: Openable
+      opened: False
+    - type: Lock
+      locked: True
+    - type: AccessReader
+      accessLog:
+      - accessor: Unknown
+        accessTime: 155.8035803
+      access:
+      - - NuclearOperative
+    - type: ContainerContainer
+      containers:
+        ItemCabinet: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 2396
+- proto: FireAxeFlaming
+  entities:
+  - uid: 2396
+    components:
+    - type: Transform
+      parent: 2395
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
 - proto: FitnessPunchingBagCaptain
   entities:
-  - uid: 662
+  - uid: 661
     components:
     - type: Transform
       pos: 10.5,3.5
       parent: 2
 - proto: FitnessWeightsBench1
   entities:
-  - uid: 663
+  - uid: 662
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,4.5
       parent: 2
-  - uid: 664
+  - uid: 663
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4340,28 +4367,28 @@ entities:
       parent: 2
 - proto: Flash
   entities:
-  - uid: 665
+  - uid: 664
     components:
     - type: Transform
       pos: 34.615303,0.110441685
       parent: 2
 - proto: FlippoLighter
   entities:
-  - uid: 666
+  - uid: 665
     components:
     - type: Transform
       pos: 8.749153,-16.456598
       parent: 2
 - proto: Floodlight
   entities:
-  - uid: 667
+  - uid: 666
     components:
     - type: Transform
       pos: 15.712837,-12.377796
       parent: 2
 - proto: FloorDrain
   entities:
-  - uid: 668
+  - uid: 667
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4369,7 +4396,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 669
+  - uid: 668
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4379,430 +4406,430 @@ entities:
       fixtures: {}
 - proto: FloorLiquidPlasmaEntity
   entities:
-  - uid: 670
+  - uid: 669
     components:
     - type: Transform
       pos: 25.5,-14.5
       parent: 2
-  - uid: 671
+  - uid: 670
     components:
     - type: Transform
       pos: 24.5,-14.5
       parent: 2
-  - uid: 672
+  - uid: 671
     components:
     - type: Transform
       pos: 23.5,-14.5
       parent: 2
-  - uid: 673
+  - uid: 672
     components:
     - type: Transform
       pos: 22.5,-14.5
       parent: 2
-  - uid: 674
+  - uid: 673
     components:
     - type: Transform
       pos: 23.5,-15.5
       parent: 2
-  - uid: 675
+  - uid: 674
     components:
     - type: Transform
       pos: 22.5,-15.5
       parent: 2
-  - uid: 676
+  - uid: 675
     components:
     - type: Transform
       pos: 21.5,-15.5
       parent: 2
-  - uid: 677
+  - uid: 676
     components:
     - type: Transform
       pos: 20.5,-15.5
       parent: 2
-  - uid: 678
+  - uid: 677
     components:
     - type: Transform
       pos: 22.5,-16.5
       parent: 2
-  - uid: 679
+  - uid: 678
     components:
     - type: Transform
       pos: 22.5,-17.5
       parent: 2
-  - uid: 680
+  - uid: 679
     components:
     - type: Transform
       pos: 22.5,-18.5
       parent: 2
-  - uid: 681
+  - uid: 680
     components:
     - type: Transform
       pos: 22.5,-19.5
       parent: 2
-  - uid: 682
+  - uid: 681
     components:
     - type: Transform
       pos: 22.5,-20.5
       parent: 2
-  - uid: 683
+  - uid: 682
     components:
     - type: Transform
       pos: 21.5,-16.5
       parent: 2
-  - uid: 684
+  - uid: 683
     components:
     - type: Transform
       pos: 21.5,-17.5
       parent: 2
-  - uid: 685
+  - uid: 684
     components:
     - type: Transform
       pos: 21.5,-18.5
       parent: 2
-  - uid: 686
+  - uid: 685
     components:
     - type: Transform
       pos: 21.5,-19.5
       parent: 2
-  - uid: 687
+  - uid: 686
     components:
     - type: Transform
       pos: 21.5,-20.5
       parent: 2
-  - uid: 688
+  - uid: 687
     components:
     - type: Transform
       pos: 20.5,-16.5
       parent: 2
-  - uid: 689
+  - uid: 688
     components:
     - type: Transform
       pos: 20.5,-17.5
       parent: 2
-  - uid: 690
+  - uid: 689
     components:
     - type: Transform
       pos: 20.5,-18.5
       parent: 2
-  - uid: 691
+  - uid: 690
     components:
     - type: Transform
       pos: 20.5,-19.5
       parent: 2
-  - uid: 692
+  - uid: 691
     components:
     - type: Transform
       pos: 20.5,-20.5
       parent: 2
-  - uid: 693
+  - uid: 692
     components:
     - type: Transform
       pos: 23.5,-21.5
       parent: 2
-  - uid: 694
+  - uid: 693
     components:
     - type: Transform
       pos: 22.5,-21.5
       parent: 2
-  - uid: 695
+  - uid: 694
     components:
     - type: Transform
       pos: 21.5,-21.5
       parent: 2
-  - uid: 696
+  - uid: 695
     components:
     - type: Transform
       pos: 20.5,-21.5
       parent: 2
-  - uid: 697
+  - uid: 696
     components:
     - type: Transform
       pos: 28.5,-22.5
       parent: 2
-  - uid: 698
+  - uid: 697
     components:
     - type: Transform
       pos: 27.5,-22.5
       parent: 2
-  - uid: 699
+  - uid: 698
     components:
     - type: Transform
       pos: 26.5,-22.5
       parent: 2
-  - uid: 700
+  - uid: 699
     components:
     - type: Transform
       pos: 25.5,-22.5
       parent: 2
-  - uid: 701
+  - uid: 700
     components:
     - type: Transform
       pos: 24.5,-22.5
       parent: 2
-  - uid: 702
+  - uid: 701
     components:
     - type: Transform
       pos: 23.5,-22.5
       parent: 2
-  - uid: 703
+  - uid: 702
     components:
     - type: Transform
       pos: 22.5,-22.5
       parent: 2
-  - uid: 704
+  - uid: 703
     components:
     - type: Transform
       pos: 21.5,-22.5
       parent: 2
-  - uid: 705
+  - uid: 704
     components:
     - type: Transform
       pos: 23.5,-23.5
       parent: 2
-  - uid: 706
+  - uid: 705
     components:
     - type: Transform
       pos: 24.5,-23.5
       parent: 2
-  - uid: 707
+  - uid: 706
     components:
     - type: Transform
       pos: 25.5,-23.5
       parent: 2
-  - uid: 708
+  - uid: 707
     components:
     - type: Transform
       pos: 26.5,-23.5
       parent: 2
-  - uid: 709
+  - uid: 708
     components:
     - type: Transform
       pos: 27.5,-23.5
       parent: 2
-  - uid: 710
+  - uid: 709
     components:
     - type: Transform
       pos: 29.5,-21.5
       parent: 2
-  - uid: 711
+  - uid: 710
     components:
     - type: Transform
       pos: 28.5,-21.5
       parent: 2
-  - uid: 712
+  - uid: 711
     components:
     - type: Transform
       pos: 24.5,-21.5
       parent: 2
-  - uid: 713
+  - uid: 712
     components:
     - type: Transform
       pos: 23.5,-20.5
       parent: 2
-  - uid: 714
+  - uid: 713
     components:
     - type: Transform
       pos: 29.5,-20.5
       parent: 2
-  - uid: 715
+  - uid: 714
     components:
     - type: Transform
       pos: 23.5,-16.5
       parent: 2
-  - uid: 716
+  - uid: 715
     components:
     - type: Transform
       pos: 24.5,-15.5
       parent: 2
 - proto: FloraTreeConifer01
   entities:
-  - uid: 717
+  - uid: 716
     components:
     - type: Transform
       pos: 21.392143,-12.729544
       parent: 2
-  - uid: 718
+  - uid: 717
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.96957,-1.4107871
       parent: 2
-  - uid: 719
+  - uid: 718
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 44.071133,4.3314004
       parent: 2
-  - uid: 720
+  - uid: 719
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 44.610195,10.118542
       parent: 2
-  - uid: 721
+  - uid: 720
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 32.038555,16.165417
       parent: 2
-  - uid: 722
+  - uid: 721
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.21776,10.212292
       parent: 2
-  - uid: 723
+  - uid: 722
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 38.739777,15.204479
       parent: 2
-  - uid: 724
+  - uid: 723
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 24.270073,7.063351
       parent: 2
-  - uid: 725
+  - uid: 724
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.942753,6.825022
       parent: 2
-  - uid: 726
+  - uid: 725
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.066328,-1.7765403
       parent: 2
-  - uid: 727
+  - uid: 726
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.019453,1.5984597
       parent: 2
-  - uid: 728
+  - uid: 727
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.4639435,3.9474778
       parent: 2
-  - uid: 729
+  - uid: 728
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.8467555,7.275603
       parent: 2
-  - uid: 730
+  - uid: 729
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.510818,2.9865403
       parent: 2
-  - uid: 731
+  - uid: 730
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.8057833,9.73654
       parent: 2
-  - uid: 732
+  - uid: 731
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.199942,11.617781
       parent: 2
-  - uid: 733
+  - uid: 732
     components:
     - type: Transform
       pos: 31.977348,-23.940697
       parent: 2
 - proto: FloraTreeConifer02
   entities:
-  - uid: 734
+  - uid: 733
     components:
     - type: Transform
       pos: 10.992382,-20.738451
       parent: 2
 - proto: FloraTreeConifer03
   entities:
-  - uid: 735
+  - uid: 734
     components:
     - type: Transform
       pos: 16.973898,-18.627144
       parent: 2
-  - uid: 736
+  - uid: 735
     components:
     - type: Transform
       pos: 16.859533,-25.557884
       parent: 2
-  - uid: 737
+  - uid: 736
     components:
     - type: Transform
       pos: 26.703283,-24.807884
       parent: 2
 - proto: FloraTreeSnow01
   entities:
-  - uid: 738
+  - uid: 737
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 20.842281,16.78661
       parent: 2
-  - uid: 739
+  - uid: 738
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 32.94993,10.88036
       parent: 2
-  - uid: 740
+  - uid: 739
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.234589,8.81786
       parent: 2
-  - uid: 741
+  - uid: 740
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.445526,15.731922
       parent: 2
-  - uid: 742
+  - uid: 741
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 38.445923,10.270985
       parent: 2
-  - uid: 743
+  - uid: 742
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.571957,16.200672
       parent: 2
-  - uid: 744
+  - uid: 743
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.61102,5.0912967
       parent: 2
-  - uid: 745
+  - uid: 744
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 44.321957,0.8710246
       parent: 2
-  - uid: 746
+  - uid: 745
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 24.94335,1.3600345
       parent: 2
-  - uid: 747
+  - uid: 746
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.3007822,5.7447276
       parent: 2
-  - uid: 748
+  - uid: 747
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4810,44 +4837,44 @@ entities:
       parent: 2
 - proto: FloraTreeSnow02
   entities:
-  - uid: 749
+  - uid: 748
     components:
     - type: Transform
       pos: 6.351757,-21.816576
       parent: 2
-  - uid: 750
+  - uid: 749
     components:
     - type: Transform
       pos: 15.540962,-14.862171
       parent: 2
-  - uid: 751
+  - uid: 750
     components:
     - type: Transform
       pos: 15.208273,-20.377144
       parent: 2
-  - uid: 752
+  - uid: 751
     components:
     - type: Transform
       pos: 32.956394,-16.27578
       parent: 2
-  - uid: 753
+  - uid: 752
     components:
     - type: Transform
       pos: 30.987646,-13.43203
       parent: 2
-  - uid: 754
+  - uid: 753
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.984393,7.361915
       parent: 2
-  - uid: 755
+  - uid: 754
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 16.976582,4.1041026
       parent: 2
-  - uid: 756
+  - uid: 755
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4855,79 +4882,79 @@ entities:
       parent: 2
 - proto: FloraTreeSnow03
   entities:
-  - uid: 757
+  - uid: 756
     components:
     - type: Transform
       pos: 18.119087,-14.159046
       parent: 2
-  - uid: 758
+  - uid: 757
     components:
     - type: Transform
       pos: 18.776403,1.4578114
       parent: 2
-  - uid: 759
+  - uid: 758
     components:
     - type: Transform
       pos: 33.386364,-21.432884
       parent: 2
-  - uid: 760
+  - uid: 759
     components:
     - type: Transform
       pos: 28.675426,-26.35476
       parent: 2
-  - uid: 761
+  - uid: 760
     components:
     - type: Transform
       pos: 22.297033,-26.214134
       parent: 2
-  - uid: 762
+  - uid: 761
     components:
     - type: Transform
       pos: 18.031408,-23.565697
       parent: 2
 - proto: FloraTreeSnow04
   entities:
-  - uid: 763
+  - uid: 762
     components:
     - type: Transform
       pos: 8.883007,-21.550951
       parent: 2
-  - uid: 764
+  - uid: 763
     components:
     - type: Transform
       pos: 17.833273,-21.095894
       parent: 2
 - proto: FloraTreeSnow06
   entities:
-  - uid: 765
+  - uid: 764
     components:
     - type: Transform
       pos: 8.508007,-19.113451
       parent: 2
-  - uid: 766
+  - uid: 765
     components:
     - type: Transform
       pos: 17.009712,-11.737171
       parent: 2
-  - uid: 767
+  - uid: 766
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 20.210957,6.1197276
       parent: 2
-  - uid: 768
+  - uid: 767
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.375019,11.838478
       parent: 2
-  - uid: 769
+  - uid: 768
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 27.448383,15.617538
       parent: 2
-  - uid: 770
+  - uid: 769
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4935,14 +4962,14 @@ entities:
       parent: 2
 - proto: FoodSnackSyndi
   entities:
-  - uid: 771
+  - uid: 770
     components:
     - type: Transform
       pos: 10.5,-1.5
       parent: 2
 - proto: GasFilter
   entities:
-  - uid: 772
+  - uid: 771
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4950,21 +4977,21 @@ entities:
       parent: 2
 - proto: GasFilterFlipped
   entities:
-  - uid: 773
+  - uid: 772
     components:
     - type: Transform
       pos: -3.5,-16.5
       parent: 2
 - proto: GasMixer
   entities:
-  - uid: 774
+  - uid: 773
     components:
     - type: Transform
       pos: -0.5,-12.5
       parent: 2
 - proto: GasOutletInjector
   entities:
-  - uid: 775
+  - uid: 774
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4972,25 +4999,25 @@ entities:
       parent: 2
 - proto: GasPassiveVent
   entities:
-  - uid: 776
+  - uid: 775
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-19.5
       parent: 2
-  - uid: 777
+  - uid: 776
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-20.5
       parent: 2
-  - uid: 778
+  - uid: 777
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-19.5
       parent: 2
-  - uid: 779
+  - uid: 778
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4998,23 +5025,23 @@ entities:
       parent: 2
 - proto: GasPipeBend
   entities:
-  - uid: 780
+  - uid: 779
     components:
     - type: Transform
       pos: -3.5,-15.5
       parent: 2
-  - uid: 781
+  - uid: 780
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-15.5
       parent: 2
-  - uid: 782
+  - uid: 781
     components:
     - type: Transform
       pos: 1.5,-16.5
       parent: 2
-  - uid: 783
+  - uid: 782
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5022,70 +5049,78 @@ entities:
       parent: 2
 - proto: GasPipeFourway
   entities:
-  - uid: 784
+  - uid: 783
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 2
 - proto: GasPipeStraight
   entities:
-  - uid: 785
+  - uid: 784
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 2
-  - uid: 786
+  - uid: 785
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 2
-  - uid: 787
+  - uid: 786
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 2
-  - uid: 788
+  - uid: 787
     components:
     - type: Transform
       pos: 6.5,0.5
       parent: 2
-  - uid: 789
+  - uid: 788
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 2
-  - uid: 790
+  - uid: 789
     components:
     - type: Transform
       pos: 8.5,-0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#404040FF'
-  - uid: 791
+  - uid: 790
     components:
     - type: Transform
       pos: 8.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#404040FF'
-  - uid: 792
+  - uid: 791
     components:
     - type: Transform
       pos: 8.5,0.5
       parent: 2
     - type: AtmosPipeColor
       color: '#404040FF'
-  - uid: 793
+  - uid: 792
     components:
     - type: Transform
       pos: 8.5,-2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#404040FF'
-  - uid: 794
+  - uid: 793
     components:
     - type: Transform
       pos: 8.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#404040FF'
+  - uid: 794
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#404040FF'
@@ -5093,7 +5128,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 6.5,-1.5
+      pos: 5.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#404040FF'
@@ -5101,7 +5136,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,-1.5
+      pos: 3.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#404040FF'
@@ -5109,7 +5144,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,-1.5
+      pos: 4.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#404040FF'
@@ -5117,62 +5152,54 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,-1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#404040FF'
-  - uid: 799
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,-0.5
       parent: 2
-  - uid: 800
+  - uid: 799
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-0.5
       parent: 2
-  - uid: 801
+  - uid: 800
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-0.5
       parent: 2
-  - uid: 802
+  - uid: 801
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 2
-  - uid: 803
+  - uid: 802
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 2
-  - uid: 804
+  - uid: 803
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-0.5
       parent: 2
-  - uid: 805
+  - uid: 804
     components:
     - type: Transform
       pos: -3.5,-18.5
       parent: 2
-  - uid: 806
+  - uid: 805
     components:
     - type: Transform
       pos: -1.5,-18.5
       parent: 2
-  - uid: 807
+  - uid: 806
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-19.5
       parent: 2
-  - uid: 808
+  - uid: 807
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5180,13 +5207,13 @@ entities:
       parent: 2
 - proto: GasPipeTJunction
   entities:
-  - uid: 809
+  - uid: 808
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-0.5
       parent: 2
-  - uid: 810
+  - uid: 809
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5194,105 +5221,105 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#404040FF'
-  - uid: 811
+  - uid: 810
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#404040FF'
-  - uid: 812
+  - uid: 811
     components:
     - type: Transform
       pos: 0.5,-16.5
       parent: 2
 - proto: GasPort
   entities:
-  - uid: 813
+  - uid: 812
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 2
-  - uid: 814
+  - uid: 813
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-12.5
       parent: 2
-  - uid: 815
+  - uid: 814
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-13.5
       parent: 2
-  - uid: 816
+  - uid: 815
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-11.5
       parent: 2
-  - uid: 817
+  - uid: 816
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-12.5
       parent: 2
-  - uid: 818
+  - uid: 817
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-17.5
       parent: 2
-  - uid: 819
+  - uid: 818
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-17.5
       parent: 2
-  - uid: 820
+  - uid: 819
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-15.5
       parent: 2
-  - uid: 821
+  - uid: 820
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-16.5
       parent: 2
-  - uid: 822
+  - uid: 821
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-15.5
       parent: 2
-  - uid: 823
+  - uid: 822
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 2
-  - uid: 824
+  - uid: 823
     components:
     - type: Transform
       pos: -1.5,-14.5
       parent: 2
 - proto: GasPressurePump
   entities:
-  - uid: 825
+  - uid: 824
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-17.5
       parent: 2
-  - uid: 826
+  - uid: 825
     components:
     - type: Transform
       pos: -1.5,-17.5
       parent: 2
 - proto: GasThermoMachineHellfireFreezer
   entities:
-  - uid: 827
+  - uid: 826
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5300,7 +5327,7 @@ entities:
       parent: 2
 - proto: GasThermoMachineHellfireHeater
   entities:
-  - uid: 828
+  - uid: 827
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5308,7 +5335,7 @@ entities:
       parent: 2
 - proto: GasValve
   entities:
-  - uid: 829
+  - uid: 828
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5316,31 +5343,31 @@ entities:
       parent: 2
 - proto: GasVentPump
   entities:
-  - uid: 830
+  - uid: 829
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-0.5
       parent: 2
-  - uid: 831
+  - uid: 830
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-0.5
       parent: 2
-  - uid: 832
+  - uid: 831
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 2
-  - uid: 833
+  - uid: 832
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 2
 - proto: GasVentScrubber
   entities:
-  - uid: 834
+  - uid: 833
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5348,7 +5375,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#404040FF'
-  - uid: 835
+  - uid: 834
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5356,14 +5383,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#404040FF'
-  - uid: 836
+  - uid: 835
     components:
     - type: Transform
       pos: 8.5,2.5
       parent: 2
     - type: AtmosPipeColor
       color: '#404040FF'
-  - uid: 837
+  - uid: 836
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5371,644 +5398,644 @@ entities:
       parent: 2
 - proto: GeneratorBasic15kW
   entities:
-  - uid: 838
+  - uid: 837
     components:
     - type: Transform
       pos: 31.5,-10.5
       parent: 2
 - proto: GeneratorRTG
   entities:
-  - uid: 839
+  - uid: 838
     components:
     - type: Transform
       pos: 30.5,-10.5
       parent: 2
-  - uid: 840
+  - uid: 839
     components:
     - type: Transform
       pos: 32.5,-9.5
       parent: 2
-  - uid: 841
+  - uid: 840
     components:
     - type: Transform
       pos: 32.5,-8.5
       parent: 2
-  - uid: 842
+  - uid: 841
     components:
     - type: Transform
       pos: 29.5,-8.5
       parent: 2
 - proto: GravityGeneratorMini
   entities:
-  - uid: 843
+  - uid: 842
     components:
     - type: Transform
       pos: 29.5,-9.5
       parent: 2
 - proto: Grille
   entities:
-  - uid: 844
+  - uid: 843
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 2
-  - uid: 845
+  - uid: 844
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 2
-  - uid: 846
+  - uid: 845
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 2
-  - uid: 847
+  - uid: 846
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 2
-  - uid: 848
+  - uid: 847
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 2
-  - uid: 849
+  - uid: 848
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 2
-  - uid: 850
+  - uid: 849
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 2
-  - uid: 851
+  - uid: 850
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 2
-  - uid: 852
+  - uid: 851
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 2
-  - uid: 853
+  - uid: 852
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 2
-  - uid: 854
+  - uid: 853
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 2
-  - uid: 855
+  - uid: 854
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 2
-  - uid: 856
+  - uid: 855
     components:
     - type: Transform
       pos: 9.5,5.5
       parent: 2
-  - uid: 857
+  - uid: 856
     components:
     - type: Transform
       pos: 9.5,4.5
       parent: 2
-  - uid: 858
+  - uid: 857
     components:
     - type: Transform
       pos: 10.5,4.5
       parent: 2
-  - uid: 859
+  - uid: 858
     components:
     - type: Transform
       pos: 11.5,4.5
       parent: 2
-  - uid: 860
+  - uid: 859
     components:
     - type: Transform
       pos: 12.5,4.5
       parent: 2
-  - uid: 861
+  - uid: 860
     components:
     - type: Transform
       pos: 12.5,3.5
       parent: 2
-  - uid: 862
+  - uid: 861
     components:
     - type: Transform
       pos: 13.5,3.5
       parent: 2
-  - uid: 863
+  - uid: 862
     components:
     - type: Transform
       pos: 13.5,2.5
       parent: 2
-  - uid: 864
+  - uid: 863
     components:
     - type: Transform
       pos: 13.5,0.5
       parent: 2
-  - uid: 865
+  - uid: 864
     components:
     - type: Transform
       pos: 13.5,-1.5
       parent: 2
-  - uid: 866
+  - uid: 865
     components:
     - type: Transform
       pos: 13.5,-2.5
       parent: 2
-  - uid: 867
+  - uid: 866
     components:
     - type: Transform
       pos: 13.5,-0.5
       parent: 2
-  - uid: 868
+  - uid: 867
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 2
-  - uid: 869
+  - uid: 868
     components:
     - type: Transform
       pos: -11.5,-16.5
       parent: 2
-  - uid: 870
+  - uid: 869
     components:
     - type: Transform
       pos: -11.5,-15.5
       parent: 2
-  - uid: 871
+  - uid: 870
     components:
     - type: Transform
       pos: -11.5,-14.5
       parent: 2
-  - uid: 872
+  - uid: 871
     components:
     - type: Transform
       pos: -12.5,-14.5
       parent: 2
-  - uid: 873
+  - uid: 872
     components:
     - type: Transform
       pos: -10.5,-14.5
       parent: 2
-  - uid: 874
+  - uid: 873
     components:
     - type: Transform
       pos: -8.5,-14.5
       parent: 2
-  - uid: 875
+  - uid: 874
     components:
     - type: Transform
       pos: -9.5,-14.5
       parent: 2
-  - uid: 876
+  - uid: 875
     components:
     - type: Transform
       pos: -8.5,-15.5
       parent: 2
-  - uid: 877
+  - uid: 876
     components:
     - type: Transform
       pos: -8.5,-16.5
       parent: 2
-  - uid: 878
+  - uid: 877
     components:
     - type: Transform
       pos: -7.5,-15.5
       parent: 2
-  - uid: 879
+  - uid: 878
     components:
     - type: Transform
       pos: -6.5,-15.5
       parent: 2
-  - uid: 880
+  - uid: 879
     components:
     - type: Transform
       pos: -6.5,-9.5
       parent: 2
-  - uid: 881
+  - uid: 880
     components:
     - type: Transform
       pos: -8.5,-9.5
       parent: 2
-  - uid: 882
+  - uid: 881
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 2
-  - uid: 883
+  - uid: 882
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 2
-  - uid: 884
+  - uid: 883
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 2
-  - uid: 885
+  - uid: 884
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 2
-  - uid: 886
+  - uid: 885
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 2
-  - uid: 887
+  - uid: 886
     components:
     - type: Transform
       pos: -7.5,-5.5
       parent: 2
-  - uid: 888
+  - uid: 887
     components:
     - type: Transform
       pos: -3.5,-18.5
       parent: 2
-  - uid: 889
+  - uid: 888
     components:
     - type: Transform
       pos: -1.5,-18.5
       parent: 2
-  - uid: 890
+  - uid: 889
     components:
     - type: Transform
       pos: 13.5,-11.5
       parent: 2
-  - uid: 891
+  - uid: 890
     components:
     - type: Transform
       pos: 13.5,-12.5
       parent: 2
-  - uid: 892
+  - uid: 891
     components:
     - type: Transform
       pos: 13.5,-14.5
       parent: 2
-  - uid: 893
+  - uid: 892
     components:
     - type: Transform
       pos: 13.5,-15.5
       parent: 2
-  - uid: 894
+  - uid: 893
     components:
     - type: Transform
       pos: 8.5,-17.5
       parent: 2
-  - uid: 895
+  - uid: 894
     components:
     - type: Transform
       pos: 7.5,-17.5
       parent: 2
-  - uid: 896
+  - uid: 895
     components:
     - type: Transform
       pos: 6.5,-17.5
       parent: 2
-  - uid: 897
+  - uid: 896
     components:
     - type: Transform
       pos: 14.5,-8.5
       parent: 2
-  - uid: 898
+  - uid: 897
     components:
     - type: Transform
       pos: 15.5,-8.5
       parent: 2
-  - uid: 899
+  - uid: 898
     components:
     - type: Transform
       pos: 16.5,-8.5
       parent: 2
-  - uid: 900
+  - uid: 899
     components:
     - type: Transform
       pos: 17.5,-8.5
       parent: 2
-  - uid: 901
+  - uid: 900
     components:
     - type: Transform
       pos: 18.5,-8.5
       parent: 2
-  - uid: 902
+  - uid: 901
     components:
     - type: Transform
       pos: 19.5,-8.5
       parent: 2
-  - uid: 903
+  - uid: 902
     components:
     - type: Transform
       pos: 20.5,-8.5
       parent: 2
-  - uid: 904
+  - uid: 903
     components:
     - type: Transform
       pos: 21.5,-8.5
       parent: 2
-  - uid: 905
+  - uid: 904
     components:
     - type: Transform
       pos: 22.5,-8.5
       parent: 2
-  - uid: 906
+  - uid: 905
     components:
     - type: Transform
       pos: 23.5,-8.5
       parent: 2
-  - uid: 907
+  - uid: 906
     components:
     - type: Transform
       pos: 24.5,-8.5
       parent: 2
-  - uid: 908
+  - uid: 907
     components:
     - type: Transform
       pos: 25.5,-8.5
       parent: 2
-  - uid: 909
+  - uid: 908
     components:
     - type: Transform
       pos: 14.5,-3.5
       parent: 2
-  - uid: 910
+  - uid: 909
     components:
     - type: Transform
       pos: 16.5,-3.5
       parent: 2
-  - uid: 911
+  - uid: 910
     components:
     - type: Transform
       pos: 15.5,-3.5
       parent: 2
-  - uid: 912
+  - uid: 911
     components:
     - type: Transform
       pos: 18.5,-3.5
       parent: 2
-  - uid: 913
+  - uid: 912
     components:
     - type: Transform
       pos: 17.5,-3.5
       parent: 2
-  - uid: 914
+  - uid: 913
     components:
     - type: Transform
       pos: 20.5,-3.5
       parent: 2
-  - uid: 915
+  - uid: 914
     components:
     - type: Transform
       pos: 19.5,-3.5
       parent: 2
-  - uid: 916
+  - uid: 915
     components:
     - type: Transform
       pos: 22.5,-3.5
       parent: 2
-  - uid: 917
+  - uid: 916
     components:
     - type: Transform
       pos: 21.5,-3.5
       parent: 2
-  - uid: 918
+  - uid: 917
     components:
     - type: Transform
       pos: 24.5,-3.5
       parent: 2
-  - uid: 919
+  - uid: 918
     components:
     - type: Transform
       pos: 23.5,-3.5
       parent: 2
-  - uid: 920
+  - uid: 919
     components:
     - type: Transform
       pos: 25.5,-3.5
       parent: 2
-  - uid: 921
+  - uid: 920
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.5,-17.5
       parent: 2
-  - uid: 922
+  - uid: 921
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 32.5,-17.5
       parent: 2
-  - uid: 923
+  - uid: 922
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 33.5,-17.5
       parent: 2
-  - uid: 924
+  - uid: 923
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.5,-19.5
       parent: 2
-  - uid: 925
+  - uid: 924
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 32.5,-19.5
       parent: 2
-  - uid: 926
+  - uid: 925
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,-17.5
       parent: 2
-  - uid: 927
+  - uid: 926
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 33.5,-19.5
       parent: 2
-  - uid: 928
+  - uid: 927
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,-16.5
       parent: 2
-  - uid: 929
+  - uid: 928
     components:
     - type: Transform
       pos: 30.5,2.5
       parent: 2
-  - uid: 930
+  - uid: 929
     components:
     - type: Transform
       pos: 30.5,-0.5
       parent: 2
-  - uid: 931
+  - uid: 930
     components:
     - type: Transform
       pos: 27.5,2.5
       parent: 2
-  - uid: 932
+  - uid: 931
     components:
     - type: Transform
       pos: 27.5,1.5
       parent: 2
-  - uid: 933
+  - uid: 932
     components:
     - type: Transform
       pos: 27.5,0.5
       parent: 2
-  - uid: 934
+  - uid: 933
     components:
     - type: Transform
       pos: 27.5,-0.5
       parent: 2
-  - uid: 935
+  - uid: 934
     components:
     - type: Transform
       pos: 31.5,4.5
       parent: 2
-  - uid: 936
+  - uid: 935
     components:
     - type: Transform
       pos: 35.5,-4.5
       parent: 2
-  - uid: 937
+  - uid: 936
     components:
     - type: Transform
       pos: 36.5,-4.5
       parent: 2
-  - uid: 938
+  - uid: 937
     components:
     - type: Transform
       pos: 38.5,-1.5
       parent: 2
-  - uid: 939
+  - uid: 938
     components:
     - type: Transform
       pos: 40.5,-1.5
       parent: 2
-  - uid: 940
+  - uid: 939
     components:
     - type: Transform
       pos: 41.5,-3.5
       parent: 2
-  - uid: 941
+  - uid: 940
     components:
     - type: Transform
       pos: 42.5,-3.5
       parent: 2
-  - uid: 942
+  - uid: 941
     components:
     - type: Transform
       pos: 43.5,-3.5
       parent: 2
-  - uid: 943
+  - uid: 942
     components:
     - type: Transform
       pos: 44.5,-3.5
       parent: 2
-  - uid: 944
+  - uid: 943
     components:
     - type: Transform
       pos: 45.5,-3.5
       parent: 2
-  - uid: 945
+  - uid: 944
     components:
     - type: Transform
       pos: 46.5,-3.5
       parent: 2
-  - uid: 946
+  - uid: 945
     components:
     - type: Transform
       pos: 47.5,-3.5
       parent: 2
-  - uid: 947
+  - uid: 946
     components:
     - type: Transform
       pos: 41.5,-5.5
       parent: 2
-  - uid: 948
+  - uid: 947
     components:
     - type: Transform
       pos: 42.5,-5.5
       parent: 2
-  - uid: 949
+  - uid: 948
     components:
     - type: Transform
       pos: 43.5,-5.5
       parent: 2
-  - uid: 950
+  - uid: 949
     components:
     - type: Transform
       pos: 44.5,-5.5
       parent: 2
-  - uid: 951
+  - uid: 950
     components:
     - type: Transform
       pos: 45.5,-5.5
       parent: 2
-  - uid: 952
+  - uid: 951
     components:
     - type: Transform
       pos: 46.5,-5.5
       parent: 2
-  - uid: 953
+  - uid: 952
     components:
     - type: Transform
       pos: 47.5,-5.5
       parent: 2
-  - uid: 954
+  - uid: 953
     components:
     - type: Transform
       pos: 43.5,-7.5
       parent: 2
-  - uid: 955
+  - uid: 954
     components:
     - type: Transform
       pos: 44.5,-7.5
       parent: 2
-  - uid: 956
+  - uid: 955
     components:
     - type: Transform
       pos: 44.5,-8.5
       parent: 2
-  - uid: 957
+  - uid: 956
     components:
     - type: Transform
       pos: 44.5,-9.5
       parent: 2
-  - uid: 958
+  - uid: 957
     components:
     - type: Transform
       pos: 44.5,-10.5
       parent: 2
-  - uid: 959
+  - uid: 958
     components:
     - type: Transform
       pos: 44.5,-11.5
       parent: 2
-  - uid: 960
+  - uid: 959
     components:
     - type: Transform
       pos: 43.5,-11.5
       parent: 2
 - proto: HeatExchanger
   entities:
-  - uid: 961
+  - uid: 960
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-16.5
       parent: 2
-  - uid: 962
+  - uid: 961
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6016,7 +6043,7 @@ entities:
       parent: 2
 - proto: HonkerCentralElectronics
   entities:
-  - uid: 963
+  - uid: 962
     components:
     - type: MetaData
       desc: The electrical control center for the Mauler mech.
@@ -6030,7 +6057,7 @@ entities:
       canCollide: False
 - proto: HonkerChassis
   entities:
-  - uid: 964
+  - uid: 963
     components:
     - type: MetaData
       desc: An abandoned project whose work cannot be continued anytime soon.
@@ -6044,41 +6071,41 @@ entities:
       canCollide: False
 - proto: HydroponicsTrayEmpty
   entities:
-  - uid: 965
+  - uid: 964
     components:
     - type: Transform
       pos: -8.5,-13.5
       parent: 2
-  - uid: 966
+  - uid: 965
     components:
     - type: Transform
       pos: -10.5,-13.5
       parent: 2
-  - uid: 967
+  - uid: 966
     components:
     - type: Transform
       pos: -12.5,-13.5
       parent: 2
 - proto: Igniter
   entities:
-  - uid: 968
+  - uid: 967
     components:
     - type: Transform
       pos: -13.219715,-3.6691022
       parent: 2
-  - uid: 969
+  - uid: 968
     components:
     - type: Transform
       pos: -13.219715,-3.2316022
       parent: 2
-  - uid: 970
+  - uid: 969
     components:
     - type: Transform
       pos: -13.20409,-2.9034772
       parent: 2
 - proto: Intellicard
   entities:
-  - uid: 971
+  - uid: 970
     components:
     - type: Transform
       pos: 39.5395,-9.547376
@@ -6089,7 +6116,7 @@ entities:
       canCollide: False
 - proto: IntercomElectronics
   entities:
-  - uid: 972
+  - uid: 971
     components:
     - type: Transform
       pos: -3.4669557,-10.273108
@@ -6100,96 +6127,96 @@ entities:
       canCollide: False
 - proto: InvisibleCrate
   entities:
-  - uid: 973
+  - uid: 972
     components:
     - type: Transform
       pos: 34.5,7.5
       parent: 2
 - proto: Katana
   entities:
-  - uid: 974
+  - uid: 973
     components:
     - type: Transform
       pos: 37.5,-0.5
       parent: 2
 - proto: KitchenElectricGrill
   entities:
-  - uid: 975
+  - uid: 974
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 2
 - proto: KitchenKnife
   entities:
-  - uid: 976
+  - uid: 975
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 2
 - proto: KitchenReagentGrinder
   entities:
-  - uid: 977
+  - uid: 976
     components:
     - type: Transform
       pos: -10.5,-10.5
       parent: 2
-  - uid: 978
+  - uid: 977
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 2
 - proto: LargeBeaker
   entities:
-  - uid: 979
+  - uid: 978
     components:
     - type: Transform
       pos: -12.699739,-11.344963
       parent: 2
-  - uid: 980
+  - uid: 979
     components:
     - type: Transform
       pos: -5.5322156,-2.3097272
       parent: 2
 - proto: LightPostSmall
   entities:
-  - uid: 981
+  - uid: 980
     components:
     - type: Transform
       pos: 18.5,-16.5
       parent: 2
-  - uid: 982
+  - uid: 981
     components:
     - type: Transform
       pos: 19.5,7.5
       parent: 2
-  - uid: 983
+  - uid: 982
     components:
     - type: Transform
       pos: 29.5,14.5
       parent: 2
-  - uid: 984
+  - uid: 983
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 2
-  - uid: 985
+  - uid: 984
     components:
     - type: Transform
       pos: 19.5,-25.5
       parent: 2
-  - uid: 986
+  - uid: 985
     components:
     - type: Transform
       pos: 30.5,-24.5
       parent: 2
-  - uid: 987
+  - uid: 986
     components:
     - type: Transform
       pos: 43.5,11.5
       parent: 2
 - proto: LockerFreezer
   entities:
-  - uid: 988
+  - uid: 987
     components:
     - type: Transform
       pos: 0.5,-4.5
@@ -6199,124 +6226,124 @@ entities:
       - - NuclearOperative
 - proto: LockerSyndicatePersonalFilled
   entities:
-  - uid: 989
+  - uid: 988
     components:
     - type: Transform
       pos: 39.5,1.5
       parent: 2
-  - uid: 990
+  - uid: 989
     components:
     - type: Transform
       pos: 40.5,1.5
       parent: 2
-  - uid: 991
+  - uid: 990
     components:
     - type: Transform
       pos: 37.5,1.5
       parent: 2
-  - uid: 992
+  - uid: 991
     components:
     - type: Transform
       pos: 38.5,1.5
       parent: 2
-  - uid: 993
+  - uid: 992
     components:
     - type: Transform
       pos: 36.5,1.5
       parent: 2
 - proto: MachineCentrifuge
   entities:
-  - uid: 994
+  - uid: 993
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 2
 - proto: MachineElectrolysisUnit
   entities:
-  - uid: 995
+  - uid: 994
     components:
     - type: Transform
       pos: -7.5,0.5
       parent: 2
 - proto: MagazinePistolHighCapacity
   entities:
-  - uid: 996
+  - uid: 995
     components:
     - type: Transform
       pos: 12.232729,-17.532574
       parent: 2
 - proto: MedicalBed
   entities:
-  - uid: 997
+  - uid: 996
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 2
 - proto: MedkitAdvancedFilled
   entities:
-  - uid: 998
+  - uid: 997
     components:
     - type: Transform
       pos: -3.6026306,-4.510801
       parent: 2
 - proto: MedkitBruteFilled
   entities:
-  - uid: 999
+  - uid: 998
     components:
     - type: Transform
       pos: -3.5870056,-2.4170508
       parent: 2
 - proto: MedkitBurnFilled
   entities:
-  - uid: 1000
+  - uid: 999
     components:
     - type: Transform
       pos: -3.3682556,-2.8076758
       parent: 2
 - proto: MedkitFilled
   entities:
-  - uid: 1001
+  - uid: 1000
     components:
     - type: Transform
       pos: -3.5870056,-3.1045508
       parent: 2
 - proto: MedkitOxygenFilled
   entities:
-  - uid: 1002
+  - uid: 1001
     components:
     - type: Transform
       pos: -3.3682556,-3.5108008
       parent: 2
 - proto: MedkitRadiationFilled
   entities:
-  - uid: 1003
+  - uid: 1002
     components:
     - type: Transform
       pos: -3.5557556,-3.8389258
       parent: 2
 - proto: MedkitToxinFilled
   entities:
-  - uid: 1004
+  - uid: 1003
     components:
     - type: Transform
       pos: -3.3682556,-4.151426
       parent: 2
 - proto: MegaSprayBottle
   entities:
-  - uid: 1005
+  - uid: 1004
     components:
     - type: Transform
       pos: -12.559114,-10.376213
       parent: 2
 - proto: Mirror
   entities:
-  - uid: 1006
+  - uid: 1005
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-17.5
       parent: 2
-  - uid: 1007
+  - uid: 1006
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6324,45 +6351,45 @@ entities:
       parent: 2
 - proto: ModularGrenade
   entities:
-  - uid: 1008
+  - uid: 1007
     components:
     - type: Transform
       pos: -13.688465,-1.7472272
       parent: 2
-  - uid: 1009
+  - uid: 1008
     components:
     - type: Transform
       pos: -13.313465,-1.4816022
       parent: 2
-  - uid: 1010
+  - uid: 1009
     components:
     - type: Transform
       pos: -13.70409,-1.2941022
       parent: 2
 - proto: MopBucketFull
   entities:
-  - uid: 1011
+  - uid: 1010
     components:
     - type: Transform
       pos: 10.5,-9.5
       parent: 2
 - proto: MopItem
   entities:
-  - uid: 1012
+  - uid: 1011
     components:
     - type: Transform
       pos: 10.476817,-9.415861
       parent: 2
 - proto: Morgue
   entities:
-  - uid: 1013
+  - uid: 1012
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 2
 - proto: Multitool
   entities:
-  - uid: 1014
+  - uid: 1013
     components:
     - type: Transform
       pos: -3.8367076,-14.575489
@@ -6372,57 +6399,57 @@ entities:
       linearDamping: 0
 - proto: NitrogenCanister
   entities:
-  - uid: 1015
+  - uid: 1014
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 2
-  - uid: 1016
+  - uid: 1015
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 2
 - proto: NitrousOxideCanister
   entities:
-  - uid: 1017
+  - uid: 1016
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 2
-  - uid: 1018
+  - uid: 1017
     components:
     - type: Transform
       pos: 1.5,-12.5
       parent: 2
 - proto: NukeDiskFake
   entities:
-  - uid: 1019
+  - uid: 1018
     components:
     - type: Transform
       pos: 27.84377,-31.284956
       parent: 2
 - proto: OperatingTable
   entities:
-  - uid: 1020
+  - uid: 1019
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 2
 - proto: OxygenCanister
   entities:
-  - uid: 1021
+  - uid: 1020
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 2
-  - uid: 1022
+  - uid: 1021
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 2
 - proto: Paper
   entities:
-  - uid: 1023
+  - uid: 1022
     components:
     - type: Transform
       pos: 39.492176,-10.416637
@@ -6446,38 +6473,38 @@ entities:
       canCollide: False
 - proto: PlasmaCanister
   entities:
-  - uid: 1024
+  - uid: 1023
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 2
-  - uid: 1025
+  - uid: 1024
     components:
     - type: Transform
       pos: 1.5,-13.5
       parent: 2
 - proto: PlushieLizard
   entities:
-  - uid: 1026
+  - uid: 1025
     components:
     - type: Transform
       pos: 41.5,-14.5
       parent: 2
 - proto: PlushieNuke
   entities:
-  - uid: 1027
+  - uid: 1026
     components:
     - type: Transform
       pos: -11.5,-7.5
       parent: 2
 - proto: PortableScrubber
   entities:
-  - uid: 1028
+  - uid: 1027
     components:
     - type: Transform
       pos: -2.5,-16.5
       parent: 2
-  - uid: 1029
+  - uid: 1028
     components:
     - type: Transform
       pos: 1.5,-15.5
@@ -6487,7 +6514,7 @@ entities:
       linearDamping: 0
 - proto: PosterContrabandBeachStarYamamoto
   entities:
-  - uid: 1030
+  - uid: 1029
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -6495,54 +6522,54 @@ entities:
       parent: 2
 - proto: PosterContrabandDDayPromo
   entities:
-  - uid: 1031
+  - uid: 1030
     components:
     - type: Transform
       pos: 31.5,-1.5
       parent: 2
 - proto: PosterContrabandDonutCorp
   entities:
-  - uid: 1032
+  - uid: 1031
     components:
     - type: Transform
       pos: 11.5,-3.5
       parent: 2
 - proto: PosterContrabandEnergySwords
   entities:
-  - uid: 1033
+  - uid: 1032
     components:
     - type: Transform
       pos: -9.5,-9.5
       parent: 2
-  - uid: 1034
+  - uid: 1033
     components:
     - type: Transform
       pos: 29.5,-7.5
       parent: 2
 - proto: PosterContrabandKudzu
   entities:
-  - uid: 1035
+  - uid: 1034
     components:
     - type: Transform
       pos: -13.5,-11.5
       parent: 2
 - proto: PosterContrabandLustyExomorph
   entities:
-  - uid: 1036
+  - uid: 1035
     components:
     - type: Transform
       pos: 41.5,0.5
       parent: 2
 - proto: PosterContrabandMoth
   entities:
-  - uid: 1037
+  - uid: 1036
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 2
 - proto: PosterContrabandPower
   entities:
-  - uid: 1038
+  - uid: 1037
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6550,42 +6577,42 @@ entities:
       parent: 2
 - proto: PosterContrabandRevolver
   entities:
-  - uid: 1039
+  - uid: 1038
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 2
 - proto: PosterContrabandRobustSoftdrinks
   entities:
-  - uid: 1040
+  - uid: 1039
     components:
     - type: Transform
       pos: 31.5,-11.5
       parent: 2
 - proto: PosterContrabandSyndicatePistol
   entities:
-  - uid: 1041
+  - uid: 1040
     components:
     - type: Transform
       pos: 37.5,2.5
       parent: 2
 - proto: PosterContrabandTheBigGasTruth
   entities:
-  - uid: 1042
+  - uid: 1041
     components:
     - type: Transform
       pos: 36.5,-16.5
       parent: 2
 - proto: PosterContrabandTools
   entities:
-  - uid: 1043
+  - uid: 1042
     components:
     - type: Transform
       pos: 34.5,-3.5
       parent: 2
 - proto: PosterContrabandVoteWeh
   entities:
-  - uid: 1044
+  - uid: 1043
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6593,40 +6620,40 @@ entities:
       parent: 2
 - proto: PosterLegitCarpMount
   entities:
-  - uid: 1045
+  - uid: 1044
     components:
     - type: Transform
       pos: 37.5,-4.5
       parent: 2
 - proto: PosterLegitIonRifle
   entities:
-  - uid: 1046
+  - uid: 1045
     components:
     - type: Transform
       pos: 36.5,-1.5
       parent: 2
 - proto: PosterLegitNoERP
   entities:
-  - uid: 1047
+  - uid: 1046
     components:
     - type: Transform
       pos: 4.5,-17.5
       parent: 2
-  - uid: 1048
+  - uid: 1047
     components:
     - type: Transform
       pos: 11.5,-13.5
       parent: 2
 - proto: PosterLegitTheOwl
   entities:
-  - uid: 1049
+  - uid: 1048
     components:
     - type: Transform
       pos: 34.5,4.5
       parent: 2
 - proto: PosterMapBagel
   entities:
-  - uid: 1050
+  - uid: 1049
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6634,204 +6661,204 @@ entities:
       parent: 2
 - proto: PosterMapMetaRight
   entities:
-  - uid: 1051
+  - uid: 1050
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 2
 - proto: PottedPlant12
   entities:
-  - uid: 1052
+  - uid: 1051
     components:
     - type: Transform
       pos: 30.5,-4.5
       parent: 2
 - proto: PottedPlant16
   entities:
-  - uid: 1053
+  - uid: 1052
     components:
     - type: Transform
       pos: 12.5,-7.5
       parent: 2
 - proto: PottedPlant2
   entities:
-  - uid: 1054
+  - uid: 1053
     components:
     - type: Transform
       pos: 31.5,-4.5
       parent: 2
 - proto: PottedPlant22
   entities:
-  - uid: 1055
+  - uid: 1054
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 2
 - proto: PottedPlant23
   entities:
-  - uid: 1056
+  - uid: 1055
     components:
     - type: Transform
       pos: 8.5,-9.5
       parent: 2
 - proto: PottedPlant26
   entities:
-  - uid: 1057
+  - uid: 1056
     components:
     - type: Transform
       pos: 33.5,-4.5
       parent: 2
 - proto: PottedPlant5
   entities:
-  - uid: 1058
+  - uid: 1057
     components:
     - type: Transform
       pos: 42.5,-6.5
       parent: 2
 - proto: Poweredlight
   entities:
-  - uid: 1059
+  - uid: 1058
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,2.5
       parent: 2
-  - uid: 1060
+  - uid: 1059
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-13.5
       parent: 2
-  - uid: 1061
+  - uid: 1060
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-13.5
       parent: 2
-  - uid: 1062
+  - uid: 1061
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-8.5
       parent: 2
-  - uid: 1063
+  - uid: 1062
     components:
     - type: Transform
       pos: -9.5,0.5
       parent: 2
-  - uid: 1064
+  - uid: 1063
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-2.5
       parent: 2
-  - uid: 1065
+  - uid: 1064
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-2.5
       parent: 2
-  - uid: 1066
+  - uid: 1065
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,-12.5
       parent: 2
-  - uid: 1067
+  - uid: 1066
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-14.5
       parent: 2
-  - uid: 1068
+  - uid: 1067
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 2
-  - uid: 1069
+  - uid: 1068
     components:
     - type: Transform
       pos: 11.5,-4.5
       parent: 2
-  - uid: 1070
+  - uid: 1069
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-8.5
       parent: 2
-  - uid: 1071
+  - uid: 1070
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-15.5
       parent: 2
-  - uid: 1072
+  - uid: 1071
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,-6.5
       parent: 2
-  - uid: 1073
+  - uid: 1072
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,-6.5
       parent: 2
-  - uid: 1074
+  - uid: 1073
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-6.5
       parent: 2
-  - uid: 1075
+  - uid: 1074
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 33.5,-3.5
       parent: 2
-  - uid: 1076
+  - uid: 1075
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 27.5,6.5
       parent: 2
-  - uid: 1077
+  - uid: 1076
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 40.5,6.5
       parent: 2
-  - uid: 1078
+  - uid: 1077
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,5.5
       parent: 2
-  - uid: 1079
+  - uid: 1078
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 38.5,3.5
       parent: 2
-  - uid: 1080
+  - uid: 1079
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 43.5,-9.5
       parent: 2
-  - uid: 1081
+  - uid: 1080
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,-8.5
       parent: 2
-  - uid: 1082
+  - uid: 1081
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 38.5,-13.5
       parent: 2
-  - uid: 1083
+  - uid: 1082
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -6839,196 +6866,196 @@ entities:
       parent: 2
 - proto: PoweredSmallLight
   entities:
-  - uid: 1084
+  - uid: 1083
     components:
     - type: Transform
       pos: 9.5,0.5
       parent: 2
-  - uid: 1085
+  - uid: 1084
     components:
     - type: Transform
       pos: 12.5,0.5
       parent: 2
-  - uid: 1086
+  - uid: 1085
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-2.5
       parent: 2
-  - uid: 1087
+  - uid: 1086
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-2.5
       parent: 2
-  - uid: 1088
+  - uid: 1087
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 2
-  - uid: 1089
+  - uid: 1088
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-2.5
       parent: 2
-  - uid: 1090
+  - uid: 1089
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-4.5
       parent: 2
-  - uid: 1091
+  - uid: 1090
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-0.5
       parent: 2
-  - uid: 1092
+  - uid: 1091
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,2.5
       parent: 2
-  - uid: 1093
+  - uid: 1092
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-13.5
       parent: 2
-  - uid: 1094
+  - uid: 1093
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-16.5
       parent: 2
-  - uid: 1095
+  - uid: 1094
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-6.5
       parent: 2
-  - uid: 1096
+  - uid: 1095
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-6.5
       parent: 2
-  - uid: 1097
+  - uid: 1096
     components:
     - type: Transform
       pos: -9.5,-10.5
       parent: 2
-  - uid: 1098
+  - uid: 1097
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-7.5
       parent: 2
-  - uid: 1099
+  - uid: 1098
     components:
     - type: Transform
       pos: 11.5,-14.5
       parent: 2
-  - uid: 1100
+  - uid: 1099
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-12.5
       parent: 2
-  - uid: 1101
+  - uid: 1100
     components:
     - type: Transform
       pos: 8.5,-11.5
       parent: 2
-  - uid: 1102
+  - uid: 1101
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-9.5
       parent: 2
-  - uid: 1103
+  - uid: 1102
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 2
-  - uid: 1104
+  - uid: 1103
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-8.5
       parent: 2
-  - uid: 1105
+  - uid: 1104
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 14.5,-4.5
       parent: 2
-  - uid: 1106
+  - uid: 1105
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,-4.5
       parent: 2
-  - uid: 1107
+  - uid: 1106
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,-18.5
       parent: 2
-  - uid: 1108
+  - uid: 1107
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,-10.5
       parent: 2
-  - uid: 1109
+  - uid: 1108
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,0.5
       parent: 2
-  - uid: 1110
+  - uid: 1109
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,1.5
       parent: 2
-  - uid: 1111
+  - uid: 1110
     components:
     - type: Transform
       pos: 31.5,3.5
       parent: 2
-  - uid: 1112
+  - uid: 1111
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 35.5,-3.5
       parent: 2
-  - uid: 1113
+  - uid: 1112
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 41.5,-14.5
       parent: 2
-  - uid: 1114
+  - uid: 1113
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 40.5,-2.5
       parent: 2
-  - uid: 1115
+  - uid: 1114
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 36.5,0.5
       parent: 2
-  - uid: 1116
+  - uid: 1115
     components:
     - type: Transform
       pos: 38.5,1.5
       parent: 2
-  - uid: 1117
+  - uid: 1116
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7036,33 +7063,33 @@ entities:
       parent: 2
 - proto: Rack
   entities:
-  - uid: 1118
+  - uid: 1117
     components:
     - type: Transform
       pos: -12.5,0.5
       parent: 2
-  - uid: 1119
+  - uid: 1118
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-8.5
       parent: 2
-  - uid: 1120
+  - uid: 1119
     components:
     - type: Transform
       pos: 36.5,-0.5
       parent: 2
-  - uid: 1121
+  - uid: 1120
     components:
     - type: Transform
       pos: 37.5,-0.5
       parent: 2
-  - uid: 1122
+  - uid: 1121
     components:
     - type: Transform
       pos: 31.5,-0.5
       parent: 2
-  - uid: 1123
+  - uid: 1122
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7070,407 +7097,407 @@ entities:
       parent: 2
 - proto: Railing
   entities:
-  - uid: 1124
+  - uid: 1123
     components:
     - type: Transform
       pos: 14.5,-4.5
       parent: 2
-  - uid: 1125
+  - uid: 1124
     components:
     - type: Transform
       pos: 15.5,-4.5
       parent: 2
-  - uid: 1126
+  - uid: 1125
     components:
     - type: Transform
       pos: 16.5,-4.5
       parent: 2
-  - uid: 1127
+  - uid: 1126
     components:
     - type: Transform
       pos: 18.5,-4.5
       parent: 2
-  - uid: 1128
+  - uid: 1127
     components:
     - type: Transform
       pos: 19.5,-4.5
       parent: 2
-  - uid: 1129
+  - uid: 1128
     components:
     - type: Transform
       pos: 20.5,-4.5
       parent: 2
-  - uid: 1130
+  - uid: 1129
     components:
     - type: Transform
       pos: 21.5,-4.5
       parent: 2
-  - uid: 1131
+  - uid: 1130
     components:
     - type: Transform
       pos: 22.5,-4.5
       parent: 2
-  - uid: 1132
+  - uid: 1131
     components:
     - type: Transform
       pos: 23.5,-4.5
       parent: 2
-  - uid: 1133
+  - uid: 1132
     components:
     - type: Transform
       pos: 24.5,-4.5
       parent: 2
-  - uid: 1134
+  - uid: 1133
     components:
     - type: Transform
       pos: 25.5,-4.5
       parent: 2
-  - uid: 1135
+  - uid: 1134
     components:
     - type: Transform
       pos: 17.5,-4.5
       parent: 2
-  - uid: 1136
+  - uid: 1135
     components:
     - type: Transform
       pos: 24.5,-6.5
       parent: 2
-  - uid: 1137
+  - uid: 1136
     components:
     - type: Transform
       pos: 23.5,-6.5
       parent: 2
-  - uid: 1138
+  - uid: 1137
     components:
     - type: Transform
       pos: 20.5,-6.5
       parent: 2
-  - uid: 1139
+  - uid: 1138
     components:
     - type: Transform
       pos: 19.5,-6.5
       parent: 2
-  - uid: 1140
+  - uid: 1139
     components:
     - type: Transform
       pos: 16.5,-6.5
       parent: 2
-  - uid: 1141
+  - uid: 1140
     components:
     - type: Transform
       pos: 15.5,-6.5
       parent: 2
-  - uid: 1142
+  - uid: 1141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,-10.5
       parent: 2
-  - uid: 1143
+  - uid: 1142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,-10.5
       parent: 2
-  - uid: 1144
+  - uid: 1143
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 17.5,-10.5
       parent: 2
-  - uid: 1145
+  - uid: 1144
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-10.5
       parent: 2
-  - uid: 1146
+  - uid: 1145
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,-10.5
       parent: 2
-  - uid: 1147
+  - uid: 1146
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 20.5,-10.5
       parent: 2
-  - uid: 1148
+  - uid: 1147
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,-10.5
       parent: 2
-  - uid: 1149
+  - uid: 1148
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,-10.5
       parent: 2
-  - uid: 1150
+  - uid: 1149
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 23.5,-10.5
       parent: 2
-  - uid: 1151
+  - uid: 1150
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,-10.5
       parent: 2
-  - uid: 1152
+  - uid: 1151
     components:
     - type: Transform
       pos: 28.5,-13.5
       parent: 2
-  - uid: 1153
+  - uid: 1152
     components:
     - type: Transform
       pos: 27.5,-13.5
       parent: 2
-  - uid: 1154
+  - uid: 1153
     components:
     - type: Transform
       pos: 26.5,-13.5
       parent: 2
-  - uid: 1155
+  - uid: 1154
     components:
     - type: Transform
       pos: 25.5,-13.5
       parent: 2
-  - uid: 1156
+  - uid: 1155
     components:
     - type: Transform
       pos: 24.5,-13.5
       parent: 2
-  - uid: 1157
+  - uid: 1156
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,-20.5
       parent: 2
-  - uid: 1158
+  - uid: 1157
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,-19.5
       parent: 2
-  - uid: 1159
+  - uid: 1158
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,-18.5
       parent: 2
-  - uid: 1160
+  - uid: 1159
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,-17.5
       parent: 2
-  - uid: 1161
+  - uid: 1160
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,-16.5
       parent: 2
-  - uid: 1162
+  - uid: 1161
     components:
     - type: Transform
       pos: 23.5,-13.5
       parent: 2
-  - uid: 1163
+  - uid: 1162
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,-23.5
       parent: 2
-  - uid: 1164
+  - uid: 1163
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 25.5,-23.5
       parent: 2
-  - uid: 1165
+  - uid: 1164
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,-23.5
       parent: 2
-  - uid: 1166
+  - uid: 1165
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,-23.5
       parent: 2
-  - uid: 1167
+  - uid: 1166
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-23.5
       parent: 2
-  - uid: 1168
+  - uid: 1167
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.5,-20.5
       parent: 2
-  - uid: 1169
+  - uid: 1168
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.5,-16.5
       parent: 2
-  - uid: 1170
+  - uid: 1169
     components:
     - type: Transform
       pos: 22.5,-13.5
       parent: 2
-  - uid: 1171
+  - uid: 1170
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,-23.5
       parent: 2
-  - uid: 1172
+  - uid: 1171
     components:
     - type: Transform
       pos: 20.5,-14.5
       parent: 2
-  - uid: 1173
+  - uid: 1172
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-20.5
       parent: 2
-  - uid: 1174
+  - uid: 1173
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-18.5
       parent: 2
-  - uid: 1175
+  - uid: 1174
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-17.5
       parent: 2
-  - uid: 1176
+  - uid: 1175
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-16.5
       parent: 2
-  - uid: 1177
+  - uid: 1176
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,11.5
       parent: 2
-  - uid: 1178
+  - uid: 1177
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,12.5
       parent: 2
-  - uid: 1179
+  - uid: 1178
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,13.5
       parent: 2
-  - uid: 1180
+  - uid: 1179
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,14.5
       parent: 2
-  - uid: 1181
+  - uid: 1180
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,15.5
       parent: 2
-  - uid: 1182
+  - uid: 1181
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,16.5
       parent: 2
-  - uid: 1183
+  - uid: 1182
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,17.5
       parent: 2
-  - uid: 1184
+  - uid: 1183
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,10.5
       parent: 2
-  - uid: 1185
+  - uid: 1184
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 48.5,9.5
       parent: 2
-  - uid: 1186
+  - uid: 1185
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,6.5
       parent: 2
-  - uid: 1187
+  - uid: 1186
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,5.5
       parent: 2
-  - uid: 1188
+  - uid: 1187
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,4.5
       parent: 2
-  - uid: 1189
+  - uid: 1188
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,3.5
       parent: 2
-  - uid: 1190
+  - uid: 1189
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,2.5
       parent: 2
-  - uid: 1191
+  - uid: 1190
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,1.5
       parent: 2
-  - uid: 1192
+  - uid: 1191
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,0.5
       parent: 2
-  - uid: 1193
+  - uid: 1192
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-0.5
       parent: 2
-  - uid: 1194
+  - uid: 1193
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-1.5
       parent: 2
-  - uid: 1195
+  - uid: 1194
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -7478,274 +7505,274 @@ entities:
       parent: 2
 - proto: RailingCorner
   entities:
-  - uid: 1196
+  - uid: 1195
     components:
     - type: Transform
       pos: 23.5,-14.5
       parent: 2
-  - uid: 1197
+  - uid: 1196
     components:
     - type: Transform
       pos: 22.5,-15.5
       parent: 2
-  - uid: 1198
+  - uid: 1197
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,-21.5
       parent: 2
-  - uid: 1199
+  - uid: 1198
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 23.5,-22.5
       parent: 2
-  - uid: 1200
+  - uid: 1199
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 29.5,-14.5
       parent: 2
-  - uid: 1201
+  - uid: 1200
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 30.5,-15.5
       parent: 2
-  - uid: 1202
+  - uid: 1201
     components:
     - type: Transform
       pos: 21.5,-14.5
       parent: 2
-  - uid: 1203
+  - uid: 1202
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,-21.5
       parent: 2
-  - uid: 1204
+  - uid: 1203
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,-22.5
       parent: 2
-  - uid: 1205
+  - uid: 1204
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 20.5,-22.5
       parent: 2
-  - uid: 1206
+  - uid: 1205
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 45.5,-6.5
       parent: 2
-  - uid: 1207
+  - uid: 1206
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 46.5,-7.5
       parent: 2
-  - uid: 1208
+  - uid: 1207
     components:
     - type: Transform
       pos: 46.5,-11.5
       parent: 2
-  - uid: 1209
+  - uid: 1208
     components:
     - type: Transform
       pos: 45.5,-12.5
       parent: 2
-  - uid: 1210
+  - uid: 1209
     components:
     - type: Transform
       pos: 48.5,8.5
       parent: 2
-  - uid: 1211
+  - uid: 1210
     components:
     - type: Transform
       pos: 47.5,7.5
       parent: 2
 - proto: RailingCornerSmall
   entities:
-  - uid: 1212
+  - uid: 1211
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 17.5,-6.5
       parent: 2
-  - uid: 1213
+  - uid: 1212
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 21.5,-6.5
       parent: 2
-  - uid: 1214
+  - uid: 1213
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,-6.5
       parent: 2
-  - uid: 1215
+  - uid: 1214
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 25.5,-6.5
       parent: 2
-  - uid: 1216
+  - uid: 1215
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-6.5
       parent: 2
-  - uid: 1217
+  - uid: 1216
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 14.5,-6.5
       parent: 2
-  - uid: 1218
+  - uid: 1217
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,-22.5
       parent: 2
-  - uid: 1219
+  - uid: 1218
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,-21.5
       parent: 2
-  - uid: 1220
+  - uid: 1219
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 21.5,-15.5
       parent: 2
-  - uid: 1221
+  - uid: 1220
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 22.5,-14.5
       parent: 2
-  - uid: 1222
+  - uid: 1221
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 29.5,-13.5
       parent: 2
-  - uid: 1223
+  - uid: 1222
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,-14.5
       parent: 2
-  - uid: 1224
+  - uid: 1223
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 31.5,-15.5
       parent: 2
-  - uid: 1225
+  - uid: 1224
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,-23.5
       parent: 2
-  - uid: 1226
+  - uid: 1225
     components:
     - type: Transform
       pos: 29.5,-23.5
       parent: 2
-  - uid: 1227
+  - uid: 1226
     components:
     - type: Transform
       pos: 30.5,-22.5
       parent: 2
-  - uid: 1228
+  - uid: 1227
     components:
     - type: Transform
       pos: 31.5,-21.5
       parent: 2
-  - uid: 1229
+  - uid: 1228
     components:
     - type: Transform
       pos: 22.5,-23.5
       parent: 2
-  - uid: 1230
+  - uid: 1229
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 20.5,-23.5
       parent: 2
-  - uid: 1231
+  - uid: 1230
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,-22.5
       parent: 2
-  - uid: 1232
+  - uid: 1231
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 19.5,-14.5
       parent: 2
-  - uid: 1233
+  - uid: 1232
     components:
     - type: Transform
       rot: 3.141592653589793 rad
+      pos: 19.5,-19.5
+      parent: 2
+  - uid: 1233
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 19.5,-19.5
       parent: 2
   - uid: 1234
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,-19.5
-      parent: 2
-  - uid: 1235
-    components:
-    - type: Transform
       rot: 3.141592653589793 rad
       pos: 45.5,-11.5
       parent: 2
-  - uid: 1236
+  - uid: 1235
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 45.5,-7.5
       parent: 2
-  - uid: 1237
+  - uid: 1236
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 46.5,-8.5
       parent: 2
-  - uid: 1238
+  - uid: 1237
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 46.5,-10.5
       parent: 2
-  - uid: 1239
+  - uid: 1238
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 44.5,-12.5
       parent: 2
-  - uid: 1240
+  - uid: 1239
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 44.5,-6.5
       parent: 2
-  - uid: 1241
+  - uid: 1240
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 47.5,8.5
       parent: 2
-  - uid: 1242
+  - uid: 1241
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -7753,668 +7780,668 @@ entities:
       parent: 2
 - proto: ReagentGrinderIndustrial
   entities:
-  - uid: 1243
+  - uid: 1242
     components:
     - type: Transform
       pos: -7.5,-14.5
       parent: 2
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 1244
+  - uid: 1243
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 2
-  - uid: 1245
+  - uid: 1244
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 2
-  - uid: 1246
+  - uid: 1245
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 2
-  - uid: 1247
+  - uid: 1246
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 2
-  - uid: 1248
+  - uid: 1247
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 2
-  - uid: 1249
+  - uid: 1248
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 2
-  - uid: 1250
+  - uid: 1249
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 2
-  - uid: 1251
+  - uid: 1250
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 2
-  - uid: 1252
+  - uid: 1251
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 2
-  - uid: 1253
+  - uid: 1252
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 2
-  - uid: 1254
+  - uid: 1253
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 2
-  - uid: 1255
+  - uid: 1254
     components:
     - type: Transform
       pos: 8.5,5.5
       parent: 2
-  - uid: 1256
+  - uid: 1255
     components:
     - type: Transform
       pos: 9.5,5.5
       parent: 2
-  - uid: 1257
+  - uid: 1256
     components:
     - type: Transform
       pos: 9.5,4.5
       parent: 2
-  - uid: 1258
+  - uid: 1257
     components:
     - type: Transform
       pos: 10.5,4.5
       parent: 2
-  - uid: 1259
+  - uid: 1258
     components:
     - type: Transform
       pos: 11.5,4.5
       parent: 2
-  - uid: 1260
+  - uid: 1259
     components:
     - type: Transform
       pos: 12.5,4.5
       parent: 2
-  - uid: 1261
+  - uid: 1260
     components:
     - type: Transform
       pos: 12.5,3.5
       parent: 2
-  - uid: 1262
+  - uid: 1261
     components:
     - type: Transform
       pos: 13.5,3.5
       parent: 2
-  - uid: 1263
+  - uid: 1262
     components:
     - type: Transform
       pos: 13.5,2.5
       parent: 2
-  - uid: 1264
+  - uid: 1263
     components:
     - type: Transform
       pos: 13.5,0.5
       parent: 2
-  - uid: 1265
+  - uid: 1264
     components:
     - type: Transform
       pos: 13.5,-0.5
       parent: 2
-  - uid: 1266
+  - uid: 1265
     components:
     - type: Transform
       pos: 13.5,-1.5
       parent: 2
-  - uid: 1267
+  - uid: 1266
     components:
     - type: Transform
       pos: 13.5,-2.5
       parent: 2
-  - uid: 1268
+  - uid: 1267
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-3.5
       parent: 2
-  - uid: 1269
+  - uid: 1268
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 2
-  - uid: 1270
+  - uid: 1269
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 2
-  - uid: 1271
+  - uid: 1270
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 2
-  - uid: 1272
+  - uid: 1271
     components:
     - type: Transform
       pos: -7.5,-5.5
       parent: 2
-  - uid: 1273
+  - uid: 1272
     components:
     - type: Transform
       pos: -8.5,-9.5
       parent: 2
-  - uid: 1274
+  - uid: 1273
     components:
     - type: Transform
       pos: -6.5,-9.5
       parent: 2
-  - uid: 1275
+  - uid: 1274
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 2
-  - uid: 1276
+  - uid: 1275
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 2
-  - uid: 1277
+  - uid: 1276
     components:
     - type: Transform
       pos: -6.5,-15.5
       parent: 2
-  - uid: 1278
+  - uid: 1277
     components:
     - type: Transform
       pos: -7.5,-15.5
       parent: 2
-  - uid: 1279
+  - uid: 1278
     components:
     - type: Transform
       pos: -8.5,-15.5
       parent: 2
-  - uid: 1280
+  - uid: 1279
     components:
     - type: Transform
       pos: -8.5,-14.5
       parent: 2
-  - uid: 1281
+  - uid: 1280
     components:
     - type: Transform
       pos: -9.5,-14.5
       parent: 2
-  - uid: 1282
+  - uid: 1281
     components:
     - type: Transform
       pos: -10.5,-14.5
       parent: 2
-  - uid: 1283
+  - uid: 1282
     components:
     - type: Transform
       pos: -11.5,-14.5
       parent: 2
-  - uid: 1284
+  - uid: 1283
     components:
     - type: Transform
       pos: -12.5,-14.5
       parent: 2
-  - uid: 1285
+  - uid: 1284
     components:
     - type: Transform
       pos: -11.5,-15.5
       parent: 2
-  - uid: 1286
+  - uid: 1285
     components:
     - type: Transform
       pos: -11.5,-16.5
       parent: 2
-  - uid: 1287
+  - uid: 1286
     components:
     - type: Transform
       pos: -8.5,-16.5
       parent: 2
-  - uid: 1288
+  - uid: 1287
     components:
     - type: Transform
       pos: -1.5,-18.5
       parent: 2
-  - uid: 1289
+  - uid: 1288
     components:
     - type: Transform
       pos: -3.5,-18.5
       parent: 2
-  - uid: 1290
+  - uid: 1289
     components:
     - type: Transform
       pos: 13.5,-11.5
       parent: 2
-  - uid: 1291
+  - uid: 1290
     components:
     - type: Transform
       pos: 13.5,-12.5
       parent: 2
-  - uid: 1292
+  - uid: 1291
     components:
     - type: Transform
       pos: 13.5,-14.5
       parent: 2
-  - uid: 1293
+  - uid: 1292
     components:
     - type: Transform
       pos: 13.5,-15.5
       parent: 2
-  - uid: 1294
+  - uid: 1293
     components:
     - type: Transform
       pos: 8.5,-17.5
       parent: 2
-  - uid: 1295
+  - uid: 1294
     components:
     - type: Transform
       pos: 7.5,-17.5
       parent: 2
-  - uid: 1296
+  - uid: 1295
     components:
     - type: Transform
       pos: 6.5,-17.5
       parent: 2
-  - uid: 1297
+  - uid: 1296
     components:
     - type: Transform
       pos: 14.5,-3.5
       parent: 2
-  - uid: 1298
+  - uid: 1297
     components:
     - type: Transform
       pos: 15.5,-3.5
       parent: 2
-  - uid: 1299
+  - uid: 1298
     components:
     - type: Transform
       pos: 16.5,-3.5
       parent: 2
-  - uid: 1300
+  - uid: 1299
     components:
     - type: Transform
       pos: 17.5,-3.5
       parent: 2
-  - uid: 1301
+  - uid: 1300
     components:
     - type: Transform
       pos: 18.5,-3.5
       parent: 2
-  - uid: 1302
+  - uid: 1301
     components:
     - type: Transform
       pos: 19.5,-3.5
       parent: 2
-  - uid: 1303
+  - uid: 1302
     components:
     - type: Transform
       pos: 20.5,-3.5
       parent: 2
-  - uid: 1304
+  - uid: 1303
     components:
     - type: Transform
       pos: 21.5,-3.5
       parent: 2
-  - uid: 1305
+  - uid: 1304
     components:
     - type: Transform
       pos: 22.5,-3.5
       parent: 2
-  - uid: 1306
+  - uid: 1305
     components:
     - type: Transform
       pos: 23.5,-3.5
       parent: 2
-  - uid: 1307
+  - uid: 1306
     components:
     - type: Transform
       pos: 24.5,-3.5
       parent: 2
-  - uid: 1308
+  - uid: 1307
     components:
     - type: Transform
       pos: 25.5,-3.5
       parent: 2
-  - uid: 1309
+  - uid: 1308
     components:
     - type: Transform
       pos: 25.5,-8.5
       parent: 2
-  - uid: 1310
+  - uid: 1309
     components:
     - type: Transform
       pos: 24.5,-8.5
       parent: 2
-  - uid: 1311
+  - uid: 1310
     components:
     - type: Transform
       pos: 23.5,-8.5
       parent: 2
-  - uid: 1312
+  - uid: 1311
     components:
     - type: Transform
       pos: 22.5,-8.5
       parent: 2
-  - uid: 1313
+  - uid: 1312
     components:
     - type: Transform
       pos: 21.5,-8.5
       parent: 2
-  - uid: 1314
+  - uid: 1313
     components:
     - type: Transform
       pos: 20.5,-8.5
       parent: 2
-  - uid: 1315
+  - uid: 1314
     components:
     - type: Transform
       pos: 19.5,-8.5
       parent: 2
-  - uid: 1316
+  - uid: 1315
     components:
     - type: Transform
       pos: 18.5,-8.5
       parent: 2
-  - uid: 1317
+  - uid: 1316
     components:
     - type: Transform
       pos: 17.5,-8.5
       parent: 2
-  - uid: 1318
+  - uid: 1317
     components:
     - type: Transform
       pos: 16.5,-8.5
       parent: 2
-  - uid: 1319
+  - uid: 1318
     components:
     - type: Transform
       pos: 15.5,-8.5
       parent: 2
-  - uid: 1320
+  - uid: 1319
     components:
     - type: Transform
       pos: 14.5,-8.5
       parent: 2
-  - uid: 1321
+  - uid: 1320
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,-17.5
       parent: 2
-  - uid: 1322
+  - uid: 1321
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,-16.5
       parent: 2
-  - uid: 1323
+  - uid: 1322
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,-17.5
       parent: 2
-  - uid: 1324
+  - uid: 1323
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,-17.5
       parent: 2
-  - uid: 1325
+  - uid: 1324
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,-17.5
       parent: 2
-  - uid: 1326
+  - uid: 1325
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,-19.5
       parent: 2
-  - uid: 1327
+  - uid: 1326
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,-19.5
       parent: 2
-  - uid: 1328
+  - uid: 1327
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,-19.5
       parent: 2
-  - uid: 1329
+  - uid: 1328
     components:
     - type: Transform
       pos: 47.5,-3.5
       parent: 2
-  - uid: 1330
+  - uid: 1329
     components:
     - type: Transform
       pos: 46.5,-3.5
       parent: 2
-  - uid: 1331
+  - uid: 1330
     components:
     - type: Transform
       pos: 45.5,-3.5
       parent: 2
-  - uid: 1332
+  - uid: 1331
     components:
     - type: Transform
       pos: 44.5,-3.5
       parent: 2
-  - uid: 1333
+  - uid: 1332
     components:
     - type: Transform
       pos: 43.5,-3.5
       parent: 2
-  - uid: 1334
+  - uid: 1333
     components:
     - type: Transform
       pos: 42.5,-3.5
       parent: 2
-  - uid: 1335
+  - uid: 1334
     components:
     - type: Transform
       pos: 41.5,-3.5
       parent: 2
-  - uid: 1336
+  - uid: 1335
     components:
     - type: Transform
       pos: 41.5,-5.5
       parent: 2
-  - uid: 1337
+  - uid: 1336
     components:
     - type: Transform
       pos: 42.5,-5.5
       parent: 2
-  - uid: 1338
+  - uid: 1337
     components:
     - type: Transform
       pos: 43.5,-5.5
       parent: 2
-  - uid: 1339
+  - uid: 1338
     components:
     - type: Transform
       pos: 44.5,-5.5
       parent: 2
-  - uid: 1340
+  - uid: 1339
     components:
     - type: Transform
       pos: 45.5,-5.5
       parent: 2
-  - uid: 1341
+  - uid: 1340
     components:
     - type: Transform
       pos: 46.5,-5.5
       parent: 2
-  - uid: 1342
+  - uid: 1341
     components:
     - type: Transform
       pos: 47.5,-5.5
       parent: 2
-  - uid: 1343
+  - uid: 1342
     components:
     - type: Transform
       pos: 43.5,-7.5
       parent: 2
-  - uid: 1344
+  - uid: 1343
     components:
     - type: Transform
       pos: 44.5,-7.5
       parent: 2
-  - uid: 1345
+  - uid: 1344
     components:
     - type: Transform
       pos: 44.5,-8.5
       parent: 2
-  - uid: 1346
+  - uid: 1345
     components:
     - type: Transform
       pos: 44.5,-9.5
       parent: 2
-  - uid: 1347
+  - uid: 1346
     components:
     - type: Transform
       pos: 44.5,-10.5
       parent: 2
-  - uid: 1348
+  - uid: 1347
     components:
     - type: Transform
       pos: 44.5,-11.5
       parent: 2
-  - uid: 1349
+  - uid: 1348
     components:
     - type: Transform
       pos: 43.5,-11.5
       parent: 2
-  - uid: 1350
+  - uid: 1349
     components:
     - type: Transform
       pos: 40.5,-1.5
       parent: 2
-  - uid: 1351
+  - uid: 1350
     components:
     - type: Transform
       pos: 38.5,-1.5
       parent: 2
-  - uid: 1352
+  - uid: 1351
     components:
     - type: Transform
       pos: 36.5,-4.5
       parent: 2
-  - uid: 1353
+  - uid: 1352
     components:
     - type: Transform
       pos: 35.5,-4.5
       parent: 2
-  - uid: 1354
+  - uid: 1353
     components:
     - type: Transform
       pos: 27.5,-0.5
       parent: 2
-  - uid: 1355
+  - uid: 1354
     components:
     - type: Transform
       pos: 27.5,0.5
       parent: 2
-  - uid: 1356
+  - uid: 1355
     components:
     - type: Transform
       pos: 27.5,1.5
       parent: 2
-  - uid: 1357
+  - uid: 1356
     components:
     - type: Transform
       pos: 27.5,2.5
       parent: 2
-  - uid: 1358
+  - uid: 1357
     components:
     - type: Transform
       pos: 30.5,2.5
       parent: 2
-  - uid: 1359
+  - uid: 1358
     components:
     - type: Transform
       pos: 30.5,-0.5
       parent: 2
-  - uid: 1360
+  - uid: 1359
     components:
     - type: Transform
       pos: 31.5,4.5
       parent: 2
 - proto: SheetPlasma10
   entities:
-  - uid: 1361
+  - uid: 1360
     components:
     - type: Transform
       pos: -12.387239,-11.251213
       parent: 2
 - proto: SheetPlasteel
   entities:
-  - uid: 1362
+  - uid: 1361
     components:
     - type: Transform
       pos: -12.475805,0.52586746
       parent: 2
 - proto: SheetSteel
   entities:
-  - uid: 1363
+  - uid: 1362
     components:
     - type: Transform
       pos: -12.569555,0.43211746
       parent: 2
 - proto: ShuttersNormal
   entities:
-  - uid: 1364
+  - uid: 1363
     components:
     - type: Transform
       pos: 31.5,-7.5
       parent: 2
-  - uid: 1365
+  - uid: 1364
     components:
     - type: Transform
       pos: 30.5,-7.5
       parent: 2
-  - uid: 1366
+  - uid: 1365
     components:
     - type: Transform
       pos: 27.5,4.5
       parent: 2
-  - uid: 1367
+  - uid: 1366
     components:
     - type: Transform
       pos: 28.5,4.5
       parent: 2
-  - uid: 1368
+  - uid: 1367
     components:
     - type: Transform
       pos: 29.5,4.5
       parent: 2
-  - uid: 1369
+  - uid: 1368
     components:
     - type: Transform
       pos: 32.5,4.5
       parent: 2
-  - uid: 1370
+  - uid: 1369
     components:
     - type: Transform
       pos: 33.5,4.5
       parent: 2
 - proto: SignalButton
   entities:
-  - uid: 1371
+  - uid: 1370
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8428,24 +8455,24 @@ entities:
         - Pressed: Toggle
 - proto: SignalTrigger
   entities:
-  - uid: 1372
+  - uid: 1371
     components:
     - type: Transform
       pos: -13.64159,-2.6691022
       parent: 2
-  - uid: 1373
+  - uid: 1372
     components:
     - type: Transform
       pos: -13.64159,-2.2941022
       parent: 2
-  - uid: 1374
+  - uid: 1373
     components:
     - type: Transform
       pos: -13.188465,-2.4191022
       parent: 2
 - proto: SignArmory
   entities:
-  - uid: 1375
+  - uid: 1374
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8453,7 +8480,7 @@ entities:
       parent: 2
 - proto: SignAtmos
   entities:
-  - uid: 1376
+  - uid: 1375
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8461,7 +8488,7 @@ entities:
       parent: 2
 - proto: SignBar
   entities:
-  - uid: 1377
+  - uid: 1376
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8469,7 +8496,7 @@ entities:
       parent: 2
 - proto: SignChem
   entities:
-  - uid: 1378
+  - uid: 1377
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8477,7 +8504,7 @@ entities:
       parent: 2
 - proto: SignDirectionalBridge
   entities:
-  - uid: 1379
+  - uid: 1378
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8485,7 +8512,7 @@ entities:
       parent: 2
 - proto: SignDirectionalEng
   entities:
-  - uid: 1380
+  - uid: 1379
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8493,7 +8520,7 @@ entities:
       parent: 2
 - proto: SignDirectionalEvac
   entities:
-  - uid: 1381
+  - uid: 1380
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8501,7 +8528,7 @@ entities:
       parent: 2
 - proto: SignDirectionalMed
   entities:
-  - uid: 1382
+  - uid: 1381
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8509,7 +8536,7 @@ entities:
       parent: 2
 - proto: SignDirectionalSci
   entities:
-  - uid: 1383
+  - uid: 1382
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8517,7 +8544,7 @@ entities:
       parent: 2
 - proto: SignDirectionalSec
   entities:
-  - uid: 1384
+  - uid: 1383
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8525,7 +8552,7 @@ entities:
       parent: 2
 - proto: SignGravity
   entities:
-  - uid: 1385
+  - uid: 1384
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8533,7 +8560,7 @@ entities:
       parent: 2
 - proto: SignJanitor
   entities:
-  - uid: 1386
+  - uid: 1385
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8541,7 +8568,7 @@ entities:
       parent: 2
 - proto: SignXenobio
   entities:
-  - uid: 1387
+  - uid: 1386
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8549,92 +8576,92 @@ entities:
       parent: 2
 - proto: SinkWide
   entities:
-  - uid: 1388
+  - uid: 1387
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 2
-  - uid: 1389
+  - uid: 1388
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-14.5
       parent: 2
-  - uid: 1390
+  - uid: 1389
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 2
-  - uid: 1391
+  - uid: 1390
     components:
     - type: Transform
       pos: 6.5,-11.5
       parent: 2
 - proto: SmallLight
   entities:
-  - uid: 1392
+  - uid: 1391
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,-16.5
       parent: 2
-  - uid: 1393
+  - uid: 1392
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,-16.5
       parent: 2
-  - uid: 1394
+  - uid: 1393
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 26.5,-17.5
       parent: 2
-  - uid: 1395
+  - uid: 1394
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 27.5,-18.5
       parent: 2
-  - uid: 1396
+  - uid: 1395
     components:
     - type: Transform
       pos: 26.5,-19.5
       parent: 2
-  - uid: 1397
+  - uid: 1396
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,-18.5
       parent: 2
-  - uid: 1398
+  - uid: 1397
     components:
     - type: Transform
       pos: 28.5,-11.5
       parent: 2
-  - uid: 1399
+  - uid: 1398
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-20.5
       parent: 2
-  - uid: 1400
+  - uid: 1399
     components:
     - type: Transform
       pos: 44.5,-4.5
       parent: 2
-  - uid: 1401
+  - uid: 1400
     components:
     - type: Transform
       pos: 0.5,-19.5
       parent: 2
-  - uid: 1402
+  - uid: 1401
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-20.5
       parent: 2
-  - uid: 1403
+  - uid: 1402
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8642,14 +8669,14 @@ entities:
       parent: 2
 - proto: SoapSyndie
   entities:
-  - uid: 1404
+  - uid: 1403
     components:
     - type: Transform
       pos: 3.5,-15.5
       parent: 2
 - proto: SodaDispenser
   entities:
-  - uid: 1405
+  - uid: 1404
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -8657,107 +8684,107 @@ entities:
       parent: 2
 - proto: SpaceCash100
   entities:
-  - uid: 1406
+  - uid: 1405
     components:
     - type: Transform
       pos: 36.5,-10.5
       parent: 2
 - proto: SpaceCash1000
   entities:
-  - uid: 1407
+  - uid: 1406
     components:
     - type: Transform
       pos: 38.5,-8.5
       parent: 2
 - proto: SpawnMobCatKitten
   entities:
-  - uid: 1408
+  - uid: 1407
     components:
     - type: Transform
       pos: 7.5,-7.5
       parent: 2
 - proto: SpawnPointNukies
   entities:
-  - uid: 1409
+  - uid: 1408
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 2
-  - uid: 1410
+  - uid: 1409
     components:
     - type: Transform
       pos: 10.5,0.5
       parent: 2
-  - uid: 1411
+  - uid: 1410
     components:
     - type: Transform
       pos: 12.5,-0.5
       parent: 2
-  - uid: 1412
+  - uid: 1411
     components:
     - type: Transform
       pos: 11.5,-2.5
       parent: 2
-  - uid: 1413
+  - uid: 1412
     components:
     - type: Transform
       pos: 9.5,-1.5
       parent: 2
 - proto: StairDark
   entities:
-  - uid: 1414
+  - uid: 1413
     components:
     - type: Transform
       pos: 27.5,-9.5
       parent: 2
-  - uid: 1415
+  - uid: 1414
     components:
     - type: Transform
       pos: 27.5,-8.5
       parent: 2
 - proto: Stool
   entities:
-  - uid: 1416
+  - uid: 1415
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,-2.5
       parent: 2
-  - uid: 1417
+  - uid: 1416
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-2.5
       parent: 2
-  - uid: 1418
+  - uid: 1417
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-1.5
       parent: 2
-  - uid: 1419
+  - uid: 1418
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-0.5
       parent: 2
-  - uid: 1420
+  - uid: 1419
     components:
     - type: Transform
       pos: 10.5,0.5
       parent: 2
-  - uid: 1421
+  - uid: 1420
     components:
     - type: Transform
       pos: 11.5,0.5
       parent: 2
-  - uid: 1422
+  - uid: 1421
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-0.5
       parent: 2
-  - uid: 1423
+  - uid: 1422
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8765,19 +8792,19 @@ entities:
       parent: 2
 - proto: StoolBar
   entities:
-  - uid: 1424
+  - uid: 1423
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-0.5
       parent: 2
-  - uid: 1425
+  - uid: 1424
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-1.5
       parent: 2
-  - uid: 1426
+  - uid: 1425
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8785,26 +8812,26 @@ entities:
       parent: 2
 - proto: StorageCanister
   entities:
-  - uid: 1427
+  - uid: 1426
     components:
     - type: Transform
       pos: 0.5,-14.5
       parent: 2
-  - uid: 1428
+  - uid: 1427
     components:
     - type: Transform
       pos: 1.5,-14.5
       parent: 2
 - proto: SubstationBasic
   entities:
-  - uid: 1429
+  - uid: 1428
     components:
     - type: Transform
       pos: 36.5,-2.5
       parent: 2
 - proto: SyndicateComputerComms
   entities:
-  - uid: 1430
+  - uid: 1429
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -8812,68 +8839,68 @@ entities:
       parent: 2
 - proto: SyndicateMicrowave
   entities:
-  - uid: 1431
+  - uid: 1430
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 2
 - proto: SyndicatePersonalAI
   entities:
-  - uid: 1432
+  - uid: 1431
     components:
     - type: Transform
       pos: 10.5,-0.5
       parent: 2
 - proto: SyndicateSpongeBox
   entities:
-  - uid: 1433
+  - uid: 1432
     components:
     - type: Transform
       pos: -9.418489,-10.329338
       parent: 2
 - proto: SyringeDermaline
   entities:
-  - uid: 1434
+  - uid: 1433
     components:
     - type: Transform
       pos: -1.3631997,-1.2615409
       parent: 2
 - proto: SyringeEthylredoxrazine
   entities:
-  - uid: 1435
+  - uid: 1434
     components:
     - type: Transform
       pos: -1.6288247,-1.2459159
       parent: 2
 - proto: SyringeTranexamicAcid
   entities:
-  - uid: 1436
+  - uid: 1435
     components:
     - type: Transform
       pos: -1.4413247,-1.0896659
       parent: 2
 - proto: Table
   entities:
-  - uid: 1437
+  - uid: 1436
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,4.5
       parent: 2
-  - uid: 1438
+  - uid: 1437
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 2
 - proto: TableCounterMetal
   entities:
-  - uid: 1439
+  - uid: 1438
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,1.5
       parent: 2
-  - uid: 1440
+  - uid: 1439
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -8881,213 +8908,213 @@ entities:
       parent: 2
 - proto: TablePlasmaGlass
   entities:
-  - uid: 1441
+  - uid: 1440
     components:
     - type: Transform
       pos: -7.5,0.5
       parent: 2
-  - uid: 1442
+  - uid: 1441
     components:
     - type: Transform
       pos: -11.5,-10.5
       parent: 2
-  - uid: 1443
+  - uid: 1442
     components:
     - type: Transform
       pos: -12.5,-10.5
       parent: 2
-  - uid: 1444
+  - uid: 1443
     components:
     - type: Transform
       pos: -12.5,-11.5
       parent: 2
-  - uid: 1445
+  - uid: 1444
     components:
     - type: Transform
       pos: -9.5,-10.5
       parent: 2
-  - uid: 1446
+  - uid: 1445
     components:
     - type: Transform
       pos: -13.5,-0.5
       parent: 2
-  - uid: 1447
+  - uid: 1446
     components:
     - type: Transform
       pos: -13.5,-1.5
       parent: 2
-  - uid: 1448
+  - uid: 1447
     components:
     - type: Transform
       pos: -13.5,-2.5
       parent: 2
-  - uid: 1449
+  - uid: 1448
     components:
     - type: Transform
       pos: -13.5,-3.5
       parent: 2
-  - uid: 1450
+  - uid: 1449
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 2
-  - uid: 1451
+  - uid: 1450
     components:
     - type: Transform
       pos: -5.5,-2.5
       parent: 2
-  - uid: 1452
+  - uid: 1451
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 2
-  - uid: 1453
+  - uid: 1452
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 2
-  - uid: 1454
+  - uid: 1453
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 2
-  - uid: 1455
+  - uid: 1454
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 2
-  - uid: 1456
+  - uid: 1455
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 2
 - proto: TableReinforced
   entities:
-  - uid: 1457
+  - uid: 1456
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 2
-  - uid: 1458
+  - uid: 1457
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 2
-  - uid: 1459
+  - uid: 1458
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 2
-  - uid: 1460
+  - uid: 1459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-14.5
       parent: 2
-  - uid: 1461
+  - uid: 1460
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-14.5
       parent: 2
-  - uid: 1462
+  - uid: 1461
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 2
-  - uid: 1463
+  - uid: 1462
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 2
-  - uid: 1464
+  - uid: 1463
     components:
     - type: Transform
       pos: 34.5,-0.5
       parent: 2
-  - uid: 1465
+  - uid: 1464
     components:
     - type: Transform
       pos: 34.5,0.5
       parent: 2
-  - uid: 1466
+  - uid: 1465
     components:
     - type: Transform
       pos: 31.5,3.5
       parent: 2
-  - uid: 1467
+  - uid: 1466
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 39.5,-8.5
       parent: 2
-  - uid: 1468
+  - uid: 1467
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-8.5
       parent: 2
-  - uid: 1469
+  - uid: 1468
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 37.5,-8.5
       parent: 2
-  - uid: 1470
+  - uid: 1469
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-8.5
       parent: 2
-  - uid: 1471
+  - uid: 1470
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-10.5
       parent: 2
-  - uid: 1472
+  - uid: 1471
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 37.5,-10.5
       parent: 2
-  - uid: 1473
+  - uid: 1472
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-10.5
       parent: 2
-  - uid: 1474
+  - uid: 1473
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 39.5,-10.5
       parent: 2
-  - uid: 1475
+  - uid: 1474
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 39.5,-9.5
       parent: 2
-  - uid: 1476
+  - uid: 1475
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-9.5
       parent: 2
-  - uid: 1477
+  - uid: 1476
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,-8.5
       parent: 2
-  - uid: 1478
+  - uid: 1477
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,-9.5
       parent: 2
-  - uid: 1479
+  - uid: 1478
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -9095,64 +9122,64 @@ entities:
       parent: 2
 - proto: TableWood
   entities:
-  - uid: 1480
+  - uid: 1479
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 2
-  - uid: 1481
+  - uid: 1480
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 2
-  - uid: 1482
+  - uid: 1481
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 2
-  - uid: 1483
+  - uid: 1482
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 2
-  - uid: 1484
+  - uid: 1483
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 2
-  - uid: 1485
+  - uid: 1484
     components:
     - type: Transform
       pos: 10.5,-0.5
       parent: 2
-  - uid: 1486
+  - uid: 1485
     components:
     - type: Transform
       pos: 10.5,-1.5
       parent: 2
-  - uid: 1487
+  - uid: 1486
     components:
     - type: Transform
       pos: 11.5,-0.5
       parent: 2
-  - uid: 1488
+  - uid: 1487
     components:
     - type: Transform
       pos: 11.5,-1.5
       parent: 2
-  - uid: 1489
+  - uid: 1488
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-15.5
       parent: 2
-  - uid: 1490
+  - uid: 1489
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-16.5
       parent: 2
-  - uid: 1491
+  - uid: 1490
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -9160,30 +9187,30 @@ entities:
       parent: 2
 - proto: TimerTrigger
   entities:
-  - uid: 1492
+  - uid: 1491
     components:
     - type: Transform
       pos: -13.67284,-3.5597272
       parent: 2
-  - uid: 1493
+  - uid: 1492
     components:
     - type: Transform
       pos: -13.67284,-3.4034772
       parent: 2
-  - uid: 1494
+  - uid: 1493
     components:
     - type: Transform
       pos: -13.657215,-3.0909772
       parent: 2
 - proto: ToiletEmpty
   entities:
-  - uid: 1495
+  - uid: 1494
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-14.5
       parent: 2
-  - uid: 1496
+  - uid: 1495
     components:
     - type: Transform
       pos: 3.5,-12.5
@@ -9192,1810 +9219,1810 @@ entities:
       toggleSeat: True
 - proto: ToyFigurineNukie
   entities:
-  - uid: 1497
+  - uid: 1496
     components:
     - type: Transform
       pos: 28.46877,-29.659956
       parent: 2
-  - uid: 1498
+  - uid: 1497
     components:
     - type: Transform
       pos: 29.453144,-30.503706
       parent: 2
-  - uid: 1499
+  - uid: 1498
     components:
     - type: Transform
       pos: 28.46877,-31.519331
       parent: 2
-  - uid: 1500
+  - uid: 1499
     components:
     - type: Transform
       pos: 27.609394,-30.456831
       parent: 2
 - proto: ToyNuke
   entities:
-  - uid: 1501
+  - uid: 1500
     components:
     - type: Transform
       pos: 28.515644,-30.613081
       parent: 2
 - proto: VendingMachineBooze
   entities:
-  - uid: 1502
+  - uid: 1501
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 2
 - proto: VendingMachineChemicalsSyndicate
   entities:
-  - uid: 1503
+  - uid: 1502
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 2
 - proto: VendingMachineCigs
   entities:
-  - uid: 1504
+  - uid: 1503
     components:
     - type: Transform
       pos: 12.5,2.5
       parent: 2
-  - uid: 1505
+  - uid: 1504
     components:
     - type: Transform
       pos: 33.5,-2.5
       parent: 2
 - proto: VendingMachineClothing
   entities:
-  - uid: 1506
+  - uid: 1505
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 2
 - proto: VendingMachineDinnerware
   entities:
-  - uid: 1507
+  - uid: 1506
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 2
 - proto: VendingMachineEngivend
   entities:
-  - uid: 1508
+  - uid: 1507
     components:
     - type: Transform
       pos: -1.5,-10.5
       parent: 2
 - proto: VendingMachineNutri
   entities:
-  - uid: 1509
+  - uid: 1508
     components:
     - type: Transform
       pos: -9.5,-13.5
       parent: 2
 - proto: VendingMachineRestockChefvend
   entities:
-  - uid: 1510
+  - uid: 1509
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 2
 - proto: VendingMachineSeeds
   entities:
-  - uid: 1511
+  - uid: 1510
     components:
     - type: Transform
       pos: -11.5,-13.5
       parent: 2
 - proto: VendingMachineSnackTeal
   entities:
-  - uid: 1512
+  - uid: 1511
     components:
     - type: Transform
       pos: 33.5,-3.5
       parent: 2
 - proto: VendingMachineYouTool
   entities:
-  - uid: 1513
+  - uid: 1512
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 2
-  - uid: 1514
+  - uid: 1513
     components:
     - type: Transform
       pos: 35.5,-2.5
       parent: 2
 - proto: WallPlastitanium
   entities:
-  - uid: 1515
+  - uid: 1514
     components:
     - type: Transform
       pos: 13.5,1.5
       parent: 2
-  - uid: 1516
+  - uid: 1515
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 2
-  - uid: 1517
+  - uid: 1516
     components:
     - type: Transform
       pos: 14.5,2.5
       parent: 2
-  - uid: 1518
+  - uid: 1517
     components:
     - type: Transform
       pos: 13.5,-3.5
       parent: 2
-  - uid: 1519
+  - uid: 1518
     components:
     - type: Transform
       pos: 12.5,-3.5
       parent: 2
-  - uid: 1520
+  - uid: 1519
     components:
     - type: Transform
       pos: 11.5,-3.5
       parent: 2
-  - uid: 1521
+  - uid: 1520
     components:
     - type: Transform
       pos: 10.5,-3.5
       parent: 2
-  - uid: 1522
+  - uid: 1521
     components:
     - type: Transform
       pos: 9.5,-3.5
       parent: 2
-  - uid: 1523
+  - uid: 1522
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 2
-  - uid: 1524
+  - uid: 1523
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 2
-  - uid: 1525
+  - uid: 1524
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 2
-  - uid: 1526
+  - uid: 1525
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 2
-  - uid: 1527
+  - uid: 1526
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 2
-  - uid: 1528
+  - uid: 1527
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 2
-  - uid: 1529
+  - uid: 1528
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 2
-  - uid: 1530
+  - uid: 1529
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 2
-  - uid: 1531
+  - uid: 1530
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 2
-  - uid: 1532
+  - uid: 1531
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 2
-  - uid: 1533
+  - uid: 1532
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 2
-  - uid: 1534
+  - uid: 1533
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 2
-  - uid: 1535
+  - uid: 1534
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 2
-  - uid: 1536
+  - uid: 1535
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 2
-  - uid: 1537
+  - uid: 1536
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 2
-  - uid: 1538
+  - uid: 1537
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 2
-  - uid: 1539
+  - uid: 1538
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 2
-  - uid: 1540
+  - uid: 1539
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 2
-  - uid: 1541
+  - uid: 1540
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 2
-  - uid: 1542
+  - uid: 1541
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 2
-  - uid: 1543
+  - uid: 1542
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 2
-  - uid: 1544
+  - uid: 1543
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 2
-  - uid: 1545
+  - uid: 1544
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 2
-  - uid: 1546
+  - uid: 1545
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 2
-  - uid: 1547
+  - uid: 1546
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 2
-  - uid: 1548
+  - uid: 1547
     components:
     - type: Transform
       pos: 9.5,1.5
       parent: 2
-  - uid: 1549
+  - uid: 1548
     components:
     - type: Transform
       pos: 10.5,1.5
       parent: 2
-  - uid: 1550
+  - uid: 1549
     components:
     - type: Transform
       pos: 11.5,1.5
       parent: 2
-  - uid: 1551
+  - uid: 1550
     components:
     - type: Transform
       pos: 12.5,1.5
       parent: 2
-  - uid: 1552
+  - uid: 1551
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 2
-  - uid: 1553
+  - uid: 1552
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-4.5
       parent: 2
-  - uid: 1554
+  - uid: 1553
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,-4.5
       parent: 2
-  - uid: 1555
+  - uid: 1554
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,-7.5
       parent: 2
-  - uid: 1556
+  - uid: 1555
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,-8.5
       parent: 2
-  - uid: 1557
+  - uid: 1556
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-8.5
       parent: 2
-  - uid: 1558
+  - uid: 1557
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-8.5
       parent: 2
-  - uid: 1559
+  - uid: 1558
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-8.5
       parent: 2
-  - uid: 1560
+  - uid: 1559
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-9.5
       parent: 2
-  - uid: 1561
+  - uid: 1560
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-10.5
       parent: 2
-  - uid: 1562
+  - uid: 1561
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-10.5
       parent: 2
-  - uid: 1563
+  - uid: 1562
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-10.5
       parent: 2
-  - uid: 1564
+  - uid: 1563
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,-10.5
       parent: 2
-  - uid: 1565
+  - uid: 1564
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-10.5
       parent: 2
-  - uid: 1566
+  - uid: 1565
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,-9.5
       parent: 2
-  - uid: 1567
+  - uid: 1566
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-10.5
       parent: 2
-  - uid: 1568
+  - uid: 1567
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-7.5
       parent: 2
-  - uid: 1569
+  - uid: 1568
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-10.5
       parent: 2
-  - uid: 1570
+  - uid: 1569
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-10.5
       parent: 2
-  - uid: 1571
+  - uid: 1570
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-10.5
       parent: 2
-  - uid: 1572
+  - uid: 1571
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-9.5
       parent: 2
-  - uid: 1573
+  - uid: 1572
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-9.5
       parent: 2
-  - uid: 1574
+  - uid: 1573
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-8.5
       parent: 2
-  - uid: 1575
+  - uid: 1574
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-6.5
       parent: 2
-  - uid: 1576
+  - uid: 1575
     components:
     - type: Transform
       pos: 7.5,-6.5
       parent: 2
-  - uid: 1577
+  - uid: 1576
     components:
     - type: Transform
       pos: -4.5,-9.5
       parent: 2
-  - uid: 1578
+  - uid: 1577
     components:
     - type: Transform
       pos: -5.5,-9.5
       parent: 2
-  - uid: 1579
+  - uid: 1578
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 2
-  - uid: 1580
+  - uid: 1579
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 2
-  - uid: 1581
+  - uid: 1580
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 2
-  - uid: 1582
+  - uid: 1581
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 2
-  - uid: 1583
+  - uid: 1582
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 2
-  - uid: 1584
+  - uid: 1583
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 2
-  - uid: 1585
+  - uid: 1584
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 2
-  - uid: 1586
+  - uid: 1585
     components:
     - type: Transform
       pos: -4.5,-5.5
       parent: 2
-  - uid: 1587
+  - uid: 1586
     components:
     - type: Transform
       pos: -8.5,-5.5
       parent: 2
-  - uid: 1588
+  - uid: 1587
     components:
     - type: Transform
       pos: -9.5,-5.5
       parent: 2
-  - uid: 1589
+  - uid: 1588
     components:
     - type: Transform
       pos: -9.5,-6.5
       parent: 2
-  - uid: 1590
+  - uid: 1589
     components:
     - type: Transform
       pos: -9.5,-8.5
       parent: 2
-  - uid: 1591
+  - uid: 1590
     components:
     - type: Transform
       pos: -9.5,-9.5
       parent: 2
-  - uid: 1592
+  - uid: 1591
     components:
     - type: Transform
       pos: -10.5,-5.5
       parent: 2
-  - uid: 1593
+  - uid: 1592
     components:
     - type: Transform
       pos: -11.5,-5.5
       parent: 2
-  - uid: 1594
+  - uid: 1593
     components:
     - type: Transform
       pos: -12.5,-5.5
       parent: 2
-  - uid: 1595
+  - uid: 1594
     components:
     - type: Transform
       pos: -10.5,-9.5
       parent: 2
-  - uid: 1596
+  - uid: 1595
     components:
     - type: Transform
       pos: -11.5,-9.5
       parent: 2
-  - uid: 1597
+  - uid: 1596
     components:
     - type: Transform
       pos: -12.5,-9.5
       parent: 2
-  - uid: 1598
+  - uid: 1597
     components:
     - type: Transform
       pos: -12.5,-8.5
       parent: 2
-  - uid: 1599
+  - uid: 1598
     components:
     - type: Transform
       pos: -12.5,-7.5
       parent: 2
-  - uid: 1600
+  - uid: 1599
     components:
     - type: Transform
       pos: -12.5,-6.5
       parent: 2
-  - uid: 1601
+  - uid: 1600
     components:
     - type: Transform
       pos: -5.5,-10.5
       parent: 2
-  - uid: 1602
+  - uid: 1601
     components:
     - type: Transform
       pos: -5.5,-11.5
       parent: 2
-  - uid: 1603
+  - uid: 1602
     components:
     - type: Transform
       pos: -5.5,-12.5
       parent: 2
-  - uid: 1604
+  - uid: 1603
     components:
     - type: Transform
       pos: -5.5,-13.5
       parent: 2
-  - uid: 1605
+  - uid: 1604
     components:
     - type: Transform
       pos: -5.5,-14.5
       parent: 2
-  - uid: 1606
+  - uid: 1605
     components:
     - type: Transform
       pos: -5.5,-15.5
       parent: 2
-  - uid: 1607
+  - uid: 1606
     components:
     - type: Transform
       pos: -5.5,-16.5
       parent: 2
-  - uid: 1608
+  - uid: 1607
     components:
     - type: Transform
       pos: -5.5,-17.5
       parent: 2
-  - uid: 1609
+  - uid: 1608
     components:
     - type: Transform
       pos: -6.5,-17.5
       parent: 2
-  - uid: 1610
+  - uid: 1609
     components:
     - type: Transform
       pos: -7.5,-17.5
       parent: 2
-  - uid: 1611
+  - uid: 1610
     components:
     - type: Transform
       pos: -8.5,-17.5
       parent: 2
-  - uid: 1612
+  - uid: 1611
     components:
     - type: Transform
       pos: -9.5,-17.5
       parent: 2
-  - uid: 1613
+  - uid: 1612
     components:
     - type: Transform
       pos: -10.5,-17.5
       parent: 2
-  - uid: 1614
+  - uid: 1613
     components:
     - type: Transform
       pos: -11.5,-17.5
       parent: 2
-  - uid: 1615
+  - uid: 1614
     components:
     - type: Transform
       pos: -12.5,-17.5
       parent: 2
-  - uid: 1616
+  - uid: 1615
     components:
     - type: Transform
       pos: -13.5,-17.5
       parent: 2
-  - uid: 1617
+  - uid: 1616
     components:
     - type: Transform
       pos: -14.5,-17.5
       parent: 2
-  - uid: 1618
+  - uid: 1617
     components:
     - type: Transform
       pos: -13.5,-14.5
       parent: 2
-  - uid: 1619
+  - uid: 1618
     components:
     - type: Transform
       pos: -13.5,-13.5
       parent: 2
-  - uid: 1620
+  - uid: 1619
     components:
     - type: Transform
       pos: -14.5,-16.5
       parent: 2
-  - uid: 1621
+  - uid: 1620
     components:
     - type: Transform
       pos: -14.5,-15.5
       parent: 2
-  - uid: 1622
+  - uid: 1621
     components:
     - type: Transform
       pos: -14.5,-14.5
       parent: 2
-  - uid: 1623
+  - uid: 1622
     components:
     - type: Transform
       pos: -14.5,-13.5
       parent: 2
-  - uid: 1624
+  - uid: 1623
     components:
     - type: Transform
       pos: -14.5,-12.5
       parent: 2
-  - uid: 1625
+  - uid: 1624
     components:
     - type: Transform
       pos: -14.5,-11.5
       parent: 2
-  - uid: 1626
+  - uid: 1625
     components:
     - type: Transform
       pos: -13.5,-11.5
       parent: 2
-  - uid: 1627
+  - uid: 1626
     components:
     - type: Transform
       pos: -13.5,-10.5
       parent: 2
-  - uid: 1628
+  - uid: 1627
     components:
     - type: Transform
       pos: -13.5,-9.5
       parent: 2
-  - uid: 1629
+  - uid: 1628
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 2
-  - uid: 1630
+  - uid: 1629
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 2
-  - uid: 1631
+  - uid: 1630
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 2
-  - uid: 1632
+  - uid: 1631
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 2
-  - uid: 1633
+  - uid: 1632
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-0.5
       parent: 2
-  - uid: 1634
+  - uid: 1633
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-1.5
       parent: 2
-  - uid: 1635
+  - uid: 1634
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-2.5
       parent: 2
-  - uid: 1636
+  - uid: 1635
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-3.5
       parent: 2
-  - uid: 1637
+  - uid: 1636
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-4.5
       parent: 2
-  - uid: 1638
+  - uid: 1637
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 2
-  - uid: 1639
+  - uid: 1638
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,0.5
       parent: 2
-  - uid: 1640
+  - uid: 1639
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,1.5
       parent: 2
-  - uid: 1641
+  - uid: 1640
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,1.5
       parent: 2
-  - uid: 1642
+  - uid: 1641
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,1.5
       parent: 2
-  - uid: 1643
+  - uid: 1642
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,1.5
       parent: 2
-  - uid: 1644
+  - uid: 1643
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-1.5
       parent: 2
-  - uid: 1645
+  - uid: 1644
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-3.5
       parent: 2
-  - uid: 1646
+  - uid: 1645
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -13.5,0.5
       parent: 2
-  - uid: 1647
+  - uid: 1646
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-4.5
       parent: 2
-  - uid: 1648
+  - uid: 1647
     components:
     - type: Transform
       pos: -13.5,-5.5
       parent: 2
-  - uid: 1649
+  - uid: 1648
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,1.5
       parent: 2
-  - uid: 1650
+  - uid: 1649
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,1.5
       parent: 2
-  - uid: 1651
+  - uid: 1650
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,1.5
       parent: 2
-  - uid: 1652
+  - uid: 1651
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -12.5,1.5
       parent: 2
-  - uid: 1653
+  - uid: 1652
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-0.5
       parent: 2
-  - uid: 1654
+  - uid: 1653
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-2.5
       parent: 2
-  - uid: 1655
+  - uid: 1654
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,0.5
       parent: 2
-  - uid: 1656
+  - uid: 1655
     components:
     - type: Transform
       pos: -2.5,-18.5
       parent: 2
-  - uid: 1657
+  - uid: 1656
     components:
     - type: Transform
       pos: -0.5,-18.5
       parent: 2
-  - uid: 1658
+  - uid: 1657
     components:
     - type: Transform
       pos: -0.5,-21.5
       parent: 2
-  - uid: 1659
+  - uid: 1658
     components:
     - type: Transform
       pos: -1.5,-21.5
       parent: 2
-  - uid: 1660
+  - uid: 1659
     components:
     - type: Transform
       pos: -2.5,-21.5
       parent: 2
-  - uid: 1661
+  - uid: 1660
     components:
     - type: Transform
       pos: -3.5,-21.5
       parent: 2
-  - uid: 1662
+  - uid: 1661
     components:
     - type: Transform
       pos: -4.5,-21.5
       parent: 2
-  - uid: 1663
+  - uid: 1662
     components:
     - type: Transform
       pos: -4.5,-20.5
       parent: 2
-  - uid: 1664
+  - uid: 1663
     components:
     - type: Transform
       pos: -4.5,-19.5
       parent: 2
-  - uid: 1665
+  - uid: 1664
     components:
     - type: Transform
       pos: -4.5,-18.5
       parent: 2
-  - uid: 1666
+  - uid: 1665
     components:
     - type: Transform
       pos: -4.5,-17.5
       parent: 2
-  - uid: 1667
+  - uid: 1666
     components:
     - type: Transform
       pos: 0.5,-21.5
       parent: 2
-  - uid: 1668
+  - uid: 1667
     components:
     - type: Transform
       pos: 0.5,-18.5
       parent: 2
-  - uid: 1669
+  - uid: 1668
     components:
     - type: Transform
       pos: 1.5,-18.5
       parent: 2
-  - uid: 1670
+  - uid: 1669
     components:
     - type: Transform
       pos: 1.5,-19.5
       parent: 2
-  - uid: 1671
+  - uid: 1670
     components:
     - type: Transform
       pos: 1.5,-20.5
       parent: 2
-  - uid: 1672
+  - uid: 1671
     components:
     - type: Transform
       pos: 1.5,-21.5
       parent: 2
-  - uid: 1673
+  - uid: 1672
     components:
     - type: Transform
       pos: 2.5,-18.5
       parent: 2
-  - uid: 1674
+  - uid: 1673
     components:
     - type: Transform
       pos: 2.5,-21.5
       parent: 2
-  - uid: 1675
+  - uid: 1674
     components:
     - type: Transform
       pos: 3.5,-18.5
       parent: 2
-  - uid: 1676
+  - uid: 1675
     components:
     - type: Transform
       pos: 3.5,-19.5
       parent: 2
-  - uid: 1677
+  - uid: 1676
     components:
     - type: Transform
       pos: 3.5,-20.5
       parent: 2
-  - uid: 1678
+  - uid: 1677
     components:
     - type: Transform
       pos: 3.5,-21.5
       parent: 2
-  - uid: 1679
+  - uid: 1678
     components:
     - type: Transform
       pos: 2.5,-17.5
       parent: 2
-  - uid: 1680
+  - uid: 1679
     components:
     - type: Transform
       pos: 3.5,-17.5
       parent: 2
-  - uid: 1681
+  - uid: 1680
     components:
     - type: Transform
       pos: 4.5,-17.5
       parent: 2
-  - uid: 1682
+  - uid: 1681
     components:
     - type: Transform
       pos: 5.5,-17.5
       parent: 2
-  - uid: 1683
+  - uid: 1682
     components:
     - type: Transform
       pos: 2.5,-16.5
       parent: 2
-  - uid: 1684
+  - uid: 1683
     components:
     - type: Transform
       pos: 2.5,-15.5
       parent: 2
-  - uid: 1685
+  - uid: 1684
     components:
     - type: Transform
       pos: 2.5,-14.5
       parent: 2
-  - uid: 1686
+  - uid: 1685
     components:
     - type: Transform
       pos: 2.5,-13.5
       parent: 2
-  - uid: 1687
+  - uid: 1686
     components:
     - type: Transform
       pos: 2.5,-12.5
       parent: 2
-  - uid: 1688
+  - uid: 1687
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 2
-  - uid: 1689
+  - uid: 1688
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 2
-  - uid: 1690
+  - uid: 1689
     components:
     - type: Transform
       pos: 5.5,-11.5
       parent: 2
-  - uid: 1691
+  - uid: 1690
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 2
-  - uid: 1692
+  - uid: 1691
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 2
-  - uid: 1693
+  - uid: 1692
     components:
     - type: Transform
       pos: 5.5,-13.5
       parent: 2
-  - uid: 1694
+  - uid: 1693
     components:
     - type: Transform
       pos: 5.5,-14.5
       parent: 2
-  - uid: 1695
+  - uid: 1694
     components:
     - type: Transform
       pos: 5.5,-15.5
       parent: 2
-  - uid: 1696
+  - uid: 1695
     components:
     - type: Transform
       pos: 5.5,-16.5
       parent: 2
-  - uid: 1697
+  - uid: 1696
     components:
     - type: Transform
       pos: 13.5,-13.5
       parent: 2
-  - uid: 1698
+  - uid: 1697
     components:
     - type: Transform
       pos: 12.5,-13.5
       parent: 2
-  - uid: 1699
+  - uid: 1698
     components:
     - type: Transform
       pos: 11.5,-13.5
       parent: 2
-  - uid: 1700
+  - uid: 1699
     components:
     - type: Transform
       pos: 10.5,-13.5
       parent: 2
-  - uid: 1701
+  - uid: 1700
     components:
     - type: Transform
       pos: 9.5,-13.5
       parent: 2
-  - uid: 1702
+  - uid: 1701
     components:
     - type: Transform
       pos: 9.5,-11.5
       parent: 2
-  - uid: 1703
+  - uid: 1702
     components:
     - type: Transform
       pos: 9.5,-15.5
       parent: 2
-  - uid: 1704
+  - uid: 1703
     components:
     - type: Transform
       pos: 9.5,-16.5
       parent: 2
-  - uid: 1705
+  - uid: 1704
     components:
     - type: Transform
       pos: 10.5,-16.5
       parent: 2
-  - uid: 1706
+  - uid: 1705
     components:
     - type: Transform
       pos: 11.5,-16.5
       parent: 2
-  - uid: 1707
+  - uid: 1706
     components:
     - type: Transform
       pos: 12.5,-16.5
       parent: 2
-  - uid: 1708
+  - uid: 1707
     components:
     - type: Transform
       pos: 13.5,-16.5
       parent: 2
-  - uid: 1709
+  - uid: 1708
     components:
     - type: Transform
       pos: 14.5,-16.5
       parent: 2
-  - uid: 1710
+  - uid: 1709
     components:
     - type: Transform
       pos: 14.5,-17.5
       parent: 2
-  - uid: 1711
+  - uid: 1710
     components:
     - type: Transform
       pos: 13.5,-17.5
       parent: 2
-  - uid: 1712
+  - uid: 1711
     components:
     - type: Transform
       pos: 9.5,-17.5
       parent: 2
-  - uid: 1713
+  - uid: 1712
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-13.5
       parent: 2
-  - uid: 1714
+  - uid: 1713
     components:
     - type: Transform
       pos: 26.5,-7.5
       parent: 2
-  - uid: 1715
+  - uid: 1714
     components:
     - type: Transform
       pos: 25.5,-7.5
       parent: 2
-  - uid: 1716
+  - uid: 1715
     components:
     - type: Transform
       pos: 21.5,-7.5
       parent: 2
-  - uid: 1717
+  - uid: 1716
     components:
     - type: Transform
       pos: 22.5,-7.5
       parent: 2
-  - uid: 1718
+  - uid: 1717
     components:
     - type: Transform
       pos: 18.5,-7.5
       parent: 2
-  - uid: 1719
+  - uid: 1718
     components:
     - type: Transform
       pos: 17.5,-7.5
       parent: 2
-  - uid: 1720
+  - uid: 1719
     components:
     - type: Transform
       pos: 26.5,-8.5
       parent: 2
-  - uid: 1721
+  - uid: 1720
     components:
     - type: Transform
       pos: 26.5,-9.5
       parent: 2
-  - uid: 1722
+  - uid: 1721
     components:
     - type: Transform
       pos: 26.5,-10.5
       parent: 2
-  - uid: 1723
+  - uid: 1722
     components:
     - type: Transform
       pos: 25.5,-10.5
       parent: 2
-  - uid: 1724
+  - uid: 1723
     components:
     - type: Transform
       pos: 26.5,-4.5
       parent: 2
-  - uid: 1725
+  - uid: 1724
     components:
     - type: Transform
       pos: 26.5,-3.5
       parent: 2
-  - uid: 1726
+  - uid: 1725
     components:
     - type: Transform
       pos: 26.5,-2.5
       parent: 2
-  - uid: 1727
+  - uid: 1726
     components:
     - type: Transform
       pos: 26.5,-1.5
       parent: 2
-  - uid: 1728
+  - uid: 1727
     components:
     - type: Transform
       pos: 27.5,-1.5
       parent: 2
-  - uid: 1729
+  - uid: 1728
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,-7.5
       parent: 2
-  - uid: 1730
+  - uid: 1729
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-7.5
       parent: 2
-  - uid: 1731
+  - uid: 1730
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-8.5
       parent: 2
-  - uid: 1732
+  - uid: 1731
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-9.5
       parent: 2
-  - uid: 1733
+  - uid: 1732
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-10.5
       parent: 2
-  - uid: 1734
+  - uid: 1733
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,-10.5
       parent: 2
-  - uid: 1735
+  - uid: 1734
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,-10.5
       parent: 2
-  - uid: 1736
+  - uid: 1735
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,-7.5
       parent: 2
-  - uid: 1737
+  - uid: 1736
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,-7.5
       parent: 2
-  - uid: 1738
+  - uid: 1737
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,-8.5
       parent: 2
-  - uid: 1739
+  - uid: 1738
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,-9.5
       parent: 2
-  - uid: 1740
+  - uid: 1739
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,-10.5
       parent: 2
-  - uid: 1741
+  - uid: 1740
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 35.5,-19.5
       parent: 2
-  - uid: 1742
+  - uid: 1741
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,-19.5
       parent: 2
-  - uid: 1743
+  - uid: 1742
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,-11.5
       parent: 2
-  - uid: 1744
+  - uid: 1743
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,-11.5
       parent: 2
-  - uid: 1745
+  - uid: 1744
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 30.5,-11.5
       parent: 2
-  - uid: 1746
+  - uid: 1745
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,-11.5
       parent: 2
-  - uid: 1747
+  - uid: 1746
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,-15.5
       parent: 2
-  - uid: 1748
+  - uid: 1747
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,-15.5
       parent: 2
-  - uid: 1749
+  - uid: 1748
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,-17.5
       parent: 2
-  - uid: 1750
+  - uid: 1749
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,-19.5
       parent: 2
-  - uid: 1751
+  - uid: 1750
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,-21.5
       parent: 2
-  - uid: 1752
+  - uid: 1751
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,-21.5
       parent: 2
-  - uid: 1753
+  - uid: 1752
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 26.5,-18.5
       parent: 2
-  - uid: 1754
+  - uid: 1753
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 29.5,-19.5
       parent: 2
-  - uid: 1755
+  - uid: 1754
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 29.5,-17.5
       parent: 2
-  - uid: 1756
+  - uid: 1755
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,-15.5
       parent: 2
-  - uid: 1757
+  - uid: 1756
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,-10.5
       parent: 2
-  - uid: 1758
+  - uid: 1757
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,-14.5
       parent: 2
-  - uid: 1759
+  - uid: 1758
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,-7.5
       parent: 2
-  - uid: 1760
+  - uid: 1759
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,-13.5
       parent: 2
-  - uid: 1761
+  - uid: 1760
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,-12.5
       parent: 2
-  - uid: 1762
+  - uid: 1761
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,-11.5
       parent: 2
-  - uid: 1763
+  - uid: 1762
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-19.5
       parent: 2
-  - uid: 1764
+  - uid: 1763
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-18.5
       parent: 2
-  - uid: 1765
+  - uid: 1764
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-17.5
       parent: 2
-  - uid: 1766
+  - uid: 1765
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-15.5
       parent: 2
-  - uid: 1767
+  - uid: 1766
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-14.5
       parent: 2
-  - uid: 1768
+  - uid: 1767
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-13.5
       parent: 2
-  - uid: 1769
+  - uid: 1768
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,-16.5
       parent: 2
-  - uid: 1770
+  - uid: 1769
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-15.5
       parent: 2
-  - uid: 1771
+  - uid: 1770
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-21.5
       parent: 2
-  - uid: 1772
+  - uid: 1771
     components:
     - type: Transform
       pos: 42.5,8.5
       parent: 2
-  - uid: 1773
+  - uid: 1772
     components:
     - type: Transform
       pos: 26.5,8.5
       parent: 2
-  - uid: 1774
+  - uid: 1773
     components:
     - type: Transform
       pos: 26.5,6.5
       parent: 2
-  - uid: 1775
+  - uid: 1774
     components:
     - type: Transform
       pos: 26.5,5.5
       parent: 2
-  - uid: 1776
+  - uid: 1775
     components:
     - type: Transform
       pos: 26.5,4.5
       parent: 2
-  - uid: 1777
+  - uid: 1776
     components:
     - type: Transform
       pos: 26.5,7.5
       parent: 2
-  - uid: 1778
+  - uid: 1777
     components:
     - type: Transform
       pos: 26.5,3.5
       parent: 2
-  - uid: 1779
+  - uid: 1778
     components:
     - type: Transform
       pos: 27.5,3.5
       parent: 2
-  - uid: 1780
+  - uid: 1779
     components:
     - type: Transform
       pos: 30.5,3.5
       parent: 2
-  - uid: 1781
+  - uid: 1780
     components:
     - type: Transform
       pos: 30.5,4.5
       parent: 2
-  - uid: 1782
+  - uid: 1781
     components:
     - type: Transform
       pos: 42.5,7.5
       parent: 2
-  - uid: 1783
+  - uid: 1782
     components:
     - type: Transform
       pos: 41.5,8.5
       parent: 2
-  - uid: 1784
+  - uid: 1783
     components:
     - type: Transform
       pos: 41.5,7.5
       parent: 2
-  - uid: 1785
+  - uid: 1784
     components:
     - type: Transform
       pos: 41.5,5.5
       parent: 2
-  - uid: 1786
+  - uid: 1785
     components:
     - type: Transform
       pos: 41.5,6.5
       parent: 2
-  - uid: 1787
+  - uid: 1786
     components:
     - type: Transform
       pos: 41.5,3.5
       parent: 2
-  - uid: 1788
+  - uid: 1787
     components:
     - type: Transform
       pos: 41.5,4.5
       parent: 2
-  - uid: 1789
+  - uid: 1788
     components:
     - type: Transform
       pos: 41.5,1.5
       parent: 2
-  - uid: 1790
+  - uid: 1789
     components:
     - type: Transform
       pos: 41.5,2.5
       parent: 2
-  - uid: 1791
+  - uid: 1790
     components:
     - type: Transform
       pos: 41.5,0.5
       parent: 2
-  - uid: 1792
+  - uid: 1791
     components:
     - type: Transform
       pos: 30.5,-1.5
       parent: 2
-  - uid: 1793
+  - uid: 1792
     components:
     - type: Transform
       pos: 31.5,-1.5
       parent: 2
-  - uid: 1794
+  - uid: 1793
     components:
     - type: Transform
       pos: 33.5,-1.5
       parent: 2
-  - uid: 1795
+  - uid: 1794
     components:
     - type: Transform
       pos: 34.5,-4.5
       parent: 2
-  - uid: 1796
+  - uid: 1795
     components:
     - type: Transform
       pos: 37.5,-4.5
       parent: 2
-  - uid: 1797
+  - uid: 1796
     components:
     - type: Transform
       pos: 37.5,-2.5
       parent: 2
-  - uid: 1798
+  - uid: 1797
     components:
     - type: Transform
       pos: 37.5,-1.5
       parent: 2
-  - uid: 1799
+  - uid: 1798
     components:
     - type: Transform
       pos: 36.5,-1.5
       parent: 2
-  - uid: 1800
+  - uid: 1799
     components:
     - type: Transform
       pos: 35.5,-1.5
       parent: 2
-  - uid: 1801
+  - uid: 1800
     components:
     - type: Transform
       pos: 34.5,-1.5
       parent: 2
-  - uid: 1802
+  - uid: 1801
     components:
     - type: Transform
       pos: 34.5,-2.5
       parent: 2
-  - uid: 1803
+  - uid: 1802
     components:
     - type: Transform
       pos: 41.5,-2.5
       parent: 2
-  - uid: 1804
+  - uid: 1803
     components:
     - type: Transform
       pos: 41.5,-1.5
       parent: 2
-  - uid: 1805
+  - uid: 1804
     components:
     - type: Transform
       pos: 41.5,-0.5
       parent: 2
-  - uid: 1806
+  - uid: 1805
     components:
     - type: Transform
       pos: 42.5,2.5
       parent: 2
-  - uid: 1807
+  - uid: 1806
     components:
     - type: Transform
       pos: 34.5,4.5
       parent: 2
-  - uid: 1808
+  - uid: 1807
     components:
     - type: Transform
       pos: 34.5,3.5
       parent: 2
-  - uid: 1809
+  - uid: 1808
     components:
     - type: Transform
       pos: 34.5,2.5
       parent: 2
-  - uid: 1810
+  - uid: 1809
     components:
     - type: Transform
       pos: 35.5,2.5
       parent: 2
-  - uid: 1811
+  - uid: 1810
     components:
     - type: Transform
       pos: 36.5,2.5
       parent: 2
-  - uid: 1812
+  - uid: 1811
     components:
     - type: Transform
       pos: 37.5,2.5
       parent: 2
-  - uid: 1813
+  - uid: 1812
     components:
     - type: Transform
       pos: 38.5,2.5
       parent: 2
-  - uid: 1814
+  - uid: 1813
     components:
     - type: Transform
       pos: 39.5,2.5
       parent: 2
-  - uid: 1815
+  - uid: 1814
     components:
     - type: Transform
       pos: 40.5,2.5
       parent: 2
-  - uid: 1816
+  - uid: 1815
     components:
     - type: Transform
       pos: 35.5,1.5
       parent: 2
-  - uid: 1817
+  - uid: 1816
     components:
     - type: Transform
       pos: 35.5,-0.5
       parent: 2
-  - uid: 1818
+  - uid: 1817
     components:
     - type: Transform
       pos: 35.5,0.5
       parent: 2
-  - uid: 1819
+  - uid: 1818
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 43.5,-12.5
       parent: 2
-  - uid: 1820
+  - uid: 1819
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 43.5,-13.5
       parent: 2
-  - uid: 1821
+  - uid: 1820
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 42.5,-13.5
       parent: 2
-  - uid: 1822
+  - uid: 1821
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 42.5,-15.5
       parent: 2
-  - uid: 1823
+  - uid: 1822
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 42.5,-14.5
       parent: 2
-  - uid: 1824
+  - uid: 1823
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,-15.5
       parent: 2
-  - uid: 1825
+  - uid: 1824
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 40.5,-15.5
       parent: 2
-  - uid: 1826
+  - uid: 1825
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 40.5,-14.5
       parent: 2
-  - uid: 1827
+  - uid: 1826
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 39.5,-14.5
       parent: 2
-  - uid: 1828
+  - uid: 1827
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,-14.5
       parent: 2
-  - uid: 1829
+  - uid: 1828
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 37.5,-14.5
       parent: 2
-  - uid: 1830
+  - uid: 1829
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 40.5,-13.5
       parent: 2
-  - uid: 1831
+  - uid: 1830
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,-3.5
       parent: 2
-  - uid: 1832
+  - uid: 1831
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -11003,70 +11030,70 @@ entities:
       parent: 2
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 1833
+  - uid: 1832
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 28.5,-15.5
       parent: 2
-  - uid: 1834
+  - uid: 1833
     components:
     - type: Transform
       pos: 24.5,-15.5
       parent: 2
-  - uid: 1835
+  - uid: 1834
     components:
     - type: Transform
       pos: 23.5,-16.5
       parent: 2
-  - uid: 1836
+  - uid: 1835
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 23.5,-20.5
       parent: 2
-  - uid: 1837
+  - uid: 1836
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 24.5,-21.5
       parent: 2
-  - uid: 1838
+  - uid: 1837
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-21.5
       parent: 2
-  - uid: 1839
+  - uid: 1838
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 29.5,-16.5
       parent: 2
-  - uid: 1840
+  - uid: 1839
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,-20.5
       parent: 2
-  - uid: 1841
+  - uid: 1840
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 28.5,-16.5
       parent: 2
-  - uid: 1842
+  - uid: 1841
     components:
     - type: Transform
       pos: 28.5,-20.5
       parent: 2
-  - uid: 1843
+  - uid: 1842
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,-20.5
       parent: 2
-  - uid: 1844
+  - uid: 1843
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -11074,13 +11101,13 @@ entities:
       parent: 2
 - proto: WallReinforced
   entities:
-  - uid: 1845
+  - uid: 1844
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,-19.5
       parent: 2
-  - uid: 1846
+  - uid: 1845
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -11088,2890 +11115,2890 @@ entities:
       parent: 2
 - proto: WallRockSnow
   entities:
-  - uid: 1847
+  - uid: 1846
     components:
     - type: Transform
       pos: -14.5,2.5
       parent: 2
-  - uid: 1848
+  - uid: 1847
     components:
     - type: Transform
       pos: -14.5,1.5
       parent: 2
-  - uid: 1849
+  - uid: 1848
     components:
     - type: Transform
       pos: -14.5,-5.5
       parent: 2
-  - uid: 1850
+  - uid: 1849
     components:
     - type: Transform
       pos: -14.5,-6.5
       parent: 2
-  - uid: 1851
+  - uid: 1850
     components:
     - type: Transform
       pos: -13.5,-6.5
       parent: 2
-  - uid: 1852
+  - uid: 1851
     components:
     - type: Transform
       pos: -13.5,-7.5
       parent: 2
-  - uid: 1853
+  - uid: 1852
     components:
     - type: Transform
       pos: -13.5,-8.5
       parent: 2
-  - uid: 1854
+  - uid: 1853
     components:
     - type: Transform
       pos: -14.5,-8.5
       parent: 2
-  - uid: 1855
+  - uid: 1854
     components:
     - type: Transform
       pos: -14.5,-9.5
       parent: 2
-  - uid: 1856
+  - uid: 1855
     components:
     - type: Transform
       pos: -14.5,-10.5
       parent: 2
-  - uid: 1857
+  - uid: 1856
     components:
     - type: Transform
       pos: -15.5,-10.5
       parent: 2
-  - uid: 1858
+  - uid: 1857
     components:
     - type: Transform
       pos: -15.5,-11.5
       parent: 2
-  - uid: 1859
+  - uid: 1858
     components:
     - type: Transform
       pos: -15.5,-12.5
       parent: 2
-  - uid: 1860
+  - uid: 1859
     components:
     - type: Transform
       pos: -15.5,-13.5
       parent: 2
-  - uid: 1861
+  - uid: 1860
     components:
     - type: Transform
       pos: -15.5,-14.5
       parent: 2
-  - uid: 1862
+  - uid: 1861
     components:
     - type: Transform
       pos: -15.5,-15.5
       parent: 2
-  - uid: 1863
+  - uid: 1862
     components:
     - type: Transform
       pos: -15.5,-16.5
       parent: 2
-  - uid: 1864
+  - uid: 1863
     components:
     - type: Transform
       pos: -15.5,-17.5
       parent: 2
-  - uid: 1865
+  - uid: 1864
     components:
     - type: Transform
       pos: -15.5,-18.5
       parent: 2
-  - uid: 1866
+  - uid: 1865
     components:
     - type: Transform
       pos: -14.5,-18.5
       parent: 2
-  - uid: 1867
+  - uid: 1866
     components:
     - type: Transform
       pos: -13.5,-18.5
       parent: 2
-  - uid: 1868
+  - uid: 1867
     components:
     - type: Transform
       pos: -11.5,-18.5
       parent: 2
-  - uid: 1869
+  - uid: 1868
     components:
     - type: Transform
       pos: -10.5,-18.5
       parent: 2
-  - uid: 1870
+  - uid: 1869
     components:
     - type: Transform
       pos: -9.5,-18.5
       parent: 2
-  - uid: 1871
+  - uid: 1870
     components:
     - type: Transform
       pos: -8.5,-18.5
       parent: 2
-  - uid: 1872
+  - uid: 1871
     components:
     - type: Transform
       pos: -12.5,-18.5
       parent: 2
-  - uid: 1873
+  - uid: 1872
     components:
     - type: Transform
       pos: -7.5,-18.5
       parent: 2
-  - uid: 1874
+  - uid: 1873
     components:
     - type: Transform
       pos: -6.5,-18.5
       parent: 2
-  - uid: 1875
+  - uid: 1874
     components:
     - type: Transform
       pos: -5.5,-18.5
       parent: 2
-  - uid: 1876
+  - uid: 1875
     components:
     - type: Transform
       pos: -5.5,-19.5
       parent: 2
-  - uid: 1877
+  - uid: 1876
     components:
     - type: Transform
       pos: -5.5,-20.5
       parent: 2
-  - uid: 1878
+  - uid: 1877
     components:
     - type: Transform
       pos: -5.5,-21.5
       parent: 2
-  - uid: 1879
+  - uid: 1878
     components:
     - type: Transform
       pos: -5.5,-22.5
       parent: 2
-  - uid: 1880
+  - uid: 1879
     components:
     - type: Transform
       pos: -4.5,-22.5
       parent: 2
-  - uid: 1881
+  - uid: 1880
     components:
     - type: Transform
       pos: -3.5,-22.5
       parent: 2
-  - uid: 1882
+  - uid: 1881
     components:
     - type: Transform
       pos: -2.5,-22.5
       parent: 2
-  - uid: 1883
+  - uid: 1882
     components:
     - type: Transform
       pos: -1.5,-22.5
       parent: 2
-  - uid: 1884
+  - uid: 1883
     components:
     - type: Transform
       pos: -0.5,-22.5
       parent: 2
-  - uid: 1885
+  - uid: 1884
     components:
     - type: Transform
       pos: 0.5,-22.5
       parent: 2
-  - uid: 1886
+  - uid: 1885
     components:
     - type: Transform
       pos: 1.5,-22.5
       parent: 2
-  - uid: 1887
+  - uid: 1886
     components:
     - type: Transform
       pos: 2.5,-22.5
       parent: 2
-  - uid: 1888
+  - uid: 1887
     components:
     - type: Transform
       pos: 3.5,-22.5
       parent: 2
-  - uid: 1889
+  - uid: 1888
     components:
     - type: Transform
       pos: 4.5,-22.5
       parent: 2
-  - uid: 1890
+  - uid: 1889
     components:
     - type: Transform
       pos: 4.5,-21.5
       parent: 2
-  - uid: 1891
+  - uid: 1890
     components:
     - type: Transform
       pos: 4.5,-20.5
       parent: 2
-  - uid: 1892
+  - uid: 1891
     components:
     - type: Transform
       pos: 4.5,-19.5
       parent: 2
-  - uid: 1893
+  - uid: 1892
     components:
     - type: Transform
       pos: 4.5,-18.5
       parent: 2
-  - uid: 1894
+  - uid: 1893
     components:
     - type: Transform
       pos: 5.5,-18.5
       parent: 2
-  - uid: 1895
+  - uid: 1894
     components:
     - type: Transform
       pos: -15.5,1.5
       parent: 2
-  - uid: 1896
+  - uid: 1895
     components:
     - type: Transform
       pos: -15.5,0.5
       parent: 2
-  - uid: 1897
+  - uid: 1896
     components:
     - type: Transform
       pos: -15.5,-0.5
       parent: 2
-  - uid: 1898
+  - uid: 1897
     components:
     - type: Transform
       pos: -15.5,-1.5
       parent: 2
-  - uid: 1899
+  - uid: 1898
     components:
     - type: Transform
       pos: -15.5,-2.5
       parent: 2
-  - uid: 1900
+  - uid: 1899
     components:
     - type: Transform
       pos: -15.5,-3.5
       parent: 2
-  - uid: 1901
+  - uid: 1900
     components:
     - type: Transform
       pos: -15.5,-4.5
       parent: 2
-  - uid: 1902
+  - uid: 1901
     components:
     - type: Transform
       pos: -15.5,-5.5
       parent: 2
-  - uid: 1903
+  - uid: 1902
     components:
     - type: Transform
       pos: -13.5,2.5
       parent: 2
-  - uid: 1904
+  - uid: 1903
     components:
     - type: Transform
       pos: -11.5,2.5
       parent: 2
-  - uid: 1905
+  - uid: 1904
     components:
     - type: Transform
       pos: -10.5,2.5
       parent: 2
-  - uid: 1906
+  - uid: 1905
     components:
     - type: Transform
       pos: -9.5,2.5
       parent: 2
-  - uid: 1907
+  - uid: 1906
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 2
-  - uid: 1908
+  - uid: 1907
     components:
     - type: Transform
       pos: -7.5,2.5
       parent: 2
-  - uid: 1909
+  - uid: 1908
     components:
     - type: Transform
       pos: -6.5,2.5
       parent: 2
-  - uid: 1910
+  - uid: 1909
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 2
-  - uid: 1911
+  - uid: 1910
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 2
-  - uid: 1912
+  - uid: 1911
     components:
     - type: Transform
       pos: -12.5,2.5
       parent: 2
-  - uid: 1913
+  - uid: 1912
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 2
-  - uid: 1914
+  - uid: 1913
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 2
-  - uid: 1915
+  - uid: 1914
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 2
-  - uid: 1916
+  - uid: 1915
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 2
-  - uid: 1917
+  - uid: 1916
     components:
     - type: Transform
       pos: 14.5,-25.5
       parent: 2
-  - uid: 1918
+  - uid: 1917
     components:
     - type: Transform
       pos: 13.5,-21.5
       parent: 2
-  - uid: 1919
+  - uid: 1918
     components:
     - type: Transform
       pos: 13.5,-22.5
       parent: 2
-  - uid: 1920
+  - uid: 1919
     components:
     - type: Transform
       pos: 12.5,-22.5
       parent: 2
-  - uid: 1921
+  - uid: 1920
     components:
     - type: Transform
       pos: 11.5,-22.5
       parent: 2
-  - uid: 1922
+  - uid: 1921
     components:
     - type: Transform
       pos: 10.5,-22.5
       parent: 2
-  - uid: 1923
+  - uid: 1922
     components:
     - type: Transform
       pos: 9.5,-22.5
       parent: 2
-  - uid: 1924
+  - uid: 1923
     components:
     - type: Transform
       pos: 8.5,-22.5
       parent: 2
-  - uid: 1925
+  - uid: 1924
     components:
     - type: Transform
       pos: 7.5,-22.5
       parent: 2
-  - uid: 1926
+  - uid: 1925
     components:
     - type: Transform
       pos: 6.5,-22.5
       parent: 2
-  - uid: 1927
+  - uid: 1926
     components:
     - type: Transform
       pos: 5.5,-22.5
       parent: 2
-  - uid: 1928
+  - uid: 1927
     components:
     - type: Transform
       pos: 14.5,-23.5
       parent: 2
-  - uid: 1929
+  - uid: 1928
     components:
     - type: Transform
       pos: 13.5,-23.5
       parent: 2
-  - uid: 1930
+  - uid: 1929
     components:
     - type: Transform
       pos: 14.5,-26.5
       parent: 2
-  - uid: 1931
+  - uid: 1930
     components:
     - type: Transform
       pos: 15.5,-26.5
       parent: 2
-  - uid: 1932
+  - uid: 1931
     components:
     - type: Transform
       pos: 14.5,-24.5
       parent: 2
-  - uid: 1933
+  - uid: 1932
     components:
     - type: Transform
       pos: 15.5,-27.5
       parent: 2
-  - uid: 1934
+  - uid: 1933
     components:
     - type: Transform
       pos: 16.5,-27.5
       parent: 2
-  - uid: 1935
+  - uid: 1934
     components:
     - type: Transform
       pos: 17.5,-27.5
       parent: 2
-  - uid: 1936
+  - uid: 1935
     components:
     - type: Transform
       pos: 18.5,-27.5
       parent: 2
-  - uid: 1937
+  - uid: 1936
     components:
     - type: Transform
       pos: 18.5,-28.5
       parent: 2
-  - uid: 1938
+  - uid: 1937
     components:
     - type: Transform
       pos: 17.5,-28.5
       parent: 2
-  - uid: 1939
+  - uid: 1938
     components:
     - type: Transform
       pos: 17.5,-29.5
       parent: 2
-  - uid: 1940
+  - uid: 1939
     components:
     - type: Transform
       pos: 17.5,-30.5
       parent: 2
-  - uid: 1941
+  - uid: 1940
     components:
     - type: Transform
       pos: 17.5,-31.5
       parent: 2
-  - uid: 1942
+  - uid: 1941
     components:
     - type: Transform
       pos: 18.5,-31.5
       parent: 2
-  - uid: 1943
+  - uid: 1942
     components:
     - type: Transform
       pos: 18.5,-32.5
       parent: 2
-  - uid: 1944
+  - uid: 1943
     components:
     - type: Transform
       pos: 19.5,-32.5
       parent: 2
-  - uid: 1945
+  - uid: 1944
     components:
     - type: Transform
       pos: 20.5,-32.5
       parent: 2
-  - uid: 1946
+  - uid: 1945
     components:
     - type: Transform
       pos: 21.5,-32.5
       parent: 2
-  - uid: 1947
+  - uid: 1946
     components:
     - type: Transform
       pos: 22.5,-32.5
       parent: 2
-  - uid: 1948
+  - uid: 1947
     components:
     - type: Transform
       pos: 23.5,-32.5
       parent: 2
-  - uid: 1949
+  - uid: 1948
     components:
     - type: Transform
       pos: 23.5,-30.5
       parent: 2
-  - uid: 1950
+  - uid: 1949
     components:
     - type: Transform
       pos: 23.5,-31.5
       parent: 2
-  - uid: 1951
+  - uid: 1950
     components:
     - type: Transform
       pos: 24.5,-31.5
       parent: 2
-  - uid: 1952
+  - uid: 1951
     components:
     - type: Transform
       pos: 25.5,-31.5
       parent: 2
-  - uid: 1953
+  - uid: 1952
     components:
     - type: Transform
       pos: 21.5,-28.5
       parent: 2
-  - uid: 1954
+  - uid: 1953
     components:
     - type: Transform
       pos: 21.5,-27.5
       parent: 2
-  - uid: 1955
+  - uid: 1954
     components:
     - type: Transform
       pos: 20.5,-27.5
       parent: 2
-  - uid: 1956
+  - uid: 1955
     components:
     - type: Transform
       pos: 22.5,-27.5
       parent: 2
-  - uid: 1957
+  - uid: 1956
     components:
     - type: Transform
       pos: 23.5,-27.5
       parent: 2
-  - uid: 1958
+  - uid: 1957
     components:
     - type: Transform
       pos: 24.5,-27.5
       parent: 2
-  - uid: 1959
+  - uid: 1958
     components:
     - type: Transform
       pos: 25.5,-27.5
       parent: 2
-  - uid: 1960
+  - uid: 1959
     components:
     - type: Transform
       pos: 26.5,-27.5
       parent: 2
-  - uid: 1961
+  - uid: 1960
     components:
     - type: Transform
       pos: 24.5,-28.5
       parent: 2
-  - uid: 1962
+  - uid: 1961
     components:
     - type: Transform
       pos: 25.5,-28.5
       parent: 2
-  - uid: 1963
+  - uid: 1962
     components:
     - type: Transform
       pos: 26.5,-28.5
       parent: 2
-  - uid: 1964
+  - uid: 1963
     components:
     - type: Transform
       pos: 27.5,-28.5
       parent: 2
-  - uid: 1965
+  - uid: 1964
     components:
     - type: Transform
       pos: 25.5,-29.5
       parent: 2
-  - uid: 1966
+  - uid: 1965
     components:
     - type: Transform
       pos: 26.5,-29.5
       parent: 2
-  - uid: 1967
+  - uid: 1966
     components:
     - type: Transform
       pos: 28.5,-28.5
       parent: 2
-  - uid: 1968
+  - uid: 1967
     components:
     - type: Transform
       pos: 29.5,-28.5
       parent: 2
-  - uid: 1969
+  - uid: 1968
     components:
     - type: Transform
       pos: 29.5,-29.5
       parent: 2
-  - uid: 1970
+  - uid: 1969
     components:
     - type: Transform
       pos: 30.5,-28.5
       parent: 2
-  - uid: 1971
+  - uid: 1970
     components:
     - type: Transform
       pos: 30.5,-29.5
       parent: 2
-  - uid: 1972
+  - uid: 1971
     components:
     - type: Transform
       pos: 31.5,-28.5
       parent: 2
-  - uid: 1973
+  - uid: 1972
     components:
     - type: Transform
       pos: 31.5,-29.5
       parent: 2
-  - uid: 1974
+  - uid: 1973
     components:
     - type: Transform
       pos: 31.5,-30.5
       parent: 2
-  - uid: 1975
+  - uid: 1974
     components:
     - type: Transform
       pos: 30.5,-30.5
       parent: 2
-  - uid: 1976
+  - uid: 1975
     components:
     - type: Transform
       pos: 30.5,-31.5
       parent: 2
-  - uid: 1977
+  - uid: 1976
     components:
     - type: Transform
       pos: 30.5,-32.5
       parent: 2
-  - uid: 1978
+  - uid: 1977
     components:
     - type: Transform
       pos: 30.5,-33.5
       parent: 2
-  - uid: 1979
+  - uid: 1978
     components:
     - type: Transform
       pos: 30.5,-34.5
       parent: 2
-  - uid: 1980
+  - uid: 1979
     components:
     - type: Transform
       pos: 29.5,-34.5
       parent: 2
-  - uid: 1981
+  - uid: 1980
     components:
     - type: Transform
       pos: 28.5,-34.5
       parent: 2
-  - uid: 1982
+  - uid: 1981
     components:
     - type: Transform
       pos: 27.5,-34.5
       parent: 2
-  - uid: 1983
+  - uid: 1982
     components:
     - type: Transform
       pos: 27.5,-33.5
       parent: 2
-  - uid: 1984
+  - uid: 1983
     components:
     - type: Transform
       pos: 26.5,-33.5
       parent: 2
-  - uid: 1985
+  - uid: 1984
     components:
     - type: Transform
       pos: 26.5,-32.5
       parent: 2
-  - uid: 1986
+  - uid: 1985
     components:
     - type: Transform
       pos: 25.5,-32.5
       parent: 2
-  - uid: 1987
+  - uid: 1986
     components:
     - type: Transform
       pos: 30.5,-27.5
       parent: 2
-  - uid: 1988
+  - uid: 1987
     components:
     - type: Transform
       pos: 31.5,-27.5
       parent: 2
-  - uid: 1989
+  - uid: 1988
     components:
     - type: Transform
       pos: 31.5,-26.5
       parent: 2
-  - uid: 1990
+  - uid: 1989
     components:
     - type: Transform
       pos: 31.5,-25.5
       parent: 2
-  - uid: 1991
+  - uid: 1990
     components:
     - type: Transform
       pos: 32.5,-25.5
       parent: 2
-  - uid: 1992
+  - uid: 1991
     components:
     - type: Transform
       pos: 33.5,-25.5
       parent: 2
-  - uid: 1993
+  - uid: 1992
     components:
     - type: Transform
       pos: 33.5,-24.5
       parent: 2
-  - uid: 1994
+  - uid: 1993
     components:
     - type: Transform
       pos: 34.5,-24.5
       parent: 2
-  - uid: 1995
+  - uid: 1994
     components:
     - type: Transform
       pos: 35.5,-24.5
       parent: 2
-  - uid: 1996
+  - uid: 1995
     components:
     - type: Transform
       pos: 35.5,-23.5
       parent: 2
-  - uid: 1997
+  - uid: 1996
     components:
     - type: Transform
       pos: 36.5,-23.5
       parent: 2
-  - uid: 1998
+  - uid: 1997
     components:
     - type: Transform
       pos: 37.5,-23.5
       parent: 2
-  - uid: 1999
+  - uid: 1998
     components:
     - type: Transform
       pos: 38.5,-23.5
       parent: 2
-  - uid: 2000
+  - uid: 1999
     components:
     - type: Transform
       pos: 38.5,-22.5
       parent: 2
-  - uid: 2001
+  - uid: 2000
     components:
     - type: Transform
       pos: 35.5,-22.5
       parent: 2
-  - uid: 2002
+  - uid: 2001
     components:
     - type: Transform
       pos: 35.5,-21.5
       parent: 2
-  - uid: 2003
+  - uid: 2002
     components:
     - type: Transform
       pos: 36.5,-21.5
       parent: 2
-  - uid: 2004
+  - uid: 2003
     components:
     - type: Transform
       pos: 37.5,-21.5
       parent: 2
-  - uid: 2005
+  - uid: 2004
     components:
     - type: Transform
       pos: 38.5,-21.5
       parent: 2
-  - uid: 2006
+  - uid: 2005
     components:
     - type: Transform
       pos: 36.5,-22.5
       parent: 2
-  - uid: 2007
+  - uid: 2006
     components:
     - type: Transform
       pos: 37.5,-22.5
       parent: 2
-  - uid: 2008
+  - uid: 2007
     components:
     - type: Transform
       pos: 39.5,-22.5
       parent: 2
-  - uid: 2009
+  - uid: 2008
     components:
     - type: Transform
       pos: 39.5,-21.5
       parent: 2
-  - uid: 2010
+  - uid: 2009
     components:
     - type: Transform
       pos: 37.5,-20.5
       parent: 2
-  - uid: 2011
+  - uid: 2010
     components:
     - type: Transform
       pos: 37.5,-19.5
       parent: 2
-  - uid: 2012
+  - uid: 2011
     components:
     - type: Transform
       pos: 37.5,-18.5
       parent: 2
-  - uid: 2013
+  - uid: 2012
     components:
     - type: Transform
       pos: 37.5,-17.5
       parent: 2
-  - uid: 2014
+  - uid: 2013
     components:
     - type: Transform
       pos: 37.5,-16.5
       parent: 2
-  - uid: 2015
+  - uid: 2014
     components:
     - type: Transform
       pos: 38.5,-20.5
       parent: 2
-  - uid: 2016
+  - uid: 2015
     components:
     - type: Transform
       pos: 38.5,-19.5
       parent: 2
-  - uid: 2017
+  - uid: 2016
     components:
     - type: Transform
       pos: 38.5,-18.5
       parent: 2
-  - uid: 2018
+  - uid: 2017
     components:
     - type: Transform
       pos: 38.5,-17.5
       parent: 2
-  - uid: 2019
+  - uid: 2018
     components:
     - type: Transform
       pos: 38.5,-16.5
       parent: 2
-  - uid: 2020
+  - uid: 2019
     components:
     - type: Transform
       pos: 39.5,-20.5
       parent: 2
-  - uid: 2021
+  - uid: 2020
     components:
     - type: Transform
       pos: 39.5,-19.5
       parent: 2
-  - uid: 2022
+  - uid: 2021
     components:
     - type: Transform
       pos: 39.5,-18.5
       parent: 2
-  - uid: 2023
+  - uid: 2022
     components:
     - type: Transform
       pos: 39.5,-17.5
       parent: 2
-  - uid: 2024
+  - uid: 2023
     components:
     - type: Transform
       pos: 39.5,-16.5
       parent: 2
-  - uid: 2025
+  - uid: 2024
     components:
     - type: Transform
       pos: 40.5,-17.5
       parent: 2
-  - uid: 2026
+  - uid: 2025
     components:
     - type: Transform
       pos: 41.5,-17.5
       parent: 2
-  - uid: 2027
+  - uid: 2026
     components:
     - type: Transform
       pos: 42.5,-17.5
       parent: 2
-  - uid: 2028
+  - uid: 2027
     components:
     - type: Transform
       pos: 43.5,-17.5
       parent: 2
-  - uid: 2029
+  - uid: 2028
     components:
     - type: Transform
       pos: 43.5,-16.5
       parent: 2
-  - uid: 2030
+  - uid: 2029
     components:
     - type: Transform
       pos: 43.5,-15.5
       parent: 2
-  - uid: 2031
+  - uid: 2030
     components:
     - type: Transform
       pos: 44.5,-17.5
       parent: 2
-  - uid: 2032
+  - uid: 2031
     components:
     - type: Transform
       pos: 44.5,-16.5
       parent: 2
-  - uid: 2033
+  - uid: 2032
     components:
     - type: Transform
       pos: 44.5,-15.5
       parent: 2
-  - uid: 2034
+  - uid: 2033
     components:
     - type: Transform
       pos: 45.5,-17.5
       parent: 2
-  - uid: 2035
+  - uid: 2034
     components:
     - type: Transform
       pos: 45.5,-16.5
       parent: 2
-  - uid: 2036
+  - uid: 2035
     components:
     - type: Transform
       pos: 45.5,-15.5
       parent: 2
-  - uid: 2037
+  - uid: 2036
     components:
     - type: Transform
       pos: 46.5,-17.5
       parent: 2
-  - uid: 2038
+  - uid: 2037
     components:
     - type: Transform
       pos: 46.5,-16.5
       parent: 2
-  - uid: 2039
+  - uid: 2038
     components:
     - type: Transform
       pos: 46.5,-15.5
       parent: 2
-  - uid: 2040
+  - uid: 2039
     components:
     - type: Transform
       pos: 44.5,-14.5
       parent: 2
-  - uid: 2041
+  - uid: 2040
     components:
     - type: Transform
       pos: 45.5,-14.5
       parent: 2
-  - uid: 2042
+  - uid: 2041
     components:
     - type: Transform
       pos: 46.5,-14.5
       parent: 2
-  - uid: 2043
+  - uid: 2042
     components:
     - type: Transform
       pos: 37.5,-15.5
       parent: 2
-  - uid: 2044
+  - uid: 2043
     components:
     - type: Transform
       pos: 38.5,-15.5
       parent: 2
-  - uid: 2045
+  - uid: 2044
     components:
     - type: Transform
       pos: 39.5,-15.5
       parent: 2
-  - uid: 2046
+  - uid: 2045
     components:
     - type: Transform
       pos: 40.5,-16.5
       parent: 2
-  - uid: 2047
+  - uid: 2046
     components:
     - type: Transform
       pos: 41.5,-16.5
       parent: 2
-  - uid: 2048
+  - uid: 2047
     components:
     - type: Transform
       pos: 42.5,-16.5
       parent: 2
-  - uid: 2049
+  - uid: 2048
     components:
     - type: Transform
       pos: 43.5,-14.5
       parent: 2
-  - uid: 2050
+  - uid: 2049
     components:
     - type: Transform
       pos: 44.5,-13.5
       parent: 2
-  - uid: 2051
+  - uid: 2050
     components:
     - type: Transform
       pos: 8.5,12.5
       parent: 2
-  - uid: 2052
+  - uid: 2051
     components:
     - type: Transform
       pos: 7.5,12.5
       parent: 2
-  - uid: 2053
+  - uid: 2052
     components:
     - type: Transform
       pos: 6.5,12.5
       parent: 2
-  - uid: 2054
+  - uid: 2053
     components:
     - type: Transform
       pos: 5.5,12.5
       parent: 2
-  - uid: 2055
+  - uid: 2054
     components:
     - type: Transform
       pos: 4.5,12.5
       parent: 2
-  - uid: 2056
+  - uid: 2055
     components:
     - type: Transform
       pos: 3.5,12.5
       parent: 2
-  - uid: 2057
+  - uid: 2056
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 2
-  - uid: 2058
+  - uid: 2057
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 2
-  - uid: 2059
+  - uid: 2058
     components:
     - type: Transform
       pos: 1.5,11.5
       parent: 2
-  - uid: 2060
+  - uid: 2059
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 2
-  - uid: 2061
+  - uid: 2060
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 2
-  - uid: 2062
+  - uid: 2061
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 2
-  - uid: 2063
+  - uid: 2062
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 2
-  - uid: 2064
+  - uid: 2063
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 2
-  - uid: 2065
+  - uid: 2064
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 2
-  - uid: 2066
+  - uid: 2065
     components:
     - type: Transform
       pos: -4.5,10.5
       parent: 2
-  - uid: 2067
+  - uid: 2066
     components:
     - type: Transform
       pos: -5.5,10.5
       parent: 2
-  - uid: 2068
+  - uid: 2067
     components:
     - type: Transform
       pos: -5.5,9.5
       parent: 2
-  - uid: 2069
+  - uid: 2068
     components:
     - type: Transform
       pos: -6.5,9.5
       parent: 2
-  - uid: 2070
+  - uid: 2069
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 2
-  - uid: 2071
+  - uid: 2070
     components:
     - type: Transform
       pos: -5.5,8.5
       parent: 2
-  - uid: 2072
+  - uid: 2071
     components:
     - type: Transform
       pos: -6.5,8.5
       parent: 2
-  - uid: 2073
+  - uid: 2072
     components:
     - type: Transform
       pos: -7.5,8.5
       parent: 2
-  - uid: 2074
+  - uid: 2073
     components:
     - type: Transform
       pos: -8.5,8.5
       parent: 2
-  - uid: 2075
+  - uid: 2074
     components:
     - type: Transform
       pos: -9.5,8.5
       parent: 2
-  - uid: 2076
+  - uid: 2075
     components:
     - type: Transform
       pos: -10.5,8.5
       parent: 2
-  - uid: 2077
+  - uid: 2076
     components:
     - type: Transform
       pos: -6.5,7.5
       parent: 2
-  - uid: 2078
+  - uid: 2077
     components:
     - type: Transform
       pos: -7.5,7.5
       parent: 2
-  - uid: 2079
+  - uid: 2078
     components:
     - type: Transform
       pos: -8.5,7.5
       parent: 2
-  - uid: 2080
+  - uid: 2079
     components:
     - type: Transform
       pos: -9.5,7.5
       parent: 2
-  - uid: 2081
+  - uid: 2080
     components:
     - type: Transform
       pos: -10.5,7.5
       parent: 2
-  - uid: 2082
+  - uid: 2081
     components:
     - type: Transform
       pos: -8.5,6.5
       parent: 2
-  - uid: 2083
+  - uid: 2082
     components:
     - type: Transform
       pos: -9.5,6.5
       parent: 2
-  - uid: 2084
+  - uid: 2083
     components:
     - type: Transform
       pos: -10.5,6.5
       parent: 2
-  - uid: 2085
+  - uid: 2084
     components:
     - type: Transform
       pos: -11.5,6.5
       parent: 2
-  - uid: 2086
+  - uid: 2085
     components:
     - type: Transform
       pos: -12.5,6.5
       parent: 2
-  - uid: 2087
+  - uid: 2086
     components:
     - type: Transform
       pos: -13.5,6.5
       parent: 2
-  - uid: 2088
+  - uid: 2087
     components:
     - type: Transform
       pos: -14.5,6.5
       parent: 2
-  - uid: 2089
+  - uid: 2088
     components:
     - type: Transform
       pos: -11.5,5.5
       parent: 2
-  - uid: 2090
+  - uid: 2089
     components:
     - type: Transform
       pos: -12.5,5.5
       parent: 2
-  - uid: 2091
+  - uid: 2090
     components:
     - type: Transform
       pos: -13.5,5.5
       parent: 2
-  - uid: 2092
+  - uid: 2091
     components:
     - type: Transform
       pos: -14.5,5.5
       parent: 2
-  - uid: 2093
+  - uid: 2092
     components:
     - type: Transform
       pos: -15.5,5.5
       parent: 2
-  - uid: 2094
+  - uid: 2093
     components:
     - type: Transform
       pos: -16.5,5.5
       parent: 2
-  - uid: 2095
+  - uid: 2094
     components:
     - type: Transform
       pos: -13.5,4.5
       parent: 2
-  - uid: 2096
+  - uid: 2095
     components:
     - type: Transform
       pos: -14.5,4.5
       parent: 2
-  - uid: 2097
+  - uid: 2096
     components:
     - type: Transform
       pos: -15.5,4.5
       parent: 2
-  - uid: 2098
+  - uid: 2097
     components:
     - type: Transform
       pos: -16.5,4.5
       parent: 2
-  - uid: 2099
+  - uid: 2098
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 2
-  - uid: 2100
+  - uid: 2099
     components:
     - type: Transform
       pos: -2.5,11.5
       parent: 2
-  - uid: 2101
+  - uid: 2100
     components:
     - type: Transform
       pos: -14.5,3.5
       parent: 2
-  - uid: 2102
+  - uid: 2101
     components:
     - type: Transform
       pos: -15.5,3.5
       parent: 2
-  - uid: 2103
+  - uid: 2102
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 2
-  - uid: 2104
+  - uid: 2103
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 2
-  - uid: 2105
+  - uid: 2104
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 2
-  - uid: 2106
+  - uid: 2105
     components:
     - type: Transform
       pos: 3.5,13.5
       parent: 2
-  - uid: 2107
+  - uid: 2106
     components:
     - type: Transform
       pos: 4.5,13.5
       parent: 2
-  - uid: 2108
+  - uid: 2107
     components:
     - type: Transform
       pos: 5.5,13.5
       parent: 2
-  - uid: 2109
+  - uid: 2108
     components:
     - type: Transform
       pos: 6.5,13.5
       parent: 2
-  - uid: 2110
+  - uid: 2109
     components:
     - type: Transform
       pos: 7.5,13.5
       parent: 2
-  - uid: 2111
+  - uid: 2110
     components:
     - type: Transform
       pos: 8.5,13.5
       parent: 2
-  - uid: 2112
+  - uid: 2111
     components:
     - type: Transform
       pos: 9.5,13.5
       parent: 2
-  - uid: 2113
+  - uid: 2112
     components:
     - type: Transform
       pos: 6.5,14.5
       parent: 2
-  - uid: 2114
+  - uid: 2113
     components:
     - type: Transform
       pos: 7.5,14.5
       parent: 2
-  - uid: 2115
+  - uid: 2114
     components:
     - type: Transform
       pos: 8.5,14.5
       parent: 2
-  - uid: 2116
+  - uid: 2115
     components:
     - type: Transform
       pos: 9.5,14.5
       parent: 2
-  - uid: 2117
+  - uid: 2116
     components:
     - type: Transform
       pos: 10.5,14.5
       parent: 2
-  - uid: 2118
+  - uid: 2117
     components:
     - type: Transform
       pos: 11.5,14.5
       parent: 2
-  - uid: 2119
+  - uid: 2118
     components:
     - type: Transform
       pos: 12.5,14.5
       parent: 2
-  - uid: 2120
+  - uid: 2119
     components:
     - type: Transform
       pos: 10.5,15.5
       parent: 2
-  - uid: 2121
+  - uid: 2120
     components:
     - type: Transform
       pos: 11.5,15.5
       parent: 2
-  - uid: 2122
+  - uid: 2121
     components:
     - type: Transform
       pos: 12.5,15.5
       parent: 2
-  - uid: 2123
+  - uid: 2122
     components:
     - type: Transform
       pos: 13.5,15.5
       parent: 2
-  - uid: 2124
+  - uid: 2123
     components:
     - type: Transform
       pos: 14.5,15.5
       parent: 2
-  - uid: 2125
+  - uid: 2124
     components:
     - type: Transform
       pos: 15.5,15.5
       parent: 2
-  - uid: 2126
+  - uid: 2125
     components:
     - type: Transform
       pos: 12.5,16.5
       parent: 2
-  - uid: 2127
+  - uid: 2126
     components:
     - type: Transform
       pos: 13.5,16.5
       parent: 2
-  - uid: 2128
+  - uid: 2127
     components:
     - type: Transform
       pos: 14.5,16.5
       parent: 2
-  - uid: 2129
+  - uid: 2128
     components:
     - type: Transform
       pos: 15.5,16.5
       parent: 2
-  - uid: 2130
+  - uid: 2129
     components:
     - type: Transform
       pos: 16.5,16.5
       parent: 2
-  - uid: 2131
+  - uid: 2130
     components:
     - type: Transform
       pos: 14.5,17.5
       parent: 2
-  - uid: 2132
+  - uid: 2131
     components:
     - type: Transform
       pos: 15.5,17.5
       parent: 2
-  - uid: 2133
+  - uid: 2132
     components:
     - type: Transform
       pos: 17.5,17.5
       parent: 2
-  - uid: 2134
+  - uid: 2133
     components:
     - type: Transform
       pos: 18.5,17.5
       parent: 2
-  - uid: 2135
+  - uid: 2134
     components:
     - type: Transform
       pos: 16.5,17.5
       parent: 2
-  - uid: 2136
+  - uid: 2135
     components:
     - type: Transform
       pos: 16.5,18.5
       parent: 2
-  - uid: 2137
+  - uid: 2136
     components:
     - type: Transform
       pos: 17.5,18.5
       parent: 2
-  - uid: 2138
+  - uid: 2137
     components:
     - type: Transform
       pos: 18.5,18.5
       parent: 2
-  - uid: 2139
+  - uid: 2138
     components:
     - type: Transform
       pos: 19.5,18.5
       parent: 2
-  - uid: 2140
+  - uid: 2139
     components:
     - type: Transform
       pos: 20.5,18.5
       parent: 2
-  - uid: 2141
+  - uid: 2140
     components:
     - type: Transform
       pos: 21.5,18.5
       parent: 2
-  - uid: 2142
+  - uid: 2141
     components:
     - type: Transform
       pos: 22.5,18.5
       parent: 2
-  - uid: 2143
+  - uid: 2142
     components:
     - type: Transform
       pos: 23.5,18.5
       parent: 2
-  - uid: 2144
+  - uid: 2143
     components:
     - type: Transform
       pos: 24.5,18.5
       parent: 2
-  - uid: 2145
+  - uid: 2144
     components:
     - type: Transform
       pos: 25.5,18.5
       parent: 2
-  - uid: 2146
+  - uid: 2145
     components:
     - type: Transform
       pos: 26.5,18.5
       parent: 2
-  - uid: 2147
+  - uid: 2146
     components:
     - type: Transform
       pos: 27.5,18.5
       parent: 2
-  - uid: 2148
+  - uid: 2147
     components:
     - type: Transform
       pos: 28.5,18.5
       parent: 2
-  - uid: 2149
+  - uid: 2148
     components:
     - type: Transform
       pos: 29.5,18.5
       parent: 2
-  - uid: 2150
+  - uid: 2149
     components:
     - type: Transform
       pos: 30.5,18.5
       parent: 2
-  - uid: 2151
+  - uid: 2150
     components:
     - type: Transform
       pos: 31.5,18.5
       parent: 2
-  - uid: 2152
+  - uid: 2151
     components:
     - type: Transform
       pos: 32.5,18.5
       parent: 2
-  - uid: 2153
+  - uid: 2152
     components:
     - type: Transform
       pos: 33.5,18.5
       parent: 2
-  - uid: 2154
+  - uid: 2153
     components:
     - type: Transform
       pos: 34.5,18.5
       parent: 2
-  - uid: 2155
+  - uid: 2154
     components:
     - type: Transform
       pos: 35.5,18.5
       parent: 2
-  - uid: 2156
+  - uid: 2155
     components:
     - type: Transform
       pos: 36.5,18.5
       parent: 2
-  - uid: 2157
+  - uid: 2156
     components:
     - type: Transform
       pos: 37.5,18.5
       parent: 2
-  - uid: 2158
+  - uid: 2157
     components:
     - type: Transform
       pos: 38.5,18.5
       parent: 2
-  - uid: 2159
+  - uid: 2158
     components:
     - type: Transform
       pos: 39.5,18.5
       parent: 2
-  - uid: 2160
+  - uid: 2159
     components:
     - type: Transform
       pos: 40.5,18.5
       parent: 2
-  - uid: 2161
+  - uid: 2160
     components:
     - type: Transform
       pos: 41.5,18.5
       parent: 2
-  - uid: 2162
+  - uid: 2161
     components:
     - type: Transform
       pos: 42.5,18.5
       parent: 2
-  - uid: 2163
+  - uid: 2162
     components:
     - type: Transform
       pos: 43.5,18.5
       parent: 2
-  - uid: 2164
+  - uid: 2163
     components:
     - type: Transform
       pos: 44.5,18.5
       parent: 2
-  - uid: 2165
+  - uid: 2164
     components:
     - type: Transform
       pos: 46.5,18.5
       parent: 2
-  - uid: 2166
+  - uid: 2165
     components:
     - type: Transform
       pos: 45.5,18.5
       parent: 2
-  - uid: 2167
+  - uid: 2166
     components:
     - type: Transform
       pos: 47.5,18.5
       parent: 2
-  - uid: 2168
+  - uid: 2167
     components:
     - type: Transform
       pos: 48.5,18.5
       parent: 2
-  - uid: 2169
+  - uid: 2168
     components:
     - type: Transform
       pos: 48.5,19.5
       parent: 2
 - proto: WallSnowCobblebrick
   entities:
-  - uid: 2170
+  - uid: 2169
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,2.5
       parent: 2
-  - uid: 2171
+  - uid: 2170
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,1.5
       parent: 2
-  - uid: 2172
+  - uid: 2171
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,0.5
       parent: 2
-  - uid: 2173
+  - uid: 2172
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-0.5
       parent: 2
-  - uid: 2174
+  - uid: 2173
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-1.5
       parent: 2
-  - uid: 2175
+  - uid: 2174
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-2.5
       parent: 2
-  - uid: 2176
+  - uid: 2175
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-3.5
       parent: 2
-  - uid: 2177
+  - uid: 2176
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-4.5
       parent: 2
-  - uid: 2178
+  - uid: 2177
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-5.5
       parent: 2
-  - uid: 2179
+  - uid: 2178
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-6.5
       parent: 2
-  - uid: 2180
+  - uid: 2179
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-6.5
       parent: 2
-  - uid: 2181
+  - uid: 2180
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-7.5
       parent: 2
-  - uid: 2182
+  - uid: 2181
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-7.5
       parent: 2
-  - uid: 2183
+  - uid: 2182
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-8.5
       parent: 2
-  - uid: 2184
+  - uid: 2183
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-9.5
       parent: 2
-  - uid: 2185
+  - uid: 2184
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-9.5
       parent: 2
-  - uid: 2186
+  - uid: 2185
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-10.5
       parent: 2
-  - uid: 2187
+  - uid: 2186
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-11.5
       parent: 2
-  - uid: 2188
+  - uid: 2187
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-12.5
       parent: 2
-  - uid: 2189
+  - uid: 2188
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-13.5
       parent: 2
-  - uid: 2190
+  - uid: 2189
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-14.5
       parent: 2
-  - uid: 2191
+  - uid: 2190
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-15.5
       parent: 2
-  - uid: 2192
+  - uid: 2191
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-16.5
       parent: 2
-  - uid: 2193
+  - uid: 2192
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-17.5
       parent: 2
-  - uid: 2194
+  - uid: 2193
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-18.5
       parent: 2
-  - uid: 2195
+  - uid: 2194
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,-19.5
       parent: 2
-  - uid: 2196
+  - uid: 2195
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-19.5
       parent: 2
-  - uid: 2197
+  - uid: 2196
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,-19.5
       parent: 2
-  - uid: 2198
+  - uid: 2197
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,-19.5
       parent: 2
-  - uid: 2199
+  - uid: 2198
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-19.5
       parent: 2
-  - uid: 2200
+  - uid: 2199
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,-19.5
       parent: 2
-  - uid: 2201
+  - uid: 2200
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,-19.5
       parent: 2
-  - uid: 2202
+  - uid: 2201
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,-19.5
       parent: 2
-  - uid: 2203
+  - uid: 2202
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,-19.5
       parent: 2
-  - uid: 2204
+  - uid: 2203
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-19.5
       parent: 2
-  - uid: 2205
+  - uid: 2204
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-19.5
       parent: 2
-  - uid: 2206
+  - uid: 2205
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-20.5
       parent: 2
-  - uid: 2207
+  - uid: 2206
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-21.5
       parent: 2
-  - uid: 2208
+  - uid: 2207
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-22.5
       parent: 2
-  - uid: 2209
+  - uid: 2208
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-23.5
       parent: 2
-  - uid: 2210
+  - uid: 2209
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-23.5
       parent: 2
-  - uid: 2211
+  - uid: 2210
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-23.5
       parent: 2
-  - uid: 2212
+  - uid: 2211
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,-23.5
       parent: 2
-  - uid: 2213
+  - uid: 2212
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-23.5
       parent: 2
-  - uid: 2214
+  - uid: 2213
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-23.5
       parent: 2
-  - uid: 2215
+  - uid: 2214
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-23.5
       parent: 2
-  - uid: 2216
+  - uid: 2215
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-23.5
       parent: 2
-  - uid: 2217
+  - uid: 2216
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-23.5
       parent: 2
-  - uid: 2218
+  - uid: 2217
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-23.5
       parent: 2
-  - uid: 2219
+  - uid: 2218
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-23.5
       parent: 2
-  - uid: 2220
+  - uid: 2219
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-23.5
       parent: 2
-  - uid: 2221
+  - uid: 2220
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-23.5
       parent: 2
-  - uid: 2222
+  - uid: 2221
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-23.5
       parent: 2
-  - uid: 2223
+  - uid: 2222
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-23.5
       parent: 2
-  - uid: 2224
+  - uid: 2223
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-23.5
       parent: 2
-  - uid: 2225
+  - uid: 2224
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-23.5
       parent: 2
-  - uid: 2226
+  - uid: 2225
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-23.5
       parent: 2
-  - uid: 2227
+  - uid: 2226
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-23.5
       parent: 2
-  - uid: 2228
+  - uid: 2227
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-23.5
       parent: 2
-  - uid: 2229
+  - uid: 2228
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,-24.5
       parent: 2
-  - uid: 2230
+  - uid: 2229
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,-24.5
       parent: 2
-  - uid: 2231
+  - uid: 2230
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,-25.5
       parent: 2
-  - uid: 2232
+  - uid: 2231
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,-26.5
       parent: 2
-  - uid: 2233
+  - uid: 2232
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,-27.5
       parent: 2
-  - uid: 2234
+  - uid: 2233
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-27.5
       parent: 2
-  - uid: 2235
+  - uid: 2234
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-28.5
       parent: 2
-  - uid: 2236
+  - uid: 2235
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,-28.5
       parent: 2
-  - uid: 2237
+  - uid: 2236
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-28.5
       parent: 2
-  - uid: 2238
+  - uid: 2237
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-29.5
       parent: 2
-  - uid: 2239
+  - uid: 2238
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-30.5
       parent: 2
-  - uid: 2240
+  - uid: 2239
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-31.5
       parent: 2
-  - uid: 2241
+  - uid: 2240
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-32.5
       parent: 2
-  - uid: 2242
+  - uid: 2241
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,-32.5
       parent: 2
-  - uid: 2243
+  - uid: 2242
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,-33.5
       parent: 2
-  - uid: 2244
+  - uid: 2243
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,-33.5
       parent: 2
-  - uid: 2245
+  - uid: 2244
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,-33.5
       parent: 2
-  - uid: 2246
+  - uid: 2245
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 20.5,-33.5
       parent: 2
-  - uid: 2247
+  - uid: 2246
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,-33.5
       parent: 2
-  - uid: 2248
+  - uid: 2247
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,-33.5
       parent: 2
-  - uid: 2249
+  - uid: 2248
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,-33.5
       parent: 2
-  - uid: 2250
+  - uid: 2249
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,-32.5
       parent: 2
-  - uid: 2251
+  - uid: 2250
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,-33.5
       parent: 2
-  - uid: 2252
+  - uid: 2251
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,-33.5
       parent: 2
-  - uid: 2253
+  - uid: 2252
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,-34.5
       parent: 2
-  - uid: 2254
+  - uid: 2253
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 26.5,-34.5
       parent: 2
-  - uid: 2255
+  - uid: 2254
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 26.5,-35.5
       parent: 2
-  - uid: 2256
+  - uid: 2255
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,-35.5
       parent: 2
-  - uid: 2257
+  - uid: 2256
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 28.5,-35.5
       parent: 2
-  - uid: 2258
+  - uid: 2257
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 29.5,-35.5
       parent: 2
-  - uid: 2259
+  - uid: 2258
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 30.5,-35.5
       parent: 2
-  - uid: 2260
+  - uid: 2259
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.5,-35.5
       parent: 2
-  - uid: 2261
+  - uid: 2260
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.5,-34.5
       parent: 2
-  - uid: 2262
+  - uid: 2261
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.5,-33.5
       parent: 2
-  - uid: 2263
+  - uid: 2262
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.5,-32.5
       parent: 2
-  - uid: 2264
+  - uid: 2263
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.5,-31.5
       parent: 2
-  - uid: 2265
+  - uid: 2264
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 43.5,19.5
       parent: 2
-  - uid: 2266
+  - uid: 2265
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 25.5,19.5
       parent: 2
-  - uid: 2267
+  - uid: 2266
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 26.5,19.5
       parent: 2
-  - uid: 2268
+  - uid: 2267
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,19.5
       parent: 2
-  - uid: 2269
+  - uid: 2268
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 19.5,19.5
       parent: 2
-  - uid: 2270
+  - uid: 2269
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,19.5
       parent: 2
-  - uid: 2271
+  - uid: 2270
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,19.5
       parent: 2
-  - uid: 2272
+  - uid: 2271
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 20.5,19.5
       parent: 2
-  - uid: 2273
+  - uid: 2272
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,19.5
       parent: 2
-  - uid: 2274
+  - uid: 2273
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 17.5,19.5
       parent: 2
-  - uid: 2275
+  - uid: 2274
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 18.5,19.5
       parent: 2
-  - uid: 2276
+  - uid: 2275
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,19.5
       parent: 2
-  - uid: 2277
+  - uid: 2276
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,19.5
       parent: 2
-  - uid: 2278
+  - uid: 2277
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 45.5,19.5
       parent: 2
-  - uid: 2279
+  - uid: 2278
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 46.5,19.5
       parent: 2
-  - uid: 2280
+  - uid: 2279
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 44.5,19.5
       parent: 2
-  - uid: 2281
+  - uid: 2280
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 42.5,19.5
       parent: 2
-  - uid: 2282
+  - uid: 2281
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 40.5,19.5
       parent: 2
-  - uid: 2283
+  - uid: 2282
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,19.5
       parent: 2
-  - uid: 2284
+  - uid: 2283
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,19.5
       parent: 2
-  - uid: 2285
+  - uid: 2284
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 39.5,19.5
       parent: 2
-  - uid: 2286
+  - uid: 2285
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 36.5,19.5
       parent: 2
-  - uid: 2287
+  - uid: 2286
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 37.5,19.5
       parent: 2
-  - uid: 2288
+  - uid: 2287
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,19.5
       parent: 2
-  - uid: 2289
+  - uid: 2288
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 35.5,19.5
       parent: 2
-  - uid: 2290
+  - uid: 2289
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 32.5,19.5
       parent: 2
-  - uid: 2291
+  - uid: 2290
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 33.5,19.5
       parent: 2
-  - uid: 2292
+  - uid: 2291
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 30.5,19.5
       parent: 2
-  - uid: 2293
+  - uid: 2292
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 31.5,19.5
       parent: 2
-  - uid: 2294
+  - uid: 2293
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 29.5,19.5
       parent: 2
-  - uid: 2295
+  - uid: 2294
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 28.5,19.5
       parent: 2
-  - uid: 2296
+  - uid: 2295
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,18.5
       parent: 2
-  - uid: 2297
+  - uid: 2296
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 27.5,19.5
       parent: 2
-  - uid: 2298
+  - uid: 2297
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,18.5
       parent: 2
-  - uid: 2299
+  - uid: 2298
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,18.5
       parent: 2
-  - uid: 2300
+  - uid: 2299
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,17.5
       parent: 2
-  - uid: 2301
+  - uid: 2300
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,17.5
       parent: 2
-  - uid: 2302
+  - uid: 2301
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,16.5
       parent: 2
-  - uid: 2303
+  - uid: 2302
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,17.5
       parent: 2
-  - uid: 2304
+  - uid: 2303
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,16.5
       parent: 2
-  - uid: 2305
+  - uid: 2304
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,16.5
       parent: 2
-  - uid: 2306
+  - uid: 2305
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,15.5
       parent: 2
-  - uid: 2307
+  - uid: 2306
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,15.5
       parent: 2
-  - uid: 2308
+  - uid: 2307
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,15.5
       parent: 2
-  - uid: 2309
+  - uid: 2308
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,15.5
       parent: 2
-  - uid: 2310
+  - uid: 2309
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,15.5
       parent: 2
-  - uid: 2311
+  - uid: 2310
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,14.5
       parent: 2
-  - uid: 2312
+  - uid: 2311
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,14.5
       parent: 2
-  - uid: 2313
+  - uid: 2312
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,14.5
       parent: 2
-  - uid: 2314
+  - uid: 2313
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,14.5
       parent: 2
-  - uid: 2315
+  - uid: 2314
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,14.5
       parent: 2
-  - uid: 2316
+  - uid: 2315
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,13.5
       parent: 2
-  - uid: 2317
+  - uid: 2316
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,13.5
       parent: 2
-  - uid: 2318
+  - uid: 2317
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,13.5
       parent: 2
-  - uid: 2319
+  - uid: 2318
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,12.5
       parent: 2
-  - uid: 2320
+  - uid: 2319
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,12.5
       parent: 2
-  - uid: 2321
+  - uid: 2320
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,12.5
       parent: 2
-  - uid: 2322
+  - uid: 2321
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,12.5
       parent: 2
-  - uid: 2323
+  - uid: 2322
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,11.5
       parent: 2
-  - uid: 2324
+  - uid: 2323
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,11.5
       parent: 2
-  - uid: 2325
+  - uid: 2324
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,11.5
       parent: 2
-  - uid: 2326
+  - uid: 2325
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,11.5
       parent: 2
-  - uid: 2327
+  - uid: 2326
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,10.5
       parent: 2
-  - uid: 2328
+  - uid: 2327
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,10.5
       parent: 2
-  - uid: 2329
+  - uid: 2328
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,9.5
       parent: 2
-  - uid: 2330
+  - uid: 2329
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -8.5,9.5
       parent: 2
-  - uid: 2331
+  - uid: 2330
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -9.5,9.5
       parent: 2
-  - uid: 2332
+  - uid: 2331
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,9.5
       parent: 2
-  - uid: 2333
+  - uid: 2332
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,9.5
       parent: 2
-  - uid: 2334
+  - uid: 2333
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,8.5
       parent: 2
-  - uid: 2335
+  - uid: 2334
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,7.5
       parent: 2
-  - uid: 2336
+  - uid: 2335
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,7.5
       parent: 2
-  - uid: 2337
+  - uid: 2336
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -13.5,7.5
       parent: 2
-  - uid: 2338
+  - uid: 2337
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -14.5,7.5
       parent: 2
-  - uid: 2339
+  - uid: 2338
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,7.5
       parent: 2
-  - uid: 2340
+  - uid: 2339
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,6.5
       parent: 2
-  - uid: 2341
+  - uid: 2340
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,6.5
       parent: 2
-  - uid: 2342
+  - uid: 2341
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,6.5
       parent: 2
-  - uid: 2343
+  - uid: 2342
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,5.5
       parent: 2
-  - uid: 2344
+  - uid: 2343
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,4.5
       parent: 2
-  - uid: 2345
+  - uid: 2344
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -17.5,3.5
       parent: 2
-  - uid: 2346
+  - uid: 2345
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,3.5
       parent: 2
-  - uid: 2347
+  - uid: 2346
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 47.5,19.5
       parent: 2
-  - uid: 2348
+  - uid: 2347
     components:
     - type: Transform
       pos: 32.5,-31.5
       parent: 2
-  - uid: 2349
+  - uid: 2348
     components:
     - type: Transform
       pos: 32.5,-30.5
       parent: 2
-  - uid: 2350
+  - uid: 2349
     components:
     - type: Transform
       pos: 32.5,-29.5
       parent: 2
-  - uid: 2351
+  - uid: 2350
     components:
     - type: Transform
       pos: 32.5,-28.5
       parent: 2
-  - uid: 2352
+  - uid: 2351
     components:
     - type: Transform
       pos: 32.5,-27.5
       parent: 2
-  - uid: 2353
+  - uid: 2352
     components:
     - type: Transform
       pos: 32.5,-26.5
       parent: 2
-  - uid: 2354
+  - uid: 2353
     components:
     - type: Transform
       pos: 33.5,-26.5
       parent: 2
-  - uid: 2355
+  - uid: 2354
     components:
     - type: Transform
       pos: 34.5,-26.5
       parent: 2
-  - uid: 2356
+  - uid: 2355
     components:
     - type: Transform
       pos: 34.5,-25.5
       parent: 2
-  - uid: 2357
+  - uid: 2356
     components:
     - type: Transform
       pos: 35.5,-25.5
       parent: 2
-  - uid: 2358
+  - uid: 2357
     components:
     - type: Transform
       pos: 36.5,-25.5
       parent: 2
-  - uid: 2359
+  - uid: 2358
     components:
     - type: Transform
       pos: 36.5,-24.5
       parent: 2
-  - uid: 2360
+  - uid: 2359
     components:
     - type: Transform
       pos: 37.5,-24.5
       parent: 2
-  - uid: 2361
+  - uid: 2360
     components:
     - type: Transform
       pos: 38.5,-24.5
       parent: 2
-  - uid: 2362
+  - uid: 2361
     components:
     - type: Transform
       pos: 39.5,-24.5
       parent: 2
-  - uid: 2363
+  - uid: 2362
     components:
     - type: Transform
       pos: 39.5,-23.5
       parent: 2
-  - uid: 2364
+  - uid: 2363
     components:
     - type: Transform
       pos: 40.5,-23.5
       parent: 2
-  - uid: 2365
+  - uid: 2364
     components:
     - type: Transform
       pos: 40.5,-22.5
       parent: 2
-  - uid: 2366
+  - uid: 2365
     components:
     - type: Transform
       pos: 40.5,-21.5
       parent: 2
-  - uid: 2367
+  - uid: 2366
     components:
     - type: Transform
       pos: 40.5,-20.5
       parent: 2
-  - uid: 2368
+  - uid: 2367
     components:
     - type: Transform
       pos: 40.5,-19.5
       parent: 2
-  - uid: 2369
+  - uid: 2368
     components:
     - type: Transform
       pos: 40.5,-18.5
       parent: 2
-  - uid: 2370
+  - uid: 2369
     components:
     - type: Transform
       pos: 41.5,-18.5
       parent: 2
-  - uid: 2371
+  - uid: 2370
     components:
     - type: Transform
       pos: 42.5,-18.5
       parent: 2
-  - uid: 2372
+  - uid: 2371
     components:
     - type: Transform
       pos: 43.5,-18.5
       parent: 2
-  - uid: 2373
+  - uid: 2372
     components:
     - type: Transform
       pos: 44.5,-18.5
       parent: 2
-  - uid: 2374
+  - uid: 2373
     components:
     - type: Transform
       pos: 45.5,-18.5
       parent: 2
 - proto: WaterTankFull
   entities:
-  - uid: 2375
+  - uid: 2374
     components:
     - type: Transform
       pos: -13.5,-4.5
       parent: 2
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 2376
+  - uid: 2375
     components:
     - type: Transform
       pos: 34.5,-0.5
       parent: 2
-  - uid: 2377
+  - uid: 2376
     components:
     - type: Transform
       pos: 37.5,-8.5
       parent: 2
-  - uid: 2378
+  - uid: 2377
     components:
     - type: Transform
       pos: 38.5,-10.5
       parent: 2
 - proto: WeaponPistolViper
   entities:
-  - uid: 2379
+  - uid: 2378
     components:
     - type: Transform
       pos: 10.786457,-17.450405
       parent: 2
 - proto: WeaponSprayNozzle
   entities:
-  - uid: 2380
+  - uid: 2379
     components:
     - type: Transform
       pos: 11.883067,-9.275236
       parent: 2
 - proto: WeldingFuelTankFull
   entities:
-  - uid: 2381
+  - uid: 2380
     components:
     - type: Transform
       pos: -11.5,0.5
       parent: 2
 - proto: Windoor
   entities:
-  - uid: 2382
+  - uid: 2381
     components:
     - type: Transform
       pos: 4.5,-14.5
       parent: 2
-  - uid: 2383
+  - uid: 2382
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 2
-  - uid: 2384
+  - uid: 2383
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,1.5
       parent: 2
-  - uid: 2385
+  - uid: 2384
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -13979,42 +14006,42 @@ entities:
       parent: 2
 - proto: WindowDirectional
   entities:
-  - uid: 2386
+  - uid: 2385
     components:
     - type: Transform
       pos: 3.5,-14.5
       parent: 2
-  - uid: 2387
+  - uid: 2386
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-13.5
       parent: 2
-  - uid: 2388
+  - uid: 2387
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 2
-  - uid: 2389
+  - uid: 2388
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 2
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 2390
+  - uid: 2389
     components:
     - type: Transform
       pos: 1.5,-14.5
       parent: 2
-  - uid: 2391
+  - uid: 2390
     components:
     - type: Transform
       pos: 0.5,-14.5
       parent: 2
 - proto: Wrench
   entities:
-  - uid: 2392
+  - uid: 2391
     components:
     - type: Transform
       pos: -4.438742,-14.360842
@@ -14022,12 +14049,12 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-  - uid: 2393
+  - uid: 2392
     components:
     - type: Transform
       pos: -12.48534,0.4715228
       parent: 2
-  - uid: 2394
+  - uid: 2393
     components:
     - type: Transform
       pos: -10.090788,-3.0192807
@@ -14038,7 +14065,7 @@ entities:
       canCollide: False
 - proto: Zipties
   entities:
-  - uid: 2395
+  - uid: 2394
     components:
     - type: Transform
       pos: 31.5,-0.5

--- a/Resources/Maps/Goobstation/Nonstations/nukieplanet.yml
+++ b/Resources/Maps/Goobstation/Nonstations/nukieplanet.yml
@@ -35,10 +35,46 @@ entities:
   - uid: 1
     components:
     - type: MetaData
-      name: grid
+    - type: Transform
+    - type: Map
+    - type: PhysicsMap
+    - type: GridTree
+    - type: MovedGrids
+    - type: FTLDestination
+      whitelist:
+        tags:
+        - Syndicate
+    - type: Broadphase
+    - type: OccluderTree
+    - type: Parallax
+      parallax: Sky
+    - type: MapAtmosphere
+      space: False
+      mixture:
+        volume: 2500
+        immutable: True
+        temperature: 248.15
+        moles:
+        - 21.824879
+        - 82.10312
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: LoadedMap
+  - uid: 2
+    components:
+    - type: MetaData
+      name: Nukieplanet
     - type: Transform
       pos: -4.024322,5.604384
-      parent: 1295
+      parent: 1
     - type: MapGrid
       chunks:
         0,0:
@@ -448,7 +484,8 @@ entities:
           -1,-1:
             0: 30583
           -4,-4:
-            0: 51212
+            2: 4
+            0: 51208
           -4,-2:
             0: 49152
           -4,-5:
@@ -456,7 +493,8 @@ entities:
           -4,-3:
             0: 136
           -3,-4:
-            0: 65286
+            0: 65282
+            2: 4
           -3,-3:
             0: 45311
           -3,-2:
@@ -703,13138 +741,13306 @@ entities:
           - 0
           - 0
           - 0
+        - volume: 2500
+          temperature: 293.14365
+          moles:
+          - 21.711672
+          - 81.677246
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
-  - uid: 1295
-    components:
-    - type: MetaData
-    - type: Transform
-    - type: Map
-    - type: PhysicsMap
-    - type: GridTree
-    - type: MovedGrids
-    - type: FTLDestination
-      whitelist:
-        tags:
-        - Syndicate
-    - type: Broadphase
-    - type: OccluderTree
-    - type: Parallax
-      parallax: Sky
-    - type: MapAtmosphere
-      space: False
-      mixture:
-        volume: 2500
-        immutable: True
-        temperature: 248.15
-        moles:
-        - 21.824879
-        - 82.10312
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-    - type: LoadedMap
 - proto: AirAlarm
   entities:
-  - uid: 533
+  - uid: 3
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-18.5
-      parent: 1
+      parent: 2
 - proto: AirlockExternalGlassNukeopLocked
   entities:
-  - uid: 1137
+  - uid: 4
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,-7.5
-      parent: 1
-  - uid: 1138
+      parent: 2
+  - uid: 5
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,-10.5
-      parent: 1
-  - uid: 1246
+      parent: 2
+  - uid: 6
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 26.5,-15.5
-      parent: 1
-  - uid: 1247
+      parent: 2
+  - uid: 7
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.5,-18.5
-      parent: 1
-  - uid: 1248
+      parent: 2
+  - uid: 8
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 26.5,-21.5
-      parent: 1
+      parent: 2
 - proto: AirlockGlassShuttle
   entities:
-  - uid: 1249
+  - uid: 9
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 29.5,-18.5
-      parent: 1
-  - uid: 1250
+      parent: 2
+  - uid: 10
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 30.5,-18.5
-      parent: 1
+      parent: 2
 - proto: AirlockGlassShuttleSyndicate
   entities:
-  - uid: 2277
+  - uid: 11
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 47.5,-4.5
-      parent: 1
+      parent: 2
     - type: GridFill
       addComponents:
       - type: NukeOpsShuttle
       path: /Maps/Goobstation/Shuttles/infiltrator.yml
 - proto: AirlockHatchSyndicate
   entities:
-  - uid: 77
+  - uid: 12
     components:
     - type: Transform
       pos: 8.5,1.5
-      parent: 1
-  - uid: 78
+      parent: 2
+  - uid: 13
     components:
     - type: Transform
       pos: 6.5,1.5
-      parent: 1
-  - uid: 79
+      parent: 2
+  - uid: 14
     components:
     - type: Transform
       pos: 2.5,1.5
-      parent: 1
-  - uid: 276
+      parent: 2
+  - uid: 15
     components:
     - type: Transform
       pos: 11.5,-8.5
-      parent: 1
-  - uid: 277
+      parent: 2
+  - uid: 16
     components:
     - type: Transform
       pos: 13.5,-6.5
-      parent: 1
-  - uid: 278
+      parent: 2
+  - uid: 17
     components:
     - type: Transform
       pos: 13.5,-5.5
-      parent: 1
-  - uid: 279
+      parent: 2
+  - uid: 18
     components:
     - type: Transform
       pos: 7.5,-10.5
-      parent: 1
-  - uid: 280
+      parent: 2
+  - uid: 19
     components:
     - type: Transform
       pos: 4.5,-7.5
-      parent: 1
-  - uid: 623
+      parent: 2
+  - uid: 20
     components:
     - type: Transform
       pos: 0.5,-7.5
-      parent: 1
-  - uid: 1026
+      parent: 2
+  - uid: 21
     components:
     - type: Transform
       pos: 26.5,-6.5
-      parent: 1
-  - uid: 1027
+      parent: 2
+  - uid: 22
     components:
     - type: Transform
       pos: 26.5,-5.5
-      parent: 1
-  - uid: 1813
+      parent: 2
+  - uid: 23
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 37.5,-3.5
-      parent: 1
-  - uid: 1903
+      parent: 2
+  - uid: 24
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 41.5,-13.5
-      parent: 1
-  - uid: 1904
+      parent: 2
+  - uid: 25
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 35.5,-13.5
-      parent: 1
+      parent: 2
 - proto: AirlockSyndicateGlassLocked
   entities:
-  - uid: 666
+  - uid: 26
     components:
     - type: Transform
       pos: -2.5,-5.5
-      parent: 1
-  - uid: 667
+      parent: 2
+  - uid: 27
     components:
     - type: Transform
       pos: -6.5,-5.5
-      parent: 1
-  - uid: 668
+      parent: 2
+  - uid: 28
     components:
     - type: Transform
       pos: -9.5,-7.5
-      parent: 1
-  - uid: 669
+      parent: 2
+  - uid: 29
     components:
     - type: Transform
       pos: -7.5,-9.5
-      parent: 1
-  - uid: 1807
+      parent: 2
+  - uid: 30
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,-1.5
-      parent: 1
-  - uid: 1808
+      parent: 2
+  - uid: 31
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 28.5,-1.5
-      parent: 1
-  - uid: 1809
+      parent: 2
+  - uid: 32
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,-6.5
-      parent: 1
-  - uid: 1810
+      parent: 2
+  - uid: 33
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 34.5,-5.5
-      parent: 1
-  - uid: 1811
+      parent: 2
+  - uid: 34
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,-1.5
-      parent: 1
-  - uid: 1895
+      parent: 2
+  - uid: 35
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 39.5,-1.5
-      parent: 1
-  - uid: 1896
+      parent: 2
+  - uid: 36
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,-4.5
-      parent: 1
+      parent: 2
 - proto: AirlockSyndicateLocked
   entities:
-  - uid: 904
+  - uid: 37
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-14.5
-      parent: 1
-  - uid: 905
+      parent: 2
+  - uid: 38
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-12.5
-      parent: 1
+      parent: 2
 - proto: AirlockSyndicateNukeopGlassLocked
   entities:
-  - uid: 101
+  - uid: 39
     components:
     - type: Transform
       pos: 6.5,-3.5
-      parent: 1
-  - uid: 102
+      parent: 2
+  - uid: 40
     components:
     - type: Transform
       pos: 8.5,-3.5
-      parent: 1
+      parent: 2
 - proto: AirlockSyndicateNukeopLocked
   entities:
-  - uid: 104
+  - uid: 41
     components:
     - type: Transform
       pos: 1.5,-3.5
-      parent: 1
-  - uid: 523
+      parent: 2
+  - uid: 42
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-12.5
-      parent: 1
-  - uid: 564
+      parent: 2
+  - uid: 43
     components:
     - type: Transform
       pos: -2.5,-9.5
-      parent: 1
+      parent: 2
 - proto: AlwaysPoweredlightBlue
   entities:
-  - uid: 1437
+  - uid: 44
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 29.5,-30.5
-      parent: 1
+      parent: 2
 - proto: APCBasic
   entities:
-  - uid: 168
+  - uid: 45
     components:
     - type: Transform
       pos: 9.5,1.5
-      parent: 1
-  - uid: 169
+      parent: 2
+  - uid: 46
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,1.5
-      parent: 1
-  - uid: 567
+      parent: 2
+  - uid: 47
     components:
     - type: Transform
       pos: -4.5,-5.5
-      parent: 1
-  - uid: 568
+      parent: 2
+  - uid: 48
     components:
     - type: Transform
       pos: -0.5,-9.5
-      parent: 1
-  - uid: 570
+      parent: 2
+  - uid: 49
     components:
     - type: Transform
       pos: -2.5,0.5
-      parent: 1
-  - uid: 645
+      parent: 2
+  - uid: 50
     components:
     - type: Transform
       pos: 9.5,-4.5
-      parent: 1
-  - uid: 695
+      parent: 2
+  - uid: 51
     components:
     - type: Transform
       pos: -8.5,1.5
-      parent: 1
-  - uid: 838
+      parent: 2
+  - uid: 52
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-13.5
-      parent: 1
-  - uid: 1085
+      parent: 2
+  - uid: 53
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,-7.5
-      parent: 1
-  - uid: 1892
+      parent: 2
+  - uid: 54
     components:
     - type: Transform
       pos: 30.5,-1.5
-      parent: 1
-  - uid: 1893
+      parent: 2
+  - uid: 55
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 35.5,0.5
-      parent: 1
-  - uid: 1894
+      parent: 2
+  - uid: 56
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,2.5
-      parent: 1
-  - uid: 1908
+      parent: 2
+  - uid: 57
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 34.5,-10.5
-      parent: 1
-  - uid: 2220
+      parent: 2
+  - uid: 58
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-13.5
-      parent: 1
+      parent: 2
 - proto: APCHyperCapacity
   entities:
-  - uid: 1879
+  - uid: 59
     components:
     - type: Transform
       pos: 32.5,-7.5
-      parent: 1
+      parent: 2
 - proto: BarSignComboCafe
   entities:
-  - uid: 71
+  - uid: 60
     components:
     - type: Transform
       pos: 3.5,-3.5
-      parent: 1
+      parent: 2
 - proto: BaseComputer
   entities:
-  - uid: 1755
+  - uid: 61
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 34.5,1.5
-      parent: 1
+      parent: 2
 - proto: BaseGasCondenser
   entities:
-  - uid: 449
+  - uid: 62
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-10.5
-      parent: 1
+      parent: 2
 - proto: Beaker
   entities:
-  - uid: 762
+  - uid: 63
     components:
     - type: Transform
       pos: -11.5,-10.5
-      parent: 1
-  - uid: 763
+      parent: 2
+  - uid: 64
     components:
     - type: Transform
       pos: -12.5,-11.5
-      parent: 1
-  - uid: 798
+      parent: 2
+  - uid: 65
     components:
     - type: Transform
       pos: -5.7040906,-2.6222272
-      parent: 1
+      parent: 2
 - proto: Bed
   entities:
-  - uid: 907
+  - uid: 66
     components:
     - type: Transform
       pos: 12.5,-11.5
-      parent: 1
-  - uid: 908
+      parent: 2
+  - uid: 67
     components:
     - type: Transform
       pos: 10.5,-11.5
-      parent: 1
-  - uid: 909
+      parent: 2
+  - uid: 68
     components:
     - type: Transform
       pos: 12.5,-15.5
-      parent: 1
-  - uid: 910
+      parent: 2
+  - uid: 69
     components:
     - type: Transform
       pos: 10.5,-15.5
-      parent: 1
+      parent: 2
 - proto: BedsheetCMO
   entities:
-  - uid: 837
+  - uid: 70
     components:
     - type: Transform
       pos: -1.5,-2.5
-      parent: 1
+      parent: 2
 - proto: BedsheetSyndie
   entities:
-  - uid: 911
+  - uid: 71
     components:
     - type: Transform
       pos: 12.5,-11.5
-      parent: 1
-  - uid: 912
-    components:
-    - type: Transform
-      pos: 10.5,-11.5
-      parent: 1
-  - uid: 913
-    components:
-    - type: Transform
-      pos: 10.5,-15.5
-      parent: 1
-  - uid: 914
-    components:
-    - type: Transform
-      pos: 12.5,-15.5
-      parent: 1
-- proto: BenchComfy
-  entities:
-  - uid: 1603
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 31.5,-3.5
-      parent: 1
-  - uid: 1604
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 31.5,-2.5
-      parent: 1
-  - uid: 1605
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 27.5,-2.5
-      parent: 1
-  - uid: 1606
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 27.5,-3.5
-      parent: 1
-  - uid: 1607
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 27.5,-4.5
-      parent: 1
-  - uid: 1608
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 30.5,-2.5
-      parent: 1
-  - uid: 1609
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 30.5,-3.5
-      parent: 1
-  - uid: 1829
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 40.5,4.5
-      parent: 1
-  - uid: 1830
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 40.5,3.5
-      parent: 1
-  - uid: 1831
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 38.5,4.5
-      parent: 1
-  - uid: 1832
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 38.5,3.5
-      parent: 1
-  - uid: 1833
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 37.5,4.5
-      parent: 1
-  - uid: 1834
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 37.5,3.5
-      parent: 1
-  - uid: 1835
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 35.5,4.5
-      parent: 1
-  - uid: 1836
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 35.5,3.5
-      parent: 1
-- proto: BenchRedComfy
-  entities:
-  - uid: 869
-    components:
-    - type: Transform
-      pos: 12.5,-4.5
-      parent: 1
-  - uid: 870
-    components:
-    - type: Transform
-      pos: 11.5,-4.5
-      parent: 1
-  - uid: 871
-    components:
-    - type: Transform
-      pos: 10.5,-4.5
-      parent: 1
-- proto: Biofabricator
-  entities:
-  - uid: 757
-    components:
-    - type: Transform
-      pos: -6.5,-10.5
-      parent: 1
-- proto: BlastDoor
-  entities:
-  - uid: 558
-    components:
-    - type: Transform
-      pos: -0.5,-19.5
-      parent: 1
-  - uid: 559
-    components:
-    - type: Transform
-      pos: -0.5,-20.5
-      parent: 1
-  - uid: 1612
-    components:
-    - type: Transform
-      pos: 27.5,8.5
-      parent: 1
-  - uid: 1613
-    components:
-    - type: Transform
-      pos: 28.5,8.5
-      parent: 1
-  - uid: 1614
-    components:
-    - type: Transform
-      pos: 29.5,8.5
-      parent: 1
-  - uid: 1615
-    components:
-    - type: Transform
-      pos: 30.5,8.5
-      parent: 1
-  - uid: 1616
-    components:
-    - type: Transform
-      pos: 31.5,8.5
-      parent: 1
-  - uid: 1617
-    components:
-    - type: Transform
-      pos: 32.5,8.5
-      parent: 1
-  - uid: 1618
-    components:
-    - type: Transform
-      pos: 33.5,8.5
-      parent: 1
-  - uid: 1619
-    components:
-    - type: Transform
-      pos: 34.5,8.5
-      parent: 1
-  - uid: 1620
-    components:
-    - type: Transform
-      pos: 35.5,8.5
-      parent: 1
-  - uid: 1621
-    components:
-    - type: Transform
-      pos: 36.5,8.5
-      parent: 1
-  - uid: 1622
-    components:
-    - type: Transform
-      pos: 37.5,8.5
-      parent: 1
-  - uid: 1623
-    components:
-    - type: Transform
-      pos: 38.5,8.5
-      parent: 1
-  - uid: 1624
-    components:
-    - type: Transform
-      pos: 39.5,8.5
-      parent: 1
-  - uid: 1625
-    components:
-    - type: Transform
-      pos: 40.5,8.5
-      parent: 1
-- proto: BoozeDispenser
-  entities:
+      parent: 2
   - uid: 72
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-2.5
-      parent: 1
-- proto: BoxEncryptionKeyPassenger
-  entities:
-  - uid: 2375
+      pos: 10.5,-11.5
+      parent: 2
+  - uid: 73
     components:
     - type: Transform
-      pos: 36.430195,-9.522374
-      parent: 1
-- proto: BoxEncryptionKeySyndie
-  entities:
-  - uid: 2376
+      pos: 10.5,-15.5
+      parent: 2
+  - uid: 74
     components:
     - type: Transform
-      pos: 41.53957,-8.444249
-      parent: 1
-- proto: BoxFolderRed
-  entities:
-  - uid: 1799
-    components:
-    - type: Transform
-      pos: 39.5,-8.5
-      parent: 1
-  - uid: 1800
-    components:
-    - type: Transform
-      pos: 36.5,-8.5
-      parent: 1
-  - uid: 1801
-    components:
-    - type: Transform
-      pos: 37.5,-10.5
-      parent: 1
-  - uid: 2374
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 41.50832,-9.569249
-      parent: 1
-- proto: BoxMagazinePistol
-  entities:
-  - uid: 1994
-    components:
-    - type: Transform
-      pos: 36.63316,-0.29581022
-      parent: 1
-- proto: BoxMagazinePistolSubMachineGun
-  entities:
-  - uid: 2369
-    components:
-    - type: Transform
-      pos: 36.32066,-0.5614352
-      parent: 1
-- proto: BoxPillCanister
-  entities:
-  - uid: 794
-    components:
-    - type: Transform
-      pos: -13.407215,-0.3722272
-      parent: 1
-- proto: BoxSyringe
-  entities:
-  - uid: 836
-    components:
-    - type: Transform
-      pos: -1.6756997,-3.620916
-      parent: 1
-- proto: Bucket
-  entities:
-  - uid: 953
-    components:
-    - type: Transform
-      pos: 12.664318,-9.525236
-      parent: 1
-- proto: ButtonFrameCaution
-  entities:
-  - uid: 561
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-18.5
-      parent: 1
-- proto: CableApcExtension
-  entities:
-  - uid: 185
-    components:
-    - type: Transform
-      pos: 9.5,1.5
-      parent: 1
-  - uid: 186
-    components:
-    - type: Transform
-      pos: 9.5,0.5
-      parent: 1
-  - uid: 187
-    components:
-    - type: Transform
-      pos: 9.5,-0.5
-      parent: 1
-  - uid: 188
-    components:
-    - type: Transform
-      pos: 9.5,-1.5
-      parent: 1
-  - uid: 189
-    components:
-    - type: Transform
-      pos: 10.5,-0.5
-      parent: 1
-  - uid: 190
-    components:
-    - type: Transform
-      pos: 11.5,-0.5
-      parent: 1
-  - uid: 191
-    components:
-    - type: Transform
-      pos: 11.5,-1.5
-      parent: 1
-  - uid: 192
-    components:
-    - type: Transform
-      pos: 8.5,-1.5
-      parent: 1
-  - uid: 193
-    components:
-    - type: Transform
-      pos: 7.5,-1.5
-      parent: 1
-  - uid: 194
-    components:
-    - type: Transform
-      pos: 6.5,-1.5
-      parent: 1
-  - uid: 195
-    components:
-    - type: Transform
-      pos: 5.5,-1.5
-      parent: 1
-  - uid: 196
-    components:
-    - type: Transform
-      pos: 4.5,-1.5
-      parent: 1
-  - uid: 197
-    components:
-    - type: Transform
-      pos: 3.5,-1.5
-      parent: 1
-  - uid: 198
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 1
-  - uid: 199
-    components:
-    - type: Transform
-      pos: 1.5,-1.5
-      parent: 1
-  - uid: 200
-    components:
-    - type: Transform
-      pos: 1.5,-2.5
-      parent: 1
-  - uid: 201
-    components:
-    - type: Transform
-      pos: 1.5,-3.5
-      parent: 1
-  - uid: 202
-    components:
-    - type: Transform
-      pos: 1.5,-4.5
-      parent: 1
-  - uid: 203
-    components:
-    - type: Transform
-      pos: 2.5,-4.5
-      parent: 1
-  - uid: 204
-    components:
-    - type: Transform
-      pos: 3.5,-4.5
-      parent: 1
-  - uid: 236
-    components:
-    - type: Transform
-      pos: 5.5,1.5
-      parent: 1
-  - uid: 237
-    components:
-    - type: Transform
-      pos: 5.5,2.5
-      parent: 1
-  - uid: 238
-    components:
-    - type: Transform
-      pos: 5.5,3.5
-      parent: 1
-  - uid: 239
-    components:
-    - type: Transform
-      pos: 6.5,3.5
-      parent: 1
-  - uid: 240
-    components:
-    - type: Transform
-      pos: 7.5,3.5
-      parent: 1
-  - uid: 241
-    components:
-    - type: Transform
-      pos: 8.5,3.5
-      parent: 1
-  - uid: 242
-    components:
-    - type: Transform
-      pos: 9.5,3.5
-      parent: 1
-  - uid: 243
-    components:
-    - type: Transform
-      pos: 10.5,3.5
-      parent: 1
-  - uid: 244
-    components:
-    - type: Transform
-      pos: 4.5,3.5
-      parent: 1
-  - uid: 245
-    components:
-    - type: Transform
-      pos: 3.5,3.5
-      parent: 1
-  - uid: 246
-    components:
-    - type: Transform
-      pos: 3.5,2.5
-      parent: 1
-  - uid: 247
-    components:
-    - type: Transform
-      pos: 2.5,2.5
-      parent: 1
-  - uid: 248
-    components:
-    - type: Transform
-      pos: 11.5,3.5
-      parent: 1
-  - uid: 249
-    components:
-    - type: Transform
-      pos: 11.5,2.5
-      parent: 1
-  - uid: 605
-    components:
-    - type: Transform
-      pos: -0.5,-9.5
-      parent: 1
-  - uid: 606
-    components:
-    - type: Transform
-      pos: -0.5,-10.5
-      parent: 1
-  - uid: 607
-    components:
-    - type: Transform
-      pos: -0.5,-11.5
-      parent: 1
-  - uid: 608
-    components:
-    - type: Transform
-      pos: -0.5,-12.5
-      parent: 1
-  - uid: 609
-    components:
-    - type: Transform
-      pos: -0.5,-13.5
-      parent: 1
-  - uid: 610
-    components:
-    - type: Transform
-      pos: -0.5,-14.5
-      parent: 1
-  - uid: 611
-    components:
-    - type: Transform
-      pos: -0.5,-15.5
-      parent: 1
-  - uid: 612
-    components:
-    - type: Transform
-      pos: -0.5,-16.5
-      parent: 1
-  - uid: 613
-    components:
-    - type: Transform
-      pos: -1.5,-16.5
-      parent: 1
-  - uid: 614
-    components:
-    - type: Transform
-      pos: -2.5,-16.5
-      parent: 1
-  - uid: 615
-    components:
-    - type: Transform
-      pos: -2.5,-15.5
-      parent: 1
-  - uid: 616
-    components:
-    - type: Transform
-      pos: -2.5,-14.5
-      parent: 1
-  - uid: 617
-    components:
-    - type: Transform
-      pos: -2.5,-13.5
-      parent: 1
-  - uid: 618
-    components:
-    - type: Transform
-      pos: -2.5,-12.5
-      parent: 1
-  - uid: 619
-    components:
-    - type: Transform
-      pos: -2.5,-11.5
-      parent: 1
-  - uid: 620
-    components:
-    - type: Transform
-      pos: -1.5,-14.5
-      parent: 1
-  - uid: 621
-    components:
-    - type: Transform
-      pos: -1.5,-12.5
-      parent: 1
-  - uid: 622
-    components:
-    - type: Transform
-      pos: -3.5,-11.5
-      parent: 1
-  - uid: 624
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 1
-  - uid: 625
-    components:
-    - type: Transform
-      pos: -2.5,-0.5
-      parent: 1
-  - uid: 626
-    components:
-    - type: Transform
-      pos: -2.5,-1.5
-      parent: 1
-  - uid: 627
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
-      parent: 1
-  - uid: 628
-    components:
-    - type: Transform
-      pos: -2.5,-3.5
-      parent: 1
-  - uid: 629
-    components:
-    - type: Transform
-      pos: -4.5,-5.5
-      parent: 1
-  - uid: 630
-    components:
-    - type: Transform
-      pos: -4.5,-6.5
-      parent: 1
-  - uid: 631
-    components:
-    - type: Transform
-      pos: -4.5,-7.5
-      parent: 1
-  - uid: 632
-    components:
-    - type: Transform
-      pos: -5.5,-7.5
-      parent: 1
-  - uid: 633
-    components:
-    - type: Transform
-      pos: -6.5,-7.5
-      parent: 1
-  - uid: 634
-    components:
-    - type: Transform
-      pos: -7.5,-7.5
-      parent: 1
-  - uid: 635
-    components:
-    - type: Transform
-      pos: -8.5,-7.5
-      parent: 1
-  - uid: 636
-    components:
-    - type: Transform
-      pos: -9.5,-7.5
-      parent: 1
-  - uid: 637
-    components:
-    - type: Transform
-      pos: -10.5,-7.5
-      parent: 1
-  - uid: 638
-    components:
-    - type: Transform
-      pos: -3.5,-7.5
-      parent: 1
-  - uid: 639
-    components:
-    - type: Transform
-      pos: -2.5,-7.5
-      parent: 1
-  - uid: 640
-    components:
-    - type: Transform
-      pos: -1.5,-7.5
-      parent: 1
-  - uid: 641
-    components:
-    - type: Transform
-      pos: -0.5,-7.5
-      parent: 1
-  - uid: 642
-    components:
-    - type: Transform
-      pos: 0.5,-7.5
-      parent: 1
-  - uid: 643
-    components:
-    - type: Transform
-      pos: 1.5,-7.5
-      parent: 1
-  - uid: 644
-    components:
-    - type: Transform
-      pos: 2.5,-7.5
-      parent: 1
-  - uid: 649
-    components:
-    - type: Transform
-      pos: 9.5,-4.5
-      parent: 1
-  - uid: 650
-    components:
-    - type: Transform
-      pos: 9.5,-5.5
-      parent: 1
-  - uid: 651
-    components:
-    - type: Transform
-      pos: 9.5,-6.5
-      parent: 1
-  - uid: 652
-    components:
-    - type: Transform
-      pos: 10.5,-6.5
-      parent: 1
-  - uid: 653
-    components:
-    - type: Transform
-      pos: 11.5,-6.5
-      parent: 1
-  - uid: 654
-    components:
-    - type: Transform
-      pos: 11.5,-5.5
-      parent: 1
-  - uid: 655
-    components:
-    - type: Transform
-      pos: 11.5,-7.5
-      parent: 1
-  - uid: 656
-    components:
-    - type: Transform
-      pos: 11.5,-8.5
-      parent: 1
-  - uid: 657
-    components:
-    - type: Transform
-      pos: 8.5,-6.5
-      parent: 1
-  - uid: 658
-    components:
-    - type: Transform
-      pos: 7.5,-6.5
-      parent: 1
-  - uid: 659
-    components:
-    - type: Transform
-      pos: 7.5,-7.5
-      parent: 1
-  - uid: 660
-    components:
-    - type: Transform
-      pos: 6.5,-7.5
-      parent: 1
-  - uid: 661
-    components:
-    - type: Transform
-      pos: 5.5,-7.5
-      parent: 1
-  - uid: 662
-    components:
-    - type: Transform
-      pos: 4.5,-7.5
-      parent: 1
-  - uid: 663
-    components:
-    - type: Transform
-      pos: 7.5,-8.5
-      parent: 1
-  - uid: 664
-    components:
-    - type: Transform
-      pos: 7.5,-9.5
-      parent: 1
-  - uid: 665
-    components:
-    - type: Transform
-      pos: 8.5,-8.5
-      parent: 1
-  - uid: 710
-    components:
-    - type: Transform
-      pos: -8.5,1.5
-      parent: 1
-  - uid: 711
-    components:
-    - type: Transform
-      pos: -8.5,0.5
-      parent: 1
-  - uid: 712
-    components:
-    - type: Transform
-      pos: -8.5,-0.5
-      parent: 1
-  - uid: 713
-    components:
-    - type: Transform
-      pos: -8.5,-1.5
-      parent: 1
-  - uid: 714
-    components:
-    - type: Transform
-      pos: -8.5,-2.5
-      parent: 1
-  - uid: 715
-    components:
-    - type: Transform
-      pos: -8.5,-3.5
-      parent: 1
-  - uid: 716
-    components:
-    - type: Transform
-      pos: -9.5,-3.5
-      parent: 1
-  - uid: 717
-    components:
-    - type: Transform
-      pos: -10.5,-3.5
-      parent: 1
-  - uid: 718
-    components:
-    - type: Transform
-      pos: -7.5,-2.5
-      parent: 1
-  - uid: 719
-    components:
-    - type: Transform
-      pos: -7.5,-0.5
-      parent: 1
-  - uid: 720
-    components:
-    - type: Transform
-      pos: -9.5,-1.5
-      parent: 1
-  - uid: 721
-    components:
-    - type: Transform
-      pos: -10.5,-1.5
-      parent: 1
-  - uid: 722
-    components:
-    - type: Transform
-      pos: -11.5,-1.5
-      parent: 1
-  - uid: 723
-    components:
-    - type: Transform
-      pos: -12.5,-1.5
-      parent: 1
-  - uid: 724
-    components:
-    - type: Transform
-      pos: -12.5,-2.5
-      parent: 1
-  - uid: 725
-    components:
-    - type: Transform
-      pos: -12.5,-3.5
-      parent: 1
-  - uid: 726
-    components:
-    - type: Transform
-      pos: -11.5,-3.5
-      parent: 1
-  - uid: 727
-    components:
-    - type: Transform
-      pos: -11.5,-0.5
-      parent: 1
-  - uid: 728
-    components:
-    - type: Transform
-      pos: -8.5,-4.5
-      parent: 1
-  - uid: 729
-    components:
-    - type: Transform
-      pos: -7.5,-4.5
-      parent: 1
-  - uid: 730
-    components:
-    - type: Transform
-      pos: -6.5,-4.5
-      parent: 1
-  - uid: 731
-    components:
-    - type: Transform
-      pos: -5.5,-4.5
-      parent: 1
-  - uid: 732
-    components:
-    - type: Transform
-      pos: -5.5,-3.5
-      parent: 1
-  - uid: 733
-    components:
-    - type: Transform
-      pos: -5.5,-2.5
-      parent: 1
-  - uid: 734
-    components:
-    - type: Transform
-      pos: -5.5,-1.5
-      parent: 1
-  - uid: 735
-    components:
-    - type: Transform
-      pos: -5.5,-0.5
-      parent: 1
-  - uid: 844
-    components:
-    - type: Transform
-      pos: -5.5,-13.5
-      parent: 1
-  - uid: 845
-    components:
-    - type: Transform
-      pos: -7.5,-13.5
-      parent: 1
-  - uid: 846
-    components:
-    - type: Transform
-      pos: -6.5,-13.5
-      parent: 1
-  - uid: 847
-    components:
-    - type: Transform
-      pos: -7.5,-12.5
-      parent: 1
-  - uid: 848
-    components:
-    - type: Transform
-      pos: -8.5,-12.5
-      parent: 1
-  - uid: 849
-    components:
-    - type: Transform
-      pos: -9.5,-12.5
-      parent: 1
-  - uid: 850
-    components:
-    - type: Transform
-      pos: -10.5,-12.5
-      parent: 1
-  - uid: 851
-    components:
-    - type: Transform
-      pos: -11.5,-12.5
-      parent: 1
-  - uid: 852
-    components:
-    - type: Transform
-      pos: -12.5,-12.5
-      parent: 1
-  - uid: 853
-    components:
-    - type: Transform
-      pos: -10.5,-11.5
-      parent: 1
-  - uid: 854
-    components:
-    - type: Transform
-      pos: -8.5,-11.5
-      parent: 1
-  - uid: 857
-    components:
-    - type: Transform
-      pos: -10.5,-13.5
-      parent: 1
-  - uid: 858
-    components:
-    - type: Transform
-      pos: -10.5,-14.5
-      parent: 1
-  - uid: 859
-    components:
-    - type: Transform
-      pos: -10.5,-15.5
-      parent: 1
-  - uid: 860
-    components:
-    - type: Transform
-      pos: -11.5,-15.5
-      parent: 1
-  - uid: 861
-    components:
-    - type: Transform
-      pos: -12.5,-15.5
-      parent: 1
-  - uid: 862
-    components:
-    - type: Transform
-      pos: -9.5,-15.5
-      parent: 1
-  - uid: 863
-    components:
-    - type: Transform
-      pos: -9.5,-16.5
-      parent: 1
-  - uid: 864
-    components:
-    - type: Transform
-      pos: -8.5,-16.5
-      parent: 1
-  - uid: 865
-    components:
-    - type: Transform
-      pos: -7.5,-16.5
-      parent: 1
-  - uid: 866
-    components:
-    - type: Transform
-      pos: -6.5,-16.5
-      parent: 1
-  - uid: 1097
-    components:
-    - type: Transform
-      pos: 18.5,-7.5
-      parent: 1
-  - uid: 1098
-    components:
-    - type: Transform
-      pos: 18.5,-6.5
-      parent: 1
-  - uid: 1099
-    components:
-    - type: Transform
-      pos: 18.5,-5.5
-      parent: 1
-  - uid: 1100
-    components:
-    - type: Transform
-      pos: 17.5,-5.5
-      parent: 1
-  - uid: 1101
-    components:
-    - type: Transform
-      pos: 16.5,-5.5
-      parent: 1
-  - uid: 1102
-    components:
-    - type: Transform
-      pos: 15.5,-5.5
-      parent: 1
-  - uid: 1103
-    components:
-    - type: Transform
-      pos: 19.5,-5.5
-      parent: 1
-  - uid: 1104
-    components:
-    - type: Transform
-      pos: 20.5,-5.5
-      parent: 1
-  - uid: 1105
-    components:
-    - type: Transform
-      pos: 21.5,-5.5
-      parent: 1
-  - uid: 1106
-    components:
-    - type: Transform
-      pos: 22.5,-5.5
-      parent: 1
-  - uid: 1107
-    components:
-    - type: Transform
-      pos: 23.5,-5.5
-      parent: 1
-  - uid: 1108
-    components:
-    - type: Transform
-      pos: 24.5,-5.5
-      parent: 1
-  - uid: 1109
-    components:
-    - type: Transform
-      pos: 14.5,-5.5
-      parent: 1
-  - uid: 1110
-    components:
-    - type: Transform
-      pos: 25.5,-5.5
-      parent: 1
-  - uid: 1881
-    components:
-    - type: Transform
-      pos: 32.5,-7.5
-      parent: 1
-  - uid: 1882
-    components:
-    - type: Transform
-      pos: 32.5,-8.5
-      parent: 1
-  - uid: 1883
-    components:
-    - type: Transform
-      pos: 31.5,-8.5
-      parent: 1
-  - uid: 1884
-    components:
-    - type: Transform
-      pos: 30.5,-8.5
-      parent: 1
-  - uid: 1885
-    components:
-    - type: Transform
-      pos: 29.5,-8.5
-      parent: 1
-  - uid: 1886
-    components:
-    - type: Transform
-      pos: 29.5,-9.5
-      parent: 1
-  - uid: 1887
-    components:
-    - type: Transform
-      pos: 30.5,-9.5
-      parent: 1
-  - uid: 1888
-    components:
-    - type: Transform
-      pos: 31.5,-9.5
-      parent: 1
-  - uid: 1889
-    components:
-    - type: Transform
-      pos: 32.5,-9.5
-      parent: 1
-  - uid: 1890
-    components:
-    - type: Transform
-      pos: 31.5,-10.5
-      parent: 1
-  - uid: 1891
-    components:
-    - type: Transform
-      pos: 30.5,-10.5
-      parent: 1
-  - uid: 1923
-    components:
-    - type: Transform
-      pos: 35.5,0.5
-      parent: 1
-  - uid: 1924
-    components:
-    - type: Transform
-      pos: 36.5,0.5
-      parent: 1
-  - uid: 1925
-    components:
-    - type: Transform
-      pos: 37.5,0.5
-      parent: 1
-  - uid: 1926
-    components:
-    - type: Transform
-      pos: 38.5,0.5
-      parent: 1
-  - uid: 1927
-    components:
-    - type: Transform
-      pos: 39.5,0.5
-      parent: 1
-  - uid: 1928
-    components:
-    - type: Transform
-      pos: 34.5,-10.5
-      parent: 1
-  - uid: 1929
-    components:
-    - type: Transform
-      pos: 35.5,-10.5
-      parent: 1
-  - uid: 1930
-    components:
-    - type: Transform
-      pos: 36.5,-10.5
-      parent: 1
-  - uid: 1931
-    components:
-    - type: Transform
-      pos: 37.5,-10.5
-      parent: 1
-  - uid: 1932
-    components:
-    - type: Transform
-      pos: 38.5,-10.5
-      parent: 1
-  - uid: 1933
-    components:
-    - type: Transform
-      pos: 39.5,-10.5
-      parent: 1
-  - uid: 1934
-    components:
-    - type: Transform
-      pos: 40.5,-10.5
-      parent: 1
-  - uid: 1935
-    components:
-    - type: Transform
-      pos: 40.5,-9.5
-      parent: 1
-  - uid: 1936
-    components:
-    - type: Transform
-      pos: 40.5,-8.5
-      parent: 1
-  - uid: 1937
-    components:
-    - type: Transform
-      pos: 40.5,-7.5
-      parent: 1
-  - uid: 1938
-    components:
-    - type: Transform
-      pos: 40.5,-6.5
-      parent: 1
-  - uid: 1939
-    components:
-    - type: Transform
-      pos: 38.5,-6.5
-      parent: 1
-  - uid: 1940
-    components:
-    - type: Transform
-      pos: 39.5,-6.5
-      parent: 1
-  - uid: 1941
-    components:
-    - type: Transform
-      pos: 37.5,-6.5
-      parent: 1
-  - uid: 1942
-    components:
-    - type: Transform
-      pos: 36.5,-6.5
-      parent: 1
-  - uid: 1943
-    components:
-    - type: Transform
-      pos: 38.5,-5.5
-      parent: 1
-  - uid: 1944
-    components:
-    - type: Transform
-      pos: 37.5,-7.5
-      parent: 1
-  - uid: 1945
-    components:
-    - type: Transform
-      pos: 37.5,-8.5
-      parent: 1
-  - uid: 1946
-    components:
-    - type: Transform
-      pos: 41.5,-9.5
-      parent: 1
-  - uid: 1947
-    components:
-    - type: Transform
-      pos: 42.5,-9.5
-      parent: 1
-  - uid: 1948
-    components:
-    - type: Transform
-      pos: 39.5,-11.5
-      parent: 1
-  - uid: 1949
-    components:
-    - type: Transform
-      pos: 39.5,-12.5
-      parent: 1
-  - uid: 1950
-    components:
-    - type: Transform
-      pos: 40.5,-12.5
-      parent: 1
-  - uid: 1951
-    components:
-    - type: Transform
-      pos: 41.5,-12.5
-      parent: 1
-  - uid: 1952
-    components:
-    - type: Transform
-      pos: 41.5,-13.5
-      parent: 1
-  - uid: 1953
-    components:
-    - type: Transform
-      pos: 36.5,-11.5
-      parent: 1
-  - uid: 1954
-    components:
-    - type: Transform
-      pos: 36.5,-12.5
-      parent: 1
-  - uid: 1955
-    components:
-    - type: Transform
-      pos: 35.5,-12.5
-      parent: 1
-  - uid: 1956
-    components:
-    - type: Transform
-      pos: 35.5,-13.5
-      parent: 1
-  - uid: 1957
-    components:
-    - type: Transform
-      pos: 35.5,-14.5
-      parent: 1
-  - uid: 1958
-    components:
-    - type: Transform
-      pos: 35.5,-15.5
-      parent: 1
-  - uid: 1959
-    components:
-    - type: Transform
-      pos: 35.5,-16.5
-      parent: 1
-  - uid: 1960
-    components:
-    - type: Transform
-      pos: 35.5,-17.5
-      parent: 1
-  - uid: 1961
-    components:
-    - type: Transform
-      pos: 35.5,-18.5
-      parent: 1
-  - uid: 1962
-    components:
-    - type: Transform
-      pos: 34.5,-18.5
-      parent: 1
-  - uid: 1963
-    components:
-    - type: Transform
-      pos: 32.5,-18.5
-      parent: 1
-  - uid: 1964
-    components:
-    - type: Transform
-      pos: 31.5,-18.5
-      parent: 1
-  - uid: 1965
-    components:
-    - type: Transform
-      pos: 33.5,-18.5
-      parent: 1
-  - uid: 1972
-    components:
-    - type: Transform
-      pos: 30.5,-1.5
-      parent: 1
-  - uid: 1973
-    components:
-    - type: Transform
-      pos: 30.5,-2.5
-      parent: 1
-  - uid: 1974
-    components:
-    - type: Transform
-      pos: 30.5,-3.5
-      parent: 1
-  - uid: 1975
-    components:
-    - type: Transform
-      pos: 30.5,-4.5
-      parent: 1
-  - uid: 1976
-    components:
-    - type: Transform
-      pos: 30.5,-5.5
-      parent: 1
-  - uid: 1977
-    components:
-    - type: Transform
-      pos: 29.5,-4.5
-      parent: 1
-  - uid: 1978
-    components:
-    - type: Transform
-      pos: 28.5,-4.5
-      parent: 1
-  - uid: 1979
-    components:
-    - type: Transform
-      pos: 31.5,-4.5
-      parent: 1
-  - uid: 1980
-    components:
-    - type: Transform
-      pos: 32.5,-4.5
-      parent: 1
-  - uid: 1981
-    components:
-    - type: Transform
-      pos: 30.5,-6.5
-      parent: 1
-  - uid: 1982
-    components:
-    - type: Transform
-      pos: 28.5,-5.5
-      parent: 1
-  - uid: 1983
-    components:
-    - type: Transform
-      pos: 28.5,-6.5
-      parent: 1
-  - uid: 1984
-    components:
-    - type: Transform
-      pos: 27.5,-6.5
-      parent: 1
-  - uid: 1985
-    components:
-    - type: Transform
-      pos: 27.5,-7.5
-      parent: 1
-  - uid: 1986
-    components:
-    - type: Transform
-      pos: 27.5,-8.5
-      parent: 1
-  - uid: 1987
-    components:
-    - type: Transform
-      pos: 27.5,-9.5
-      parent: 1
-  - uid: 1988
-    components:
-    - type: Transform
-      pos: 27.5,-10.5
-      parent: 1
-  - uid: 1989
-    components:
-    - type: Transform
-      pos: 27.5,-11.5
-      parent: 1
-  - uid: 2228
-    components:
-    - type: Transform
-      pos: 6.5,-13.5
-      parent: 1
-  - uid: 2231
-    components:
-    - type: Transform
-      pos: 7.5,-13.5
-      parent: 1
-  - uid: 2293
-    components:
-    - type: Transform
-      pos: 38.5,-4.5
-      parent: 1
-  - uid: 2294
-    components:
-    - type: Transform
-      pos: 38.5,-3.5
-      parent: 1
-  - uid: 2295
-    components:
-    - type: Transform
-      pos: 37.5,-3.5
-      parent: 1
-  - uid: 2296
-    components:
-    - type: Transform
-      pos: 36.5,-3.5
-      parent: 1
-  - uid: 2297
-    components:
-    - type: Transform
-      pos: 35.5,-3.5
-      parent: 1
-  - uid: 2298
-    components:
-    - type: Transform
-      pos: 35.5,-2.5
-      parent: 1
-  - uid: 2341
-    components:
-    - type: Transform
-      pos: 5.5,-13.5
-      parent: 1
-  - uid: 2342
-    components:
-    - type: Transform
-      pos: 4.5,-13.5
-      parent: 1
-  - uid: 2343
-    components:
-    - type: Transform
-      pos: 4.5,-14.5
-      parent: 1
-  - uid: 2344
-    components:
-    - type: Transform
-      pos: 4.5,-15.5
-      parent: 1
-  - uid: 2345
-    components:
-    - type: Transform
-      pos: 7.5,-14.5
-      parent: 1
-  - uid: 2346
-    components:
-    - type: Transform
-      pos: 7.5,-15.5
-      parent: 1
-  - uid: 2347
-    components:
-    - type: Transform
-      pos: 8.5,-14.5
-      parent: 1
-  - uid: 2348
-    components:
-    - type: Transform
-      pos: 9.5,-14.5
-      parent: 1
-  - uid: 2349
-    components:
-    - type: Transform
-      pos: 10.5,-14.5
-      parent: 1
-  - uid: 2350
-    components:
-    - type: Transform
-      pos: 11.5,-14.5
-      parent: 1
-  - uid: 2351
-    components:
-    - type: Transform
-      pos: 7.5,-12.5
-      parent: 1
-  - uid: 2352
-    components:
-    - type: Transform
-      pos: 8.5,-12.5
-      parent: 1
-  - uid: 2353
-    components:
-    - type: Transform
-      pos: 9.5,-12.5
-      parent: 1
-  - uid: 2354
-    components:
-    - type: Transform
-      pos: 10.5,-12.5
-      parent: 1
-  - uid: 2355
-    components:
-    - type: Transform
-      pos: 11.5,-12.5
-      parent: 1
-  - uid: 2356
-    components:
-    - type: Transform
-      pos: 40.5,-5.5
-      parent: 1
-  - uid: 2357
-    components:
-    - type: Transform
-      pos: 40.5,-4.5
-      parent: 1
-  - uid: 2358
-    components:
-    - type: Transform
-      pos: 41.5,-4.5
-      parent: 1
-  - uid: 2359
-    components:
-    - type: Transform
-      pos: 42.5,-4.5
-      parent: 1
-  - uid: 2360
-    components:
-    - type: Transform
-      pos: 43.5,-4.5
-      parent: 1
-  - uid: 2361
-    components:
-    - type: Transform
-      pos: 44.5,-4.5
-      parent: 1
-  - uid: 2362
-    components:
-    - type: Transform
-      pos: 45.5,-4.5
-      parent: 1
-  - uid: 2363
-    components:
-    - type: Transform
-      pos: 46.5,-4.5
-      parent: 1
-- proto: CableApcStack
-  entities:
-  - uid: 793
-    components:
-    - type: Transform
-      pos: -13.344715,-1.9034772
-      parent: 1
-- proto: CableHV
-  entities:
-  - uid: 1869
-    components:
-    - type: Transform
-      pos: 30.5,-10.5
-      parent: 1
-  - uid: 1870
-    components:
-    - type: Transform
-      pos: 31.5,-10.5
-      parent: 1
-  - uid: 1871
-    components:
-    - type: Transform
-      pos: 31.5,-9.5
-      parent: 1
-  - uid: 1872
-    components:
-    - type: Transform
-      pos: 32.5,-9.5
-      parent: 1
-  - uid: 1873
-    components:
-    - type: Transform
-      pos: 32.5,-8.5
-      parent: 1
-  - uid: 1874
-    components:
-    - type: Transform
-      pos: 30.5,-9.5
-      parent: 1
-  - uid: 1875
-    components:
-    - type: Transform
-      pos: 29.5,-9.5
-      parent: 1
-  - uid: 1876
-    components:
-    - type: Transform
-      pos: 29.5,-8.5
-      parent: 1
-  - uid: 1877
-    components:
-    - type: Transform
-      pos: 30.5,-8.5
-      parent: 1
-  - uid: 1878
-    components:
-    - type: Transform
-      pos: 31.5,-8.5
-      parent: 1
-  - uid: 2278
-    components:
-    - type: Transform
-      pos: 31.5,-7.5
-      parent: 1
-  - uid: 2279
-    components:
-    - type: Transform
-      pos: 31.5,-6.5
-      parent: 1
-  - uid: 2280
-    components:
-    - type: Transform
-      pos: 32.5,-6.5
-      parent: 1
-  - uid: 2281
-    components:
-    - type: Transform
-      pos: 33.5,-6.5
-      parent: 1
-  - uid: 2282
-    components:
-    - type: Transform
-      pos: 34.5,-6.5
-      parent: 1
-  - uid: 2283
-    components:
-    - type: Transform
-      pos: 35.5,-6.5
-      parent: 1
-  - uid: 2284
-    components:
-    - type: Transform
-      pos: 36.5,-6.5
-      parent: 1
-  - uid: 2285
-    components:
-    - type: Transform
-      pos: 37.5,-6.5
-      parent: 1
-  - uid: 2286
-    components:
-    - type: Transform
-      pos: 38.5,-6.5
-      parent: 1
-  - uid: 2287
-    components:
-    - type: Transform
-      pos: 38.5,-5.5
-      parent: 1
-  - uid: 2288
-    components:
-    - type: Transform
-      pos: 38.5,-4.5
-      parent: 1
-  - uid: 2289
-    components:
-    - type: Transform
-      pos: 38.5,-3.5
-      parent: 1
-  - uid: 2290
-    components:
-    - type: Transform
-      pos: 37.5,-3.5
-      parent: 1
-  - uid: 2291
-    components:
-    - type: Transform
-      pos: 36.5,-3.5
-      parent: 1
-  - uid: 2292
-    components:
-    - type: Transform
-      pos: 36.5,-2.5
-      parent: 1
-- proto: CableMV
-  entities:
-  - uid: 170
-    components:
-    - type: Transform
-      pos: 5.5,1.5
-      parent: 1
-  - uid: 171
-    components:
-    - type: Transform
-      pos: 5.5,2.5
-      parent: 1
-  - uid: 172
-    components:
-    - type: Transform
-      pos: 6.5,2.5
-      parent: 1
-  - uid: 173
-    components:
-    - type: Transform
-      pos: 6.5,1.5
-      parent: 1
-  - uid: 174
-    components:
-    - type: Transform
-      pos: 6.5,0.5
-      parent: 1
-  - uid: 175
-    components:
-    - type: Transform
-      pos: 7.5,0.5
-      parent: 1
-  - uid: 176
-    components:
-    - type: Transform
-      pos: 8.5,0.5
-      parent: 1
-  - uid: 177
-    components:
-    - type: Transform
-      pos: 9.5,0.5
-      parent: 1
-  - uid: 178
-    components:
-    - type: Transform
-      pos: 9.5,1.5
-      parent: 1
-  - uid: 179
-    components:
-    - type: Transform
-      pos: 6.5,-0.5
-      parent: 1
-  - uid: 180
-    components:
-    - type: Transform
-      pos: 6.5,-1.5
-      parent: 1
-  - uid: 181
-    components:
-    - type: Transform
-      pos: 7.5,-1.5
-      parent: 1
-  - uid: 182
-    components:
-    - type: Transform
-      pos: 7.5,-2.5
-      parent: 1
-  - uid: 183
-    components:
-    - type: Transform
-      pos: 7.5,-3.5
-      parent: 1
-  - uid: 184
-    components:
-    - type: Transform
-      pos: 7.5,-4.5
-      parent: 1
-  - uid: 571
-    components:
-    - type: Transform
-      pos: 7.5,-5.5
-      parent: 1
-  - uid: 572
-    components:
-    - type: Transform
-      pos: 7.5,-6.5
-      parent: 1
-  - uid: 573
-    components:
-    - type: Transform
-      pos: 7.5,-7.5
-      parent: 1
-  - uid: 574
-    components:
-    - type: Transform
-      pos: 6.5,-7.5
-      parent: 1
-  - uid: 575
-    components:
-    - type: Transform
-      pos: 5.5,-7.5
-      parent: 1
-  - uid: 576
-    components:
-    - type: Transform
-      pos: 4.5,-7.5
-      parent: 1
-  - uid: 577
-    components:
-    - type: Transform
-      pos: 3.5,-7.5
-      parent: 1
-  - uid: 578
-    components:
-    - type: Transform
-      pos: 2.5,-7.5
-      parent: 1
-  - uid: 579
-    components:
-    - type: Transform
-      pos: 1.5,-7.5
-      parent: 1
-  - uid: 580
-    components:
-    - type: Transform
-      pos: 0.5,-7.5
-      parent: 1
-  - uid: 581
-    components:
-    - type: Transform
-      pos: -0.5,-7.5
-      parent: 1
-  - uid: 582
-    components:
-    - type: Transform
-      pos: -1.5,-7.5
-      parent: 1
-  - uid: 583
-    components:
-    - type: Transform
-      pos: -2.5,-7.5
-      parent: 1
-  - uid: 584
-    components:
-    - type: Transform
-      pos: -3.5,-7.5
-      parent: 1
-  - uid: 585
-    components:
-    - type: Transform
-      pos: -4.5,-7.5
-      parent: 1
-  - uid: 586
-    components:
-    - type: Transform
-      pos: -5.5,-7.5
-      parent: 1
-  - uid: 587
-    components:
-    - type: Transform
-      pos: -6.5,-7.5
-      parent: 1
-  - uid: 588
-    components:
-    - type: Transform
-      pos: -7.5,-7.5
-      parent: 1
-  - uid: 589
-    components:
-    - type: Transform
-      pos: -2.5,-8.5
-      parent: 1
-  - uid: 590
-    components:
-    - type: Transform
-      pos: -2.5,-9.5
-      parent: 1
-  - uid: 591
-    components:
-    - type: Transform
-      pos: -2.5,-10.5
-      parent: 1
-  - uid: 592
-    components:
-    - type: Transform
-      pos: -1.5,-10.5
-      parent: 1
-  - uid: 593
-    components:
-    - type: Transform
-      pos: -0.5,-10.5
-      parent: 1
-  - uid: 594
-    components:
-    - type: Transform
-      pos: -0.5,-9.5
-      parent: 1
-  - uid: 595
-    components:
-    - type: Transform
-      pos: -4.5,-6.5
-      parent: 1
-  - uid: 596
-    components:
-    - type: Transform
-      pos: -4.5,-5.5
-      parent: 1
-  - uid: 597
-    components:
-    - type: Transform
-      pos: -2.5,-6.5
-      parent: 1
-  - uid: 598
-    components:
-    - type: Transform
-      pos: -2.5,-5.5
-      parent: 1
-  - uid: 599
-    components:
-    - type: Transform
-      pos: -2.5,-4.5
-      parent: 1
-  - uid: 600
-    components:
-    - type: Transform
-      pos: -2.5,-3.5
-      parent: 1
-  - uid: 601
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
-      parent: 1
-  - uid: 602
-    components:
-    - type: Transform
-      pos: -2.5,-1.5
-      parent: 1
-  - uid: 603
-    components:
-    - type: Transform
-      pos: -2.5,-0.5
-      parent: 1
-  - uid: 604
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 1
-  - uid: 646
-    components:
-    - type: Transform
-      pos: 8.5,-5.5
-      parent: 1
-  - uid: 647
-    components:
-    - type: Transform
-      pos: 9.5,-5.5
-      parent: 1
-  - uid: 648
-    components:
-    - type: Transform
-      pos: 9.5,-4.5
-      parent: 1
-  - uid: 696
-    components:
-    - type: Transform
-      pos: -7.5,-8.5
-      parent: 1
-  - uid: 697
-    components:
-    - type: Transform
-      pos: -7.5,-9.5
-      parent: 1
-  - uid: 698
-    components:
-    - type: Transform
-      pos: -7.5,-10.5
-      parent: 1
-  - uid: 699
-    components:
-    - type: Transform
-      pos: -6.5,-6.5
-      parent: 1
-  - uid: 700
-    components:
-    - type: Transform
-      pos: -6.5,-5.5
-      parent: 1
-  - uid: 701
-    components:
-    - type: Transform
-      pos: -6.5,-4.5
-      parent: 1
-  - uid: 702
-    components:
-    - type: Transform
-      pos: -6.5,-3.5
-      parent: 1
-  - uid: 703
-    components:
-    - type: Transform
-      pos: -7.5,-3.5
-      parent: 1
-  - uid: 704
-    components:
-    - type: Transform
-      pos: -8.5,-3.5
-      parent: 1
-  - uid: 705
-    components:
-    - type: Transform
-      pos: -8.5,-2.5
-      parent: 1
-  - uid: 706
-    components:
-    - type: Transform
-      pos: -8.5,-1.5
-      parent: 1
-  - uid: 707
-    components:
-    - type: Transform
-      pos: -8.5,-0.5
-      parent: 1
-  - uid: 708
-    components:
-    - type: Transform
-      pos: -8.5,0.5
-      parent: 1
-  - uid: 709
-    components:
-    - type: Transform
-      pos: -8.5,1.5
-      parent: 1
-  - uid: 839
-    components:
-    - type: Transform
-      pos: -7.5,-11.5
-      parent: 1
-  - uid: 840
-    components:
-    - type: Transform
-      pos: -7.5,-12.5
-      parent: 1
-  - uid: 841
-    components:
-    - type: Transform
-      pos: -7.5,-13.5
-      parent: 1
-  - uid: 842
-    components:
-    - type: Transform
-      pos: -6.5,-13.5
-      parent: 1
-  - uid: 843
-    components:
-    - type: Transform
-      pos: -5.5,-13.5
-      parent: 1
-  - uid: 1086
-    components:
-    - type: Transform
-      pos: 9.5,-6.5
-      parent: 1
-  - uid: 1087
-    components:
-    - type: Transform
-      pos: 10.5,-6.5
-      parent: 1
-  - uid: 1088
-    components:
-    - type: Transform
-      pos: 11.5,-6.5
-      parent: 1
-  - uid: 1089
-    components:
-    - type: Transform
-      pos: 12.5,-6.5
-      parent: 1
-  - uid: 1090
-    components:
-    - type: Transform
-      pos: 13.5,-6.5
-      parent: 1
-  - uid: 1091
-    components:
-    - type: Transform
-      pos: 14.5,-6.5
-      parent: 1
-  - uid: 1092
-    components:
-    - type: Transform
-      pos: 15.5,-6.5
-      parent: 1
-  - uid: 1093
-    components:
-    - type: Transform
-      pos: 16.5,-6.5
-      parent: 1
-  - uid: 1094
-    components:
-    - type: Transform
-      pos: 17.5,-6.5
-      parent: 1
-  - uid: 1095
-    components:
-    - type: Transform
-      pos: 18.5,-6.5
-      parent: 1
-  - uid: 1096
-    components:
-    - type: Transform
-      pos: 18.5,-7.5
-      parent: 1
-  - uid: 1111
-    components:
-    - type: Transform
-      pos: 19.5,-6.5
-      parent: 1
-  - uid: 1112
-    components:
-    - type: Transform
-      pos: 20.5,-6.5
-      parent: 1
-  - uid: 1113
-    components:
-    - type: Transform
-      pos: 21.5,-6.5
-      parent: 1
-  - uid: 1114
-    components:
-    - type: Transform
-      pos: 22.5,-6.5
-      parent: 1
-  - uid: 1115
-    components:
-    - type: Transform
-      pos: 23.5,-6.5
-      parent: 1
-  - uid: 1116
-    components:
-    - type: Transform
-      pos: 24.5,-6.5
-      parent: 1
-  - uid: 1117
-    components:
-    - type: Transform
-      pos: 25.5,-6.5
-      parent: 1
-  - uid: 1118
-    components:
-    - type: Transform
-      pos: 26.5,-6.5
-      parent: 1
-  - uid: 1845
-    components:
-    - type: Transform
-      pos: 27.5,-6.5
-      parent: 1
-  - uid: 1846
-    components:
-    - type: Transform
-      pos: 28.5,-6.5
-      parent: 1
-  - uid: 1847
-    components:
-    - type: Transform
-      pos: 29.5,-6.5
-      parent: 1
-  - uid: 1848
-    components:
-    - type: Transform
-      pos: 30.5,-6.5
-      parent: 1
-  - uid: 1849
-    components:
-    - type: Transform
-      pos: 31.5,-6.5
-      parent: 1
-  - uid: 1850
-    components:
-    - type: Transform
-      pos: 32.5,-6.5
-      parent: 1
-  - uid: 1851
-    components:
-    - type: Transform
-      pos: 33.5,-6.5
-      parent: 1
-  - uid: 1852
-    components:
-    - type: Transform
-      pos: 34.5,-6.5
-      parent: 1
-  - uid: 1853
-    components:
-    - type: Transform
-      pos: 35.5,-6.5
-      parent: 1
-  - uid: 1854
-    components:
-    - type: Transform
-      pos: 36.5,-6.5
-      parent: 1
-  - uid: 1855
-    components:
-    - type: Transform
-      pos: 37.5,-6.5
-      parent: 1
-  - uid: 1856
-    components:
-    - type: Transform
-      pos: 38.5,-6.5
-      parent: 1
-  - uid: 1857
-    components:
-    - type: Transform
-      pos: 38.5,-5.5
-      parent: 1
-  - uid: 1858
-    components:
-    - type: Transform
-      pos: 38.5,-4.5
-      parent: 1
-  - uid: 1859
-    components:
-    - type: Transform
-      pos: 38.5,-3.5
-      parent: 1
-  - uid: 1860
-    components:
-    - type: Transform
-      pos: 37.5,-3.5
-      parent: 1
-  - uid: 1861
-    components:
-    - type: Transform
-      pos: 36.5,-3.5
-      parent: 1
-  - uid: 1862
-    components:
-    - type: Transform
-      pos: 36.5,-2.5
-      parent: 1
-  - uid: 1880
-    components:
-    - type: Transform
-      pos: 32.5,-7.5
-      parent: 1
-  - uid: 1909
-    components:
-    - type: Transform
-      pos: 35.5,-7.5
-      parent: 1
-  - uid: 1910
-    components:
-    - type: Transform
-      pos: 35.5,-8.5
-      parent: 1
-  - uid: 1911
-    components:
-    - type: Transform
-      pos: 35.5,-9.5
-      parent: 1
-  - uid: 1912
-    components:
-    - type: Transform
-      pos: 35.5,-10.5
-      parent: 1
-  - uid: 1913
-    components:
-    - type: Transform
-      pos: 34.5,-10.5
-      parent: 1
-  - uid: 1914
-    components:
-    - type: Transform
-      pos: 39.5,-3.5
-      parent: 1
-  - uid: 1915
-    components:
-    - type: Transform
-      pos: 39.5,-2.5
-      parent: 1
-  - uid: 1916
-    components:
-    - type: Transform
-      pos: 39.5,-1.5
-      parent: 1
-  - uid: 1917
-    components:
-    - type: Transform
-      pos: 39.5,-0.5
-      parent: 1
-  - uid: 1918
-    components:
-    - type: Transform
-      pos: 39.5,0.5
-      parent: 1
-  - uid: 1919
-    components:
-    - type: Transform
-      pos: 38.5,0.5
-      parent: 1
-  - uid: 1920
-    components:
-    - type: Transform
-      pos: 37.5,0.5
-      parent: 1
-  - uid: 1921
-    components:
-    - type: Transform
-      pos: 36.5,0.5
-      parent: 1
-  - uid: 1922
-    components:
-    - type: Transform
-      pos: 35.5,0.5
-      parent: 1
-  - uid: 1966
-    components:
-    - type: Transform
-      pos: 31.5,-5.5
-      parent: 1
-  - uid: 1967
-    components:
-    - type: Transform
-      pos: 31.5,-4.5
-      parent: 1
-  - uid: 1968
-    components:
-    - type: Transform
-      pos: 30.5,-4.5
-      parent: 1
-  - uid: 1969
-    components:
-    - type: Transform
-      pos: 30.5,-3.5
-      parent: 1
-  - uid: 1970
-    components:
-    - type: Transform
-      pos: 30.5,-2.5
-      parent: 1
-  - uid: 1971
-    components:
-    - type: Transform
-      pos: 30.5,-1.5
-      parent: 1
-  - uid: 2221
-    components:
-    - type: Transform
-      pos: 7.5,-8.5
-      parent: 1
-  - uid: 2222
-    components:
-    - type: Transform
-      pos: 7.5,-9.5
-      parent: 1
-  - uid: 2223
-    components:
-    - type: Transform
-      pos: 7.5,-10.5
-      parent: 1
-  - uid: 2224
-    components:
-    - type: Transform
-      pos: 7.5,-11.5
-      parent: 1
-  - uid: 2225
-    components:
-    - type: Transform
-      pos: 7.5,-12.5
-      parent: 1
-  - uid: 2226
-    components:
-    - type: Transform
-      pos: 7.5,-13.5
-      parent: 1
-  - uid: 2227
-    components:
-    - type: Transform
-      pos: 6.5,-13.5
-      parent: 1
-- proto: Catwalk
-  entities:
-  - uid: 963
-    components:
-    - type: Transform
-      pos: 14.5,-15.5
-      parent: 1
-  - uid: 964
-    components:
-    - type: Transform
-      pos: 14.5,-14.5
-      parent: 1
-  - uid: 965
-    components:
-    - type: Transform
-      pos: 14.5,-12.5
-      parent: 1
-  - uid: 966
-    components:
-    - type: Transform
-      pos: 14.5,-11.5
-      parent: 1
-  - uid: 967
-    components:
-    - type: Transform
-      pos: 14.5,-13.5
-      parent: 1
-  - uid: 1057
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,-9.5
-      parent: 1
-  - uid: 1058
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 15.5,-9.5
-      parent: 1
-  - uid: 1059
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,-9.5
-      parent: 1
-  - uid: 1060
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,-9.5
-      parent: 1
-  - uid: 1061
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-9.5
-      parent: 1
-  - uid: 1062
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-9.5
-      parent: 1
-  - uid: 1063
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-9.5
-      parent: 1
-  - uid: 1064
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-9.5
-      parent: 1
-  - uid: 1065
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,-9.5
-      parent: 1
-  - uid: 1066
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,-9.5
-      parent: 1
-  - uid: 1067
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 24.5,-9.5
-      parent: 1
-  - uid: 1068
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,-9.5
-      parent: 1
-  - uid: 1141
-    components:
-    - type: Transform
-      pos: 28.5,-14.5
-      parent: 1
-  - uid: 1142
-    components:
-    - type: Transform
-      pos: 27.5,-14.5
-      parent: 1
-  - uid: 1143
-    components:
-    - type: Transform
-      pos: 30.5,-16.5
-      parent: 1
-  - uid: 1144
-    components:
-    - type: Transform
-      pos: 29.5,-15.5
-      parent: 1
-  - uid: 1145
-    components:
-    - type: Transform
-      pos: 26.5,-14.5
-      parent: 1
-  - uid: 1172
-    components:
-    - type: Transform
-      pos: 30.5,-20.5
-      parent: 1
-  - uid: 1173
-    components:
-    - type: Transform
-      pos: 29.5,-21.5
-      parent: 1
-  - uid: 1174
-    components:
-    - type: Transform
-      pos: 28.5,-22.5
-      parent: 1
-  - uid: 1175
-    components:
-    - type: Transform
-      pos: 27.5,-22.5
-      parent: 1
-  - uid: 1176
-    components:
-    - type: Transform
-      pos: 26.5,-22.5
-      parent: 1
-  - uid: 1177
-    components:
-    - type: Transform
-      pos: 25.5,-22.5
-      parent: 1
-  - uid: 1178
-    components:
-    - type: Transform
-      pos: 24.5,-22.5
-      parent: 1
-  - uid: 1179
-    components:
-    - type: Transform
-      pos: 23.5,-21.5
-      parent: 1
-  - uid: 1180
-    components:
-    - type: Transform
-      pos: 22.5,-20.5
-      parent: 1
-  - uid: 1181
-    components:
-    - type: Transform
-      pos: 22.5,-19.5
-      parent: 1
-  - uid: 1182
-    components:
-    - type: Transform
-      pos: 22.5,-18.5
-      parent: 1
-  - uid: 1183
-    components:
-    - type: Transform
-      pos: 22.5,-17.5
-      parent: 1
-  - uid: 1184
-    components:
-    - type: Transform
-      pos: 22.5,-16.5
-      parent: 1
-  - uid: 1185
-    components:
-    - type: Transform
-      pos: 23.5,-15.5
-      parent: 1
-  - uid: 1186
-    components:
-    - type: Transform
-      pos: 24.5,-14.5
-      parent: 1
-  - uid: 1187
-    components:
-    - type: Transform
-      pos: 25.5,-14.5
-      parent: 1
-  - uid: 1320
-    components:
-    - type: Transform
-      pos: 23.5,-20.5
-      parent: 1
-  - uid: 1321
-    components:
-    - type: Transform
-      pos: 24.5,-21.5
-      parent: 1
-  - uid: 1322
-    components:
-    - type: Transform
-      pos: 28.5,-21.5
-      parent: 1
-  - uid: 1323
-    components:
-    - type: Transform
-      pos: 29.5,-20.5
-      parent: 1
-  - uid: 1324
-    components:
-    - type: Transform
-      pos: 23.5,-16.5
-      parent: 1
-  - uid: 1325
-    components:
-    - type: Transform
-      pos: 24.5,-15.5
-      parent: 1
-  - uid: 2006
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 45.5,-2.5
-      parent: 1
-  - uid: 2007
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 45.5,-1.5
-      parent: 1
-  - uid: 2008
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 45.5,-0.5
-      parent: 1
-  - uid: 2009
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 45.5,0.5
-      parent: 1
-  - uid: 2010
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 45.5,1.5
-      parent: 1
-  - uid: 2011
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 45.5,2.5
-      parent: 1
-  - uid: 2012
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 45.5,3.5
-      parent: 1
-  - uid: 2013
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 45.5,4.5
-      parent: 1
-  - uid: 2014
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 45.5,5.5
-      parent: 1
-  - uid: 2015
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 45.5,6.5
-      parent: 1
-  - uid: 2016
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 45.5,7.5
-      parent: 1
-  - uid: 2017
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 45.5,8.5
-      parent: 1
-- proto: Chair
-  entities:
-  - uid: 153
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,3.5
-      parent: 1
-  - uid: 956
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-8.5
-      parent: 1
-  - uid: 957
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-8.5
-      parent: 1
-- proto: ChairOfficeDark
-  entities:
-  - uid: 782
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-1.5
-      parent: 1
-- proto: ChairOfficeLight
-  entities:
-  - uid: 447
-    components:
-    - type: Transform
-      pos: -3.5,-13.5
-      parent: 1
-  - uid: 758
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-13.5
-      parent: 1
-- proto: ChairPilotSeat
-  entities:
-  - uid: 1169
-    components:
-    - type: Transform
-      pos: 27.5,-16.5
-      parent: 1
-  - uid: 1216
-    components:
-    - type: Transform
-      pos: 25.5,-16.5
-      parent: 1
-  - uid: 1232
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 24.5,-17.5
-      parent: 1
-  - uid: 1233
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 28.5,-17.5
-      parent: 1
-  - uid: 1234
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 28.5,-19.5
-      parent: 1
-  - uid: 1235
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,-20.5
-      parent: 1
-  - uid: 1236
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 27.5,-18.5
-      parent: 1
-  - uid: 1237
-    components:
-    - type: Transform
-      pos: 26.5,-19.5
-      parent: 1
-  - uid: 1238
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 27.5,-20.5
-      parent: 1
-  - uid: 1239
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 24.5,-19.5
-      parent: 1
-  - uid: 1240
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 25.5,-18.5
-      parent: 1
-  - uid: 1241
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 26.5,-17.5
-      parent: 1
-- proto: ChemDispenser
-  entities:
-  - uid: 778
-    components:
-    - type: Transform
-      pos: -5.5,-1.5
-      parent: 1
-- proto: ChemDispenserEmpty
-  entities:
-  - uid: 756
-    components:
-    - type: Transform
-      pos: -6.5,-11.5
-      parent: 1
-- proto: ChemMaster
-  entities:
-  - uid: 779
-    components:
-    - type: Transform
-      pos: -5.5,-0.5
-      parent: 1
-- proto: CigaretteSpent
-  entities:
-  - uid: 929
-    components:
-    - type: Transform
-      pos: 7.1085286,-15.394098
-      parent: 1
-  - uid: 930
-    components:
-    - type: Transform
-      pos: 7.5616536,-16.019098
-      parent: 1
-  - uid: 931
-    components:
-    - type: Transform
-      pos: 7.1866536,-16.644098
-      parent: 1
-  - uid: 932
-    components:
-    - type: Transform
-      pos: 7.2335286,-16.065973
-      parent: 1
-  - uid: 933
-    components:
-    - type: Transform
-      pos: 7.5772786,-15.550348
-      parent: 1
-  - uid: 934
-    components:
-    - type: Transform
-      pos: 7.3116536,-14.972223
-      parent: 1
-- proto: CigPackSyndicate
-  entities:
-  - uid: 928
-    components:
-    - type: Transform
-      pos: 8.296028,-16.487848
-      parent: 1
-- proto: ClosetEmergencyFilledRandom
-  entities:
-  - uid: 958
-    components:
-    - type: Transform
-      pos: 3.5,-6.5
-      parent: 1
-- proto: ClosetFireFilled
-  entities:
-  - uid: 959
-    components:
-    - type: Transform
-      pos: 2.5,-6.5
-      parent: 1
-- proto: ClothingBackpackWaterTank
-  entities:
-  - uid: 947
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.126606,-9.469422
-      parent: 1
-- proto: ClothingEyesGlassesChemical
-  entities:
-  - uid: 768
-    components:
-    - type: Transform
-      pos: -12.043489,-10.235588
-      parent: 1
-- proto: ClothingHandsGlovesNitrile
-  entities:
-  - uid: 769
-    components:
-    - type: Transform
-      pos: -12.074739,-10.610588
-      parent: 1
-- proto: ComfyChair
-  entities:
-  - uid: 924
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-15.5
-      parent: 1
-  - uid: 925
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-16.5
-      parent: 1
-  - uid: 1790
-    components:
-    - type: Transform
-      pos: 39.5,-7.5
-      parent: 1
-  - uid: 1791
-    components:
-    - type: Transform
-      pos: 38.5,-7.5
-      parent: 1
-  - uid: 1792
-    components:
-    - type: Transform
-      pos: 37.5,-7.5
-      parent: 1
-  - uid: 1793
-    components:
-    - type: Transform
-      pos: 36.5,-7.5
-      parent: 1
-  - uid: 1794
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 39.5,-11.5
-      parent: 1
-  - uid: 1795
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 38.5,-11.5
-      parent: 1
-  - uid: 1796
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 37.5,-11.5
-      parent: 1
-  - uid: 1797
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 36.5,-11.5
-      parent: 1
-  - uid: 1798
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 42.5,-9.5
-      parent: 1
-- proto: ComputerFrame
-  entities:
-  - uid: 755
-    components:
-    - type: Transform
-      pos: -6.5,-12.5
-      parent: 1
-- proto: ComputerTelevision
-  entities:
-  - uid: 923
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,-15.5
-      parent: 1
-- proto: CrateFreezer
-  entities:
-  - uid: 164
-    components:
-    - type: Transform
-      pos: 0.5,-2.5
-      parent: 1
-  - uid: 165
-    components:
-    - type: Transform
-      pos: 2.5,-4.5
-      parent: 1
-  - uid: 166
-    components:
-    - type: Transform
-      pos: 3.5,-4.5
-      parent: 1
-  - uid: 167
-    components:
-    - type: Transform
-      pos: 4.5,-4.5
-      parent: 1
-- proto: CrateVendingMachineRestockAutoDrobeFilled
-  entities:
-  - uid: 1838
-    components:
-    - type: Transform
-      pos: 27.5,5.5
-      parent: 1
-- proto: CrateVendingMachineRestockBoozeFilled
-  entities:
-  - uid: 1839
-    components:
-    - type: Transform
-      pos: 39.5,6.5
-      parent: 1
-- proto: CryostasisBeaker
-  entities:
-  - uid: 800
-    components:
-    - type: Transform
-      pos: -5.3134656,-2.7472272
-      parent: 1
-- proto: CyberPen
-  entities:
-  - uid: 2377
-    components:
-    - type: Transform
-      pos: 41.430195,-10.256749
-      parent: 1
-- proto: DeathRattleImplanter
-  entities:
-  - uid: 961
-    components:
-    - type: Transform
-      pos: 3.5470674,-8.528731
-      parent: 1
-- proto: DogBed
-  entities:
-  - uid: 274
-    components:
-    - type: Transform
-      pos: 7.5,-7.5
-      parent: 1
-- proto: DonkpocketBoxSpawner
-  entities:
-  - uid: 9
-    components:
-    - type: Transform
-      pos: 4.5,-0.5
-      parent: 1
-- proto: DresserFilled
-  entities:
-  - uid: 915
-    components:
-    - type: Transform
-      pos: 11.5,-11.5
-      parent: 1
-  - uid: 916
-    components:
-    - type: Transform
-      pos: 11.5,-15.5
-      parent: 1
-- proto: DrinkBeerGrowler
-  entities:
-  - uid: 926
-    components:
-    - type: Transform
-      pos: 6.4054036,-14.222223
-      parent: 1
-- proto: DrinkJuiceOrangeCartonXL
-  entities:
-  - uid: 150
-    components:
-    - type: Transform
-      pos: 7.5,4.5
-      parent: 1
-- proto: DrinkJuiceTomatoCarton
-  entities:
-  - uid: 154
-    components:
-    - type: Transform
-      pos: 2.5,3.5
-      parent: 1
-- proto: DrinkShaker
-  entities:
-  - uid: 143
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
-- proto: DrinkWineBottleFull
-  entities:
-  - uid: 163
-    components:
-    - type: Transform
-      pos: 11.5,-1.5
-      parent: 1
-- proto: EphedrineChemistryBottle
-  entities:
-  - uid: 831
-    components:
-    - type: Transform
-      pos: -1.4256997,-0.3865409
-      parent: 1
-- proto: EpinephrineChemistryBottle
-  entities:
-  - uid: 832
-    components:
-    - type: Transform
-      pos: -1.6288247,-0.8396659
-      parent: 1
-- proto: FenceMetalBroken
-  entities:
-  - uid: 1359
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,-21.5
-      parent: 1
-- proto: FenceMetalGate
-  entities:
-  - uid: 1356
-    components:
-    - type: Transform
-      pos: 16.5,-21.5
-      parent: 1
-- proto: FenceMetalStraight
-  entities:
-  - uid: 1357
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,-21.5
-      parent: 1
-  - uid: 1358
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 17.5,-21.5
-      parent: 1
-  - uid: 1360
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,-21.5
-      parent: 1
-- proto: FireAxeFlaming
-  entities:
-  - uid: 2370
-    components:
-    - type: Transform
-      pos: -2.2713957,-20.14453
-      parent: 1
-- proto: FitnessPunchingBagCaptain
-  entities:
-  - uid: 148
-    components:
-    - type: Transform
-      pos: 10.5,3.5
-      parent: 1
-- proto: FitnessWeightsBench1
-  entities:
-  - uid: 138
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,4.5
-      parent: 1
-  - uid: 139
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,4.5
-      parent: 1
-- proto: Flash
-  entities:
-  - uid: 1373
-    components:
-    - type: Transform
-      pos: 34.615303,0.110441685
-      parent: 1
-- proto: FlippoLighter
-  entities:
-  - uid: 927
-    components:
-    - type: Transform
-      pos: 8.749153,-16.456598
-      parent: 1
-- proto: Floodlight
-  entities:
-  - uid: 942
-    components:
-    - type: Transform
-      pos: 15.712837,-12.377796
-      parent: 1
-- proto: FloorDrain
-  entities:
-  - uid: 522
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,-16.5
-      parent: 1
-    - type: Fixtures
-      fixtures: {}
-  - uid: 797
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,-3.5
-      parent: 1
-    - type: Fixtures
-      fixtures: {}
-- proto: FloorLiquidPlasmaEntity
-  entities:
-  - uid: 1146
-    components:
-    - type: Transform
-      pos: 25.5,-14.5
-      parent: 1
-  - uid: 1147
-    components:
-    - type: Transform
-      pos: 24.5,-14.5
-      parent: 1
-  - uid: 1148
-    components:
-    - type: Transform
-      pos: 23.5,-14.5
-      parent: 1
-  - uid: 1149
-    components:
-    - type: Transform
-      pos: 22.5,-14.5
-      parent: 1
-  - uid: 1150
-    components:
-    - type: Transform
-      pos: 23.5,-15.5
-      parent: 1
-  - uid: 1151
-    components:
-    - type: Transform
-      pos: 22.5,-15.5
-      parent: 1
-  - uid: 1152
-    components:
-    - type: Transform
-      pos: 21.5,-15.5
-      parent: 1
-  - uid: 1153
-    components:
-    - type: Transform
-      pos: 20.5,-15.5
-      parent: 1
-  - uid: 1154
-    components:
-    - type: Transform
-      pos: 22.5,-16.5
-      parent: 1
-  - uid: 1155
-    components:
-    - type: Transform
-      pos: 22.5,-17.5
-      parent: 1
-  - uid: 1156
-    components:
-    - type: Transform
-      pos: 22.5,-18.5
-      parent: 1
-  - uid: 1157
-    components:
-    - type: Transform
-      pos: 22.5,-19.5
-      parent: 1
-  - uid: 1158
-    components:
-    - type: Transform
-      pos: 22.5,-20.5
-      parent: 1
-  - uid: 1159
-    components:
-    - type: Transform
-      pos: 21.5,-16.5
-      parent: 1
-  - uid: 1160
-    components:
-    - type: Transform
-      pos: 21.5,-17.5
-      parent: 1
-  - uid: 1161
-    components:
-    - type: Transform
-      pos: 21.5,-18.5
-      parent: 1
-  - uid: 1162
-    components:
-    - type: Transform
-      pos: 21.5,-19.5
-      parent: 1
-  - uid: 1163
-    components:
-    - type: Transform
-      pos: 21.5,-20.5
-      parent: 1
-  - uid: 1164
-    components:
-    - type: Transform
-      pos: 20.5,-16.5
-      parent: 1
-  - uid: 1165
-    components:
-    - type: Transform
-      pos: 20.5,-17.5
-      parent: 1
-  - uid: 1166
-    components:
-    - type: Transform
-      pos: 20.5,-18.5
-      parent: 1
-  - uid: 1167
-    components:
-    - type: Transform
-      pos: 20.5,-19.5
-      parent: 1
-  - uid: 1168
-    components:
-    - type: Transform
-      pos: 20.5,-20.5
-      parent: 1
-  - uid: 1296
-    components:
-    - type: Transform
-      pos: 23.5,-21.5
-      parent: 1
-  - uid: 1297
-    components:
-    - type: Transform
-      pos: 22.5,-21.5
-      parent: 1
-  - uid: 1298
-    components:
-    - type: Transform
-      pos: 21.5,-21.5
-      parent: 1
-  - uid: 1299
-    components:
-    - type: Transform
-      pos: 20.5,-21.5
-      parent: 1
-  - uid: 1300
-    components:
-    - type: Transform
-      pos: 28.5,-22.5
-      parent: 1
-  - uid: 1301
-    components:
-    - type: Transform
-      pos: 27.5,-22.5
-      parent: 1
-  - uid: 1302
-    components:
-    - type: Transform
-      pos: 26.5,-22.5
-      parent: 1
-  - uid: 1303
-    components:
-    - type: Transform
-      pos: 25.5,-22.5
-      parent: 1
-  - uid: 1304
-    components:
-    - type: Transform
-      pos: 24.5,-22.5
-      parent: 1
-  - uid: 1305
-    components:
-    - type: Transform
-      pos: 23.5,-22.5
-      parent: 1
-  - uid: 1306
-    components:
-    - type: Transform
-      pos: 22.5,-22.5
-      parent: 1
-  - uid: 1307
-    components:
-    - type: Transform
-      pos: 21.5,-22.5
-      parent: 1
-  - uid: 1308
-    components:
-    - type: Transform
-      pos: 23.5,-23.5
-      parent: 1
-  - uid: 1309
-    components:
-    - type: Transform
-      pos: 24.5,-23.5
-      parent: 1
-  - uid: 1310
-    components:
-    - type: Transform
-      pos: 25.5,-23.5
-      parent: 1
-  - uid: 1311
-    components:
-    - type: Transform
-      pos: 26.5,-23.5
-      parent: 1
-  - uid: 1312
-    components:
-    - type: Transform
-      pos: 27.5,-23.5
-      parent: 1
-  - uid: 1313
-    components:
-    - type: Transform
-      pos: 29.5,-21.5
-      parent: 1
-  - uid: 1314
-    components:
-    - type: Transform
-      pos: 28.5,-21.5
-      parent: 1
-  - uid: 1315
-    components:
-    - type: Transform
-      pos: 24.5,-21.5
-      parent: 1
-  - uid: 1316
-    components:
-    - type: Transform
-      pos: 23.5,-20.5
-      parent: 1
-  - uid: 1317
-    components:
-    - type: Transform
-      pos: 29.5,-20.5
-      parent: 1
-  - uid: 1318
-    components:
-    - type: Transform
-      pos: 23.5,-16.5
-      parent: 1
-  - uid: 1319
-    components:
-    - type: Transform
-      pos: 24.5,-15.5
-      parent: 1
-- proto: FloraTreeConifer01
-  entities:
-  - uid: 1291
-    components:
-    - type: Transform
-      pos: 21.392143,-12.729544
-      parent: 1
-  - uid: 2244
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 42.96957,-1.4107871
-      parent: 1
-  - uid: 2245
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 44.071133,4.3314004
-      parent: 1
-  - uid: 2246
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 44.610195,10.118542
-      parent: 1
-  - uid: 2247
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 32.038555,16.165417
-      parent: 1
-  - uid: 2248
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 25.21776,10.212292
-      parent: 1
-  - uid: 2249
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 38.739777,15.204479
-      parent: 1
-  - uid: 2250
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 24.270073,7.063351
-      parent: 1
-  - uid: 2251
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.942753,6.825022
-      parent: 1
-  - uid: 2252
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 16.066328,-1.7765403
-      parent: 1
-  - uid: 2253
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 22.019453,1.5984597
-      parent: 1
-  - uid: 2254
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -11.4639435,3.9474778
-      parent: 1
-  - uid: 2255
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.8467555,7.275603
-      parent: 1
-  - uid: 2256
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.510818,2.9865403
-      parent: 1
-  - uid: 2257
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.8057833,9.73654
-      parent: 1
-  - uid: 2258
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.199942,11.617781
-      parent: 1
-  - uid: 2313
-    components:
-    - type: Transform
-      pos: 31.977348,-23.940697
-      parent: 1
-- proto: FloraTreeConifer02
-  entities:
-  - uid: 941
-    components:
-    - type: Transform
-      pos: 10.992382,-20.738451
-      parent: 1
-- proto: FloraTreeConifer03
-  entities:
-  - uid: 1290
-    components:
-    - type: Transform
-      pos: 16.973898,-18.627144
-      parent: 1
-  - uid: 2311
-    components:
-    - type: Transform
-      pos: 16.859533,-25.557884
-      parent: 1
-  - uid: 2312
-    components:
-    - type: Transform
-      pos: 26.703283,-24.807884
-      parent: 1
-- proto: FloraTreeSnow01
-  entities:
-  - uid: 2259
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 20.842281,16.78661
-      parent: 1
-  - uid: 2260
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 32.94993,10.88036
-      parent: 1
-  - uid: 2261
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 21.234589,8.81786
-      parent: 1
-  - uid: 2262
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 36.445526,15.731922
-      parent: 1
-  - uid: 2263
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 38.445923,10.270985
-      parent: 1
-  - uid: 2264
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 46.571957,16.200672
-      parent: 1
-  - uid: 2265
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 42.61102,5.0912967
-      parent: 1
-  - uid: 2266
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 44.321957,0.8710246
-      parent: 1
-  - uid: 2267
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 24.94335,1.3600345
-      parent: 1
-  - uid: 2268
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.3007822,5.7447276
-      parent: 1
-  - uid: 2269
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.884738,9.986916
-      parent: 1
-- proto: FloraTreeSnow02
-  entities:
-  - uid: 938
-    components:
-    - type: Transform
-      pos: 6.351757,-21.816576
-      parent: 1
-  - uid: 943
-    components:
-    - type: Transform
-      pos: 15.540962,-14.862171
-      parent: 1
-  - uid: 1288
-    components:
-    - type: Transform
-      pos: 15.208273,-20.377144
-      parent: 1
-  - uid: 1292
-    components:
-    - type: Transform
-      pos: 32.956394,-16.27578
-      parent: 1
-  - uid: 1293
-    components:
-    - type: Transform
-      pos: 30.987646,-13.43203
-      parent: 1
-  - uid: 2270
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.984393,7.361915
-      parent: 1
-  - uid: 2271
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 16.976582,4.1041026
-      parent: 1
-  - uid: 2272
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 20.93752,-1.8255849
-      parent: 1
-- proto: FloraTreeSnow03
-  entities:
-  - uid: 945
-    components:
-    - type: Transform
-      pos: 18.119087,-14.159046
-      parent: 1
-  - uid: 2306
-    components:
-    - type: Transform
-      pos: 18.776403,1.4578114
-      parent: 1
-  - uid: 2307
-    components:
-    - type: Transform
-      pos: 33.386364,-21.432884
-      parent: 1
-  - uid: 2308
-    components:
-    - type: Transform
-      pos: 28.675426,-26.35476
-      parent: 1
-  - uid: 2309
-    components:
-    - type: Transform
-      pos: 22.297033,-26.214134
-      parent: 1
-  - uid: 2310
-    components:
-    - type: Transform
-      pos: 18.031408,-23.565697
-      parent: 1
-- proto: FloraTreeSnow04
-  entities:
-  - uid: 940
-    components:
-    - type: Transform
-      pos: 8.883007,-21.550951
-      parent: 1
-  - uid: 1289
-    components:
-    - type: Transform
-      pos: 17.833273,-21.095894
-      parent: 1
-- proto: FloraTreeSnow06
-  entities:
-  - uid: 939
-    components:
-    - type: Transform
-      pos: 8.508007,-19.113451
-      parent: 1
-  - uid: 944
-    components:
-    - type: Transform
-      pos: 17.009712,-11.737171
-      parent: 1
-  - uid: 2273
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 20.210957,6.1197276
-      parent: 1
-  - uid: 2274
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.375019,11.838478
-      parent: 1
-  - uid: 2275
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 27.448383,15.617538
-      parent: 1
-  - uid: 2276
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 43.091564,14.422716
-      parent: 1
-- proto: FoodSnackSyndi
-  entities:
-  - uid: 162
-    components:
-    - type: Transform
-      pos: 10.5,-1.5
-      parent: 1
-- proto: GasFilter
-  entities:
-  - uid: 544
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-15.5
-      parent: 1
-- proto: GasFilterFlipped
-  entities:
-  - uid: 527
-    components:
-    - type: Transform
-      pos: -3.5,-16.5
-      parent: 1
-- proto: GasMixer
-  entities:
-  - uid: 437
-    components:
-    - type: Transform
-      pos: -0.5,-12.5
-      parent: 1
-- proto: GasOutletInjector
-  entities:
-  - uid: 531
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-19.5
-      parent: 1
-- proto: GasPassiveVent
-  entities:
-  - uid: 552
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-19.5
-      parent: 1
-  - uid: 553
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-20.5
-      parent: 1
-  - uid: 554
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-19.5
-      parent: 1
-  - uid: 556
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-20.5
-      parent: 1
-- proto: GasPipeBend
-  entities:
-  - uid: 528
-    components:
-    - type: Transform
-      pos: -3.5,-15.5
-      parent: 1
-  - uid: 545
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-15.5
-      parent: 1
-  - uid: 546
-    components:
-    - type: Transform
-      pos: 1.5,-16.5
-      parent: 1
-  - uid: 547
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-16.5
-      parent: 1
-- proto: GasPipeFourway
-  entities:
-  - uid: 230
-    components:
-    - type: Transform
-      pos: 6.5,-0.5
-      parent: 1
-- proto: GasPipeStraight
-  entities:
-  - uid: 209
-    components:
-    - type: Transform
-      pos: 6.5,-1.5
-      parent: 1
-  - uid: 210
-    components:
-    - type: Transform
-      pos: 6.5,-2.5
-      parent: 1
-  - uid: 211
-    components:
-    - type: Transform
-      pos: 6.5,-3.5
-      parent: 1
-  - uid: 212
-    components:
-    - type: Transform
-      pos: 6.5,0.5
-      parent: 1
-  - uid: 213
-    components:
-    - type: Transform
-      pos: 6.5,1.5
-      parent: 1
-  - uid: 214
-    components:
-    - type: Transform
-      pos: 8.5,-0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#404040FF'
-  - uid: 215
-    components:
-    - type: Transform
-      pos: 8.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#404040FF'
-  - uid: 216
-    components:
-    - type: Transform
-      pos: 8.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#404040FF'
-  - uid: 217
-    components:
-    - type: Transform
-      pos: 8.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#404040FF'
-  - uid: 218
-    components:
-    - type: Transform
-      pos: 8.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#404040FF'
-  - uid: 219
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#404040FF'
-  - uid: 220
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#404040FF'
-  - uid: 221
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#404040FF'
-  - uid: 222
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#404040FF'
-  - uid: 223
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-0.5
-      parent: 1
-  - uid: 224
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,-0.5
-      parent: 1
-  - uid: 225
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,-0.5
-      parent: 1
-  - uid: 233
-    components:
-    - type: Transform
-      pos: 6.5,2.5
-      parent: 1
-  - uid: 234
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-0.5
-      parent: 1
-  - uid: 235
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-0.5
-      parent: 1
-  - uid: 529
-    components:
-    - type: Transform
-      pos: -3.5,-18.5
-      parent: 1
-  - uid: 530
-    components:
-    - type: Transform
-      pos: -1.5,-18.5
-      parent: 1
-  - uid: 555
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-19.5
-      parent: 1
-  - uid: 557
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-20.5
-      parent: 1
-- proto: GasPipeTJunction
-  entities:
-  - uid: 206
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-0.5
-      parent: 1
-  - uid: 207
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#404040FF'
-  - uid: 208
-    components:
-    - type: Transform
-      pos: 7.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#404040FF'
-  - uid: 548
-    components:
-    - type: Transform
-      pos: 0.5,-16.5
-      parent: 1
-- proto: GasPort
-  entities:
-  - uid: 438
-    components:
-    - type: Transform
-      pos: -0.5,-11.5
-      parent: 1
-  - uid: 439
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-12.5
-      parent: 1
-  - uid: 440
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-13.5
-      parent: 1
-  - uid: 441
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-11.5
-      parent: 1
-  - uid: 442
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-12.5
-      parent: 1
-  - uid: 537
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-17.5
-      parent: 1
-  - uid: 538
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,-17.5
-      parent: 1
-  - uid: 539
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-15.5
-      parent: 1
-  - uid: 540
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-16.5
-      parent: 1
-  - uid: 541
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-15.5
-      parent: 1
-  - uid: 542
-    components:
-    - type: Transform
-      pos: -0.5,-14.5
-      parent: 1
-  - uid: 543
-    components:
-    - type: Transform
-      pos: -1.5,-14.5
-      parent: 1
-- proto: GasPressurePump
-  entities:
-  - uid: 534
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-17.5
-      parent: 1
-  - uid: 535
-    components:
-    - type: Transform
-      pos: -1.5,-17.5
-      parent: 1
-- proto: GasThermoMachineHellfireFreezer
-  entities:
-  - uid: 443
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-11.5
-      parent: 1
-- proto: GasThermoMachineHellfireHeater
-  entities:
-  - uid: 444
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-12.5
-      parent: 1
-- proto: GasValve
-  entities:
-  - uid: 536
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-16.5
-      parent: 1
-- proto: GasVentPump
-  entities:
-  - uid: 205
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-0.5
-      parent: 1
-  - uid: 226
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,-0.5
-      parent: 1
-  - uid: 227
-    components:
-    - type: Transform
-      pos: 7.5,0.5
-      parent: 1
-  - uid: 231
-    components:
-    - type: Transform
-      pos: 6.5,3.5
-      parent: 1
-- proto: GasVentScrubber
-  entities:
-  - uid: 228
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#404040FF'
-  - uid: 229
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#404040FF'
-  - uid: 232
-    components:
-    - type: Transform
-      pos: 8.5,2.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#404040FF'
-  - uid: 532
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-19.5
-      parent: 1
-- proto: GeneratorBasic15kW
-  entities:
-  - uid: 1868
-    components:
-    - type: Transform
-      pos: 31.5,-10.5
-      parent: 1
-- proto: GeneratorRTG
-  entities:
-  - uid: 1864
-    components:
-    - type: Transform
-      pos: 30.5,-10.5
-      parent: 1
-  - uid: 1865
-    components:
-    - type: Transform
-      pos: 32.5,-9.5
-      parent: 1
-  - uid: 1866
-    components:
-    - type: Transform
-      pos: 32.5,-8.5
-      parent: 1
-  - uid: 1867
-    components:
-    - type: Transform
-      pos: 29.5,-8.5
-      parent: 1
-- proto: GravityGeneratorMini
-  entities:
-  - uid: 1863
-    components:
-    - type: Transform
-      pos: 29.5,-9.5
-      parent: 1
-- proto: Grille
-  entities:
-  - uid: 27
-    components:
-    - type: Transform
-      pos: 0.5,2.5
-      parent: 1
-  - uid: 28
-    components:
-    - type: Transform
-      pos: 0.5,3.5
-      parent: 1
-  - uid: 29
-    components:
-    - type: Transform
-      pos: 1.5,3.5
-      parent: 1
-  - uid: 30
-    components:
-    - type: Transform
-      pos: 1.5,4.5
-      parent: 1
-  - uid: 80
-    components:
-    - type: Transform
-      pos: 2.5,4.5
-      parent: 1
-  - uid: 81
-    components:
-    - type: Transform
-      pos: 3.5,4.5
-      parent: 1
-  - uid: 82
-    components:
-    - type: Transform
-      pos: 4.5,4.5
-      parent: 1
-  - uid: 83
-    components:
-    - type: Transform
-      pos: 4.5,5.5
-      parent: 1
-  - uid: 84
-    components:
-    - type: Transform
-      pos: 5.5,5.5
-      parent: 1
-  - uid: 85
-    components:
-    - type: Transform
-      pos: 6.5,5.5
-      parent: 1
-  - uid: 86
-    components:
-    - type: Transform
-      pos: 7.5,5.5
-      parent: 1
-  - uid: 87
-    components:
-    - type: Transform
-      pos: 8.5,5.5
-      parent: 1
-  - uid: 88
-    components:
-    - type: Transform
-      pos: 9.5,5.5
-      parent: 1
-  - uid: 89
-    components:
-    - type: Transform
-      pos: 9.5,4.5
-      parent: 1
-  - uid: 90
-    components:
-    - type: Transform
-      pos: 10.5,4.5
-      parent: 1
-  - uid: 91
-    components:
-    - type: Transform
-      pos: 11.5,4.5
-      parent: 1
-  - uid: 92
-    components:
-    - type: Transform
-      pos: 12.5,4.5
-      parent: 1
-  - uid: 93
-    components:
-    - type: Transform
-      pos: 12.5,3.5
-      parent: 1
-  - uid: 94
-    components:
-    - type: Transform
-      pos: 13.5,3.5
-      parent: 1
-  - uid: 95
-    components:
-    - type: Transform
-      pos: 13.5,2.5
-      parent: 1
-  - uid: 96
-    components:
-    - type: Transform
-      pos: 13.5,0.5
-      parent: 1
-  - uid: 97
-    components:
-    - type: Transform
-      pos: 13.5,-1.5
-      parent: 1
-  - uid: 98
-    components:
-    - type: Transform
-      pos: 13.5,-2.5
-      parent: 1
-  - uid: 99
-    components:
-    - type: Transform
-      pos: 13.5,-0.5
-      parent: 1
-  - uid: 103
-    components:
-    - type: Transform
-      pos: 7.5,-3.5
-      parent: 1
-  - uid: 281
-    components:
-    - type: Transform
-      pos: -11.5,-16.5
-      parent: 1
-  - uid: 282
-    components:
-    - type: Transform
-      pos: -11.5,-15.5
-      parent: 1
-  - uid: 283
-    components:
-    - type: Transform
-      pos: -11.5,-14.5
-      parent: 1
-  - uid: 284
-    components:
-    - type: Transform
-      pos: -12.5,-14.5
-      parent: 1
-  - uid: 285
-    components:
-    - type: Transform
-      pos: -10.5,-14.5
-      parent: 1
-  - uid: 286
-    components:
-    - type: Transform
-      pos: -8.5,-14.5
-      parent: 1
-  - uid: 287
-    components:
-    - type: Transform
-      pos: -9.5,-14.5
-      parent: 1
-  - uid: 288
-    components:
-    - type: Transform
-      pos: -8.5,-15.5
-      parent: 1
-  - uid: 289
-    components:
-    - type: Transform
-      pos: -8.5,-16.5
-      parent: 1
-  - uid: 290
-    components:
-    - type: Transform
-      pos: -7.5,-15.5
-      parent: 1
-  - uid: 291
-    components:
-    - type: Transform
-      pos: -6.5,-15.5
-      parent: 1
-  - uid: 292
-    components:
-    - type: Transform
-      pos: -6.5,-9.5
-      parent: 1
-  - uid: 293
-    components:
-    - type: Transform
-      pos: -8.5,-9.5
-      parent: 1
-  - uid: 294
-    components:
-    - type: Transform
-      pos: -3.5,-9.5
-      parent: 1
-  - uid: 295
-    components:
-    - type: Transform
-      pos: -1.5,-9.5
-      parent: 1
-  - uid: 296
-    components:
-    - type: Transform
-      pos: -1.5,-5.5
-      parent: 1
-  - uid: 297
-    components:
-    - type: Transform
-      pos: -3.5,-5.5
-      parent: 1
-  - uid: 298
-    components:
-    - type: Transform
-      pos: -5.5,-5.5
-      parent: 1
-  - uid: 299
-    components:
-    - type: Transform
-      pos: -7.5,-5.5
-      parent: 1
-  - uid: 451
-    components:
-    - type: Transform
-      pos: -3.5,-18.5
-      parent: 1
-  - uid: 452
-    components:
-    - type: Transform
-      pos: -1.5,-18.5
-      parent: 1
-  - uid: 874
-    components:
-    - type: Transform
-      pos: 13.5,-11.5
-      parent: 1
-  - uid: 875
-    components:
-    - type: Transform
-      pos: 13.5,-12.5
-      parent: 1
-  - uid: 876
-    components:
-    - type: Transform
-      pos: 13.5,-14.5
-      parent: 1
-  - uid: 877
-    components:
-    - type: Transform
-      pos: 13.5,-15.5
-      parent: 1
-  - uid: 878
-    components:
-    - type: Transform
-      pos: 8.5,-17.5
-      parent: 1
-  - uid: 879
-    components:
-    - type: Transform
-      pos: 7.5,-17.5
-      parent: 1
-  - uid: 880
-    components:
-    - type: Transform
-      pos: 6.5,-17.5
-      parent: 1
-  - uid: 968
-    components:
-    - type: Transform
-      pos: 14.5,-8.5
-      parent: 1
-  - uid: 969
-    components:
-    - type: Transform
-      pos: 15.5,-8.5
-      parent: 1
-  - uid: 970
-    components:
-    - type: Transform
-      pos: 16.5,-8.5
-      parent: 1
-  - uid: 971
-    components:
-    - type: Transform
-      pos: 17.5,-8.5
-      parent: 1
-  - uid: 972
-    components:
-    - type: Transform
-      pos: 18.5,-8.5
-      parent: 1
-  - uid: 973
-    components:
-    - type: Transform
-      pos: 19.5,-8.5
-      parent: 1
-  - uid: 974
-    components:
-    - type: Transform
-      pos: 20.5,-8.5
-      parent: 1
-  - uid: 975
-    components:
-    - type: Transform
-      pos: 21.5,-8.5
-      parent: 1
-  - uid: 976
-    components:
-    - type: Transform
-      pos: 22.5,-8.5
-      parent: 1
-  - uid: 977
-    components:
-    - type: Transform
-      pos: 23.5,-8.5
-      parent: 1
-  - uid: 978
-    components:
-    - type: Transform
-      pos: 24.5,-8.5
-      parent: 1
-  - uid: 979
-    components:
-    - type: Transform
-      pos: 25.5,-8.5
-      parent: 1
-  - uid: 980
-    components:
-    - type: Transform
-      pos: 14.5,-3.5
-      parent: 1
-  - uid: 981
-    components:
-    - type: Transform
-      pos: 16.5,-3.5
-      parent: 1
-  - uid: 982
-    components:
-    - type: Transform
-      pos: 15.5,-3.5
-      parent: 1
-  - uid: 983
-    components:
-    - type: Transform
-      pos: 18.5,-3.5
-      parent: 1
-  - uid: 984
-    components:
-    - type: Transform
-      pos: 17.5,-3.5
-      parent: 1
-  - uid: 985
-    components:
-    - type: Transform
-      pos: 20.5,-3.5
-      parent: 1
-  - uid: 986
-    components:
-    - type: Transform
-      pos: 19.5,-3.5
-      parent: 1
-  - uid: 987
-    components:
-    - type: Transform
-      pos: 22.5,-3.5
-      parent: 1
-  - uid: 988
-    components:
-    - type: Transform
-      pos: 21.5,-3.5
-      parent: 1
-  - uid: 989
-    components:
-    - type: Transform
-      pos: 24.5,-3.5
-      parent: 1
-  - uid: 990
-    components:
-    - type: Transform
-      pos: 23.5,-3.5
-      parent: 1
-  - uid: 991
-    components:
-    - type: Transform
-      pos: 25.5,-3.5
-      parent: 1
-  - uid: 1252
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 31.5,-17.5
-      parent: 1
-  - uid: 1253
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 32.5,-17.5
-      parent: 1
-  - uid: 1254
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 33.5,-17.5
-      parent: 1
-  - uid: 1257
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 31.5,-19.5
-      parent: 1
-  - uid: 1258
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 32.5,-19.5
-      parent: 1
-  - uid: 1259
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 34.5,-17.5
-      parent: 1
-  - uid: 1260
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 33.5,-19.5
-      parent: 1
-  - uid: 1261
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 34.5,-16.5
-      parent: 1
-  - uid: 1646
-    components:
-    - type: Transform
-      pos: 30.5,2.5
-      parent: 1
-  - uid: 1647
-    components:
-    - type: Transform
-      pos: 30.5,-0.5
-      parent: 1
-  - uid: 1648
-    components:
-    - type: Transform
-      pos: 27.5,2.5
-      parent: 1
-  - uid: 1649
-    components:
-    - type: Transform
-      pos: 27.5,1.5
-      parent: 1
-  - uid: 1650
-    components:
-    - type: Transform
-      pos: 27.5,0.5
-      parent: 1
-  - uid: 1651
-    components:
-    - type: Transform
-      pos: 27.5,-0.5
-      parent: 1
-  - uid: 1652
-    components:
-    - type: Transform
-      pos: 31.5,4.5
-      parent: 1
-  - uid: 1653
-    components:
-    - type: Transform
-      pos: 35.5,-4.5
-      parent: 1
-  - uid: 1654
-    components:
-    - type: Transform
-      pos: 36.5,-4.5
-      parent: 1
-  - uid: 1655
-    components:
-    - type: Transform
-      pos: 38.5,-1.5
-      parent: 1
-  - uid: 1656
-    components:
-    - type: Transform
-      pos: 40.5,-1.5
-      parent: 1
-  - uid: 1657
-    components:
-    - type: Transform
-      pos: 41.5,-3.5
-      parent: 1
-  - uid: 1658
-    components:
-    - type: Transform
-      pos: 42.5,-3.5
-      parent: 1
-  - uid: 1659
-    components:
-    - type: Transform
-      pos: 43.5,-3.5
-      parent: 1
-  - uid: 1660
-    components:
-    - type: Transform
-      pos: 44.5,-3.5
-      parent: 1
-  - uid: 1661
-    components:
-    - type: Transform
-      pos: 45.5,-3.5
-      parent: 1
-  - uid: 1662
-    components:
-    - type: Transform
-      pos: 46.5,-3.5
-      parent: 1
-  - uid: 1663
-    components:
-    - type: Transform
-      pos: 47.5,-3.5
-      parent: 1
-  - uid: 1664
-    components:
-    - type: Transform
-      pos: 41.5,-5.5
-      parent: 1
-  - uid: 1665
-    components:
-    - type: Transform
-      pos: 42.5,-5.5
-      parent: 1
-  - uid: 1666
-    components:
-    - type: Transform
-      pos: 43.5,-5.5
-      parent: 1
-  - uid: 1667
-    components:
-    - type: Transform
-      pos: 44.5,-5.5
-      parent: 1
-  - uid: 1668
-    components:
-    - type: Transform
-      pos: 45.5,-5.5
-      parent: 1
-  - uid: 1669
-    components:
-    - type: Transform
-      pos: 46.5,-5.5
-      parent: 1
-  - uid: 1670
-    components:
-    - type: Transform
-      pos: 47.5,-5.5
-      parent: 1
-  - uid: 1671
-    components:
-    - type: Transform
-      pos: 43.5,-7.5
-      parent: 1
-  - uid: 1672
-    components:
-    - type: Transform
-      pos: 44.5,-7.5
-      parent: 1
-  - uid: 1673
-    components:
-    - type: Transform
-      pos: 44.5,-8.5
-      parent: 1
-  - uid: 1674
-    components:
-    - type: Transform
-      pos: 44.5,-9.5
-      parent: 1
-  - uid: 1675
-    components:
-    - type: Transform
-      pos: 44.5,-10.5
-      parent: 1
-  - uid: 1676
-    components:
-    - type: Transform
-      pos: 44.5,-11.5
-      parent: 1
-  - uid: 1677
-    components:
-    - type: Transform
-      pos: 43.5,-11.5
-      parent: 1
-- proto: HeatExchanger
-  entities:
-  - uid: 807
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-16.5
-      parent: 1
-  - uid: 808
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-16.5
-      parent: 1
-- proto: HydroponicsTrayEmpty
-  entities:
-  - uid: 751
-    components:
-    - type: Transform
-      pos: -8.5,-13.5
-      parent: 1
-  - uid: 752
-    components:
-    - type: Transform
-      pos: -10.5,-13.5
-      parent: 1
-  - uid: 753
-    components:
-    - type: Transform
-      pos: -12.5,-13.5
-      parent: 1
-- proto: Igniter
-  entities:
-  - uid: 2
-    components:
-    - type: Transform
-      pos: -13.219715,-3.6691022
-      parent: 1
-  - uid: 551
-    components:
-    - type: Transform
-      pos: -13.219715,-3.2316022
-      parent: 1
-  - uid: 783
-    components:
-    - type: Transform
-      pos: -13.20409,-2.9034772
-      parent: 1
-- proto: InvisibleCrate
-  entities:
-  - uid: 1837
-    components:
-    - type: Transform
-      pos: 34.5,7.5
-      parent: 1
-- proto: Katana
-  entities:
-  - uid: 1744
-    components:
-    - type: Transform
-      pos: 37.5,-0.5
-      parent: 1
-- proto: KitchenElectricGrill
-  entities:
-  - uid: 3
-    components:
-    - type: Transform
-      pos: 0.5,-1.5
-      parent: 1
-- proto: KitchenKnife
+      pos: 12.5,-15.5
+      parent: 2
+- proto: BenchComfy
   entities:
   - uid: 75
     components:
     - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
-- proto: KitchenReagentGrinder
+      rot: 1.5707963267948966 rad
+      pos: 31.5,-3.5
+      parent: 2
+  - uid: 76
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 31.5,-2.5
+      parent: 2
+  - uid: 77
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 27.5,-2.5
+      parent: 2
+  - uid: 78
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 27.5,-3.5
+      parent: 2
+  - uid: 79
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 27.5,-4.5
+      parent: 2
+  - uid: 80
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 30.5,-2.5
+      parent: 2
+  - uid: 81
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 30.5,-3.5
+      parent: 2
+  - uid: 82
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 40.5,4.5
+      parent: 2
+  - uid: 83
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 40.5,3.5
+      parent: 2
+  - uid: 84
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 38.5,4.5
+      parent: 2
+  - uid: 85
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 38.5,3.5
+      parent: 2
+  - uid: 86
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 37.5,4.5
+      parent: 2
+  - uid: 87
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 37.5,3.5
+      parent: 2
+  - uid: 88
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 35.5,4.5
+      parent: 2
+  - uid: 89
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 35.5,3.5
+      parent: 2
+- proto: BenchRedComfy
   entities:
-  - uid: 748
+  - uid: 90
     components:
     - type: Transform
-      pos: -10.5,-10.5
-      parent: 1
-  - uid: 781
+      pos: 12.5,-4.5
+      parent: 2
+  - uid: 91
     components:
     - type: Transform
-      pos: -5.5,-3.5
-      parent: 1
-- proto: LargeBeaker
+      pos: 11.5,-4.5
+      parent: 2
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 10.5,-4.5
+      parent: 2
+- proto: Biofabricator
   entities:
-  - uid: 764
+  - uid: 93
     components:
     - type: Transform
-      pos: -12.699739,-11.344963
-      parent: 1
-  - uid: 799
-    components:
-    - type: Transform
-      pos: -5.5322156,-2.3097272
-      parent: 1
-- proto: LightPostSmall
+      pos: -6.5,-10.5
+      parent: 2
+- proto: BlastDoor
   entities:
-  - uid: 1285
+  - uid: 94
     components:
     - type: Transform
-      pos: 18.5,-16.5
-      parent: 1
-  - uid: 2300
+      pos: -0.5,-19.5
+      parent: 2
+  - uid: 95
     components:
     - type: Transform
-      pos: 19.5,7.5
-      parent: 1
-  - uid: 2301
+      pos: -0.5,-20.5
+      parent: 2
+  - uid: 96
     components:
     - type: Transform
-      pos: 29.5,14.5
-      parent: 1
-  - uid: 2302
+      pos: 27.5,8.5
+      parent: 2
+  - uid: 97
     components:
     - type: Transform
-      pos: -3.5,6.5
-      parent: 1
-  - uid: 2303
+      pos: 28.5,8.5
+      parent: 2
+  - uid: 98
     components:
     - type: Transform
-      pos: 19.5,-25.5
-      parent: 1
-  - uid: 2304
+      pos: 29.5,8.5
+      parent: 2
+  - uid: 99
     components:
     - type: Transform
-      pos: 30.5,-24.5
-      parent: 1
-  - uid: 2305
+      pos: 30.5,8.5
+      parent: 2
+  - uid: 100
     components:
     - type: Transform
-      pos: 43.5,11.5
-      parent: 1
-- proto: LockerFreezer
+      pos: 31.5,8.5
+      parent: 2
+  - uid: 101
+    components:
+    - type: Transform
+      pos: 32.5,8.5
+      parent: 2
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 33.5,8.5
+      parent: 2
+  - uid: 103
+    components:
+    - type: Transform
+      pos: 34.5,8.5
+      parent: 2
+  - uid: 104
+    components:
+    - type: Transform
+      pos: 35.5,8.5
+      parent: 2
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 36.5,8.5
+      parent: 2
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 37.5,8.5
+      parent: 2
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 38.5,8.5
+      parent: 2
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 39.5,8.5
+      parent: 2
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 40.5,8.5
+      parent: 2
+- proto: BoozeDispenser
   entities:
+  - uid: 110
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-2.5
+      parent: 2
+- proto: BoxEncryptionKeyPassenger
+  entities:
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 36.430195,-9.522374
+      parent: 2
+- proto: BoxEncryptionKeySyndie
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 41.53957,-8.444249
+      parent: 2
+- proto: BoxFolderRed
+  entities:
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 39.5,-8.5
+      parent: 2
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 36.5,-8.5
+      parent: 2
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 37.5,-10.5
+      parent: 2
+- proto: BoxMagazinePistol
+  entities:
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 36.63316,-0.29581022
+      parent: 2
+- proto: BoxMagazinePistolSubMachineGun
+  entities:
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 36.32066,-0.5614352
+      parent: 2
+- proto: BoxPillCanister
+  entities:
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -13.407215,-0.3722272
+      parent: 2
+- proto: BoxSyringe
+  entities:
+  - uid: 119
+    components:
+    - type: Transform
+      pos: -1.6756997,-3.620916
+      parent: 2
+- proto: Bucket
+  entities:
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 12.664318,-9.525236
+      parent: 2
+- proto: ButtonFrameCaution
+  entities:
+  - uid: 121
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-18.5
+      parent: 2
+- proto: CableApcExtension
+  entities:
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 2
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 2
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 9.5,-0.5
+      parent: 2
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 2
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 2
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 11.5,-0.5
+      parent: 2
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 11.5,-1.5
+      parent: 2
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 2
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 2
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 2
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 2
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 2
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 2
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 2
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 2
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 2
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 2
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 2
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 2
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 2
   - uid: 144
     components:
     - type: Transform
+      pos: 5.5,3.5
+      parent: 2
+  - uid: 145
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 2
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 2
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 8.5,3.5
+      parent: 2
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 9.5,3.5
+      parent: 2
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 10.5,3.5
+      parent: 2
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 2
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 2
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 2
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 2
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 11.5,3.5
+      parent: 2
+  - uid: 155
+    components:
+    - type: Transform
+      pos: 11.5,2.5
+      parent: 2
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 2
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 2
+  - uid: 158
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 2
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 2
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -0.5,-13.5
+      parent: 2
+  - uid: 161
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 2
+  - uid: 162
+    components:
+    - type: Transform
+      pos: -0.5,-15.5
+      parent: 2
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -0.5,-16.5
+      parent: 2
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -1.5,-16.5
+      parent: 2
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -2.5,-16.5
+      parent: 2
+  - uid: 166
+    components:
+    - type: Transform
+      pos: -2.5,-15.5
+      parent: 2
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -2.5,-14.5
+      parent: 2
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -2.5,-13.5
+      parent: 2
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -2.5,-12.5
+      parent: 2
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 2
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 2
+  - uid: 172
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 2
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 2
+  - uid: 174
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 175
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 176
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 177
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 178
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 2
+  - uid: 179
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 2
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -4.5,-6.5
+      parent: 2
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 2
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 2
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 2
+  - uid: 185
+    components:
+    - type: Transform
+      pos: -8.5,-7.5
+      parent: 2
+  - uid: 186
+    components:
+    - type: Transform
+      pos: -9.5,-7.5
+      parent: 2
+  - uid: 187
+    components:
+    - type: Transform
+      pos: -10.5,-7.5
+      parent: 2
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 2
+  - uid: 189
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 2
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 2
+  - uid: 191
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 2
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 2
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 2
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 2
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 9.5,-5.5
+      parent: 2
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 9.5,-6.5
+      parent: 2
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 10.5,-6.5
+      parent: 2
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 11.5,-6.5
+      parent: 2
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 11.5,-5.5
+      parent: 2
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 11.5,-7.5
+      parent: 2
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 11.5,-8.5
+      parent: 2
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 8.5,-6.5
+      parent: 2
+  - uid: 204
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 2
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 2
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 2
+  - uid: 208
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 2
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 7.5,-8.5
+      parent: 2
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 7.5,-9.5
+      parent: 2
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 8.5,-8.5
+      parent: 2
+  - uid: 212
+    components:
+    - type: Transform
+      pos: -8.5,1.5
+      parent: 2
+  - uid: 213
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 2
+  - uid: 214
+    components:
+    - type: Transform
+      pos: -8.5,-0.5
+      parent: 2
+  - uid: 215
+    components:
+    - type: Transform
+      pos: -8.5,-1.5
+      parent: 2
+  - uid: 216
+    components:
+    - type: Transform
+      pos: -8.5,-2.5
+      parent: 2
+  - uid: 217
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 2
+  - uid: 218
+    components:
+    - type: Transform
+      pos: -9.5,-3.5
+      parent: 2
+  - uid: 219
+    components:
+    - type: Transform
+      pos: -10.5,-3.5
+      parent: 2
+  - uid: 220
+    components:
+    - type: Transform
+      pos: -7.5,-2.5
+      parent: 2
+  - uid: 221
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 2
+  - uid: 222
+    components:
+    - type: Transform
+      pos: -9.5,-1.5
+      parent: 2
+  - uid: 223
+    components:
+    - type: Transform
+      pos: -10.5,-1.5
+      parent: 2
+  - uid: 224
+    components:
+    - type: Transform
+      pos: -11.5,-1.5
+      parent: 2
+  - uid: 225
+    components:
+    - type: Transform
+      pos: -12.5,-1.5
+      parent: 2
+  - uid: 226
+    components:
+    - type: Transform
+      pos: -12.5,-2.5
+      parent: 2
+  - uid: 227
+    components:
+    - type: Transform
+      pos: -12.5,-3.5
+      parent: 2
+  - uid: 228
+    components:
+    - type: Transform
+      pos: -11.5,-3.5
+      parent: 2
+  - uid: 229
+    components:
+    - type: Transform
+      pos: -11.5,-0.5
+      parent: 2
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 2
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 2
+  - uid: 232
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 2
+  - uid: 233
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 2
+  - uid: 234
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 2
+  - uid: 235
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 2
+  - uid: 236
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 2
+  - uid: 237
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 2
+  - uid: 238
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 2
+  - uid: 239
+    components:
+    - type: Transform
+      pos: -7.5,-13.5
+      parent: 2
+  - uid: 240
+    components:
+    - type: Transform
+      pos: -6.5,-13.5
+      parent: 2
+  - uid: 241
+    components:
+    - type: Transform
+      pos: -7.5,-12.5
+      parent: 2
+  - uid: 242
+    components:
+    - type: Transform
+      pos: -8.5,-12.5
+      parent: 2
+  - uid: 243
+    components:
+    - type: Transform
+      pos: -9.5,-12.5
+      parent: 2
+  - uid: 244
+    components:
+    - type: Transform
+      pos: -10.5,-12.5
+      parent: 2
+  - uid: 245
+    components:
+    - type: Transform
+      pos: -11.5,-12.5
+      parent: 2
+  - uid: 246
+    components:
+    - type: Transform
+      pos: -12.5,-12.5
+      parent: 2
+  - uid: 247
+    components:
+    - type: Transform
+      pos: -10.5,-11.5
+      parent: 2
+  - uid: 248
+    components:
+    - type: Transform
+      pos: -8.5,-11.5
+      parent: 2
+  - uid: 249
+    components:
+    - type: Transform
+      pos: -10.5,-13.5
+      parent: 2
+  - uid: 250
+    components:
+    - type: Transform
+      pos: -10.5,-14.5
+      parent: 2
+  - uid: 251
+    components:
+    - type: Transform
+      pos: -10.5,-15.5
+      parent: 2
+  - uid: 252
+    components:
+    - type: Transform
+      pos: -11.5,-15.5
+      parent: 2
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -12.5,-15.5
+      parent: 2
+  - uid: 254
+    components:
+    - type: Transform
+      pos: -9.5,-15.5
+      parent: 2
+  - uid: 255
+    components:
+    - type: Transform
+      pos: -9.5,-16.5
+      parent: 2
+  - uid: 256
+    components:
+    - type: Transform
+      pos: -8.5,-16.5
+      parent: 2
+  - uid: 257
+    components:
+    - type: Transform
+      pos: -7.5,-16.5
+      parent: 2
+  - uid: 258
+    components:
+    - type: Transform
+      pos: -6.5,-16.5
+      parent: 2
+  - uid: 259
+    components:
+    - type: Transform
+      pos: 18.5,-7.5
+      parent: 2
+  - uid: 260
+    components:
+    - type: Transform
+      pos: 18.5,-6.5
+      parent: 2
+  - uid: 261
+    components:
+    - type: Transform
+      pos: 18.5,-5.5
+      parent: 2
+  - uid: 262
+    components:
+    - type: Transform
+      pos: 17.5,-5.5
+      parent: 2
+  - uid: 263
+    components:
+    - type: Transform
+      pos: 16.5,-5.5
+      parent: 2
+  - uid: 264
+    components:
+    - type: Transform
+      pos: 15.5,-5.5
+      parent: 2
+  - uid: 265
+    components:
+    - type: Transform
+      pos: 19.5,-5.5
+      parent: 2
+  - uid: 266
+    components:
+    - type: Transform
+      pos: 20.5,-5.5
+      parent: 2
+  - uid: 267
+    components:
+    - type: Transform
+      pos: 21.5,-5.5
+      parent: 2
+  - uid: 268
+    components:
+    - type: Transform
+      pos: 22.5,-5.5
+      parent: 2
+  - uid: 269
+    components:
+    - type: Transform
+      pos: 23.5,-5.5
+      parent: 2
+  - uid: 270
+    components:
+    - type: Transform
+      pos: 24.5,-5.5
+      parent: 2
+  - uid: 271
+    components:
+    - type: Transform
+      pos: 14.5,-5.5
+      parent: 2
+  - uid: 272
+    components:
+    - type: Transform
+      pos: 25.5,-5.5
+      parent: 2
+  - uid: 273
+    components:
+    - type: Transform
+      pos: 32.5,-7.5
+      parent: 2
+  - uid: 274
+    components:
+    - type: Transform
+      pos: 32.5,-8.5
+      parent: 2
+  - uid: 275
+    components:
+    - type: Transform
+      pos: 31.5,-8.5
+      parent: 2
+  - uid: 276
+    components:
+    - type: Transform
+      pos: 30.5,-8.5
+      parent: 2
+  - uid: 277
+    components:
+    - type: Transform
+      pos: 29.5,-8.5
+      parent: 2
+  - uid: 278
+    components:
+    - type: Transform
+      pos: 29.5,-9.5
+      parent: 2
+  - uid: 279
+    components:
+    - type: Transform
+      pos: 30.5,-9.5
+      parent: 2
+  - uid: 280
+    components:
+    - type: Transform
+      pos: 31.5,-9.5
+      parent: 2
+  - uid: 281
+    components:
+    - type: Transform
+      pos: 32.5,-9.5
+      parent: 2
+  - uid: 282
+    components:
+    - type: Transform
+      pos: 31.5,-10.5
+      parent: 2
+  - uid: 283
+    components:
+    - type: Transform
+      pos: 30.5,-10.5
+      parent: 2
+  - uid: 284
+    components:
+    - type: Transform
+      pos: 35.5,0.5
+      parent: 2
+  - uid: 285
+    components:
+    - type: Transform
+      pos: 36.5,0.5
+      parent: 2
+  - uid: 286
+    components:
+    - type: Transform
+      pos: 37.5,0.5
+      parent: 2
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 38.5,0.5
+      parent: 2
+  - uid: 288
+    components:
+    - type: Transform
+      pos: 39.5,0.5
+      parent: 2
+  - uid: 289
+    components:
+    - type: Transform
+      pos: 34.5,-10.5
+      parent: 2
+  - uid: 290
+    components:
+    - type: Transform
+      pos: 35.5,-10.5
+      parent: 2
+  - uid: 291
+    components:
+    - type: Transform
+      pos: 36.5,-10.5
+      parent: 2
+  - uid: 292
+    components:
+    - type: Transform
+      pos: 37.5,-10.5
+      parent: 2
+  - uid: 293
+    components:
+    - type: Transform
+      pos: 38.5,-10.5
+      parent: 2
+  - uid: 294
+    components:
+    - type: Transform
+      pos: 39.5,-10.5
+      parent: 2
+  - uid: 295
+    components:
+    - type: Transform
+      pos: 40.5,-10.5
+      parent: 2
+  - uid: 296
+    components:
+    - type: Transform
+      pos: 40.5,-9.5
+      parent: 2
+  - uid: 297
+    components:
+    - type: Transform
+      pos: 40.5,-8.5
+      parent: 2
+  - uid: 298
+    components:
+    - type: Transform
+      pos: 40.5,-7.5
+      parent: 2
+  - uid: 299
+    components:
+    - type: Transform
+      pos: 40.5,-6.5
+      parent: 2
+  - uid: 300
+    components:
+    - type: Transform
+      pos: 38.5,-6.5
+      parent: 2
+  - uid: 301
+    components:
+    - type: Transform
+      pos: 39.5,-6.5
+      parent: 2
+  - uid: 302
+    components:
+    - type: Transform
+      pos: 37.5,-6.5
+      parent: 2
+  - uid: 303
+    components:
+    - type: Transform
+      pos: 36.5,-6.5
+      parent: 2
+  - uid: 304
+    components:
+    - type: Transform
+      pos: 38.5,-5.5
+      parent: 2
+  - uid: 305
+    components:
+    - type: Transform
+      pos: 37.5,-7.5
+      parent: 2
+  - uid: 306
+    components:
+    - type: Transform
+      pos: 37.5,-8.5
+      parent: 2
+  - uid: 307
+    components:
+    - type: Transform
+      pos: 41.5,-9.5
+      parent: 2
+  - uid: 308
+    components:
+    - type: Transform
+      pos: 42.5,-9.5
+      parent: 2
+  - uid: 309
+    components:
+    - type: Transform
+      pos: 39.5,-11.5
+      parent: 2
+  - uid: 310
+    components:
+    - type: Transform
+      pos: 39.5,-12.5
+      parent: 2
+  - uid: 311
+    components:
+    - type: Transform
+      pos: 40.5,-12.5
+      parent: 2
+  - uid: 312
+    components:
+    - type: Transform
+      pos: 41.5,-12.5
+      parent: 2
+  - uid: 313
+    components:
+    - type: Transform
+      pos: 41.5,-13.5
+      parent: 2
+  - uid: 314
+    components:
+    - type: Transform
+      pos: 36.5,-11.5
+      parent: 2
+  - uid: 315
+    components:
+    - type: Transform
+      pos: 36.5,-12.5
+      parent: 2
+  - uid: 316
+    components:
+    - type: Transform
+      pos: 35.5,-12.5
+      parent: 2
+  - uid: 317
+    components:
+    - type: Transform
+      pos: 35.5,-13.5
+      parent: 2
+  - uid: 318
+    components:
+    - type: Transform
+      pos: 35.5,-14.5
+      parent: 2
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 35.5,-15.5
+      parent: 2
+  - uid: 320
+    components:
+    - type: Transform
+      pos: 35.5,-16.5
+      parent: 2
+  - uid: 321
+    components:
+    - type: Transform
+      pos: 35.5,-17.5
+      parent: 2
+  - uid: 322
+    components:
+    - type: Transform
+      pos: 35.5,-18.5
+      parent: 2
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 34.5,-18.5
+      parent: 2
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 32.5,-18.5
+      parent: 2
+  - uid: 325
+    components:
+    - type: Transform
+      pos: 31.5,-18.5
+      parent: 2
+  - uid: 326
+    components:
+    - type: Transform
+      pos: 33.5,-18.5
+      parent: 2
+  - uid: 327
+    components:
+    - type: Transform
+      pos: 30.5,-1.5
+      parent: 2
+  - uid: 328
+    components:
+    - type: Transform
+      pos: 30.5,-2.5
+      parent: 2
+  - uid: 329
+    components:
+    - type: Transform
+      pos: 30.5,-3.5
+      parent: 2
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 30.5,-4.5
+      parent: 2
+  - uid: 331
+    components:
+    - type: Transform
+      pos: 30.5,-5.5
+      parent: 2
+  - uid: 332
+    components:
+    - type: Transform
+      pos: 29.5,-4.5
+      parent: 2
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 28.5,-4.5
+      parent: 2
+  - uid: 334
+    components:
+    - type: Transform
+      pos: 31.5,-4.5
+      parent: 2
+  - uid: 335
+    components:
+    - type: Transform
+      pos: 32.5,-4.5
+      parent: 2
+  - uid: 336
+    components:
+    - type: Transform
+      pos: 30.5,-6.5
+      parent: 2
+  - uid: 337
+    components:
+    - type: Transform
+      pos: 28.5,-5.5
+      parent: 2
+  - uid: 338
+    components:
+    - type: Transform
+      pos: 28.5,-6.5
+      parent: 2
+  - uid: 339
+    components:
+    - type: Transform
+      pos: 27.5,-6.5
+      parent: 2
+  - uid: 340
+    components:
+    - type: Transform
+      pos: 27.5,-7.5
+      parent: 2
+  - uid: 341
+    components:
+    - type: Transform
+      pos: 27.5,-8.5
+      parent: 2
+  - uid: 342
+    components:
+    - type: Transform
+      pos: 27.5,-9.5
+      parent: 2
+  - uid: 343
+    components:
+    - type: Transform
+      pos: 27.5,-10.5
+      parent: 2
+  - uid: 344
+    components:
+    - type: Transform
+      pos: 27.5,-11.5
+      parent: 2
+  - uid: 345
+    components:
+    - type: Transform
+      pos: 6.5,-13.5
+      parent: 2
+  - uid: 346
+    components:
+    - type: Transform
+      pos: 7.5,-13.5
+      parent: 2
+  - uid: 347
+    components:
+    - type: Transform
+      pos: 38.5,-4.5
+      parent: 2
+  - uid: 348
+    components:
+    - type: Transform
+      pos: 38.5,-3.5
+      parent: 2
+  - uid: 349
+    components:
+    - type: Transform
+      pos: 37.5,-3.5
+      parent: 2
+  - uid: 350
+    components:
+    - type: Transform
+      pos: 36.5,-3.5
+      parent: 2
+  - uid: 351
+    components:
+    - type: Transform
+      pos: 35.5,-3.5
+      parent: 2
+  - uid: 352
+    components:
+    - type: Transform
+      pos: 35.5,-2.5
+      parent: 2
+  - uid: 353
+    components:
+    - type: Transform
+      pos: 5.5,-13.5
+      parent: 2
+  - uid: 354
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 2
+  - uid: 355
+    components:
+    - type: Transform
+      pos: 4.5,-14.5
+      parent: 2
+  - uid: 356
+    components:
+    - type: Transform
+      pos: 4.5,-15.5
+      parent: 2
+  - uid: 357
+    components:
+    - type: Transform
+      pos: 7.5,-14.5
+      parent: 2
+  - uid: 358
+    components:
+    - type: Transform
+      pos: 7.5,-15.5
+      parent: 2
+  - uid: 359
+    components:
+    - type: Transform
+      pos: 8.5,-14.5
+      parent: 2
+  - uid: 360
+    components:
+    - type: Transform
+      pos: 9.5,-14.5
+      parent: 2
+  - uid: 361
+    components:
+    - type: Transform
+      pos: 10.5,-14.5
+      parent: 2
+  - uid: 362
+    components:
+    - type: Transform
+      pos: 11.5,-14.5
+      parent: 2
+  - uid: 363
+    components:
+    - type: Transform
+      pos: 7.5,-12.5
+      parent: 2
+  - uid: 364
+    components:
+    - type: Transform
+      pos: 8.5,-12.5
+      parent: 2
+  - uid: 365
+    components:
+    - type: Transform
+      pos: 9.5,-12.5
+      parent: 2
+  - uid: 366
+    components:
+    - type: Transform
+      pos: 10.5,-12.5
+      parent: 2
+  - uid: 367
+    components:
+    - type: Transform
+      pos: 11.5,-12.5
+      parent: 2
+  - uid: 368
+    components:
+    - type: Transform
+      pos: 40.5,-5.5
+      parent: 2
+  - uid: 369
+    components:
+    - type: Transform
+      pos: 40.5,-4.5
+      parent: 2
+  - uid: 370
+    components:
+    - type: Transform
+      pos: 41.5,-4.5
+      parent: 2
+  - uid: 371
+    components:
+    - type: Transform
+      pos: 42.5,-4.5
+      parent: 2
+  - uid: 372
+    components:
+    - type: Transform
+      pos: 43.5,-4.5
+      parent: 2
+  - uid: 373
+    components:
+    - type: Transform
+      pos: 44.5,-4.5
+      parent: 2
+  - uid: 374
+    components:
+    - type: Transform
+      pos: 45.5,-4.5
+      parent: 2
+  - uid: 375
+    components:
+    - type: Transform
+      pos: 46.5,-4.5
+      parent: 2
+- proto: CableApcStack
+  entities:
+  - uid: 376
+    components:
+    - type: Transform
+      pos: -13.344715,-1.9034772
+      parent: 2
+- proto: CableHV
+  entities:
+  - uid: 377
+    components:
+    - type: Transform
+      pos: 30.5,-10.5
+      parent: 2
+  - uid: 378
+    components:
+    - type: Transform
+      pos: 31.5,-10.5
+      parent: 2
+  - uid: 379
+    components:
+    - type: Transform
+      pos: 31.5,-9.5
+      parent: 2
+  - uid: 380
+    components:
+    - type: Transform
+      pos: 32.5,-9.5
+      parent: 2
+  - uid: 381
+    components:
+    - type: Transform
+      pos: 32.5,-8.5
+      parent: 2
+  - uid: 382
+    components:
+    - type: Transform
+      pos: 30.5,-9.5
+      parent: 2
+  - uid: 383
+    components:
+    - type: Transform
+      pos: 29.5,-9.5
+      parent: 2
+  - uid: 384
+    components:
+    - type: Transform
+      pos: 29.5,-8.5
+      parent: 2
+  - uid: 385
+    components:
+    - type: Transform
+      pos: 30.5,-8.5
+      parent: 2
+  - uid: 386
+    components:
+    - type: Transform
+      pos: 31.5,-8.5
+      parent: 2
+  - uid: 387
+    components:
+    - type: Transform
+      pos: 31.5,-7.5
+      parent: 2
+  - uid: 388
+    components:
+    - type: Transform
+      pos: 31.5,-6.5
+      parent: 2
+  - uid: 389
+    components:
+    - type: Transform
+      pos: 32.5,-6.5
+      parent: 2
+  - uid: 390
+    components:
+    - type: Transform
+      pos: 33.5,-6.5
+      parent: 2
+  - uid: 391
+    components:
+    - type: Transform
+      pos: 34.5,-6.5
+      parent: 2
+  - uid: 392
+    components:
+    - type: Transform
+      pos: 35.5,-6.5
+      parent: 2
+  - uid: 393
+    components:
+    - type: Transform
+      pos: 36.5,-6.5
+      parent: 2
+  - uid: 394
+    components:
+    - type: Transform
+      pos: 37.5,-6.5
+      parent: 2
+  - uid: 395
+    components:
+    - type: Transform
+      pos: 38.5,-6.5
+      parent: 2
+  - uid: 396
+    components:
+    - type: Transform
+      pos: 38.5,-5.5
+      parent: 2
+  - uid: 397
+    components:
+    - type: Transform
+      pos: 38.5,-4.5
+      parent: 2
+  - uid: 398
+    components:
+    - type: Transform
+      pos: 38.5,-3.5
+      parent: 2
+  - uid: 399
+    components:
+    - type: Transform
+      pos: 37.5,-3.5
+      parent: 2
+  - uid: 400
+    components:
+    - type: Transform
+      pos: 36.5,-3.5
+      parent: 2
+  - uid: 401
+    components:
+    - type: Transform
+      pos: 36.5,-2.5
+      parent: 2
+- proto: CableMV
+  entities:
+  - uid: 402
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 2
+  - uid: 403
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 2
+  - uid: 404
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 2
+  - uid: 405
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 2
+  - uid: 406
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 2
+  - uid: 407
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 2
+  - uid: 408
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 2
+  - uid: 409
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 2
+  - uid: 410
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 2
+  - uid: 411
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 2
+  - uid: 412
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 2
+  - uid: 413
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 2
+  - uid: 414
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 2
+  - uid: 415
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 2
+  - uid: 416
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
+      parent: 2
+  - uid: 417
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 2
+  - uid: 418
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 2
+  - uid: 419
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 2
+  - uid: 420
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
+  - uid: 421
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 2
+  - uid: 422
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 2
+  - uid: 423
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 2
+  - uid: 424
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 2
+  - uid: 425
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 2
+  - uid: 426
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 427
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 2
+  - uid: 428
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 2
+  - uid: 429
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 2
+  - uid: 430
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 2
+  - uid: 431
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 2
+  - uid: 432
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 2
+  - uid: 433
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+  - uid: 434
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 2
+  - uid: 435
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 2
+  - uid: 436
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 2
+  - uid: 437
+    components:
+    - type: Transform
+      pos: -2.5,-10.5
+      parent: 2
+  - uid: 438
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 2
+  - uid: 439
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 2
+  - uid: 440
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 2
+  - uid: 441
+    components:
+    - type: Transform
+      pos: -4.5,-6.5
+      parent: 2
+  - uid: 442
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 2
+  - uid: 443
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 2
+  - uid: 444
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 2
+  - uid: 445
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 2
+  - uid: 446
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 2
+  - uid: 447
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 448
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 449
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 450
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 451
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 2
+  - uid: 452
+    components:
+    - type: Transform
+      pos: 9.5,-5.5
+      parent: 2
+  - uid: 453
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 2
+  - uid: 454
+    components:
+    - type: Transform
+      pos: -7.5,-8.5
+      parent: 2
+  - uid: 455
+    components:
+    - type: Transform
+      pos: -7.5,-9.5
+      parent: 2
+  - uid: 456
+    components:
+    - type: Transform
+      pos: -7.5,-10.5
+      parent: 2
+  - uid: 457
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 2
+  - uid: 458
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 2
+  - uid: 459
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 2
+  - uid: 460
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 2
+  - uid: 461
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 2
+  - uid: 462
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 2
+  - uid: 463
+    components:
+    - type: Transform
+      pos: -8.5,-2.5
+      parent: 2
+  - uid: 464
+    components:
+    - type: Transform
+      pos: -8.5,-1.5
+      parent: 2
+  - uid: 465
+    components:
+    - type: Transform
+      pos: -8.5,-0.5
+      parent: 2
+  - uid: 466
+    components:
+    - type: Transform
+      pos: -8.5,0.5
+      parent: 2
+  - uid: 467
+    components:
+    - type: Transform
+      pos: -8.5,1.5
+      parent: 2
+  - uid: 468
+    components:
+    - type: Transform
+      pos: -7.5,-11.5
+      parent: 2
+  - uid: 469
+    components:
+    - type: Transform
+      pos: -7.5,-12.5
+      parent: 2
+  - uid: 470
+    components:
+    - type: Transform
+      pos: -7.5,-13.5
+      parent: 2
+  - uid: 471
+    components:
+    - type: Transform
+      pos: -6.5,-13.5
+      parent: 2
+  - uid: 472
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 2
+  - uid: 473
+    components:
+    - type: Transform
+      pos: 9.5,-6.5
+      parent: 2
+  - uid: 474
+    components:
+    - type: Transform
+      pos: 10.5,-6.5
+      parent: 2
+  - uid: 475
+    components:
+    - type: Transform
+      pos: 11.5,-6.5
+      parent: 2
+  - uid: 476
+    components:
+    - type: Transform
+      pos: 12.5,-6.5
+      parent: 2
+  - uid: 477
+    components:
+    - type: Transform
+      pos: 13.5,-6.5
+      parent: 2
+  - uid: 478
+    components:
+    - type: Transform
+      pos: 14.5,-6.5
+      parent: 2
+  - uid: 479
+    components:
+    - type: Transform
+      pos: 15.5,-6.5
+      parent: 2
+  - uid: 480
+    components:
+    - type: Transform
+      pos: 16.5,-6.5
+      parent: 2
+  - uid: 481
+    components:
+    - type: Transform
+      pos: 17.5,-6.5
+      parent: 2
+  - uid: 482
+    components:
+    - type: Transform
+      pos: 18.5,-6.5
+      parent: 2
+  - uid: 483
+    components:
+    - type: Transform
+      pos: 18.5,-7.5
+      parent: 2
+  - uid: 484
+    components:
+    - type: Transform
+      pos: 19.5,-6.5
+      parent: 2
+  - uid: 485
+    components:
+    - type: Transform
+      pos: 20.5,-6.5
+      parent: 2
+  - uid: 486
+    components:
+    - type: Transform
+      pos: 21.5,-6.5
+      parent: 2
+  - uid: 487
+    components:
+    - type: Transform
+      pos: 22.5,-6.5
+      parent: 2
+  - uid: 488
+    components:
+    - type: Transform
+      pos: 23.5,-6.5
+      parent: 2
+  - uid: 489
+    components:
+    - type: Transform
+      pos: 24.5,-6.5
+      parent: 2
+  - uid: 490
+    components:
+    - type: Transform
+      pos: 25.5,-6.5
+      parent: 2
+  - uid: 491
+    components:
+    - type: Transform
+      pos: 26.5,-6.5
+      parent: 2
+  - uid: 492
+    components:
+    - type: Transform
+      pos: 27.5,-6.5
+      parent: 2
+  - uid: 493
+    components:
+    - type: Transform
+      pos: 28.5,-6.5
+      parent: 2
+  - uid: 494
+    components:
+    - type: Transform
+      pos: 29.5,-6.5
+      parent: 2
+  - uid: 495
+    components:
+    - type: Transform
+      pos: 30.5,-6.5
+      parent: 2
+  - uid: 496
+    components:
+    - type: Transform
+      pos: 31.5,-6.5
+      parent: 2
+  - uid: 497
+    components:
+    - type: Transform
+      pos: 32.5,-6.5
+      parent: 2
+  - uid: 498
+    components:
+    - type: Transform
+      pos: 33.5,-6.5
+      parent: 2
+  - uid: 499
+    components:
+    - type: Transform
+      pos: 34.5,-6.5
+      parent: 2
+  - uid: 500
+    components:
+    - type: Transform
+      pos: 35.5,-6.5
+      parent: 2
+  - uid: 501
+    components:
+    - type: Transform
+      pos: 36.5,-6.5
+      parent: 2
+  - uid: 502
+    components:
+    - type: Transform
+      pos: 37.5,-6.5
+      parent: 2
+  - uid: 503
+    components:
+    - type: Transform
+      pos: 38.5,-6.5
+      parent: 2
+  - uid: 504
+    components:
+    - type: Transform
+      pos: 38.5,-5.5
+      parent: 2
+  - uid: 505
+    components:
+    - type: Transform
+      pos: 38.5,-4.5
+      parent: 2
+  - uid: 506
+    components:
+    - type: Transform
+      pos: 38.5,-3.5
+      parent: 2
+  - uid: 507
+    components:
+    - type: Transform
+      pos: 37.5,-3.5
+      parent: 2
+  - uid: 508
+    components:
+    - type: Transform
+      pos: 36.5,-3.5
+      parent: 2
+  - uid: 509
+    components:
+    - type: Transform
+      pos: 36.5,-2.5
+      parent: 2
+  - uid: 510
+    components:
+    - type: Transform
+      pos: 32.5,-7.5
+      parent: 2
+  - uid: 511
+    components:
+    - type: Transform
+      pos: 35.5,-7.5
+      parent: 2
+  - uid: 512
+    components:
+    - type: Transform
+      pos: 35.5,-8.5
+      parent: 2
+  - uid: 513
+    components:
+    - type: Transform
+      pos: 35.5,-9.5
+      parent: 2
+  - uid: 514
+    components:
+    - type: Transform
+      pos: 35.5,-10.5
+      parent: 2
+  - uid: 515
+    components:
+    - type: Transform
+      pos: 34.5,-10.5
+      parent: 2
+  - uid: 516
+    components:
+    - type: Transform
+      pos: 39.5,-3.5
+      parent: 2
+  - uid: 517
+    components:
+    - type: Transform
+      pos: 39.5,-2.5
+      parent: 2
+  - uid: 518
+    components:
+    - type: Transform
+      pos: 39.5,-1.5
+      parent: 2
+  - uid: 519
+    components:
+    - type: Transform
+      pos: 39.5,-0.5
+      parent: 2
+  - uid: 520
+    components:
+    - type: Transform
+      pos: 39.5,0.5
+      parent: 2
+  - uid: 521
+    components:
+    - type: Transform
+      pos: 38.5,0.5
+      parent: 2
+  - uid: 522
+    components:
+    - type: Transform
+      pos: 37.5,0.5
+      parent: 2
+  - uid: 523
+    components:
+    - type: Transform
+      pos: 36.5,0.5
+      parent: 2
+  - uid: 524
+    components:
+    - type: Transform
+      pos: 35.5,0.5
+      parent: 2
+  - uid: 525
+    components:
+    - type: Transform
+      pos: 31.5,-5.5
+      parent: 2
+  - uid: 526
+    components:
+    - type: Transform
+      pos: 31.5,-4.5
+      parent: 2
+  - uid: 527
+    components:
+    - type: Transform
+      pos: 30.5,-4.5
+      parent: 2
+  - uid: 528
+    components:
+    - type: Transform
+      pos: 30.5,-3.5
+      parent: 2
+  - uid: 529
+    components:
+    - type: Transform
+      pos: 30.5,-2.5
+      parent: 2
+  - uid: 530
+    components:
+    - type: Transform
+      pos: 30.5,-1.5
+      parent: 2
+  - uid: 531
+    components:
+    - type: Transform
+      pos: 7.5,-8.5
+      parent: 2
+  - uid: 532
+    components:
+    - type: Transform
+      pos: 7.5,-9.5
+      parent: 2
+  - uid: 533
+    components:
+    - type: Transform
+      pos: 7.5,-10.5
+      parent: 2
+  - uid: 534
+    components:
+    - type: Transform
+      pos: 7.5,-11.5
+      parent: 2
+  - uid: 535
+    components:
+    - type: Transform
+      pos: 7.5,-12.5
+      parent: 2
+  - uid: 536
+    components:
+    - type: Transform
+      pos: 7.5,-13.5
+      parent: 2
+  - uid: 537
+    components:
+    - type: Transform
+      pos: 6.5,-13.5
+      parent: 2
+- proto: Catwalk
+  entities:
+  - uid: 538
+    components:
+    - type: Transform
+      pos: 14.5,-15.5
+      parent: 2
+  - uid: 539
+    components:
+    - type: Transform
+      pos: 14.5,-14.5
+      parent: 2
+  - uid: 540
+    components:
+    - type: Transform
+      pos: 14.5,-12.5
+      parent: 2
+  - uid: 541
+    components:
+    - type: Transform
+      pos: 14.5,-11.5
+      parent: 2
+  - uid: 542
+    components:
+    - type: Transform
+      pos: 14.5,-13.5
+      parent: 2
+  - uid: 543
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-9.5
+      parent: 2
+  - uid: 544
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-9.5
+      parent: 2
+  - uid: 545
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 16.5,-9.5
+      parent: 2
+  - uid: 546
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-9.5
+      parent: 2
+  - uid: 547
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-9.5
+      parent: 2
+  - uid: 548
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-9.5
+      parent: 2
+  - uid: 549
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-9.5
+      parent: 2
+  - uid: 550
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 21.5,-9.5
+      parent: 2
+  - uid: 551
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-9.5
+      parent: 2
+  - uid: 552
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 23.5,-9.5
+      parent: 2
+  - uid: 553
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 24.5,-9.5
+      parent: 2
+  - uid: 554
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 25.5,-9.5
+      parent: 2
+  - uid: 555
+    components:
+    - type: Transform
+      pos: 28.5,-14.5
+      parent: 2
+  - uid: 556
+    components:
+    - type: Transform
+      pos: 27.5,-14.5
+      parent: 2
+  - uid: 557
+    components:
+    - type: Transform
+      pos: 30.5,-16.5
+      parent: 2
+  - uid: 558
+    components:
+    - type: Transform
+      pos: 29.5,-15.5
+      parent: 2
+  - uid: 559
+    components:
+    - type: Transform
+      pos: 26.5,-14.5
+      parent: 2
+  - uid: 560
+    components:
+    - type: Transform
+      pos: 30.5,-20.5
+      parent: 2
+  - uid: 561
+    components:
+    - type: Transform
+      pos: 29.5,-21.5
+      parent: 2
+  - uid: 562
+    components:
+    - type: Transform
+      pos: 28.5,-22.5
+      parent: 2
+  - uid: 563
+    components:
+    - type: Transform
+      pos: 27.5,-22.5
+      parent: 2
+  - uid: 564
+    components:
+    - type: Transform
+      pos: 26.5,-22.5
+      parent: 2
+  - uid: 565
+    components:
+    - type: Transform
+      pos: 25.5,-22.5
+      parent: 2
+  - uid: 566
+    components:
+    - type: Transform
+      pos: 24.5,-22.5
+      parent: 2
+  - uid: 567
+    components:
+    - type: Transform
+      pos: 23.5,-21.5
+      parent: 2
+  - uid: 568
+    components:
+    - type: Transform
+      pos: 22.5,-20.5
+      parent: 2
+  - uid: 569
+    components:
+    - type: Transform
+      pos: 22.5,-19.5
+      parent: 2
+  - uid: 570
+    components:
+    - type: Transform
+      pos: 22.5,-18.5
+      parent: 2
+  - uid: 571
+    components:
+    - type: Transform
+      pos: 22.5,-17.5
+      parent: 2
+  - uid: 572
+    components:
+    - type: Transform
+      pos: 22.5,-16.5
+      parent: 2
+  - uid: 573
+    components:
+    - type: Transform
+      pos: 23.5,-15.5
+      parent: 2
+  - uid: 574
+    components:
+    - type: Transform
+      pos: 24.5,-14.5
+      parent: 2
+  - uid: 575
+    components:
+    - type: Transform
+      pos: 25.5,-14.5
+      parent: 2
+  - uid: 576
+    components:
+    - type: Transform
+      pos: 23.5,-20.5
+      parent: 2
+  - uid: 577
+    components:
+    - type: Transform
+      pos: 24.5,-21.5
+      parent: 2
+  - uid: 578
+    components:
+    - type: Transform
+      pos: 28.5,-21.5
+      parent: 2
+  - uid: 579
+    components:
+    - type: Transform
+      pos: 29.5,-20.5
+      parent: 2
+  - uid: 580
+    components:
+    - type: Transform
+      pos: 23.5,-16.5
+      parent: 2
+  - uid: 581
+    components:
+    - type: Transform
+      pos: 24.5,-15.5
+      parent: 2
+  - uid: 582
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 45.5,-2.5
+      parent: 2
+  - uid: 583
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 45.5,-1.5
+      parent: 2
+  - uid: 584
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 45.5,-0.5
+      parent: 2
+  - uid: 585
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 45.5,0.5
+      parent: 2
+  - uid: 586
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 45.5,1.5
+      parent: 2
+  - uid: 587
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 45.5,2.5
+      parent: 2
+  - uid: 588
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 45.5,3.5
+      parent: 2
+  - uid: 589
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 45.5,4.5
+      parent: 2
+  - uid: 590
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 45.5,5.5
+      parent: 2
+  - uid: 591
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 45.5,6.5
+      parent: 2
+  - uid: 592
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 45.5,7.5
+      parent: 2
+  - uid: 593
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 45.5,8.5
+      parent: 2
+- proto: Chair
+  entities:
+  - uid: 594
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 2
+  - uid: 595
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-8.5
+      parent: 2
+  - uid: 596
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-8.5
+      parent: 2
+- proto: ChairOfficeDark
+  entities:
+  - uid: 597
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-1.5
+      parent: 2
+- proto: ChairOfficeLight
+  entities:
+  - uid: 598
+    components:
+    - type: Transform
+      pos: -3.5,-13.5
+      parent: 2
+  - uid: 599
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-13.5
+      parent: 2
+- proto: ChairPilotSeat
+  entities:
+  - uid: 600
+    components:
+    - type: Transform
+      pos: 27.5,-16.5
+      parent: 2
+  - uid: 601
+    components:
+    - type: Transform
+      pos: 25.5,-16.5
+      parent: 2
+  - uid: 602
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 24.5,-17.5
+      parent: 2
+  - uid: 603
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 28.5,-17.5
+      parent: 2
+  - uid: 604
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 28.5,-19.5
+      parent: 2
+  - uid: 605
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 25.5,-20.5
+      parent: 2
+  - uid: 606
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 27.5,-18.5
+      parent: 2
+  - uid: 607
+    components:
+    - type: Transform
+      pos: 26.5,-19.5
+      parent: 2
+  - uid: 608
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 27.5,-20.5
+      parent: 2
+  - uid: 609
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 24.5,-19.5
+      parent: 2
+  - uid: 610
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-18.5
+      parent: 2
+  - uid: 611
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 26.5,-17.5
+      parent: 2
+- proto: ChemDispenser
+  entities:
+  - uid: 612
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 2
+- proto: ChemDispenserEmpty
+  entities:
+  - uid: 613
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 2
+- proto: ChemistryHotplate
+  entities:
+  - uid: 614
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 2
+- proto: ChemMaster
+  entities:
+  - uid: 615
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 2
+- proto: CigPackSyndicate
+  entities:
+  - uid: 616
+    components:
+    - type: Transform
+      pos: 8.343843,-16.416794
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+- proto: ClosetEmergencyFilledRandom
+  entities:
+  - uid: 617
+    components:
+    - type: Transform
+      pos: 3.5,-6.5
+      parent: 2
+- proto: ClosetFireFilled
+  entities:
+  - uid: 618
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 2
+- proto: ClothingBackpackWaterTank
+  entities:
+  - uid: 619
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.126606,-9.469422
+      parent: 2
+- proto: ClothingEyesGlassesChemical
+  entities:
+  - uid: 620
+    components:
+    - type: Transform
+      pos: -12.043489,-10.235588
+      parent: 2
+- proto: ClothingHandsGlovesNitrile
+  entities:
+  - uid: 621
+    components:
+    - type: Transform
+      pos: -12.074739,-10.610588
+      parent: 2
+- proto: ComfyChair
+  entities:
+  - uid: 622
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-15.5
+      parent: 2
+  - uid: 623
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-16.5
+      parent: 2
+  - uid: 624
+    components:
+    - type: Transform
+      pos: 39.5,-7.5
+      parent: 2
+  - uid: 625
+    components:
+    - type: Transform
+      pos: 38.5,-7.5
+      parent: 2
+  - uid: 626
+    components:
+    - type: Transform
+      pos: 37.5,-7.5
+      parent: 2
+  - uid: 627
+    components:
+    - type: Transform
+      pos: 36.5,-7.5
+      parent: 2
+  - uid: 628
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 39.5,-11.5
+      parent: 2
+  - uid: 629
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 38.5,-11.5
+      parent: 2
+  - uid: 630
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 37.5,-11.5
+      parent: 2
+  - uid: 631
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 36.5,-11.5
+      parent: 2
+  - uid: 632
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 42.5,-9.5
+      parent: 2
+- proto: ComputerFrame
+  entities:
+  - uid: 633
+    components:
+    - type: Transform
+      pos: -6.5,-12.5
+      parent: 2
+- proto: ComputerTelevision
+  entities:
+  - uid: 634
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-15.5
+      parent: 2
+- proto: CrateFreezer
+  entities:
+  - uid: 635
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 636
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 2
+  - uid: 637
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 2
+  - uid: 638
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 2
+- proto: CrateVendingMachineRestockAutoDrobeFilled
+  entities:
+  - uid: 639
+    components:
+    - type: Transform
+      pos: 27.5,5.5
+      parent: 2
+- proto: CrateVendingMachineRestockBoozeFilled
+  entities:
+  - uid: 640
+    components:
+    - type: Transform
+      pos: 39.5,6.5
+      parent: 2
+- proto: CryostasisBeaker
+  entities:
+  - uid: 641
+    components:
+    - type: Transform
+      pos: -5.3134656,-2.7472272
+      parent: 2
+- proto: CyberPen
+  entities:
+  - uid: 642
+    components:
+    - type: Transform
+      pos: 41.523464,-10.282842
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+- proto: DeathRattleImplanter
+  entities:
+  - uid: 643
+    components:
+    - type: Transform
+      pos: 3.5470674,-8.528731
+      parent: 2
+- proto: DogBed
+  entities:
+  - uid: 644
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 2
+- proto: DonkpocketBoxSpawner
+  entities:
+  - uid: 645
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 2
+- proto: DresserFilled
+  entities:
+  - uid: 646
+    components:
+    - type: Transform
+      pos: 11.5,-11.5
+      parent: 2
+  - uid: 647
+    components:
+    - type: Transform
+      pos: 11.5,-15.5
+      parent: 2
+- proto: DrinkBeerGrowler
+  entities:
+  - uid: 648
+    components:
+    - type: Transform
+      pos: 6.4054036,-14.222223
+      parent: 2
+- proto: DrinkJuiceOrangeCartonXL
+  entities:
+  - uid: 649
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 2
+- proto: DrinkJuiceTomatoCarton
+  entities:
+  - uid: 650
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 2
+- proto: DrinkShaker
+  entities:
+  - uid: 651
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+- proto: DrinkWineBottleFull
+  entities:
+  - uid: 652
+    components:
+    - type: Transform
+      pos: 11.5,-1.5
+      parent: 2
+- proto: EphedrineChemistryBottle
+  entities:
+  - uid: 653
+    components:
+    - type: Transform
+      pos: -1.4256997,-0.3865409
+      parent: 2
+- proto: EpinephrineChemistryBottle
+  entities:
+  - uid: 654
+    components:
+    - type: Transform
+      pos: -1.6288247,-0.8396659
+      parent: 2
+- proto: FaxMachineSyndie
+  entities:
+  - uid: 655
+    components:
+    - type: Transform
+      pos: 41.5,-9.5
+      parent: 2
+- proto: FenceMetalBroken
+  entities:
+  - uid: 656
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-21.5
+      parent: 2
+- proto: FenceMetalGate
+  entities:
+  - uid: 657
+    components:
+    - type: Transform
+      pos: 16.5,-21.5
+      parent: 2
+- proto: FenceMetalStraight
+  entities:
+  - uid: 658
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,-21.5
+      parent: 2
+  - uid: 659
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-21.5
+      parent: 2
+  - uid: 660
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-21.5
+      parent: 2
+- proto: FireAxeFlaming
+  entities:
+  - uid: 661
+    components:
+    - type: Transform
+      pos: -2.2713957,-20.14453
+      parent: 2
+- proto: FitnessPunchingBagCaptain
+  entities:
+  - uid: 662
+    components:
+    - type: Transform
+      pos: 10.5,3.5
+      parent: 2
+- proto: FitnessWeightsBench1
+  entities:
+  - uid: 663
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,4.5
+      parent: 2
+  - uid: 664
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 2
+- proto: Flash
+  entities:
+  - uid: 665
+    components:
+    - type: Transform
+      pos: 34.615303,0.110441685
+      parent: 2
+- proto: FlippoLighter
+  entities:
+  - uid: 666
+    components:
+    - type: Transform
+      pos: 8.749153,-16.456598
+      parent: 2
+- proto: Floodlight
+  entities:
+  - uid: 667
+    components:
+    - type: Transform
+      pos: 15.712837,-12.377796
+      parent: 2
+- proto: FloorDrain
+  entities:
+  - uid: 668
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-16.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 669
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-3.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: FloorLiquidPlasmaEntity
+  entities:
+  - uid: 670
+    components:
+    - type: Transform
+      pos: 25.5,-14.5
+      parent: 2
+  - uid: 671
+    components:
+    - type: Transform
+      pos: 24.5,-14.5
+      parent: 2
+  - uid: 672
+    components:
+    - type: Transform
+      pos: 23.5,-14.5
+      parent: 2
+  - uid: 673
+    components:
+    - type: Transform
+      pos: 22.5,-14.5
+      parent: 2
+  - uid: 674
+    components:
+    - type: Transform
+      pos: 23.5,-15.5
+      parent: 2
+  - uid: 675
+    components:
+    - type: Transform
+      pos: 22.5,-15.5
+      parent: 2
+  - uid: 676
+    components:
+    - type: Transform
+      pos: 21.5,-15.5
+      parent: 2
+  - uid: 677
+    components:
+    - type: Transform
+      pos: 20.5,-15.5
+      parent: 2
+  - uid: 678
+    components:
+    - type: Transform
+      pos: 22.5,-16.5
+      parent: 2
+  - uid: 679
+    components:
+    - type: Transform
+      pos: 22.5,-17.5
+      parent: 2
+  - uid: 680
+    components:
+    - type: Transform
+      pos: 22.5,-18.5
+      parent: 2
+  - uid: 681
+    components:
+    - type: Transform
+      pos: 22.5,-19.5
+      parent: 2
+  - uid: 682
+    components:
+    - type: Transform
+      pos: 22.5,-20.5
+      parent: 2
+  - uid: 683
+    components:
+    - type: Transform
+      pos: 21.5,-16.5
+      parent: 2
+  - uid: 684
+    components:
+    - type: Transform
+      pos: 21.5,-17.5
+      parent: 2
+  - uid: 685
+    components:
+    - type: Transform
+      pos: 21.5,-18.5
+      parent: 2
+  - uid: 686
+    components:
+    - type: Transform
+      pos: 21.5,-19.5
+      parent: 2
+  - uid: 687
+    components:
+    - type: Transform
+      pos: 21.5,-20.5
+      parent: 2
+  - uid: 688
+    components:
+    - type: Transform
+      pos: 20.5,-16.5
+      parent: 2
+  - uid: 689
+    components:
+    - type: Transform
+      pos: 20.5,-17.5
+      parent: 2
+  - uid: 690
+    components:
+    - type: Transform
+      pos: 20.5,-18.5
+      parent: 2
+  - uid: 691
+    components:
+    - type: Transform
+      pos: 20.5,-19.5
+      parent: 2
+  - uid: 692
+    components:
+    - type: Transform
+      pos: 20.5,-20.5
+      parent: 2
+  - uid: 693
+    components:
+    - type: Transform
+      pos: 23.5,-21.5
+      parent: 2
+  - uid: 694
+    components:
+    - type: Transform
+      pos: 22.5,-21.5
+      parent: 2
+  - uid: 695
+    components:
+    - type: Transform
+      pos: 21.5,-21.5
+      parent: 2
+  - uid: 696
+    components:
+    - type: Transform
+      pos: 20.5,-21.5
+      parent: 2
+  - uid: 697
+    components:
+    - type: Transform
+      pos: 28.5,-22.5
+      parent: 2
+  - uid: 698
+    components:
+    - type: Transform
+      pos: 27.5,-22.5
+      parent: 2
+  - uid: 699
+    components:
+    - type: Transform
+      pos: 26.5,-22.5
+      parent: 2
+  - uid: 700
+    components:
+    - type: Transform
+      pos: 25.5,-22.5
+      parent: 2
+  - uid: 701
+    components:
+    - type: Transform
+      pos: 24.5,-22.5
+      parent: 2
+  - uid: 702
+    components:
+    - type: Transform
+      pos: 23.5,-22.5
+      parent: 2
+  - uid: 703
+    components:
+    - type: Transform
+      pos: 22.5,-22.5
+      parent: 2
+  - uid: 704
+    components:
+    - type: Transform
+      pos: 21.5,-22.5
+      parent: 2
+  - uid: 705
+    components:
+    - type: Transform
+      pos: 23.5,-23.5
+      parent: 2
+  - uid: 706
+    components:
+    - type: Transform
+      pos: 24.5,-23.5
+      parent: 2
+  - uid: 707
+    components:
+    - type: Transform
+      pos: 25.5,-23.5
+      parent: 2
+  - uid: 708
+    components:
+    - type: Transform
+      pos: 26.5,-23.5
+      parent: 2
+  - uid: 709
+    components:
+    - type: Transform
+      pos: 27.5,-23.5
+      parent: 2
+  - uid: 710
+    components:
+    - type: Transform
+      pos: 29.5,-21.5
+      parent: 2
+  - uid: 711
+    components:
+    - type: Transform
+      pos: 28.5,-21.5
+      parent: 2
+  - uid: 712
+    components:
+    - type: Transform
+      pos: 24.5,-21.5
+      parent: 2
+  - uid: 713
+    components:
+    - type: Transform
+      pos: 23.5,-20.5
+      parent: 2
+  - uid: 714
+    components:
+    - type: Transform
+      pos: 29.5,-20.5
+      parent: 2
+  - uid: 715
+    components:
+    - type: Transform
+      pos: 23.5,-16.5
+      parent: 2
+  - uid: 716
+    components:
+    - type: Transform
+      pos: 24.5,-15.5
+      parent: 2
+- proto: FloraTreeConifer01
+  entities:
+  - uid: 717
+    components:
+    - type: Transform
+      pos: 21.392143,-12.729544
+      parent: 2
+  - uid: 718
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 42.96957,-1.4107871
+      parent: 2
+  - uid: 719
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 44.071133,4.3314004
+      parent: 2
+  - uid: 720
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 44.610195,10.118542
+      parent: 2
+  - uid: 721
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 32.038555,16.165417
+      parent: 2
+  - uid: 722
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 25.21776,10.212292
+      parent: 2
+  - uid: 723
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 38.739777,15.204479
+      parent: 2
+  - uid: 724
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 24.270073,7.063351
+      parent: 2
+  - uid: 725
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.942753,6.825022
+      parent: 2
+  - uid: 726
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.066328,-1.7765403
+      parent: 2
+  - uid: 727
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 22.019453,1.5984597
+      parent: 2
+  - uid: 728
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.4639435,3.9474778
+      parent: 2
+  - uid: 729
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.8467555,7.275603
+      parent: 2
+  - uid: 730
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.510818,2.9865403
+      parent: 2
+  - uid: 731
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.8057833,9.73654
+      parent: 2
+  - uid: 732
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.199942,11.617781
+      parent: 2
+  - uid: 733
+    components:
+    - type: Transform
+      pos: 31.977348,-23.940697
+      parent: 2
+- proto: FloraTreeConifer02
+  entities:
+  - uid: 734
+    components:
+    - type: Transform
+      pos: 10.992382,-20.738451
+      parent: 2
+- proto: FloraTreeConifer03
+  entities:
+  - uid: 735
+    components:
+    - type: Transform
+      pos: 16.973898,-18.627144
+      parent: 2
+  - uid: 736
+    components:
+    - type: Transform
+      pos: 16.859533,-25.557884
+      parent: 2
+  - uid: 737
+    components:
+    - type: Transform
+      pos: 26.703283,-24.807884
+      parent: 2
+- proto: FloraTreeSnow01
+  entities:
+  - uid: 738
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 20.842281,16.78661
+      parent: 2
+  - uid: 739
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 32.94993,10.88036
+      parent: 2
+  - uid: 740
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 21.234589,8.81786
+      parent: 2
+  - uid: 741
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 36.445526,15.731922
+      parent: 2
+  - uid: 742
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 38.445923,10.270985
+      parent: 2
+  - uid: 743
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 46.571957,16.200672
+      parent: 2
+  - uid: 744
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 42.61102,5.0912967
+      parent: 2
+  - uid: 745
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 44.321957,0.8710246
+      parent: 2
+  - uid: 746
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 24.94335,1.3600345
+      parent: 2
+  - uid: 747
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.3007822,5.7447276
+      parent: 2
+  - uid: 748
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.884738,9.986916
+      parent: 2
+- proto: FloraTreeSnow02
+  entities:
+  - uid: 749
+    components:
+    - type: Transform
+      pos: 6.351757,-21.816576
+      parent: 2
+  - uid: 750
+    components:
+    - type: Transform
+      pos: 15.540962,-14.862171
+      parent: 2
+  - uid: 751
+    components:
+    - type: Transform
+      pos: 15.208273,-20.377144
+      parent: 2
+  - uid: 752
+    components:
+    - type: Transform
+      pos: 32.956394,-16.27578
+      parent: 2
+  - uid: 753
+    components:
+    - type: Transform
+      pos: 30.987646,-13.43203
+      parent: 2
+  - uid: 754
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.984393,7.361915
+      parent: 2
+  - uid: 755
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.976582,4.1041026
+      parent: 2
+  - uid: 756
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 20.93752,-1.8255849
+      parent: 2
+- proto: FloraTreeSnow03
+  entities:
+  - uid: 757
+    components:
+    - type: Transform
+      pos: 18.119087,-14.159046
+      parent: 2
+  - uid: 758
+    components:
+    - type: Transform
+      pos: 18.776403,1.4578114
+      parent: 2
+  - uid: 759
+    components:
+    - type: Transform
+      pos: 33.386364,-21.432884
+      parent: 2
+  - uid: 760
+    components:
+    - type: Transform
+      pos: 28.675426,-26.35476
+      parent: 2
+  - uid: 761
+    components:
+    - type: Transform
+      pos: 22.297033,-26.214134
+      parent: 2
+  - uid: 762
+    components:
+    - type: Transform
+      pos: 18.031408,-23.565697
+      parent: 2
+- proto: FloraTreeSnow04
+  entities:
+  - uid: 763
+    components:
+    - type: Transform
+      pos: 8.883007,-21.550951
+      parent: 2
+  - uid: 764
+    components:
+    - type: Transform
+      pos: 17.833273,-21.095894
+      parent: 2
+- proto: FloraTreeSnow06
+  entities:
+  - uid: 765
+    components:
+    - type: Transform
+      pos: 8.508007,-19.113451
+      parent: 2
+  - uid: 766
+    components:
+    - type: Transform
+      pos: 17.009712,-11.737171
+      parent: 2
+  - uid: 767
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 20.210957,6.1197276
+      parent: 2
+  - uid: 768
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.375019,11.838478
+      parent: 2
+  - uid: 769
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 27.448383,15.617538
+      parent: 2
+  - uid: 770
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 43.091564,14.422716
+      parent: 2
+- proto: FoodSnackSyndi
+  entities:
+  - uid: 771
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 2
+- proto: GasFilter
+  entities:
+  - uid: 772
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-15.5
+      parent: 2
+- proto: GasFilterFlipped
+  entities:
+  - uid: 773
+    components:
+    - type: Transform
+      pos: -3.5,-16.5
+      parent: 2
+- proto: GasMixer
+  entities:
+  - uid: 774
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 2
+- proto: GasOutletInjector
+  entities:
+  - uid: 775
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-19.5
+      parent: 2
+- proto: GasPassiveVent
+  entities:
+  - uid: 776
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-19.5
+      parent: 2
+  - uid: 777
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-20.5
+      parent: 2
+  - uid: 778
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-19.5
+      parent: 2
+  - uid: 779
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-20.5
+      parent: 2
+- proto: GasPipeBend
+  entities:
+  - uid: 780
+    components:
+    - type: Transform
+      pos: -3.5,-15.5
+      parent: 2
+  - uid: 781
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-15.5
+      parent: 2
+  - uid: 782
+    components:
+    - type: Transform
+      pos: 1.5,-16.5
+      parent: 2
+  - uid: 783
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-16.5
+      parent: 2
+- proto: GasPipeFourway
+  entities:
+  - uid: 784
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 2
+- proto: GasPipeStraight
+  entities:
+  - uid: 785
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 2
+  - uid: 786
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 2
+  - uid: 787
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 2
+  - uid: 788
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 2
+  - uid: 789
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 2
+  - uid: 790
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#404040FF'
+  - uid: 791
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#404040FF'
+  - uid: 792
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#404040FF'
+  - uid: 793
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#404040FF'
+  - uid: 794
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#404040FF'
+  - uid: 795
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#404040FF'
+  - uid: 796
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#404040FF'
+  - uid: 797
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#404040FF'
+  - uid: 798
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#404040FF'
+  - uid: 799
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-0.5
+      parent: 2
+  - uid: 800
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-0.5
+      parent: 2
+  - uid: 801
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-0.5
+      parent: 2
+  - uid: 802
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 2
+  - uid: 803
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 2
+  - uid: 804
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 2
+  - uid: 805
+    components:
+    - type: Transform
+      pos: -3.5,-18.5
+      parent: 2
+  - uid: 806
+    components:
+    - type: Transform
+      pos: -1.5,-18.5
+      parent: 2
+  - uid: 807
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-19.5
+      parent: 2
+  - uid: 808
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-20.5
+      parent: 2
+- proto: GasPipeTJunction
+  entities:
+  - uid: 809
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-0.5
+      parent: 2
+  - uid: 810
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#404040FF'
+  - uid: 811
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#404040FF'
+  - uid: 812
+    components:
+    - type: Transform
+      pos: 0.5,-16.5
+      parent: 2
+- proto: GasPort
+  entities:
+  - uid: 813
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 2
+  - uid: 814
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-12.5
+      parent: 2
+  - uid: 815
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-13.5
+      parent: 2
+  - uid: 816
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-11.5
+      parent: 2
+  - uid: 817
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-12.5
+      parent: 2
+  - uid: 818
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-17.5
+      parent: 2
+  - uid: 819
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-17.5
+      parent: 2
+  - uid: 820
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-15.5
+      parent: 2
+  - uid: 821
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-16.5
+      parent: 2
+  - uid: 822
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-15.5
+      parent: 2
+  - uid: 823
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 2
+  - uid: 824
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 2
+- proto: GasPressurePump
+  entities:
+  - uid: 825
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-17.5
+      parent: 2
+  - uid: 826
+    components:
+    - type: Transform
+      pos: -1.5,-17.5
+      parent: 2
+- proto: GasThermoMachineHellfireFreezer
+  entities:
+  - uid: 827
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-11.5
+      parent: 2
+- proto: GasThermoMachineHellfireHeater
+  entities:
+  - uid: 828
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-12.5
+      parent: 2
+- proto: GasValve
+  entities:
+  - uid: 829
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-16.5
+      parent: 2
+- proto: GasVentPump
+  entities:
+  - uid: 830
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-0.5
+      parent: 2
+  - uid: 831
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-0.5
+      parent: 2
+  - uid: 832
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 2
+  - uid: 833
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 2
+- proto: GasVentScrubber
+  entities:
+  - uid: 834
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#404040FF'
+  - uid: 835
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#404040FF'
+  - uid: 836
+    components:
+    - type: Transform
+      pos: 8.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#404040FF'
+  - uid: 837
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-19.5
+      parent: 2
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 838
+    components:
+    - type: Transform
+      pos: 31.5,-10.5
+      parent: 2
+- proto: GeneratorRTG
+  entities:
+  - uid: 839
+    components:
+    - type: Transform
+      pos: 30.5,-10.5
+      parent: 2
+  - uid: 840
+    components:
+    - type: Transform
+      pos: 32.5,-9.5
+      parent: 2
+  - uid: 841
+    components:
+    - type: Transform
+      pos: 32.5,-8.5
+      parent: 2
+  - uid: 842
+    components:
+    - type: Transform
+      pos: 29.5,-8.5
+      parent: 2
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 843
+    components:
+    - type: Transform
+      pos: 29.5,-9.5
+      parent: 2
+- proto: Grille
+  entities:
+  - uid: 844
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 845
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 2
+  - uid: 846
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 2
+  - uid: 847
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+  - uid: 848
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 849
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 850
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+  - uid: 851
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 2
+  - uid: 852
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 2
+  - uid: 853
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 2
+  - uid: 854
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 2
+  - uid: 855
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 2
+  - uid: 856
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 2
+  - uid: 857
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 2
+  - uid: 858
+    components:
+    - type: Transform
+      pos: 10.5,4.5
+      parent: 2
+  - uid: 859
+    components:
+    - type: Transform
+      pos: 11.5,4.5
+      parent: 2
+  - uid: 860
+    components:
+    - type: Transform
+      pos: 12.5,4.5
+      parent: 2
+  - uid: 861
+    components:
+    - type: Transform
+      pos: 12.5,3.5
+      parent: 2
+  - uid: 862
+    components:
+    - type: Transform
+      pos: 13.5,3.5
+      parent: 2
+  - uid: 863
+    components:
+    - type: Transform
+      pos: 13.5,2.5
+      parent: 2
+  - uid: 864
+    components:
+    - type: Transform
+      pos: 13.5,0.5
+      parent: 2
+  - uid: 865
+    components:
+    - type: Transform
+      pos: 13.5,-1.5
+      parent: 2
+  - uid: 866
+    components:
+    - type: Transform
+      pos: 13.5,-2.5
+      parent: 2
+  - uid: 867
+    components:
+    - type: Transform
+      pos: 13.5,-0.5
+      parent: 2
+  - uid: 868
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 2
+  - uid: 869
+    components:
+    - type: Transform
+      pos: -11.5,-16.5
+      parent: 2
+  - uid: 870
+    components:
+    - type: Transform
+      pos: -11.5,-15.5
+      parent: 2
+  - uid: 871
+    components:
+    - type: Transform
+      pos: -11.5,-14.5
+      parent: 2
+  - uid: 872
+    components:
+    - type: Transform
+      pos: -12.5,-14.5
+      parent: 2
+  - uid: 873
+    components:
+    - type: Transform
+      pos: -10.5,-14.5
+      parent: 2
+  - uid: 874
+    components:
+    - type: Transform
+      pos: -8.5,-14.5
+      parent: 2
+  - uid: 875
+    components:
+    - type: Transform
+      pos: -9.5,-14.5
+      parent: 2
+  - uid: 876
+    components:
+    - type: Transform
+      pos: -8.5,-15.5
+      parent: 2
+  - uid: 877
+    components:
+    - type: Transform
+      pos: -8.5,-16.5
+      parent: 2
+  - uid: 878
+    components:
+    - type: Transform
+      pos: -7.5,-15.5
+      parent: 2
+  - uid: 879
+    components:
+    - type: Transform
+      pos: -6.5,-15.5
+      parent: 2
+  - uid: 880
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 2
+  - uid: 881
+    components:
+    - type: Transform
+      pos: -8.5,-9.5
+      parent: 2
+  - uid: 882
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 2
+  - uid: 883
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 2
+  - uid: 884
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 2
+  - uid: 885
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 886
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 2
+  - uid: 887
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 2
+  - uid: 888
+    components:
+    - type: Transform
+      pos: -3.5,-18.5
+      parent: 2
+  - uid: 889
+    components:
+    - type: Transform
+      pos: -1.5,-18.5
+      parent: 2
+  - uid: 890
+    components:
+    - type: Transform
+      pos: 13.5,-11.5
+      parent: 2
+  - uid: 891
+    components:
+    - type: Transform
+      pos: 13.5,-12.5
+      parent: 2
+  - uid: 892
+    components:
+    - type: Transform
+      pos: 13.5,-14.5
+      parent: 2
+  - uid: 893
+    components:
+    - type: Transform
+      pos: 13.5,-15.5
+      parent: 2
+  - uid: 894
+    components:
+    - type: Transform
+      pos: 8.5,-17.5
+      parent: 2
+  - uid: 895
+    components:
+    - type: Transform
+      pos: 7.5,-17.5
+      parent: 2
+  - uid: 896
+    components:
+    - type: Transform
+      pos: 6.5,-17.5
+      parent: 2
+  - uid: 897
+    components:
+    - type: Transform
+      pos: 14.5,-8.5
+      parent: 2
+  - uid: 898
+    components:
+    - type: Transform
+      pos: 15.5,-8.5
+      parent: 2
+  - uid: 899
+    components:
+    - type: Transform
+      pos: 16.5,-8.5
+      parent: 2
+  - uid: 900
+    components:
+    - type: Transform
+      pos: 17.5,-8.5
+      parent: 2
+  - uid: 901
+    components:
+    - type: Transform
+      pos: 18.5,-8.5
+      parent: 2
+  - uid: 902
+    components:
+    - type: Transform
+      pos: 19.5,-8.5
+      parent: 2
+  - uid: 903
+    components:
+    - type: Transform
+      pos: 20.5,-8.5
+      parent: 2
+  - uid: 904
+    components:
+    - type: Transform
+      pos: 21.5,-8.5
+      parent: 2
+  - uid: 905
+    components:
+    - type: Transform
+      pos: 22.5,-8.5
+      parent: 2
+  - uid: 906
+    components:
+    - type: Transform
+      pos: 23.5,-8.5
+      parent: 2
+  - uid: 907
+    components:
+    - type: Transform
+      pos: 24.5,-8.5
+      parent: 2
+  - uid: 908
+    components:
+    - type: Transform
+      pos: 25.5,-8.5
+      parent: 2
+  - uid: 909
+    components:
+    - type: Transform
+      pos: 14.5,-3.5
+      parent: 2
+  - uid: 910
+    components:
+    - type: Transform
+      pos: 16.5,-3.5
+      parent: 2
+  - uid: 911
+    components:
+    - type: Transform
+      pos: 15.5,-3.5
+      parent: 2
+  - uid: 912
+    components:
+    - type: Transform
+      pos: 18.5,-3.5
+      parent: 2
+  - uid: 913
+    components:
+    - type: Transform
+      pos: 17.5,-3.5
+      parent: 2
+  - uid: 914
+    components:
+    - type: Transform
+      pos: 20.5,-3.5
+      parent: 2
+  - uid: 915
+    components:
+    - type: Transform
+      pos: 19.5,-3.5
+      parent: 2
+  - uid: 916
+    components:
+    - type: Transform
+      pos: 22.5,-3.5
+      parent: 2
+  - uid: 917
+    components:
+    - type: Transform
+      pos: 21.5,-3.5
+      parent: 2
+  - uid: 918
+    components:
+    - type: Transform
+      pos: 24.5,-3.5
+      parent: 2
+  - uid: 919
+    components:
+    - type: Transform
+      pos: 23.5,-3.5
+      parent: 2
+  - uid: 920
+    components:
+    - type: Transform
+      pos: 25.5,-3.5
+      parent: 2
+  - uid: 921
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-17.5
+      parent: 2
+  - uid: 922
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 32.5,-17.5
+      parent: 2
+  - uid: 923
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 33.5,-17.5
+      parent: 2
+  - uid: 924
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-19.5
+      parent: 2
+  - uid: 925
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 32.5,-19.5
+      parent: 2
+  - uid: 926
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 34.5,-17.5
+      parent: 2
+  - uid: 927
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 33.5,-19.5
+      parent: 2
+  - uid: 928
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 34.5,-16.5
+      parent: 2
+  - uid: 929
+    components:
+    - type: Transform
+      pos: 30.5,2.5
+      parent: 2
+  - uid: 930
+    components:
+    - type: Transform
+      pos: 30.5,-0.5
+      parent: 2
+  - uid: 931
+    components:
+    - type: Transform
+      pos: 27.5,2.5
+      parent: 2
+  - uid: 932
+    components:
+    - type: Transform
+      pos: 27.5,1.5
+      parent: 2
+  - uid: 933
+    components:
+    - type: Transform
+      pos: 27.5,0.5
+      parent: 2
+  - uid: 934
+    components:
+    - type: Transform
+      pos: 27.5,-0.5
+      parent: 2
+  - uid: 935
+    components:
+    - type: Transform
+      pos: 31.5,4.5
+      parent: 2
+  - uid: 936
+    components:
+    - type: Transform
+      pos: 35.5,-4.5
+      parent: 2
+  - uid: 937
+    components:
+    - type: Transform
+      pos: 36.5,-4.5
+      parent: 2
+  - uid: 938
+    components:
+    - type: Transform
+      pos: 38.5,-1.5
+      parent: 2
+  - uid: 939
+    components:
+    - type: Transform
+      pos: 40.5,-1.5
+      parent: 2
+  - uid: 940
+    components:
+    - type: Transform
+      pos: 41.5,-3.5
+      parent: 2
+  - uid: 941
+    components:
+    - type: Transform
+      pos: 42.5,-3.5
+      parent: 2
+  - uid: 942
+    components:
+    - type: Transform
+      pos: 43.5,-3.5
+      parent: 2
+  - uid: 943
+    components:
+    - type: Transform
+      pos: 44.5,-3.5
+      parent: 2
+  - uid: 944
+    components:
+    - type: Transform
+      pos: 45.5,-3.5
+      parent: 2
+  - uid: 945
+    components:
+    - type: Transform
+      pos: 46.5,-3.5
+      parent: 2
+  - uid: 946
+    components:
+    - type: Transform
+      pos: 47.5,-3.5
+      parent: 2
+  - uid: 947
+    components:
+    - type: Transform
+      pos: 41.5,-5.5
+      parent: 2
+  - uid: 948
+    components:
+    - type: Transform
+      pos: 42.5,-5.5
+      parent: 2
+  - uid: 949
+    components:
+    - type: Transform
+      pos: 43.5,-5.5
+      parent: 2
+  - uid: 950
+    components:
+    - type: Transform
+      pos: 44.5,-5.5
+      parent: 2
+  - uid: 951
+    components:
+    - type: Transform
+      pos: 45.5,-5.5
+      parent: 2
+  - uid: 952
+    components:
+    - type: Transform
+      pos: 46.5,-5.5
+      parent: 2
+  - uid: 953
+    components:
+    - type: Transform
+      pos: 47.5,-5.5
+      parent: 2
+  - uid: 954
+    components:
+    - type: Transform
+      pos: 43.5,-7.5
+      parent: 2
+  - uid: 955
+    components:
+    - type: Transform
+      pos: 44.5,-7.5
+      parent: 2
+  - uid: 956
+    components:
+    - type: Transform
+      pos: 44.5,-8.5
+      parent: 2
+  - uid: 957
+    components:
+    - type: Transform
+      pos: 44.5,-9.5
+      parent: 2
+  - uid: 958
+    components:
+    - type: Transform
+      pos: 44.5,-10.5
+      parent: 2
+  - uid: 959
+    components:
+    - type: Transform
+      pos: 44.5,-11.5
+      parent: 2
+  - uid: 960
+    components:
+    - type: Transform
+      pos: 43.5,-11.5
+      parent: 2
+- proto: HeatExchanger
+  entities:
+  - uid: 961
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-16.5
+      parent: 2
+  - uid: 962
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-16.5
+      parent: 2
+- proto: HonkerCentralElectronics
+  entities:
+  - uid: 963
+    components:
+    - type: MetaData
+      desc: The electrical control center for the Mauler mech.
+      name: Mauler central control module
+    - type: Transform
+      pos: -8.781206,-2.9449494
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+- proto: HonkerChassis
+  entities:
+  - uid: 964
+    components:
+    - type: MetaData
+      desc: An abandoned project whose work cannot be continued anytime soon.
+      name: Mauler chassis
+    - type: Transform
+      pos: -9.495659,-2.4384387
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+- proto: HydroponicsTrayEmpty
+  entities:
+  - uid: 965
+    components:
+    - type: Transform
+      pos: -8.5,-13.5
+      parent: 2
+  - uid: 966
+    components:
+    - type: Transform
+      pos: -10.5,-13.5
+      parent: 2
+  - uid: 967
+    components:
+    - type: Transform
+      pos: -12.5,-13.5
+      parent: 2
+- proto: Igniter
+  entities:
+  - uid: 968
+    components:
+    - type: Transform
+      pos: -13.219715,-3.6691022
+      parent: 2
+  - uid: 969
+    components:
+    - type: Transform
+      pos: -13.219715,-3.2316022
+      parent: 2
+  - uid: 970
+    components:
+    - type: Transform
+      pos: -13.20409,-2.9034772
+      parent: 2
+- proto: Intellicard
+  entities:
+  - uid: 971
+    components:
+    - type: Transform
+      pos: 39.5395,-9.547376
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+- proto: IntercomElectronics
+  entities:
+  - uid: 972
+    components:
+    - type: Transform
+      pos: -3.4669557,-10.273108
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+- proto: InvisibleCrate
+  entities:
+  - uid: 973
+    components:
+    - type: Transform
+      pos: 34.5,7.5
+      parent: 2
+- proto: Katana
+  entities:
+  - uid: 974
+    components:
+    - type: Transform
+      pos: 37.5,-0.5
+      parent: 2
+- proto: KitchenElectricGrill
+  entities:
+  - uid: 975
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+- proto: KitchenKnife
+  entities:
+  - uid: 976
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+- proto: KitchenReagentGrinder
+  entities:
+  - uid: 977
+    components:
+    - type: Transform
+      pos: -10.5,-10.5
+      parent: 2
+  - uid: 978
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 2
+- proto: LargeBeaker
+  entities:
+  - uid: 979
+    components:
+    - type: Transform
+      pos: -12.699739,-11.344963
+      parent: 2
+  - uid: 980
+    components:
+    - type: Transform
+      pos: -5.5322156,-2.3097272
+      parent: 2
+- proto: LightPostSmall
+  entities:
+  - uid: 981
+    components:
+    - type: Transform
+      pos: 18.5,-16.5
+      parent: 2
+  - uid: 982
+    components:
+    - type: Transform
+      pos: 19.5,7.5
+      parent: 2
+  - uid: 983
+    components:
+    - type: Transform
+      pos: 29.5,14.5
+      parent: 2
+  - uid: 984
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 2
+  - uid: 985
+    components:
+    - type: Transform
+      pos: 19.5,-25.5
+      parent: 2
+  - uid: 986
+    components:
+    - type: Transform
+      pos: 30.5,-24.5
+      parent: 2
+  - uid: 987
+    components:
+    - type: Transform
+      pos: 43.5,11.5
+      parent: 2
+- proto: LockerFreezer
+  entities:
+  - uid: 988
+    components:
+    - type: Transform
       pos: 0.5,-4.5
-      parent: 1
+      parent: 2
     - type: AccessReader
       access:
       - - NuclearOperative
 - proto: LockerSyndicatePersonalFilled
   entities:
-  - uid: 526
+  - uid: 989
     components:
     - type: Transform
       pos: 39.5,1.5
-      parent: 1
-  - uid: 1725
+      parent: 2
+  - uid: 990
     components:
     - type: Transform
       pos: 40.5,1.5
-      parent: 1
-  - uid: 1729
+      parent: 2
+  - uid: 991
     components:
     - type: Transform
       pos: 37.5,1.5
-      parent: 1
-  - uid: 1747
+      parent: 2
+  - uid: 992
     components:
     - type: Transform
       pos: 38.5,1.5
-      parent: 1
-  - uid: 2368
+      parent: 2
+  - uid: 993
     components:
     - type: Transform
       pos: 36.5,1.5
-      parent: 1
+      parent: 2
+- proto: MachineCentrifuge
+  entities:
+  - uid: 994
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 2
+- proto: MachineElectrolysisUnit
+  entities:
+  - uid: 995
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 2
 - proto: MagazinePistolHighCapacity
   entities:
-  - uid: 1287
+  - uid: 996
     components:
     - type: Transform
       pos: 12.232729,-17.532574
-      parent: 1
+      parent: 2
 - proto: MedicalBed
   entities:
-  - uid: 819
+  - uid: 997
     components:
     - type: Transform
       pos: -1.5,-2.5
-      parent: 1
+      parent: 2
 - proto: MedkitAdvancedFilled
   entities:
-  - uid: 830
+  - uid: 998
     components:
     - type: Transform
       pos: -3.6026306,-4.510801
-      parent: 1
+      parent: 2
 - proto: MedkitBruteFilled
   entities:
-  - uid: 824
+  - uid: 999
     components:
     - type: Transform
       pos: -3.5870056,-2.4170508
-      parent: 1
+      parent: 2
 - proto: MedkitBurnFilled
   entities:
-  - uid: 825
+  - uid: 1000
     components:
     - type: Transform
       pos: -3.3682556,-2.8076758
-      parent: 1
+      parent: 2
 - proto: MedkitFilled
   entities:
-  - uid: 826
+  - uid: 1001
     components:
     - type: Transform
       pos: -3.5870056,-3.1045508
-      parent: 1
+      parent: 2
 - proto: MedkitOxygenFilled
   entities:
-  - uid: 827
+  - uid: 1002
     components:
     - type: Transform
       pos: -3.3682556,-3.5108008
-      parent: 1
+      parent: 2
 - proto: MedkitRadiationFilled
   entities:
-  - uid: 828
+  - uid: 1003
     components:
     - type: Transform
       pos: -3.5557556,-3.8389258
-      parent: 1
+      parent: 2
 - proto: MedkitToxinFilled
   entities:
-  - uid: 829
+  - uid: 1004
     components:
     - type: Transform
       pos: -3.3682556,-4.151426
-      parent: 1
+      parent: 2
 - proto: MegaSprayBottle
   entities:
-  - uid: 767
+  - uid: 1005
     components:
     - type: Transform
       pos: -12.559114,-10.376213
-      parent: 1
+      parent: 2
 - proto: Mirror
   entities:
-  - uid: 801
+  - uid: 1006
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-17.5
-      parent: 1
-  - uid: 802
+      parent: 2
+  - uid: 1007
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-14.5
-      parent: 1
+      parent: 2
 - proto: ModularGrenade
   entities:
-  - uid: 790
+  - uid: 1008
     components:
     - type: Transform
       pos: -13.688465,-1.7472272
-      parent: 1
-  - uid: 791
+      parent: 2
+  - uid: 1009
     components:
     - type: Transform
       pos: -13.313465,-1.4816022
-      parent: 1
-  - uid: 792
+      parent: 2
+  - uid: 1010
     components:
     - type: Transform
       pos: -13.70409,-1.2941022
-      parent: 1
+      parent: 2
 - proto: MopBucketFull
   entities:
-  - uid: 952
+  - uid: 1011
     components:
     - type: Transform
       pos: 10.5,-9.5
-      parent: 1
+      parent: 2
 - proto: MopItem
   entities:
-  - uid: 951
+  - uid: 1012
     components:
     - type: Transform
       pos: 10.476817,-9.415861
-      parent: 1
+      parent: 2
 - proto: Morgue
   entities:
-  - uid: 815
+  - uid: 1013
     components:
     - type: Transform
       pos: -3.5,-0.5
-      parent: 1
+      parent: 2
 - proto: Multitool
   entities:
-  - uid: 562
+  - uid: 1014
     components:
     - type: Transform
       pos: -3.8367076,-14.575489
-      parent: 1
+      parent: 2
     - type: Physics
       angularDamping: 0
       linearDamping: 0
 - proto: NitrogenCanister
   entities:
-  - uid: 429
+  - uid: 1015
     components:
     - type: Transform
       pos: 0.5,-11.5
-      parent: 1
-  - uid: 430
+      parent: 2
+  - uid: 1016
     components:
     - type: Transform
       pos: 1.5,-11.5
-      parent: 1
+      parent: 2
 - proto: NitrousOxideCanister
   entities:
-  - uid: 431
+  - uid: 1017
     components:
     - type: Transform
       pos: 0.5,-12.5
-      parent: 1
-  - uid: 432
+      parent: 2
+  - uid: 1018
     components:
     - type: Transform
       pos: 1.5,-12.5
-      parent: 1
+      parent: 2
 - proto: NukeDiskFake
   entities:
-  - uid: 1435
+  - uid: 1019
     components:
     - type: Transform
       pos: 27.84377,-31.284956
-      parent: 1
+      parent: 2
 - proto: OperatingTable
   entities:
-  - uid: 816
+  - uid: 1020
     components:
     - type: Transform
       pos: -2.5,-0.5
-      parent: 1
+      parent: 2
 - proto: OxygenCanister
   entities:
-  - uid: 427
+  - uid: 1021
     components:
     - type: Transform
       pos: 0.5,-10.5
-      parent: 1
-  - uid: 428
+      parent: 2
+  - uid: 1022
     components:
     - type: Transform
       pos: 1.5,-10.5
-      parent: 1
+      parent: 2
+- proto: Paper
+  entities:
+  - uid: 1023
+    components:
+    - type: Transform
+      pos: 39.492176,-10.416637
+      parent: 2
+    - type: Paper
+      stampState: paper_stamp-syndicate
+      stampedBy:
+      - stampedColor: '#850000FF'
+        stampedName: stamp-component-stamped-name-syndicate
+      content: >
+        So, if you find out that station AI has to be pain in the ass you can use this intellicard to get rid of it.
+
+
+        Anyway, you can always put emag in their AI upload to change it's laws to ours. Just, don't forget that this won't provide them access to your syndicate radio. We'll live you intercom board in outpost engineering so you will be able to build intercom near AI with syndicate encryption key.
+
+
+        Good luck on the mission, Operatives.
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
 - proto: PlasmaCanister
   entities:
-  - uid: 433
+  - uid: 1024
     components:
     - type: Transform
       pos: 0.5,-13.5
-      parent: 1
-  - uid: 434
+      parent: 2
+  - uid: 1025
     components:
     - type: Transform
       pos: 1.5,-13.5
-      parent: 1
+      parent: 2
 - proto: PlushieLizard
   entities:
-  - uid: 1995
+  - uid: 1026
     components:
     - type: Transform
       pos: 41.5,-14.5
-      parent: 1
+      parent: 2
 - proto: PlushieNuke
   entities:
-  - uid: 739
+  - uid: 1027
     components:
     - type: Transform
       pos: -11.5,-7.5
-      parent: 1
+      parent: 2
 - proto: PortableScrubber
   entities:
-  - uid: 448
-    components:
-    - type: Transform
-      pos: -1.5,-11.5
-      parent: 1
-  - uid: 569
+  - uid: 1028
     components:
     - type: Transform
       pos: -2.5,-16.5
-      parent: 1
+      parent: 2
+  - uid: 1029
+    components:
+    - type: Transform
+      pos: 1.5,-15.5
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: PosterContrabandBeachStarYamamoto
   entities:
-  - uid: 1355
+  - uid: 1030
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 23.5,-17.5
-      parent: 1
+      parent: 2
 - proto: PosterContrabandDDayPromo
   entities:
-  - uid: 2364
+  - uid: 1031
     components:
     - type: Transform
       pos: 31.5,-1.5
-      parent: 1
+      parent: 2
 - proto: PosterContrabandDonutCorp
   entities:
-  - uid: 156
+  - uid: 1032
     components:
     - type: Transform
       pos: 11.5,-3.5
-      parent: 1
+      parent: 2
 - proto: PosterContrabandEnergySwords
-  entities:
-  - uid: 805
-    components:
-    - type: Transform
-      pos: -9.5,-9.5
-      parent: 1
-  - uid: 2365
-    components:
-    - type: Transform
-      pos: 29.5,-7.5
-      parent: 1
-- proto: PosterContrabandEnlistGorlex
-  entities:
-  - uid: 1083
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-4.5
-      parent: 1
-- proto: PosterContrabandFreeDrone
-  entities:
-  - uid: 1084
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,-4.5
-      parent: 1
-- proto: PosterContrabandKudzu
-  entities:
-  - uid: 806
-    components:
-    - type: Transform
-      pos: -13.5,-11.5
-      parent: 1
-- proto: PosterContrabandLustyExomorph
-  entities:
-  - uid: 1746
-    components:
-    - type: Transform
-      pos: 41.5,0.5
-      parent: 1
-- proto: PosterContrabandMoth
-  entities:
-  - uid: 76
-    components:
-    - type: Transform
-      pos: 1.5,1.5
-      parent: 1
-- proto: PosterContrabandPower
-  entities:
-  - uid: 809
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,1.5
-      parent: 1
-- proto: PosterContrabandRevolver
-  entities:
-  - uid: 810
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,1.5
-      parent: 1
-- proto: PosterContrabandRobustSoftdrinks
-  entities:
-  - uid: 2366
-    components:
-    - type: Transform
-      pos: 31.5,-11.5
-      parent: 1
-- proto: PosterContrabandSyndicatePistol
-  entities:
-  - uid: 1726
-    components:
-    - type: Transform
-      pos: 37.5,2.5
-      parent: 1
-- proto: PosterContrabandTheBigGasTruth
-  entities:
-  - uid: 2367
-    components:
-    - type: Transform
-      pos: 36.5,-16.5
-      parent: 1
-- proto: PosterContrabandTools
-  entities:
-  - uid: 1728
-    components:
-    - type: Transform
-      pos: 34.5,-3.5
-      parent: 1
-- proto: PosterContrabandVoteWeh
-  entities:
-  - uid: 1993
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 41.5,-15.5
-      parent: 1
-- proto: PosterLegitCarpMount
-  entities:
-  - uid: 1991
-    components:
-    - type: Transform
-      pos: 37.5,-4.5
-      parent: 1
-- proto: PosterLegitIonRifle
-  entities:
-  - uid: 1745
-    components:
-    - type: Transform
-      pos: 36.5,-1.5
-      parent: 1
-- proto: PosterLegitNoERP
-  entities:
-  - uid: 495
-    components:
-    - type: Transform
-      pos: 4.5,-17.5
-      parent: 1
-  - uid: 906
-    components:
-    - type: Transform
-      pos: 11.5,-13.5
-      parent: 1
-- proto: PosterLegitTheOwl
-  entities:
-  - uid: 1727
-    components:
-    - type: Transform
-      pos: 34.5,4.5
-      parent: 1
-- proto: PosterMapMetaRight
-  entities:
-  - uid: 155
-    components:
-    - type: Transform
-      pos: 11.5,1.5
-      parent: 1
-- proto: PosterMapWaystation
-  entities:
-  - uid: 962
-    components:
-    - type: Transform
-      pos: 7.5,-6.5
-      parent: 1
-- proto: PottedPlant12
-  entities:
-  - uid: 1602
-    components:
-    - type: Transform
-      pos: 30.5,-4.5
-      parent: 1
-- proto: PottedPlant16
-  entities:
-  - uid: 872
-    components:
-    - type: Transform
-      pos: 12.5,-7.5
-      parent: 1
-- proto: PottedPlant2
-  entities:
-  - uid: 1601
-    components:
-    - type: Transform
-      pos: 31.5,-4.5
-      parent: 1
-- proto: PottedPlant22
-  entities:
-  - uid: 823
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 1
-- proto: PottedPlant23
-  entities:
-  - uid: 873
-    components:
-    - type: Transform
-      pos: 8.5,-9.5
-      parent: 1
-- proto: PottedPlant26
-  entities:
-  - uid: 1600
-    components:
-    - type: Transform
-      pos: 33.5,-4.5
-      parent: 1
-- proto: PottedPlant5
-  entities:
-  - uid: 1898
-    components:
-    - type: Transform
-      pos: 42.5,-6.5
-      parent: 1
-- proto: Poweredlight
-  entities:
-  - uid: 146
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,2.5
-      parent: 1
-  - uid: 524
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-13.5
-      parent: 1
-  - uid: 525
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-13.5
-      parent: 1
-  - uid: 670
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-8.5
-      parent: 1
-  - uid: 736
-    components:
-    - type: Transform
-      pos: -9.5,0.5
-      parent: 1
-  - uid: 737
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-2.5
-      parent: 1
-  - uid: 738
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,-2.5
-      parent: 1
-  - uid: 743
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,-12.5
-      parent: 1
-  - uid: 759
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-14.5
-      parent: 1
-  - uid: 811
-    components:
-    - type: Transform
-      pos: -2.5,-0.5
-      parent: 1
-  - uid: 867
-    components:
-    - type: Transform
-      pos: 11.5,-4.5
-      parent: 1
-  - uid: 868
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-8.5
-      parent: 1
-  - uid: 935
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-15.5
-      parent: 1
-  - uid: 1079
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,-6.5
-      parent: 1
-  - uid: 1080
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-6.5
-      parent: 1
-  - uid: 1599
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 28.5,-6.5
-      parent: 1
-  - uid: 1822
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 33.5,-3.5
-      parent: 1
-  - uid: 1840
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 27.5,6.5
-      parent: 1
-  - uid: 1841
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 40.5,6.5
-      parent: 1
-  - uid: 1842
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 34.5,5.5
-      parent: 1
-  - uid: 1843
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 38.5,3.5
-      parent: 1
-  - uid: 1899
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 43.5,-9.5
-      parent: 1
-  - uid: 1900
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 34.5,-8.5
-      parent: 1
-  - uid: 1901
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 38.5,-13.5
-      parent: 1
-  - uid: 1990
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 25.5,-9.5
-      parent: 1
-- proto: PoweredSmallLight
-  entities:
-  - uid: 129
-    components:
-    - type: Transform
-      pos: 9.5,0.5
-      parent: 1
-  - uid: 130
-    components:
-    - type: Transform
-      pos: 12.5,0.5
-      parent: 1
-  - uid: 131
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,-2.5
-      parent: 1
-  - uid: 132
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 9.5,-2.5
-      parent: 1
-  - uid: 133
-    components:
-    - type: Transform
-      pos: 5.5,0.5
-      parent: 1
-  - uid: 134
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-2.5
-      parent: 1
-  - uid: 135
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-4.5
-      parent: 1
-  - uid: 136
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-0.5
-      parent: 1
-  - uid: 147
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,2.5
-      parent: 1
-  - uid: 520
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-13.5
-      parent: 1
-  - uid: 521
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-16.5
-      parent: 1
-  - uid: 671
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-6.5
-      parent: 1
-  - uid: 672
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,-6.5
-      parent: 1
-  - uid: 855
-    components:
-    - type: Transform
-      pos: -9.5,-10.5
-      parent: 1
-  - uid: 856
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -11.5,-7.5
-      parent: 1
-  - uid: 917
-    components:
-    - type: Transform
-      pos: 11.5,-14.5
-      parent: 1
-  - uid: 918
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,-12.5
-      parent: 1
-  - uid: 936
-    components:
-    - type: Transform
-      pos: 8.5,-11.5
-      parent: 1
-  - uid: 946
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,-9.5
-      parent: 1
-  - uid: 954
-    components:
-    - type: Transform
-      pos: 2.5,-6.5
-      parent: 1
-  - uid: 955
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-8.5
-      parent: 1
-  - uid: 1081
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,-4.5
-      parent: 1
-  - uid: 1082
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 25.5,-4.5
-      parent: 1
-  - uid: 1276
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 35.5,-18.5
-      parent: 1
-  - uid: 1806
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 31.5,-10.5
-      parent: 1
-  - uid: 1819
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 28.5,0.5
-      parent: 1
-  - uid: 1820
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 34.5,1.5
-      parent: 1
-  - uid: 1821
-    components:
-    - type: Transform
-      pos: 31.5,3.5
-      parent: 1
-  - uid: 1844
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 35.5,-3.5
-      parent: 1
-  - uid: 1902
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 41.5,-14.5
-      parent: 1
-  - uid: 1905
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 40.5,-2.5
-      parent: 1
-  - uid: 1906
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 36.5,0.5
-      parent: 1
-  - uid: 1907
-    components:
-    - type: Transform
-      pos: 38.5,1.5
-      parent: 1
-- proto: Rack
-  entities:
-  - uid: 563
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-10.5
-      parent: 1
-  - uid: 771
-    components:
-    - type: Transform
-      pos: -12.5,0.5
-      parent: 1
-  - uid: 960
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-8.5
-      parent: 1
-  - uid: 1730
-    components:
-    - type: Transform
-      pos: 36.5,-0.5
-      parent: 1
-  - uid: 1731
-    components:
-    - type: Transform
-      pos: 37.5,-0.5
-      parent: 1
-  - uid: 1751
-    components:
-    - type: Transform
-      pos: 31.5,-0.5
-      parent: 1
-- proto: Railing
   entities:
   - uid: 1033
     components:
     - type: Transform
-      pos: 14.5,-4.5
-      parent: 1
+      pos: -9.5,-9.5
+      parent: 2
   - uid: 1034
     components:
     - type: Transform
-      pos: 15.5,-4.5
-      parent: 1
+      pos: 29.5,-7.5
+      parent: 2
+- proto: PosterContrabandKudzu
+  entities:
   - uid: 1035
     components:
     - type: Transform
-      pos: 16.5,-4.5
-      parent: 1
+      pos: -13.5,-11.5
+      parent: 2
+- proto: PosterContrabandLustyExomorph
+  entities:
   - uid: 1036
     components:
     - type: Transform
-      pos: 18.5,-4.5
-      parent: 1
+      pos: 41.5,0.5
+      parent: 2
+- proto: PosterContrabandMoth
+  entities:
   - uid: 1037
     components:
     - type: Transform
-      pos: 19.5,-4.5
-      parent: 1
+      pos: 1.5,1.5
+      parent: 2
+- proto: PosterContrabandPower
+  entities:
   - uid: 1038
     components:
     - type: Transform
-      pos: 20.5,-4.5
-      parent: 1
+      rot: -1.5707963267948966 rad
+      pos: -10.5,1.5
+      parent: 2
+- proto: PosterContrabandRevolver
+  entities:
   - uid: 1039
     components:
     - type: Transform
-      pos: 21.5,-4.5
-      parent: 1
+      pos: -5.5,0.5
+      parent: 2
+- proto: PosterContrabandRobustSoftdrinks
+  entities:
   - uid: 1040
     components:
     - type: Transform
-      pos: 22.5,-4.5
-      parent: 1
+      pos: 31.5,-11.5
+      parent: 2
+- proto: PosterContrabandSyndicatePistol
+  entities:
   - uid: 1041
     components:
     - type: Transform
-      pos: 23.5,-4.5
-      parent: 1
+      pos: 37.5,2.5
+      parent: 2
+- proto: PosterContrabandTheBigGasTruth
+  entities:
   - uid: 1042
     components:
     - type: Transform
-      pos: 24.5,-4.5
-      parent: 1
+      pos: 36.5,-16.5
+      parent: 2
+- proto: PosterContrabandTools
+  entities:
   - uid: 1043
     components:
     - type: Transform
-      pos: 25.5,-4.5
-      parent: 1
+      pos: 34.5,-3.5
+      parent: 2
+- proto: PosterContrabandVoteWeh
+  entities:
   - uid: 1044
-    components:
-    - type: Transform
-      pos: 17.5,-4.5
-      parent: 1
-  - uid: 1045
-    components:
-    - type: Transform
-      pos: 24.5,-6.5
-      parent: 1
-  - uid: 1046
-    components:
-    - type: Transform
-      pos: 23.5,-6.5
-      parent: 1
-  - uid: 1047
-    components:
-    - type: Transform
-      pos: 20.5,-6.5
-      parent: 1
-  - uid: 1048
-    components:
-    - type: Transform
-      pos: 19.5,-6.5
-      parent: 1
-  - uid: 1049
-    components:
-    - type: Transform
-      pos: 16.5,-6.5
-      parent: 1
-  - uid: 1050
-    components:
-    - type: Transform
-      pos: 15.5,-6.5
-      parent: 1
-  - uid: 1069
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 15.5,-10.5
-      parent: 1
-  - uid: 1070
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,-10.5
-      parent: 1
-  - uid: 1071
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,-10.5
-      parent: 1
-  - uid: 1072
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-10.5
-      parent: 1
-  - uid: 1073
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-10.5
-      parent: 1
-  - uid: 1074
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-10.5
-      parent: 1
-  - uid: 1075
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-10.5
-      parent: 1
-  - uid: 1076
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,-10.5
-      parent: 1
-  - uid: 1077
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,-10.5
-      parent: 1
-  - uid: 1078
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 24.5,-10.5
-      parent: 1
-  - uid: 1188
-    components:
-    - type: Transform
-      pos: 28.5,-13.5
-      parent: 1
-  - uid: 1189
-    components:
-    - type: Transform
-      pos: 27.5,-13.5
-      parent: 1
-  - uid: 1190
-    components:
-    - type: Transform
-      pos: 26.5,-13.5
-      parent: 1
-  - uid: 1191
-    components:
-    - type: Transform
-      pos: 25.5,-13.5
-      parent: 1
-  - uid: 1192
-    components:
-    - type: Transform
-      pos: 24.5,-13.5
-      parent: 1
-  - uid: 1199
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 21.5,-20.5
-      parent: 1
-  - uid: 1200
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 21.5,-19.5
-      parent: 1
-  - uid: 1201
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 21.5,-18.5
-      parent: 1
-  - uid: 1202
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 21.5,-17.5
-      parent: 1
-  - uid: 1203
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 21.5,-16.5
-      parent: 1
-  - uid: 1206
-    components:
-    - type: Transform
-      pos: 23.5,-13.5
-      parent: 1
-  - uid: 1327
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 24.5,-23.5
-      parent: 1
-  - uid: 1328
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 25.5,-23.5
-      parent: 1
-  - uid: 1329
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 26.5,-23.5
-      parent: 1
-  - uid: 1330
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 27.5,-23.5
-      parent: 1
-  - uid: 1331
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 28.5,-23.5
-      parent: 1
-  - uid: 1337
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 31.5,-20.5
-      parent: 1
-  - uid: 1338
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 31.5,-16.5
-      parent: 1
-  - uid: 1339
-    components:
-    - type: Transform
-      pos: 22.5,-13.5
-      parent: 1
-  - uid: 1340
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-23.5
-      parent: 1
-  - uid: 1347
-    components:
-    - type: Transform
-      pos: 20.5,-14.5
-      parent: 1
-  - uid: 1349
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,-20.5
-      parent: 1
-  - uid: 1350
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,-18.5
-      parent: 1
-  - uid: 1351
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,-17.5
-      parent: 1
-  - uid: 1352
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,-16.5
-      parent: 1
-  - uid: 1589
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 48.5,11.5
-      parent: 1
-  - uid: 1590
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 48.5,12.5
-      parent: 1
-  - uid: 1591
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 48.5,13.5
-      parent: 1
-  - uid: 1592
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 48.5,14.5
-      parent: 1
-  - uid: 1593
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 48.5,15.5
-      parent: 1
-  - uid: 1594
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 48.5,16.5
-      parent: 1
-  - uid: 1595
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 48.5,17.5
-      parent: 1
-  - uid: 1596
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 48.5,10.5
-      parent: 1
-  - uid: 1754
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 48.5,9.5
-      parent: 1
-  - uid: 2234
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 46.5,6.5
-      parent: 1
-  - uid: 2235
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 46.5,5.5
-      parent: 1
-  - uid: 2236
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 46.5,4.5
-      parent: 1
-  - uid: 2237
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 46.5,3.5
-      parent: 1
-  - uid: 2238
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 46.5,2.5
-      parent: 1
-  - uid: 2239
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 46.5,1.5
-      parent: 1
-  - uid: 2240
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 46.5,0.5
-      parent: 1
-  - uid: 2241
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 46.5,-0.5
-      parent: 1
-  - uid: 2242
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 46.5,-1.5
-      parent: 1
-  - uid: 2243
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 46.5,-2.5
-      parent: 1
-- proto: RailingCorner
-  entities:
-  - uid: 1193
-    components:
-    - type: Transform
-      pos: 23.5,-14.5
-      parent: 1
-  - uid: 1194
-    components:
-    - type: Transform
-      pos: 22.5,-15.5
-      parent: 1
-  - uid: 1195
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 22.5,-21.5
-      parent: 1
-  - uid: 1196
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 23.5,-22.5
-      parent: 1
-  - uid: 1210
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 29.5,-14.5
-      parent: 1
-  - uid: 1211
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 30.5,-15.5
-      parent: 1
-  - uid: 1294
-    components:
-    - type: Transform
-      pos: 21.5,-14.5
-      parent: 1
-  - uid: 1332
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 30.5,-21.5
-      parent: 1
-  - uid: 1333
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 29.5,-22.5
-      parent: 1
-  - uid: 1354
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 20.5,-22.5
-      parent: 1
-  - uid: 1996
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 45.5,-6.5
-      parent: 1
-  - uid: 1997
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 46.5,-7.5
-      parent: 1
-  - uid: 1998
-    components:
-    - type: Transform
-      pos: 46.5,-11.5
-      parent: 1
-  - uid: 1999
-    components:
-    - type: Transform
-      pos: 45.5,-12.5
-      parent: 1
-  - uid: 2229
-    components:
-    - type: Transform
-      pos: 48.5,8.5
-      parent: 1
-  - uid: 2230
-    components:
-    - type: Transform
-      pos: 47.5,7.5
-      parent: 1
-- proto: RailingCornerSmall
-  entities:
-  - uid: 1051
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 17.5,-6.5
-      parent: 1
-  - uid: 1052
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 21.5,-6.5
-      parent: 1
-  - uid: 1053
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,-6.5
-      parent: 1
-  - uid: 1054
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 25.5,-6.5
-      parent: 1
-  - uid: 1055
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-6.5
-      parent: 1
-  - uid: 1056
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,-6.5
-      parent: 1
-  - uid: 1197
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 22.5,-22.5
-      parent: 1
-  - uid: 1198
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-21.5
-      parent: 1
-  - uid: 1204
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,-15.5
-      parent: 1
-  - uid: 1205
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,-14.5
-      parent: 1
-  - uid: 1207
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 29.5,-13.5
-      parent: 1
-  - uid: 1208
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 30.5,-14.5
-      parent: 1
-  - uid: 1209
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 31.5,-15.5
-      parent: 1
-  - uid: 1326
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 23.5,-23.5
-      parent: 1
-  - uid: 1334
-    components:
-    - type: Transform
-      pos: 29.5,-23.5
-      parent: 1
-  - uid: 1335
-    components:
-    - type: Transform
-      pos: 30.5,-22.5
-      parent: 1
-  - uid: 1336
-    components:
-    - type: Transform
-      pos: 31.5,-21.5
-      parent: 1
-  - uid: 1341
-    components:
-    - type: Transform
-      pos: 22.5,-23.5
-      parent: 1
-  - uid: 1342
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 20.5,-23.5
-      parent: 1
-  - uid: 1343
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,-22.5
-      parent: 1
-  - uid: 1344
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-14.5
-      parent: 1
-  - uid: 1345
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-19.5
-      parent: 1
-  - uid: 1346
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,-19.5
-      parent: 1
-  - uid: 2000
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 45.5,-11.5
-      parent: 1
-  - uid: 2001
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 45.5,-7.5
-      parent: 1
-  - uid: 2002
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 46.5,-8.5
-      parent: 1
-  - uid: 2003
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 46.5,-10.5
-      parent: 1
-  - uid: 2004
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 44.5,-12.5
-      parent: 1
-  - uid: 2005
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 44.5,-6.5
-      parent: 1
-  - uid: 2232
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 47.5,8.5
-      parent: 1
-  - uid: 2233
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 46.5,7.5
-      parent: 1
-- proto: RCD
-  entities:
-  - uid: 494
-    components:
-    - type: Transform
-      pos: -1.5,-10.5
-      parent: 1
-- proto: ReagentGrinderIndustrial
-  entities:
-  - uid: 760
-    components:
-    - type: Transform
-      pos: -7.5,-14.5
-      parent: 1
-- proto: ReinforcedPlasmaWindow
-  entities:
-  - uid: 105
-    components:
-    - type: Transform
-      pos: 0.5,2.5
-      parent: 1
-  - uid: 106
-    components:
-    - type: Transform
-      pos: 0.5,3.5
-      parent: 1
-  - uid: 107
-    components:
-    - type: Transform
-      pos: 1.5,3.5
-      parent: 1
-  - uid: 108
-    components:
-    - type: Transform
-      pos: 1.5,4.5
-      parent: 1
-  - uid: 109
-    components:
-    - type: Transform
-      pos: 2.5,4.5
-      parent: 1
-  - uid: 110
-    components:
-    - type: Transform
-      pos: 3.5,4.5
-      parent: 1
-  - uid: 111
-    components:
-    - type: Transform
-      pos: 4.5,4.5
-      parent: 1
-  - uid: 112
-    components:
-    - type: Transform
-      pos: 4.5,5.5
-      parent: 1
-  - uid: 113
-    components:
-    - type: Transform
-      pos: 5.5,5.5
-      parent: 1
-  - uid: 114
-    components:
-    - type: Transform
-      pos: 6.5,5.5
-      parent: 1
-  - uid: 115
-    components:
-    - type: Transform
-      pos: 7.5,5.5
-      parent: 1
-  - uid: 116
-    components:
-    - type: Transform
-      pos: 8.5,5.5
-      parent: 1
-  - uid: 117
-    components:
-    - type: Transform
-      pos: 9.5,5.5
-      parent: 1
-  - uid: 118
-    components:
-    - type: Transform
-      pos: 9.5,4.5
-      parent: 1
-  - uid: 119
-    components:
-    - type: Transform
-      pos: 10.5,4.5
-      parent: 1
-  - uid: 120
-    components:
-    - type: Transform
-      pos: 11.5,4.5
-      parent: 1
-  - uid: 121
-    components:
-    - type: Transform
-      pos: 12.5,4.5
-      parent: 1
-  - uid: 122
-    components:
-    - type: Transform
-      pos: 12.5,3.5
-      parent: 1
-  - uid: 123
-    components:
-    - type: Transform
-      pos: 13.5,3.5
-      parent: 1
-  - uid: 124
-    components:
-    - type: Transform
-      pos: 13.5,2.5
-      parent: 1
-  - uid: 125
-    components:
-    - type: Transform
-      pos: 13.5,0.5
-      parent: 1
-  - uid: 126
-    components:
-    - type: Transform
-      pos: 13.5,-0.5
-      parent: 1
-  - uid: 127
-    components:
-    - type: Transform
-      pos: 13.5,-1.5
-      parent: 1
-  - uid: 128
-    components:
-    - type: Transform
-      pos: 13.5,-2.5
-      parent: 1
-  - uid: 137
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,-3.5
-      parent: 1
-  - uid: 300
-    components:
-    - type: Transform
-      pos: -1.5,-5.5
-      parent: 1
-  - uid: 301
-    components:
-    - type: Transform
-      pos: -3.5,-5.5
-      parent: 1
-  - uid: 302
-    components:
-    - type: Transform
-      pos: -5.5,-5.5
-      parent: 1
-  - uid: 303
-    components:
-    - type: Transform
-      pos: -7.5,-5.5
-      parent: 1
-  - uid: 304
-    components:
-    - type: Transform
-      pos: -8.5,-9.5
-      parent: 1
-  - uid: 305
-    components:
-    - type: Transform
-      pos: -6.5,-9.5
-      parent: 1
-  - uid: 306
-    components:
-    - type: Transform
-      pos: -3.5,-9.5
-      parent: 1
-  - uid: 307
-    components:
-    - type: Transform
-      pos: -1.5,-9.5
-      parent: 1
-  - uid: 308
-    components:
-    - type: Transform
-      pos: -6.5,-15.5
-      parent: 1
-  - uid: 309
-    components:
-    - type: Transform
-      pos: -7.5,-15.5
-      parent: 1
-  - uid: 310
-    components:
-    - type: Transform
-      pos: -8.5,-15.5
-      parent: 1
-  - uid: 311
-    components:
-    - type: Transform
-      pos: -8.5,-14.5
-      parent: 1
-  - uid: 312
-    components:
-    - type: Transform
-      pos: -9.5,-14.5
-      parent: 1
-  - uid: 313
-    components:
-    - type: Transform
-      pos: -10.5,-14.5
-      parent: 1
-  - uid: 314
-    components:
-    - type: Transform
-      pos: -11.5,-14.5
-      parent: 1
-  - uid: 315
-    components:
-    - type: Transform
-      pos: -12.5,-14.5
-      parent: 1
-  - uid: 316
-    components:
-    - type: Transform
-      pos: -11.5,-15.5
-      parent: 1
-  - uid: 317
-    components:
-    - type: Transform
-      pos: -11.5,-16.5
-      parent: 1
-  - uid: 318
-    components:
-    - type: Transform
-      pos: -8.5,-16.5
-      parent: 1
-  - uid: 565
-    components:
-    - type: Transform
-      pos: -1.5,-18.5
-      parent: 1
-  - uid: 566
-    components:
-    - type: Transform
-      pos: -3.5,-18.5
-      parent: 1
-  - uid: 897
-    components:
-    - type: Transform
-      pos: 13.5,-11.5
-      parent: 1
-  - uid: 898
-    components:
-    - type: Transform
-      pos: 13.5,-12.5
-      parent: 1
-  - uid: 899
-    components:
-    - type: Transform
-      pos: 13.5,-14.5
-      parent: 1
-  - uid: 900
-    components:
-    - type: Transform
-      pos: 13.5,-15.5
-      parent: 1
-  - uid: 901
-    components:
-    - type: Transform
-      pos: 8.5,-17.5
-      parent: 1
-  - uid: 902
-    components:
-    - type: Transform
-      pos: 7.5,-17.5
-      parent: 1
-  - uid: 903
-    components:
-    - type: Transform
-      pos: 6.5,-17.5
-      parent: 1
-  - uid: 1002
-    components:
-    - type: Transform
-      pos: 14.5,-3.5
-      parent: 1
-  - uid: 1003
-    components:
-    - type: Transform
-      pos: 15.5,-3.5
-      parent: 1
-  - uid: 1004
-    components:
-    - type: Transform
-      pos: 16.5,-3.5
-      parent: 1
-  - uid: 1005
-    components:
-    - type: Transform
-      pos: 17.5,-3.5
-      parent: 1
-  - uid: 1006
-    components:
-    - type: Transform
-      pos: 18.5,-3.5
-      parent: 1
-  - uid: 1007
-    components:
-    - type: Transform
-      pos: 19.5,-3.5
-      parent: 1
-  - uid: 1008
-    components:
-    - type: Transform
-      pos: 20.5,-3.5
-      parent: 1
-  - uid: 1009
-    components:
-    - type: Transform
-      pos: 21.5,-3.5
-      parent: 1
-  - uid: 1010
-    components:
-    - type: Transform
-      pos: 22.5,-3.5
-      parent: 1
-  - uid: 1011
-    components:
-    - type: Transform
-      pos: 23.5,-3.5
-      parent: 1
-  - uid: 1012
-    components:
-    - type: Transform
-      pos: 24.5,-3.5
-      parent: 1
-  - uid: 1013
-    components:
-    - type: Transform
-      pos: 25.5,-3.5
-      parent: 1
-  - uid: 1014
-    components:
-    - type: Transform
-      pos: 25.5,-8.5
-      parent: 1
-  - uid: 1015
-    components:
-    - type: Transform
-      pos: 24.5,-8.5
-      parent: 1
-  - uid: 1016
-    components:
-    - type: Transform
-      pos: 23.5,-8.5
-      parent: 1
-  - uid: 1017
-    components:
-    - type: Transform
-      pos: 22.5,-8.5
-      parent: 1
-  - uid: 1018
-    components:
-    - type: Transform
-      pos: 21.5,-8.5
-      parent: 1
-  - uid: 1019
-    components:
-    - type: Transform
-      pos: 20.5,-8.5
-      parent: 1
-  - uid: 1020
-    components:
-    - type: Transform
-      pos: 19.5,-8.5
-      parent: 1
-  - uid: 1021
-    components:
-    - type: Transform
-      pos: 18.5,-8.5
-      parent: 1
-  - uid: 1022
-    components:
-    - type: Transform
-      pos: 17.5,-8.5
-      parent: 1
-  - uid: 1023
-    components:
-    - type: Transform
-      pos: 16.5,-8.5
-      parent: 1
-  - uid: 1024
-    components:
-    - type: Transform
-      pos: 15.5,-8.5
-      parent: 1
-  - uid: 1025
-    components:
-    - type: Transform
-      pos: 14.5,-8.5
-      parent: 1
-  - uid: 1274
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 34.5,-17.5
-      parent: 1
-  - uid: 1275
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 34.5,-16.5
-      parent: 1
-  - uid: 1278
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 33.5,-17.5
-      parent: 1
-  - uid: 1279
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 32.5,-17.5
-      parent: 1
-  - uid: 1280
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 31.5,-17.5
-      parent: 1
-  - uid: 1281
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 31.5,-19.5
-      parent: 1
-  - uid: 1282
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 32.5,-19.5
-      parent: 1
-  - uid: 1283
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 33.5,-19.5
-      parent: 1
-  - uid: 1678
-    components:
-    - type: Transform
-      pos: 47.5,-3.5
-      parent: 1
-  - uid: 1679
-    components:
-    - type: Transform
-      pos: 46.5,-3.5
-      parent: 1
-  - uid: 1680
-    components:
-    - type: Transform
-      pos: 45.5,-3.5
-      parent: 1
-  - uid: 1681
-    components:
-    - type: Transform
-      pos: 44.5,-3.5
-      parent: 1
-  - uid: 1682
-    components:
-    - type: Transform
-      pos: 43.5,-3.5
-      parent: 1
-  - uid: 1683
-    components:
-    - type: Transform
-      pos: 42.5,-3.5
-      parent: 1
-  - uid: 1684
-    components:
-    - type: Transform
-      pos: 41.5,-3.5
-      parent: 1
-  - uid: 1685
-    components:
-    - type: Transform
-      pos: 41.5,-5.5
-      parent: 1
-  - uid: 1686
-    components:
-    - type: Transform
-      pos: 42.5,-5.5
-      parent: 1
-  - uid: 1687
-    components:
-    - type: Transform
-      pos: 43.5,-5.5
-      parent: 1
-  - uid: 1688
-    components:
-    - type: Transform
-      pos: 44.5,-5.5
-      parent: 1
-  - uid: 1689
-    components:
-    - type: Transform
-      pos: 45.5,-5.5
-      parent: 1
-  - uid: 1690
-    components:
-    - type: Transform
-      pos: 46.5,-5.5
-      parent: 1
-  - uid: 1691
-    components:
-    - type: Transform
-      pos: 47.5,-5.5
-      parent: 1
-  - uid: 1692
-    components:
-    - type: Transform
-      pos: 43.5,-7.5
-      parent: 1
-  - uid: 1693
-    components:
-    - type: Transform
-      pos: 44.5,-7.5
-      parent: 1
-  - uid: 1694
-    components:
-    - type: Transform
-      pos: 44.5,-8.5
-      parent: 1
-  - uid: 1695
-    components:
-    - type: Transform
-      pos: 44.5,-9.5
-      parent: 1
-  - uid: 1696
-    components:
-    - type: Transform
-      pos: 44.5,-10.5
-      parent: 1
-  - uid: 1697
-    components:
-    - type: Transform
-      pos: 44.5,-11.5
-      parent: 1
-  - uid: 1698
-    components:
-    - type: Transform
-      pos: 43.5,-11.5
-      parent: 1
-  - uid: 1699
-    components:
-    - type: Transform
-      pos: 40.5,-1.5
-      parent: 1
-  - uid: 1700
-    components:
-    - type: Transform
-      pos: 38.5,-1.5
-      parent: 1
-  - uid: 1701
-    components:
-    - type: Transform
-      pos: 36.5,-4.5
-      parent: 1
-  - uid: 1702
-    components:
-    - type: Transform
-      pos: 35.5,-4.5
-      parent: 1
-  - uid: 1703
-    components:
-    - type: Transform
-      pos: 27.5,-0.5
-      parent: 1
-  - uid: 1704
-    components:
-    - type: Transform
-      pos: 27.5,0.5
-      parent: 1
-  - uid: 1705
-    components:
-    - type: Transform
-      pos: 27.5,1.5
-      parent: 1
-  - uid: 1706
-    components:
-    - type: Transform
-      pos: 27.5,2.5
-      parent: 1
-  - uid: 1707
-    components:
-    - type: Transform
-      pos: 30.5,2.5
-      parent: 1
-  - uid: 1708
-    components:
-    - type: Transform
-      pos: 30.5,-0.5
-      parent: 1
-  - uid: 1709
-    components:
-    - type: Transform
-      pos: 31.5,4.5
-      parent: 1
-- proto: SheetPlasma10
-  entities:
-  - uid: 765
-    components:
-    - type: Transform
-      pos: -12.387239,-11.251213
-      parent: 1
-- proto: SheetPlasteel
-  entities:
-  - uid: 803
-    components:
-    - type: Transform
-      pos: -12.475805,0.52586746
-      parent: 1
-- proto: SheetSteel
-  entities:
-  - uid: 804
-    components:
-    - type: Transform
-      pos: -12.569555,0.43211746
-      parent: 1
-- proto: ShuttersNormal
-  entities:
-  - uid: 1597
-    components:
-    - type: Transform
-      pos: 31.5,-7.5
-      parent: 1
-  - uid: 1598
-    components:
-    - type: Transform
-      pos: 30.5,-7.5
-      parent: 1
-  - uid: 1824
-    components:
-    - type: Transform
-      pos: 27.5,4.5
-      parent: 1
-  - uid: 1825
-    components:
-    - type: Transform
-      pos: 28.5,4.5
-      parent: 1
-  - uid: 1826
-    components:
-    - type: Transform
-      pos: 29.5,4.5
-      parent: 1
-  - uid: 1827
-    components:
-    - type: Transform
-      pos: 32.5,4.5
-      parent: 1
-  - uid: 1828
-    components:
-    - type: Transform
-      pos: 33.5,4.5
-      parent: 1
-- proto: SignalButton
-  entities:
-  - uid: 560
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-18.5
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        558:
-        - Pressed: Toggle
-        559:
-        - Pressed: Toggle
-- proto: SignalTrigger
-  entities:
-  - uid: 787
-    components:
-    - type: Transform
-      pos: -13.64159,-2.6691022
-      parent: 1
-  - uid: 788
-    components:
-    - type: Transform
-      pos: -13.64159,-2.2941022
-      parent: 1
-  - uid: 789
-    components:
-    - type: Transform
-      pos: -13.188465,-2.4191022
-      parent: 1
-- proto: SinkWide
-  entities:
-  - uid: 142
-    components:
-    - type: Transform
-      pos: 3.5,0.5
-      parent: 1
-  - uid: 761
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-14.5
-      parent: 1
-  - uid: 796
-    components:
-    - type: Transform
-      pos: -6.5,0.5
-      parent: 1
-  - uid: 937
-    components:
-    - type: Transform
-      pos: 6.5,-11.5
-      parent: 1
-- proto: SmallLight
-  entities:
-  - uid: 740
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,-16.5
-      parent: 1
-  - uid: 741
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-16.5
-      parent: 1
-  - uid: 1242
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 26.5,-17.5
-      parent: 1
-  - uid: 1243
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 27.5,-18.5
-      parent: 1
-  - uid: 1244
-    components:
-    - type: Transform
-      pos: 26.5,-19.5
-      parent: 1
-  - uid: 1245
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 25.5,-18.5
-      parent: 1
-  - uid: 1284
-    components:
-    - type: Transform
-      pos: 28.5,-11.5
-      parent: 1
-  - uid: 1992
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,-20.5
-      parent: 1
-  - uid: 2299
-    components:
-    - type: Transform
-      pos: 44.5,-4.5
-      parent: 1
-  - uid: 2371
-    components:
-    - type: Transform
-      pos: 0.5,-19.5
-      parent: 1
-  - uid: 2372
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-20.5
-      parent: 1
-  - uid: 2373
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-16.5
-      parent: 1
-- proto: SoapSyndie
-  entities:
-  - uid: 496
-    components:
-    - type: Transform
-      pos: 3.5,-15.5
-      parent: 1
-- proto: SodaDispenser
-  entities:
-  - uid: 73
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-2.5
-      parent: 1
-- proto: SpaceCash100
-  entities:
-  - uid: 1805
-    components:
-    - type: Transform
-      pos: 36.5,-10.5
-      parent: 1
-- proto: SpaceCash1000
-  entities:
-  - uid: 1804
-    components:
-    - type: Transform
-      pos: 38.5,-8.5
-      parent: 1
-- proto: SpawnMobAdultSlimesGreenAngry
-  entities:
-  - uid: 742
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,-16.5
-      parent: 1
-- proto: SpawnMobCatKitten
-  entities:
-  - uid: 275
-    components:
-    - type: Transform
-      pos: 7.5,-7.5
-      parent: 1
-- proto: SpawnPointNukies
-  entities:
-  - uid: 21
-    components:
-    - type: Transform
-      pos: 3.5,-1.5
-      parent: 1
-  - uid: 22
-    components:
-    - type: Transform
-      pos: 10.5,0.5
-      parent: 1
-  - uid: 23
-    components:
-    - type: Transform
-      pos: 12.5,-0.5
-      parent: 1
-  - uid: 24
-    components:
-    - type: Transform
-      pos: 11.5,-2.5
-      parent: 1
-  - uid: 25
-    components:
-    - type: Transform
-      pos: 9.5,-1.5
-      parent: 1
-- proto: StairDark
-  entities:
-  - uid: 1139
-    components:
-    - type: Transform
-      pos: 27.5,-9.5
-      parent: 1
-  - uid: 1140
-    components:
-    - type: Transform
-      pos: 27.5,-8.5
-      parent: 1
-- proto: Stool
-  entities:
-  - uid: 13
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,-2.5
-      parent: 1
-  - uid: 14
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,-2.5
-      parent: 1
-  - uid: 15
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,-1.5
-      parent: 1
-  - uid: 16
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,-0.5
-      parent: 1
-  - uid: 17
-    components:
-    - type: Transform
-      pos: 10.5,0.5
-      parent: 1
-  - uid: 18
-    components:
-    - type: Transform
-      pos: 11.5,0.5
-      parent: 1
-  - uid: 19
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,-0.5
-      parent: 1
-  - uid: 20
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,-1.5
-      parent: 1
-- proto: StoolBar
-  entities:
-  - uid: 10
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-0.5
-      parent: 1
-  - uid: 11
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-1.5
-      parent: 1
-  - uid: 12
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-2.5
-      parent: 1
-- proto: StorageCanister
-  entities:
-  - uid: 435
-    components:
-    - type: Transform
-      pos: 0.5,-14.5
-      parent: 1
-  - uid: 436
-    components:
-    - type: Transform
-      pos: 1.5,-14.5
-      parent: 1
-- proto: SubstationBasic
-  entities:
-  - uid: 1823
-    components:
-    - type: Transform
-      pos: 36.5,-2.5
-      parent: 1
-- proto: SyndicateComputerComms
-  entities:
-  - uid: 1756
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 43.5,-9.5
-      parent: 1
-- proto: SyndicateMicrowave
-  entities:
-  - uid: 70
-    components:
-    - type: Transform
-      pos: 0.5,0.5
-      parent: 1
-- proto: SyndicatePersonalAI
-  entities:
-  - uid: 161
-    components:
-    - type: Transform
-      pos: 10.5,-0.5
-      parent: 1
-- proto: SyndicateSpongeBox
-  entities:
-  - uid: 766
-    components:
-    - type: Transform
-      pos: -9.418489,-10.329338
-      parent: 1
-- proto: SyringeDermaline
-  entities:
-  - uid: 833
-    components:
-    - type: Transform
-      pos: -1.3631997,-1.2615409
-      parent: 1
-- proto: SyringeEthylredoxrazine
-  entities:
-  - uid: 834
-    components:
-    - type: Transform
-      pos: -1.6288247,-1.2459159
-      parent: 1
-- proto: SyringeTranexamicAcid
-  entities:
-  - uid: 835
-    components:
-    - type: Transform
-      pos: -1.4413247,-1.0896659
-      parent: 1
-- proto: Table
-  entities:
-  - uid: 140
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,4.5
-      parent: 1
-  - uid: 152
-    components:
-    - type: Transform
-      pos: 2.5,3.5
-      parent: 1
-- proto: TableCounterMetal
-  entities:
-  - uid: 1817
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 30.5,1.5
-      parent: 1
-  - uid: 1818
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 30.5,0.5
-      parent: 1
-- proto: TablePlasmaGlass
-  entities:
-  - uid: 744
-    components:
-    - type: Transform
-      pos: -11.5,-10.5
-      parent: 1
-  - uid: 745
-    components:
-    - type: Transform
-      pos: -12.5,-10.5
-      parent: 1
-  - uid: 746
-    components:
-    - type: Transform
-      pos: -12.5,-11.5
-      parent: 1
-  - uid: 747
-    components:
-    - type: Transform
-      pos: -9.5,-10.5
-      parent: 1
-  - uid: 772
-    components:
-    - type: Transform
-      pos: -13.5,-0.5
-      parent: 1
-  - uid: 773
-    components:
-    - type: Transform
-      pos: -13.5,-1.5
-      parent: 1
-  - uid: 774
-    components:
-    - type: Transform
-      pos: -13.5,-2.5
-      parent: 1
-  - uid: 775
-    components:
-    - type: Transform
-      pos: -13.5,-3.5
-      parent: 1
-  - uid: 776
-    components:
-    - type: Transform
-      pos: -5.5,-3.5
-      parent: 1
-  - uid: 777
-    components:
-    - type: Transform
-      pos: -5.5,-2.5
-      parent: 1
-  - uid: 812
-    components:
-    - type: Transform
-      pos: -3.5,-4.5
-      parent: 1
-  - uid: 813
-    components:
-    - type: Transform
-      pos: -3.5,-3.5
-      parent: 1
-  - uid: 814
-    components:
-    - type: Transform
-      pos: -3.5,-2.5
-      parent: 1
-- proto: TableReinforced
-  entities:
-  - uid: 67
-    components:
-    - type: Transform
-      pos: 0.5,0.5
-      parent: 1
-  - uid: 68
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 1
-  - uid: 69
-    components:
-    - type: Transform
-      pos: 0.5,-1.5
-      parent: 1
-  - uid: 445
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-14.5
-      parent: 1
-  - uid: 446
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-14.5
-      parent: 1
-  - uid: 817
-    components:
-    - type: Transform
-      pos: -1.5,-0.5
-      parent: 1
-  - uid: 818
-    components:
-    - type: Transform
-      pos: -1.5,-1.5
-      parent: 1
-  - uid: 1748
-    components:
-    - type: Transform
-      pos: 34.5,-0.5
-      parent: 1
-  - uid: 1749
-    components:
-    - type: Transform
-      pos: 34.5,0.5
-      parent: 1
-  - uid: 1750
-    components:
-    - type: Transform
-      pos: 31.5,3.5
-      parent: 1
-  - uid: 1777
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 39.5,-8.5
-      parent: 1
-  - uid: 1778
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 38.5,-8.5
-      parent: 1
-  - uid: 1779
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 37.5,-8.5
-      parent: 1
-  - uid: 1780
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 36.5,-8.5
-      parent: 1
-  - uid: 1781
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 36.5,-10.5
-      parent: 1
-  - uid: 1782
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 37.5,-10.5
-      parent: 1
-  - uid: 1783
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 38.5,-10.5
-      parent: 1
-  - uid: 1784
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 39.5,-10.5
-      parent: 1
-  - uid: 1785
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 39.5,-9.5
-      parent: 1
-  - uid: 1786
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 36.5,-9.5
-      parent: 1
-  - uid: 1787
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 41.5,-8.5
-      parent: 1
-  - uid: 1788
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 41.5,-9.5
-      parent: 1
-  - uid: 1789
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 41.5,-10.5
-      parent: 1
-- proto: TableWood
-  entities:
-  - uid: 4
-    components:
-    - type: Transform
-      pos: 4.5,-0.5
-      parent: 1
-  - uid: 5
-    components:
-    - type: Transform
-      pos: 4.5,-1.5
-      parent: 1
-  - uid: 6
-    components:
-    - type: Transform
-      pos: 4.5,-2.5
-      parent: 1
-  - uid: 7
-    components:
-    - type: Transform
-      pos: 3.5,-2.5
-      parent: 1
-  - uid: 8
-    components:
-    - type: Transform
-      pos: 2.5,-2.5
-      parent: 1
-  - uid: 157
-    components:
-    - type: Transform
-      pos: 10.5,-0.5
-      parent: 1
-  - uid: 158
-    components:
-    - type: Transform
-      pos: 10.5,-1.5
-      parent: 1
-  - uid: 159
-    components:
-    - type: Transform
-      pos: 11.5,-0.5
-      parent: 1
-  - uid: 160
-    components:
-    - type: Transform
-      pos: 11.5,-1.5
-      parent: 1
-  - uid: 920
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,-15.5
-      parent: 1
-  - uid: 921
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,-16.5
-      parent: 1
-  - uid: 922
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-14.5
-      parent: 1
-- proto: TimerTrigger
-  entities:
-  - uid: 784
-    components:
-    - type: Transform
-      pos: -13.67284,-3.5597272
-      parent: 1
-  - uid: 785
-    components:
-    - type: Transform
-      pos: -13.67284,-3.4034772
-      parent: 1
-  - uid: 786
-    components:
-    - type: Transform
-      pos: -13.657215,-3.0909772
-      parent: 1
-- proto: ToiletEmpty
-  entities:
-  - uid: 497
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-14.5
-      parent: 1
-  - uid: 499
-    components:
-    - type: Transform
-      pos: 3.5,-12.5
-      parent: 1
-    - type: Toilet
-      toggleSeat: True
-- proto: ToyFigurineNukie
-  entities:
-  - uid: 1431
-    components:
-    - type: Transform
-      pos: 28.46877,-29.659956
-      parent: 1
-  - uid: 1432
-    components:
-    - type: Transform
-      pos: 29.453144,-30.503706
-      parent: 1
-  - uid: 1433
-    components:
-    - type: Transform
-      pos: 28.46877,-31.519331
-      parent: 1
-  - uid: 1434
-    components:
-    - type: Transform
-      pos: 27.609394,-30.456831
-      parent: 1
-- proto: ToyNuke
-  entities:
-  - uid: 1436
-    components:
-    - type: Transform
-      pos: 28.515644,-30.613081
-      parent: 1
-- proto: VendingMachineBooze
-  entities:
-  - uid: 74
-    components:
-    - type: Transform
-      pos: 4.5,1.5
-      parent: 1
-- proto: VendingMachineChemicalsSyndicate
-  entities:
-  - uid: 780
-    components:
-    - type: Transform
-      pos: -5.5,-4.5
-      parent: 1
-- proto: VendingMachineCigs
-  entities:
-  - uid: 149
-    components:
-    - type: Transform
-      pos: 12.5,2.5
-      parent: 1
-  - uid: 1610
-    components:
-    - type: Transform
-      pos: 33.5,-2.5
-      parent: 1
-- proto: VendingMachineClothing
-  entities:
-  - uid: 151
-    components:
-    - type: Transform
-      pos: 5.5,4.5
-      parent: 1
-- proto: VendingMachineDinnerware
-  entities:
-  - uid: 141
-    components:
-    - type: Transform
-      pos: 1.5,2.5
-      parent: 1
-- proto: VendingMachineNutri
-  entities:
-  - uid: 750
-    components:
-    - type: Transform
-      pos: -9.5,-13.5
-      parent: 1
-- proto: VendingMachineRestockChefvend
-  entities:
-  - uid: 145
-    components:
-    - type: Transform
-      pos: 4.5,-2.5
-      parent: 1
-- proto: VendingMachineSeeds
-  entities:
-  - uid: 749
-    components:
-    - type: Transform
-      pos: -11.5,-13.5
-      parent: 1
-- proto: VendingMachineSnackTeal
-  entities:
-  - uid: 1611
-    components:
-    - type: Transform
-      pos: 33.5,-3.5
-      parent: 1
-- proto: VendingMachineYouTool
-  entities:
-  - uid: 1814
-    components:
-    - type: Transform
-      pos: 35.5,-2.5
-      parent: 1
-- proto: WallPlastitanium
-  entities:
-  - uid: 26
-    components:
-    - type: Transform
-      pos: 13.5,1.5
-      parent: 1
-  - uid: 31
-    components:
-    - type: Transform
-      pos: 14.5,1.5
-      parent: 1
-  - uid: 32
-    components:
-    - type: Transform
-      pos: 14.5,2.5
-      parent: 1
-  - uid: 33
-    components:
-    - type: Transform
-      pos: 13.5,-3.5
-      parent: 1
-  - uid: 34
-    components:
-    - type: Transform
-      pos: 12.5,-3.5
-      parent: 1
-  - uid: 35
-    components:
-    - type: Transform
-      pos: 11.5,-3.5
-      parent: 1
-  - uid: 36
-    components:
-    - type: Transform
-      pos: 10.5,-3.5
-      parent: 1
-  - uid: 37
-    components:
-    - type: Transform
-      pos: 9.5,-3.5
-      parent: 1
-  - uid: 38
-    components:
-    - type: Transform
-      pos: 2.5,-3.5
-      parent: 1
-  - uid: 39
-    components:
-    - type: Transform
-      pos: 3.5,-3.5
-      parent: 1
-  - uid: 40
-    components:
-    - type: Transform
-      pos: 4.5,-3.5
-      parent: 1
-  - uid: 41
-    components:
-    - type: Transform
-      pos: 5.5,-3.5
-      parent: 1
-  - uid: 42
-    components:
-    - type: Transform
-      pos: 5.5,-4.5
-      parent: 1
-  - uid: 43
-    components:
-    - type: Transform
-      pos: 5.5,-5.5
-      parent: 1
-  - uid: 44
-    components:
-    - type: Transform
-      pos: 4.5,-5.5
-      parent: 1
-  - uid: 45
-    components:
-    - type: Transform
-      pos: 3.5,-5.5
-      parent: 1
-  - uid: 46
-    components:
-    - type: Transform
-      pos: 2.5,-5.5
-      parent: 1
-  - uid: 47
-    components:
-    - type: Transform
-      pos: 1.5,-5.5
-      parent: 1
-  - uid: 48
-    components:
-    - type: Transform
-      pos: 0.5,-5.5
-      parent: 1
-  - uid: 49
-    components:
-    - type: Transform
-      pos: -0.5,-5.5
-      parent: 1
-  - uid: 50
-    components:
-    - type: Transform
-      pos: -0.5,-4.5
-      parent: 1
-  - uid: 51
-    components:
-    - type: Transform
-      pos: -0.5,-3.5
-      parent: 1
-  - uid: 52
-    components:
-    - type: Transform
-      pos: 0.5,-3.5
-      parent: 1
-  - uid: 53
-    components:
-    - type: Transform
-      pos: -0.5,-2.5
-      parent: 1
-  - uid: 54
-    components:
-    - type: Transform
-      pos: -0.5,-1.5
-      parent: 1
-  - uid: 55
-    components:
-    - type: Transform
-      pos: -0.5,-0.5
-      parent: 1
-  - uid: 56
-    components:
-    - type: Transform
-      pos: -0.5,0.5
-      parent: 1
-  - uid: 57
-    components:
-    - type: Transform
-      pos: -0.5,1.5
-      parent: 1
-  - uid: 58
-    components:
-    - type: Transform
-      pos: 0.5,1.5
-      parent: 1
-  - uid: 59
-    components:
-    - type: Transform
-      pos: 1.5,1.5
-      parent: 1
-  - uid: 60
-    components:
-    - type: Transform
-      pos: 3.5,1.5
-      parent: 1
-  - uid: 61
-    components:
-    - type: Transform
-      pos: 5.5,1.5
-      parent: 1
-  - uid: 62
-    components:
-    - type: Transform
-      pos: 7.5,1.5
-      parent: 1
-  - uid: 63
-    components:
-    - type: Transform
-      pos: 9.5,1.5
-      parent: 1
-  - uid: 64
-    components:
-    - type: Transform
-      pos: 10.5,1.5
-      parent: 1
-  - uid: 65
-    components:
-    - type: Transform
-      pos: 11.5,1.5
-      parent: 1
-  - uid: 66
-    components:
-    - type: Transform
-      pos: 12.5,1.5
-      parent: 1
-  - uid: 100
-    components:
-    - type: Transform
-      pos: -0.5,2.5
-      parent: 1
-  - uid: 250
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,-4.5
-      parent: 1
-  - uid: 251
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-4.5
-      parent: 1
-  - uid: 252
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-7.5
-      parent: 1
-  - uid: 253
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-8.5
-      parent: 1
-  - uid: 254
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,-8.5
-      parent: 1
-  - uid: 255
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,-8.5
-      parent: 1
-  - uid: 256
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,-8.5
-      parent: 1
-  - uid: 257
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,-9.5
-      parent: 1
-  - uid: 258
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,-10.5
-      parent: 1
-  - uid: 259
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,-10.5
-      parent: 1
-  - uid: 260
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,-10.5
-      parent: 1
-  - uid: 261
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-10.5
-      parent: 1
-  - uid: 262
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,-10.5
-      parent: 1
-  - uid: 263
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-9.5
-      parent: 1
-  - uid: 264
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,-10.5
-      parent: 1
-  - uid: 265
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,-7.5
-      parent: 1
-  - uid: 266
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-10.5
-      parent: 1
-  - uid: 267
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-10.5
-      parent: 1
-  - uid: 268
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-10.5
-      parent: 1
-  - uid: 269
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-9.5
-      parent: 1
-  - uid: 270
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-9.5
-      parent: 1
-  - uid: 271
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-8.5
-      parent: 1
-  - uid: 272
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-6.5
-      parent: 1
-  - uid: 273
-    components:
-    - type: Transform
-      pos: 7.5,-6.5
-      parent: 1
-  - uid: 319
-    components:
-    - type: Transform
-      pos: -4.5,-9.5
-      parent: 1
-  - uid: 320
-    components:
-    - type: Transform
-      pos: -5.5,-9.5
-      parent: 1
-  - uid: 321
-    components:
-    - type: Transform
-      pos: 0.5,-8.5
-      parent: 1
-  - uid: 322
-    components:
-    - type: Transform
-      pos: 0.5,-6.5
-      parent: 1
-  - uid: 323
-    components:
-    - type: Transform
-      pos: 3.5,-9.5
-      parent: 1
-  - uid: 324
-    components:
-    - type: Transform
-      pos: 2.5,-9.5
-      parent: 1
-  - uid: 325
-    components:
-    - type: Transform
-      pos: 1.5,-9.5
-      parent: 1
-  - uid: 326
-    components:
-    - type: Transform
-      pos: 0.5,-9.5
-      parent: 1
-  - uid: 327
-    components:
-    - type: Transform
-      pos: -0.5,-9.5
-      parent: 1
-  - uid: 328
-    components:
-    - type: Transform
-      pos: -4.5,-5.5
-      parent: 1
-  - uid: 329
-    components:
-    - type: Transform
-      pos: -8.5,-5.5
-      parent: 1
-  - uid: 330
-    components:
-    - type: Transform
-      pos: -9.5,-5.5
-      parent: 1
-  - uid: 331
-    components:
-    - type: Transform
-      pos: -9.5,-6.5
-      parent: 1
-  - uid: 332
-    components:
-    - type: Transform
-      pos: -9.5,-8.5
-      parent: 1
-  - uid: 333
-    components:
-    - type: Transform
-      pos: -9.5,-9.5
-      parent: 1
-  - uid: 334
-    components:
-    - type: Transform
-      pos: -10.5,-5.5
-      parent: 1
-  - uid: 335
-    components:
-    - type: Transform
-      pos: -11.5,-5.5
-      parent: 1
-  - uid: 336
-    components:
-    - type: Transform
-      pos: -12.5,-5.5
-      parent: 1
-  - uid: 337
-    components:
-    - type: Transform
-      pos: -10.5,-9.5
-      parent: 1
-  - uid: 338
-    components:
-    - type: Transform
-      pos: -11.5,-9.5
-      parent: 1
-  - uid: 339
-    components:
-    - type: Transform
-      pos: -12.5,-9.5
-      parent: 1
-  - uid: 340
-    components:
-    - type: Transform
-      pos: -12.5,-8.5
-      parent: 1
-  - uid: 341
-    components:
-    - type: Transform
-      pos: -12.5,-7.5
-      parent: 1
-  - uid: 342
-    components:
-    - type: Transform
-      pos: -12.5,-6.5
-      parent: 1
-  - uid: 343
-    components:
-    - type: Transform
-      pos: -5.5,-10.5
-      parent: 1
-  - uid: 344
-    components:
-    - type: Transform
-      pos: -5.5,-11.5
-      parent: 1
-  - uid: 345
-    components:
-    - type: Transform
-      pos: -5.5,-12.5
-      parent: 1
-  - uid: 346
-    components:
-    - type: Transform
-      pos: -5.5,-13.5
-      parent: 1
-  - uid: 347
-    components:
-    - type: Transform
-      pos: -5.5,-14.5
-      parent: 1
-  - uid: 348
-    components:
-    - type: Transform
-      pos: -5.5,-15.5
-      parent: 1
-  - uid: 349
-    components:
-    - type: Transform
-      pos: -5.5,-16.5
-      parent: 1
-  - uid: 350
-    components:
-    - type: Transform
-      pos: -5.5,-17.5
-      parent: 1
-  - uid: 351
-    components:
-    - type: Transform
-      pos: -6.5,-17.5
-      parent: 1
-  - uid: 352
-    components:
-    - type: Transform
-      pos: -7.5,-17.5
-      parent: 1
-  - uid: 353
-    components:
-    - type: Transform
-      pos: -8.5,-17.5
-      parent: 1
-  - uid: 354
-    components:
-    - type: Transform
-      pos: -9.5,-17.5
-      parent: 1
-  - uid: 355
-    components:
-    - type: Transform
-      pos: -10.5,-17.5
-      parent: 1
-  - uid: 356
-    components:
-    - type: Transform
-      pos: -11.5,-17.5
-      parent: 1
-  - uid: 357
-    components:
-    - type: Transform
-      pos: -12.5,-17.5
-      parent: 1
-  - uid: 358
-    components:
-    - type: Transform
-      pos: -13.5,-17.5
-      parent: 1
-  - uid: 359
-    components:
-    - type: Transform
-      pos: -14.5,-17.5
-      parent: 1
-  - uid: 360
-    components:
-    - type: Transform
-      pos: -13.5,-14.5
-      parent: 1
-  - uid: 361
-    components:
-    - type: Transform
-      pos: -13.5,-13.5
-      parent: 1
-  - uid: 362
-    components:
-    - type: Transform
-      pos: -14.5,-16.5
-      parent: 1
-  - uid: 363
-    components:
-    - type: Transform
-      pos: -14.5,-15.5
-      parent: 1
-  - uid: 364
-    components:
-    - type: Transform
-      pos: -14.5,-14.5
-      parent: 1
-  - uid: 365
-    components:
-    - type: Transform
-      pos: -14.5,-13.5
-      parent: 1
-  - uid: 366
-    components:
-    - type: Transform
-      pos: -14.5,-12.5
-      parent: 1
-  - uid: 367
-    components:
-    - type: Transform
-      pos: -14.5,-11.5
-      parent: 1
-  - uid: 368
-    components:
-    - type: Transform
-      pos: -13.5,-11.5
-      parent: 1
-  - uid: 369
-    components:
-    - type: Transform
-      pos: -13.5,-10.5
-      parent: 1
-  - uid: 370
-    components:
-    - type: Transform
-      pos: -13.5,-9.5
-      parent: 1
-  - uid: 371
-    components:
-    - type: Transform
-      pos: -1.5,0.5
-      parent: 1
-  - uid: 372
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 1
-  - uid: 373
-    components:
-    - type: Transform
-      pos: -3.5,0.5
-      parent: 1
-  - uid: 374
-    components:
-    - type: Transform
-      pos: -4.5,0.5
-      parent: 1
-  - uid: 376
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-0.5
-      parent: 1
-  - uid: 377
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-1.5
-      parent: 1
-  - uid: 378
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-2.5
-      parent: 1
-  - uid: 379
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-3.5
-      parent: 1
-  - uid: 380
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-4.5
-      parent: 1
-  - uid: 381
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,1.5
-      parent: 1
-  - uid: 382
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,0.5
-      parent: 1
-  - uid: 383
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,1.5
-      parent: 1
-  - uid: 384
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,1.5
-      parent: 1
-  - uid: 385
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,1.5
-      parent: 1
-  - uid: 386
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -11.5,1.5
-      parent: 1
-  - uid: 387
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,-1.5
-      parent: 1
-  - uid: 388
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,-3.5
-      parent: 1
-  - uid: 389
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,0.5
-      parent: 1
-  - uid: 390
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,-4.5
-      parent: 1
-  - uid: 391
-    components:
-    - type: Transform
-      pos: -13.5,-5.5
-      parent: 1
-  - uid: 392
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,1.5
-      parent: 1
-  - uid: 393
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,1.5
-      parent: 1
-  - uid: 394
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,1.5
-      parent: 1
-  - uid: 395
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,1.5
-      parent: 1
-  - uid: 396
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,-0.5
-      parent: 1
-  - uid: 397
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,-2.5
-      parent: 1
-  - uid: 398
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,0.5
-      parent: 1
-  - uid: 453
-    components:
-    - type: Transform
-      pos: -2.5,-18.5
-      parent: 1
-  - uid: 454
-    components:
-    - type: Transform
-      pos: -0.5,-18.5
-      parent: 1
-  - uid: 455
-    components:
-    - type: Transform
-      pos: -0.5,-21.5
-      parent: 1
-  - uid: 456
-    components:
-    - type: Transform
-      pos: -1.5,-21.5
-      parent: 1
-  - uid: 457
-    components:
-    - type: Transform
-      pos: -2.5,-21.5
-      parent: 1
-  - uid: 458
-    components:
-    - type: Transform
-      pos: -3.5,-21.5
-      parent: 1
-  - uid: 459
-    components:
-    - type: Transform
-      pos: -4.5,-21.5
-      parent: 1
-  - uid: 460
-    components:
-    - type: Transform
-      pos: -4.5,-20.5
-      parent: 1
-  - uid: 461
-    components:
-    - type: Transform
-      pos: -4.5,-19.5
-      parent: 1
-  - uid: 462
-    components:
-    - type: Transform
-      pos: -4.5,-18.5
-      parent: 1
-  - uid: 463
-    components:
-    - type: Transform
-      pos: -4.5,-17.5
-      parent: 1
-  - uid: 464
-    components:
-    - type: Transform
-      pos: 0.5,-21.5
-      parent: 1
-  - uid: 465
-    components:
-    - type: Transform
-      pos: 0.5,-18.5
-      parent: 1
-  - uid: 466
-    components:
-    - type: Transform
-      pos: 1.5,-18.5
-      parent: 1
-  - uid: 467
-    components:
-    - type: Transform
-      pos: 1.5,-19.5
-      parent: 1
-  - uid: 468
-    components:
-    - type: Transform
-      pos: 1.5,-20.5
-      parent: 1
-  - uid: 469
-    components:
-    - type: Transform
-      pos: 1.5,-21.5
-      parent: 1
-  - uid: 470
-    components:
-    - type: Transform
-      pos: 2.5,-18.5
-      parent: 1
-  - uid: 471
-    components:
-    - type: Transform
-      pos: 2.5,-21.5
-      parent: 1
-  - uid: 472
-    components:
-    - type: Transform
-      pos: 3.5,-18.5
-      parent: 1
-  - uid: 473
-    components:
-    - type: Transform
-      pos: 3.5,-19.5
-      parent: 1
-  - uid: 474
-    components:
-    - type: Transform
-      pos: 3.5,-20.5
-      parent: 1
-  - uid: 475
-    components:
-    - type: Transform
-      pos: 3.5,-21.5
-      parent: 1
-  - uid: 476
-    components:
-    - type: Transform
-      pos: 2.5,-17.5
-      parent: 1
-  - uid: 477
-    components:
-    - type: Transform
-      pos: 3.5,-17.5
-      parent: 1
-  - uid: 478
-    components:
-    - type: Transform
-      pos: 4.5,-17.5
-      parent: 1
-  - uid: 479
-    components:
-    - type: Transform
-      pos: 5.5,-17.5
-      parent: 1
-  - uid: 480
-    components:
-    - type: Transform
-      pos: 2.5,-16.5
-      parent: 1
-  - uid: 481
-    components:
-    - type: Transform
-      pos: 2.5,-15.5
-      parent: 1
-  - uid: 482
-    components:
-    - type: Transform
-      pos: 2.5,-14.5
-      parent: 1
-  - uid: 483
-    components:
-    - type: Transform
-      pos: 2.5,-13.5
-      parent: 1
-  - uid: 484
-    components:
-    - type: Transform
-      pos: 2.5,-12.5
-      parent: 1
-  - uid: 485
-    components:
-    - type: Transform
-      pos: 2.5,-11.5
-      parent: 1
-  - uid: 486
-    components:
-    - type: Transform
-      pos: 2.5,-10.5
-      parent: 1
-  - uid: 487
-    components:
-    - type: Transform
-      pos: 5.5,-11.5
-      parent: 1
-  - uid: 488
-    components:
-    - type: Transform
-      pos: 4.5,-11.5
-      parent: 1
-  - uid: 489
-    components:
-    - type: Transform
-      pos: 3.5,-11.5
-      parent: 1
-  - uid: 490
-    components:
-    - type: Transform
-      pos: 5.5,-13.5
-      parent: 1
-  - uid: 491
-    components:
-    - type: Transform
-      pos: 5.5,-14.5
-      parent: 1
-  - uid: 492
-    components:
-    - type: Transform
-      pos: 5.5,-15.5
-      parent: 1
-  - uid: 493
-    components:
-    - type: Transform
-      pos: 5.5,-16.5
-      parent: 1
-  - uid: 881
-    components:
-    - type: Transform
-      pos: 13.5,-13.5
-      parent: 1
-  - uid: 882
-    components:
-    - type: Transform
-      pos: 12.5,-13.5
-      parent: 1
-  - uid: 883
-    components:
-    - type: Transform
-      pos: 11.5,-13.5
-      parent: 1
-  - uid: 884
-    components:
-    - type: Transform
-      pos: 10.5,-13.5
-      parent: 1
-  - uid: 885
-    components:
-    - type: Transform
-      pos: 9.5,-13.5
-      parent: 1
-  - uid: 886
-    components:
-    - type: Transform
-      pos: 9.5,-11.5
-      parent: 1
-  - uid: 887
-    components:
-    - type: Transform
-      pos: 9.5,-15.5
-      parent: 1
-  - uid: 888
-    components:
-    - type: Transform
-      pos: 9.5,-16.5
-      parent: 1
-  - uid: 889
-    components:
-    - type: Transform
-      pos: 10.5,-16.5
-      parent: 1
-  - uid: 890
-    components:
-    - type: Transform
-      pos: 11.5,-16.5
-      parent: 1
-  - uid: 891
-    components:
-    - type: Transform
-      pos: 12.5,-16.5
-      parent: 1
-  - uid: 892
-    components:
-    - type: Transform
-      pos: 13.5,-16.5
-      parent: 1
-  - uid: 893
-    components:
-    - type: Transform
-      pos: 14.5,-16.5
-      parent: 1
-  - uid: 894
-    components:
-    - type: Transform
-      pos: 14.5,-17.5
-      parent: 1
-  - uid: 895
-    components:
-    - type: Transform
-      pos: 13.5,-17.5
-      parent: 1
-  - uid: 896
-    components:
-    - type: Transform
-      pos: 9.5,-17.5
-      parent: 1
-  - uid: 919
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-13.5
-      parent: 1
-  - uid: 992
-    components:
-    - type: Transform
-      pos: 26.5,-7.5
-      parent: 1
-  - uid: 993
-    components:
-    - type: Transform
-      pos: 25.5,-7.5
-      parent: 1
-  - uid: 994
-    components:
-    - type: Transform
-      pos: 21.5,-7.5
-      parent: 1
-  - uid: 995
-    components:
-    - type: Transform
-      pos: 22.5,-7.5
-      parent: 1
-  - uid: 996
-    components:
-    - type: Transform
-      pos: 18.5,-7.5
-      parent: 1
-  - uid: 997
-    components:
-    - type: Transform
-      pos: 17.5,-7.5
-      parent: 1
-  - uid: 998
-    components:
-    - type: Transform
-      pos: 26.5,-8.5
-      parent: 1
-  - uid: 999
-    components:
-    - type: Transform
-      pos: 26.5,-9.5
-      parent: 1
-  - uid: 1000
-    components:
-    - type: Transform
-      pos: 26.5,-10.5
-      parent: 1
-  - uid: 1001
-    components:
-    - type: Transform
-      pos: 25.5,-10.5
-      parent: 1
-  - uid: 1028
-    components:
-    - type: Transform
-      pos: 26.5,-4.5
-      parent: 1
-  - uid: 1029
-    components:
-    - type: Transform
-      pos: 26.5,-3.5
-      parent: 1
-  - uid: 1030
-    components:
-    - type: Transform
-      pos: 26.5,-2.5
-      parent: 1
-  - uid: 1031
-    components:
-    - type: Transform
-      pos: 26.5,-1.5
-      parent: 1
-  - uid: 1032
-    components:
-    - type: Transform
-      pos: 27.5,-1.5
-      parent: 1
-  - uid: 1119
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 29.5,-7.5
-      parent: 1
-  - uid: 1120
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 28.5,-7.5
-      parent: 1
-  - uid: 1121
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 28.5,-8.5
-      parent: 1
-  - uid: 1122
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 28.5,-9.5
-      parent: 1
-  - uid: 1123
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 28.5,-10.5
-      parent: 1
-  - uid: 1124
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 29.5,-10.5
-      parent: 1
-  - uid: 1125
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 32.5,-10.5
-      parent: 1
-  - uid: 1126
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 32.5,-7.5
-      parent: 1
-  - uid: 1127
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 33.5,-7.5
-      parent: 1
-  - uid: 1128
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 33.5,-8.5
-      parent: 1
-  - uid: 1129
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 33.5,-9.5
-      parent: 1
-  - uid: 1130
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 33.5,-10.5
-      parent: 1
-  - uid: 1131
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 35.5,-19.5
-      parent: 1
-  - uid: 1132
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 34.5,-19.5
-      parent: 1
-  - uid: 1133
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 32.5,-11.5
-      parent: 1
-  - uid: 1134
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 31.5,-11.5
-      parent: 1
-  - uid: 1135
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 30.5,-11.5
-      parent: 1
-  - uid: 1136
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 29.5,-11.5
-      parent: 1
-  - uid: 1170
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 27.5,-15.5
-      parent: 1
-  - uid: 1212
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 25.5,-15.5
-      parent: 1
-  - uid: 1215
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 23.5,-17.5
-      parent: 1
-  - uid: 1217
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 23.5,-19.5
-      parent: 1
-  - uid: 1220
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 25.5,-21.5
-      parent: 1
-  - uid: 1221
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 27.5,-21.5
-      parent: 1
-  - uid: 1223
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 26.5,-18.5
-      parent: 1
-  - uid: 1226
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 29.5,-19.5
-      parent: 1
-  - uid: 1227
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 29.5,-17.5
-      parent: 1
-  - uid: 1251
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 34.5,-15.5
-      parent: 1
-  - uid: 1255
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 34.5,-10.5
-      parent: 1
-  - uid: 1256
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 34.5,-14.5
-      parent: 1
-  - uid: 1264
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 34.5,-7.5
-      parent: 1
-  - uid: 1265
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 34.5,-13.5
-      parent: 1
-  - uid: 1266
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 34.5,-12.5
-      parent: 1
-  - uid: 1267
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 34.5,-11.5
-      parent: 1
-  - uid: 1268
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 36.5,-19.5
-      parent: 1
-  - uid: 1269
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 36.5,-18.5
-      parent: 1
-  - uid: 1270
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 36.5,-17.5
-      parent: 1
-  - uid: 1271
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 36.5,-15.5
-      parent: 1
-  - uid: 1272
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 36.5,-14.5
-      parent: 1
-  - uid: 1273
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 36.5,-13.5
-      parent: 1
-  - uid: 1277
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 36.5,-16.5
-      parent: 1
-  - uid: 1348
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,-15.5
-      parent: 1
-  - uid: 1353
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,-21.5
-      parent: 1
-  - uid: 1626
-    components:
-    - type: Transform
-      pos: 42.5,8.5
-      parent: 1
-  - uid: 1627
-    components:
-    - type: Transform
-      pos: 26.5,8.5
-      parent: 1
-  - uid: 1628
-    components:
-    - type: Transform
-      pos: 26.5,6.5
-      parent: 1
-  - uid: 1629
-    components:
-    - type: Transform
-      pos: 26.5,5.5
-      parent: 1
-  - uid: 1630
-    components:
-    - type: Transform
-      pos: 26.5,4.5
-      parent: 1
-  - uid: 1631
-    components:
-    - type: Transform
-      pos: 26.5,7.5
-      parent: 1
-  - uid: 1632
-    components:
-    - type: Transform
-      pos: 26.5,3.5
-      parent: 1
-  - uid: 1633
-    components:
-    - type: Transform
-      pos: 27.5,3.5
-      parent: 1
-  - uid: 1634
-    components:
-    - type: Transform
-      pos: 30.5,3.5
-      parent: 1
-  - uid: 1635
-    components:
-    - type: Transform
-      pos: 30.5,4.5
-      parent: 1
-  - uid: 1636
-    components:
-    - type: Transform
-      pos: 42.5,7.5
-      parent: 1
-  - uid: 1637
-    components:
-    - type: Transform
-      pos: 41.5,8.5
-      parent: 1
-  - uid: 1638
-    components:
-    - type: Transform
-      pos: 41.5,7.5
-      parent: 1
-  - uid: 1639
-    components:
-    - type: Transform
-      pos: 41.5,5.5
-      parent: 1
-  - uid: 1640
-    components:
-    - type: Transform
-      pos: 41.5,6.5
-      parent: 1
-  - uid: 1641
-    components:
-    - type: Transform
-      pos: 41.5,3.5
-      parent: 1
-  - uid: 1642
-    components:
-    - type: Transform
-      pos: 41.5,4.5
-      parent: 1
-  - uid: 1643
-    components:
-    - type: Transform
-      pos: 41.5,1.5
-      parent: 1
-  - uid: 1644
-    components:
-    - type: Transform
-      pos: 41.5,2.5
-      parent: 1
-  - uid: 1645
-    components:
-    - type: Transform
-      pos: 41.5,0.5
-      parent: 1
-  - uid: 1710
-    components:
-    - type: Transform
-      pos: 30.5,-1.5
-      parent: 1
-  - uid: 1711
-    components:
-    - type: Transform
-      pos: 31.5,-1.5
-      parent: 1
-  - uid: 1712
-    components:
-    - type: Transform
-      pos: 33.5,-1.5
-      parent: 1
-  - uid: 1713
-    components:
-    - type: Transform
-      pos: 34.5,-4.5
-      parent: 1
-  - uid: 1714
-    components:
-    - type: Transform
-      pos: 37.5,-4.5
-      parent: 1
-  - uid: 1715
-    components:
-    - type: Transform
-      pos: 37.5,-2.5
-      parent: 1
-  - uid: 1716
-    components:
-    - type: Transform
-      pos: 37.5,-1.5
-      parent: 1
-  - uid: 1717
-    components:
-    - type: Transform
-      pos: 36.5,-1.5
-      parent: 1
-  - uid: 1718
-    components:
-    - type: Transform
-      pos: 35.5,-1.5
-      parent: 1
-  - uid: 1719
-    components:
-    - type: Transform
-      pos: 34.5,-1.5
-      parent: 1
-  - uid: 1720
-    components:
-    - type: Transform
-      pos: 34.5,-2.5
-      parent: 1
-  - uid: 1721
-    components:
-    - type: Transform
-      pos: 41.5,-2.5
-      parent: 1
-  - uid: 1722
-    components:
-    - type: Transform
-      pos: 41.5,-1.5
-      parent: 1
-  - uid: 1723
-    components:
-    - type: Transform
-      pos: 41.5,-0.5
-      parent: 1
-  - uid: 1724
-    components:
-    - type: Transform
-      pos: 42.5,2.5
-      parent: 1
-  - uid: 1732
-    components:
-    - type: Transform
-      pos: 34.5,4.5
-      parent: 1
-  - uid: 1733
-    components:
-    - type: Transform
-      pos: 34.5,3.5
-      parent: 1
-  - uid: 1734
-    components:
-    - type: Transform
-      pos: 34.5,2.5
-      parent: 1
-  - uid: 1735
-    components:
-    - type: Transform
-      pos: 35.5,2.5
-      parent: 1
-  - uid: 1736
-    components:
-    - type: Transform
-      pos: 36.5,2.5
-      parent: 1
-  - uid: 1737
-    components:
-    - type: Transform
-      pos: 37.5,2.5
-      parent: 1
-  - uid: 1738
-    components:
-    - type: Transform
-      pos: 38.5,2.5
-      parent: 1
-  - uid: 1739
-    components:
-    - type: Transform
-      pos: 39.5,2.5
-      parent: 1
-  - uid: 1740
-    components:
-    - type: Transform
-      pos: 40.5,2.5
-      parent: 1
-  - uid: 1741
-    components:
-    - type: Transform
-      pos: 35.5,1.5
-      parent: 1
-  - uid: 1742
-    components:
-    - type: Transform
-      pos: 35.5,-0.5
-      parent: 1
-  - uid: 1743
-    components:
-    - type: Transform
-      pos: 35.5,0.5
-      parent: 1
-  - uid: 1757
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 43.5,-12.5
-      parent: 1
-  - uid: 1758
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 43.5,-13.5
-      parent: 1
-  - uid: 1759
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 42.5,-13.5
-      parent: 1
-  - uid: 1760
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 42.5,-15.5
-      parent: 1
-  - uid: 1761
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 42.5,-14.5
-      parent: 1
-  - uid: 1762
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 41.5,-15.5
-      parent: 1
-  - uid: 1763
+      parent: 2
+- proto: PosterLegitCarpMount
+  entities:
+  - uid: 1045
+    components:
+    - type: Transform
+      pos: 37.5,-4.5
+      parent: 2
+- proto: PosterLegitIonRifle
+  entities:
+  - uid: 1046
+    components:
+    - type: Transform
+      pos: 36.5,-1.5
+      parent: 2
+- proto: PosterLegitNoERP
+  entities:
+  - uid: 1047
+    components:
+    - type: Transform
+      pos: 4.5,-17.5
+      parent: 2
+  - uid: 1048
+    components:
+    - type: Transform
+      pos: 11.5,-13.5
+      parent: 2
+- proto: PosterLegitTheOwl
+  entities:
+  - uid: 1049
+    components:
+    - type: Transform
+      pos: 34.5,4.5
+      parent: 2
+- proto: PosterMapBagel
+  entities:
+  - uid: 1050
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 40.5,-15.5
-      parent: 1
-  - uid: 1764
+      pos: 7.5,-6.5
+      parent: 2
+- proto: PosterMapMetaRight
+  entities:
+  - uid: 1051
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 40.5,-14.5
-      parent: 1
-  - uid: 1765
+      pos: 11.5,1.5
+      parent: 2
+- proto: PottedPlant12
+  entities:
+  - uid: 1052
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 39.5,-14.5
-      parent: 1
-  - uid: 1766
+      pos: 30.5,-4.5
+      parent: 2
+- proto: PottedPlant16
+  entities:
+  - uid: 1053
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 38.5,-14.5
-      parent: 1
-  - uid: 1767
+      pos: 12.5,-7.5
+      parent: 2
+- proto: PottedPlant2
+  entities:
+  - uid: 1054
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 37.5,-14.5
-      parent: 1
-  - uid: 1768
+      pos: 31.5,-4.5
+      parent: 2
+- proto: PottedPlant22
+  entities:
+  - uid: 1055
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 40.5,-13.5
-      parent: 1
-  - uid: 1812
+      pos: -1.5,-4.5
+      parent: 2
+- proto: PottedPlant23
+  entities:
+  - uid: 1056
+    components:
+    - type: Transform
+      pos: 8.5,-9.5
+      parent: 2
+- proto: PottedPlant26
+  entities:
+  - uid: 1057
+    components:
+    - type: Transform
+      pos: 33.5,-4.5
+      parent: 2
+- proto: PottedPlant5
+  entities:
+  - uid: 1058
+    components:
+    - type: Transform
+      pos: 42.5,-6.5
+      parent: 2
+- proto: Poweredlight
+  entities:
+  - uid: 1059
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 34.5,-3.5
-      parent: 1
-  - uid: 1897
+      pos: 5.5,2.5
+      parent: 2
+  - uid: 1060
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-13.5
+      parent: 2
+  - uid: 1061
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 43.5,-6.5
-      parent: 1
-- proto: WallPlastitaniumDiagonal
+      pos: 1.5,-13.5
+      parent: 2
+  - uid: 1062
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-8.5
+      parent: 2
+  - uid: 1063
+    components:
+    - type: Transform
+      pos: -9.5,0.5
+      parent: 2
+  - uid: 1064
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-2.5
+      parent: 2
+  - uid: 1065
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-2.5
+      parent: 2
+  - uid: 1066
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-12.5
+      parent: 2
+  - uid: 1067
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-14.5
+      parent: 2
+  - uid: 1068
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 1069
+    components:
+    - type: Transform
+      pos: 11.5,-4.5
+      parent: 2
+  - uid: 1070
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-8.5
+      parent: 2
+  - uid: 1071
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-15.5
+      parent: 2
+  - uid: 1072
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-6.5
+      parent: 2
+  - uid: 1073
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 21.5,-6.5
+      parent: 2
+  - uid: 1074
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 28.5,-6.5
+      parent: 2
+  - uid: 1075
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 33.5,-3.5
+      parent: 2
+  - uid: 1076
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 27.5,6.5
+      parent: 2
+  - uid: 1077
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 40.5,6.5
+      parent: 2
+  - uid: 1078
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 34.5,5.5
+      parent: 2
+  - uid: 1079
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 38.5,3.5
+      parent: 2
+  - uid: 1080
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 43.5,-9.5
+      parent: 2
+  - uid: 1081
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 34.5,-8.5
+      parent: 2
+  - uid: 1082
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 38.5,-13.5
+      parent: 2
+  - uid: 1083
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-9.5
+      parent: 2
+- proto: PoweredSmallLight
   entities:
+  - uid: 1084
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 2
+  - uid: 1085
+    components:
+    - type: Transform
+      pos: 12.5,0.5
+      parent: 2
+  - uid: 1086
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-2.5
+      parent: 2
+  - uid: 1087
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-2.5
+      parent: 2
+  - uid: 1088
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 2
+  - uid: 1089
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-2.5
+      parent: 2
+  - uid: 1090
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-4.5
+      parent: 2
+  - uid: 1091
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-0.5
+      parent: 2
+  - uid: 1092
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,2.5
+      parent: 2
+  - uid: 1093
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-13.5
+      parent: 2
+  - uid: 1094
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-16.5
+      parent: 2
+  - uid: 1095
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-6.5
+      parent: 2
+  - uid: 1096
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-6.5
+      parent: 2
+  - uid: 1097
+    components:
+    - type: Transform
+      pos: -9.5,-10.5
+      parent: 2
+  - uid: 1098
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-7.5
+      parent: 2
+  - uid: 1099
+    components:
+    - type: Transform
+      pos: 11.5,-14.5
+      parent: 2
+  - uid: 1100
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-12.5
+      parent: 2
+  - uid: 1101
+    components:
+    - type: Transform
+      pos: 8.5,-11.5
+      parent: 2
+  - uid: 1102
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-9.5
+      parent: 2
+  - uid: 1103
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 2
+  - uid: 1104
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-8.5
+      parent: 2
+  - uid: 1105
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-4.5
+      parent: 2
+  - uid: 1106
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-4.5
+      parent: 2
+  - uid: 1107
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 35.5,-18.5
+      parent: 2
+  - uid: 1108
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 31.5,-10.5
+      parent: 2
+  - uid: 1109
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 28.5,0.5
+      parent: 2
+  - uid: 1110
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 34.5,1.5
+      parent: 2
+  - uid: 1111
+    components:
+    - type: Transform
+      pos: 31.5,3.5
+      parent: 2
+  - uid: 1112
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 35.5,-3.5
+      parent: 2
+  - uid: 1113
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 41.5,-14.5
+      parent: 2
+  - uid: 1114
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 40.5,-2.5
+      parent: 2
+  - uid: 1115
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 36.5,0.5
+      parent: 2
+  - uid: 1116
+    components:
+    - type: Transform
+      pos: 38.5,1.5
+      parent: 2
+  - uid: 1117
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-5.5
+      parent: 2
+- proto: Rack
+  entities:
+  - uid: 1118
+    components:
+    - type: Transform
+      pos: -12.5,0.5
+      parent: 2
+  - uid: 1119
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-8.5
+      parent: 2
+  - uid: 1120
+    components:
+    - type: Transform
+      pos: 36.5,-0.5
+      parent: 2
+  - uid: 1121
+    components:
+    - type: Transform
+      pos: 37.5,-0.5
+      parent: 2
+  - uid: 1122
+    components:
+    - type: Transform
+      pos: 31.5,-0.5
+      parent: 2
+  - uid: 1123
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-10.5
+      parent: 2
+- proto: Railing
+  entities:
+  - uid: 1124
+    components:
+    - type: Transform
+      pos: 14.5,-4.5
+      parent: 2
+  - uid: 1125
+    components:
+    - type: Transform
+      pos: 15.5,-4.5
+      parent: 2
+  - uid: 1126
+    components:
+    - type: Transform
+      pos: 16.5,-4.5
+      parent: 2
+  - uid: 1127
+    components:
+    - type: Transform
+      pos: 18.5,-4.5
+      parent: 2
+  - uid: 1128
+    components:
+    - type: Transform
+      pos: 19.5,-4.5
+      parent: 2
+  - uid: 1129
+    components:
+    - type: Transform
+      pos: 20.5,-4.5
+      parent: 2
+  - uid: 1130
+    components:
+    - type: Transform
+      pos: 21.5,-4.5
+      parent: 2
+  - uid: 1131
+    components:
+    - type: Transform
+      pos: 22.5,-4.5
+      parent: 2
+  - uid: 1132
+    components:
+    - type: Transform
+      pos: 23.5,-4.5
+      parent: 2
+  - uid: 1133
+    components:
+    - type: Transform
+      pos: 24.5,-4.5
+      parent: 2
+  - uid: 1134
+    components:
+    - type: Transform
+      pos: 25.5,-4.5
+      parent: 2
+  - uid: 1135
+    components:
+    - type: Transform
+      pos: 17.5,-4.5
+      parent: 2
+  - uid: 1136
+    components:
+    - type: Transform
+      pos: 24.5,-6.5
+      parent: 2
+  - uid: 1137
+    components:
+    - type: Transform
+      pos: 23.5,-6.5
+      parent: 2
+  - uid: 1138
+    components:
+    - type: Transform
+      pos: 20.5,-6.5
+      parent: 2
+  - uid: 1139
+    components:
+    - type: Transform
+      pos: 19.5,-6.5
+      parent: 2
+  - uid: 1140
+    components:
+    - type: Transform
+      pos: 16.5,-6.5
+      parent: 2
+  - uid: 1141
+    components:
+    - type: Transform
+      pos: 15.5,-6.5
+      parent: 2
+  - uid: 1142
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-10.5
+      parent: 2
+  - uid: 1143
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 16.5,-10.5
+      parent: 2
+  - uid: 1144
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-10.5
+      parent: 2
+  - uid: 1145
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-10.5
+      parent: 2
+  - uid: 1146
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-10.5
+      parent: 2
+  - uid: 1147
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-10.5
+      parent: 2
+  - uid: 1148
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 21.5,-10.5
+      parent: 2
+  - uid: 1149
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-10.5
+      parent: 2
+  - uid: 1150
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 23.5,-10.5
+      parent: 2
+  - uid: 1151
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 24.5,-10.5
+      parent: 2
+  - uid: 1152
+    components:
+    - type: Transform
+      pos: 28.5,-13.5
+      parent: 2
+  - uid: 1153
+    components:
+    - type: Transform
+      pos: 27.5,-13.5
+      parent: 2
+  - uid: 1154
+    components:
+    - type: Transform
+      pos: 26.5,-13.5
+      parent: 2
+  - uid: 1155
+    components:
+    - type: Transform
+      pos: 25.5,-13.5
+      parent: 2
+  - uid: 1156
+    components:
+    - type: Transform
+      pos: 24.5,-13.5
+      parent: 2
+  - uid: 1157
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 21.5,-20.5
+      parent: 2
+  - uid: 1158
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 21.5,-19.5
+      parent: 2
+  - uid: 1159
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 21.5,-18.5
+      parent: 2
+  - uid: 1160
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 21.5,-17.5
+      parent: 2
+  - uid: 1161
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 21.5,-16.5
+      parent: 2
+  - uid: 1162
+    components:
+    - type: Transform
+      pos: 23.5,-13.5
+      parent: 2
+  - uid: 1163
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 24.5,-23.5
+      parent: 2
+  - uid: 1164
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 25.5,-23.5
+      parent: 2
+  - uid: 1165
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 26.5,-23.5
+      parent: 2
+  - uid: 1166
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 27.5,-23.5
+      parent: 2
+  - uid: 1167
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 28.5,-23.5
+      parent: 2
+  - uid: 1168
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-20.5
+      parent: 2
+  - uid: 1169
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-16.5
+      parent: 2
+  - uid: 1170
+    components:
+    - type: Transform
+      pos: 22.5,-13.5
+      parent: 2
   - uid: 1171
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 21.5,-23.5
+      parent: 2
+  - uid: 1172
+    components:
+    - type: Transform
+      pos: 20.5,-14.5
+      parent: 2
+  - uid: 1173
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-20.5
+      parent: 2
+  - uid: 1174
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-18.5
+      parent: 2
+  - uid: 1175
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-17.5
+      parent: 2
+  - uid: 1176
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-16.5
+      parent: 2
+  - uid: 1177
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 48.5,11.5
+      parent: 2
+  - uid: 1178
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 48.5,12.5
+      parent: 2
+  - uid: 1179
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 48.5,13.5
+      parent: 2
+  - uid: 1180
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 48.5,14.5
+      parent: 2
+  - uid: 1181
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 48.5,15.5
+      parent: 2
+  - uid: 1182
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 48.5,16.5
+      parent: 2
+  - uid: 1183
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 48.5,17.5
+      parent: 2
+  - uid: 1184
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 48.5,10.5
+      parent: 2
+  - uid: 1185
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 48.5,9.5
+      parent: 2
+  - uid: 1186
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 46.5,6.5
+      parent: 2
+  - uid: 1187
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 46.5,5.5
+      parent: 2
+  - uid: 1188
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 46.5,4.5
+      parent: 2
+  - uid: 1189
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 46.5,3.5
+      parent: 2
+  - uid: 1190
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 46.5,2.5
+      parent: 2
+  - uid: 1191
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 46.5,1.5
+      parent: 2
+  - uid: 1192
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 46.5,0.5
+      parent: 2
+  - uid: 1193
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 46.5,-0.5
+      parent: 2
+  - uid: 1194
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 46.5,-1.5
+      parent: 2
+  - uid: 1195
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 46.5,-2.5
+      parent: 2
+- proto: RailingCorner
+  entities:
+  - uid: 1196
+    components:
+    - type: Transform
+      pos: 23.5,-14.5
+      parent: 2
+  - uid: 1197
+    components:
+    - type: Transform
+      pos: 22.5,-15.5
+      parent: 2
+  - uid: 1198
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 22.5,-21.5
+      parent: 2
+  - uid: 1199
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 23.5,-22.5
+      parent: 2
+  - uid: 1200
+    components:
+    - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 28.5,-15.5
-      parent: 1
+      pos: 29.5,-14.5
+      parent: 2
+  - uid: 1201
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 30.5,-15.5
+      parent: 2
+  - uid: 1202
+    components:
+    - type: Transform
+      pos: 21.5,-14.5
+      parent: 2
+  - uid: 1203
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 30.5,-21.5
+      parent: 2
+  - uid: 1204
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 29.5,-22.5
+      parent: 2
+  - uid: 1205
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 20.5,-22.5
+      parent: 2
+  - uid: 1206
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 45.5,-6.5
+      parent: 2
+  - uid: 1207
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 46.5,-7.5
+      parent: 2
+  - uid: 1208
+    components:
+    - type: Transform
+      pos: 46.5,-11.5
+      parent: 2
+  - uid: 1209
+    components:
+    - type: Transform
+      pos: 45.5,-12.5
+      parent: 2
+  - uid: 1210
+    components:
+    - type: Transform
+      pos: 48.5,8.5
+      parent: 2
+  - uid: 1211
+    components:
+    - type: Transform
+      pos: 47.5,7.5
+      parent: 2
+- proto: RailingCornerSmall
+  entities:
+  - uid: 1212
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 17.5,-6.5
+      parent: 2
   - uid: 1213
     components:
     - type: Transform
-      pos: 24.5,-15.5
-      parent: 1
+      rot: 1.5707963267948966 rad
+      pos: 21.5,-6.5
+      parent: 2
   - uid: 1214
     components:
     - type: Transform
-      pos: 23.5,-16.5
-      parent: 1
+      rot: 3.141592653589793 rad
+      pos: 22.5,-6.5
+      parent: 2
+  - uid: 1215
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 25.5,-6.5
+      parent: 2
+  - uid: 1216
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-6.5
+      parent: 2
+  - uid: 1217
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-6.5
+      parent: 2
   - uid: 1218
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 23.5,-20.5
-      parent: 1
+      rot: -1.5707963267948966 rad
+      pos: 22.5,-22.5
+      parent: 2
   - uid: 1219
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 24.5,-21.5
-      parent: 1
+      rot: -1.5707963267948966 rad
+      pos: 21.5,-21.5
+      parent: 2
+  - uid: 1220
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 21.5,-15.5
+      parent: 2
+  - uid: 1221
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-14.5
+      parent: 2
   - uid: 1222
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 28.5,-21.5
-      parent: 1
-  - uid: 1224
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 29.5,-16.5
-      parent: 1
-  - uid: 1225
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 29.5,-20.5
-      parent: 1
-  - uid: 1228
+      rot: 1.5707963267948966 rad
+      pos: 29.5,-13.5
+      parent: 2
+  - uid: 1223
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 28.5,-16.5
-      parent: 1
+      pos: 30.5,-14.5
+      parent: 2
+  - uid: 1224
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 31.5,-15.5
+      parent: 2
+  - uid: 1225
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-23.5
+      parent: 2
+  - uid: 1226
+    components:
+    - type: Transform
+      pos: 29.5,-23.5
+      parent: 2
+  - uid: 1227
+    components:
+    - type: Transform
+      pos: 30.5,-22.5
+      parent: 2
+  - uid: 1228
+    components:
+    - type: Transform
+      pos: 31.5,-21.5
+      parent: 2
   - uid: 1229
     components:
     - type: Transform
-      pos: 28.5,-20.5
-      parent: 1
+      pos: 22.5,-23.5
+      parent: 2
   - uid: 1230
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 24.5,-20.5
-      parent: 1
+      pos: 20.5,-23.5
+      parent: 2
   - uid: 1231
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-22.5
+      parent: 2
+  - uid: 1232
+    components:
+    - type: Transform
       rot: 3.141592653589793 rad
-      pos: 24.5,-16.5
-      parent: 1
-- proto: WallReinforced
+      pos: 19.5,-14.5
+      parent: 2
+  - uid: 1233
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-19.5
+      parent: 2
+  - uid: 1234
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-19.5
+      parent: 2
+  - uid: 1235
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 45.5,-11.5
+      parent: 2
+  - uid: 1236
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 45.5,-7.5
+      parent: 2
+  - uid: 1237
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 46.5,-8.5
+      parent: 2
+  - uid: 1238
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 46.5,-10.5
+      parent: 2
+  - uid: 1239
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 44.5,-12.5
+      parent: 2
+  - uid: 1240
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 44.5,-6.5
+      parent: 2
+  - uid: 1241
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 47.5,8.5
+      parent: 2
+  - uid: 1242
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 46.5,7.5
+      parent: 2
+- proto: ReagentGrinderIndustrial
   entities:
+  - uid: 1243
+    components:
+    - type: Transform
+      pos: -7.5,-14.5
+      parent: 2
+- proto: ReinforcedPlasmaWindow
+  entities:
+  - uid: 1244
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 1245
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 2
+  - uid: 1246
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 2
+  - uid: 1247
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+  - uid: 1248
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 1249
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 1250
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 2
+  - uid: 1251
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 2
+  - uid: 1252
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 2
+  - uid: 1253
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 2
+  - uid: 1254
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 2
+  - uid: 1255
+    components:
+    - type: Transform
+      pos: 8.5,5.5
+      parent: 2
+  - uid: 1256
+    components:
+    - type: Transform
+      pos: 9.5,5.5
+      parent: 2
+  - uid: 1257
+    components:
+    - type: Transform
+      pos: 9.5,4.5
+      parent: 2
+  - uid: 1258
+    components:
+    - type: Transform
+      pos: 10.5,4.5
+      parent: 2
+  - uid: 1259
+    components:
+    - type: Transform
+      pos: 11.5,4.5
+      parent: 2
+  - uid: 1260
+    components:
+    - type: Transform
+      pos: 12.5,4.5
+      parent: 2
+  - uid: 1261
+    components:
+    - type: Transform
+      pos: 12.5,3.5
+      parent: 2
   - uid: 1262
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 30.5,-19.5
-      parent: 1
+      pos: 13.5,3.5
+      parent: 2
   - uid: 1263
     components:
     - type: Transform
+      pos: 13.5,2.5
+      parent: 2
+  - uid: 1264
+    components:
+    - type: Transform
+      pos: 13.5,0.5
+      parent: 2
+  - uid: 1265
+    components:
+    - type: Transform
+      pos: 13.5,-0.5
+      parent: 2
+  - uid: 1266
+    components:
+    - type: Transform
+      pos: 13.5,-1.5
+      parent: 2
+  - uid: 1267
+    components:
+    - type: Transform
+      pos: 13.5,-2.5
+      parent: 2
+  - uid: 1268
+    components:
+    - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 30.5,-17.5
-      parent: 1
-- proto: WallRockSnow
-  entities:
-  - uid: 375
+      pos: 7.5,-3.5
+      parent: 2
+  - uid: 1269
     components:
     - type: Transform
-      pos: -14.5,2.5
-      parent: 1
-  - uid: 399
+      pos: -1.5,-5.5
+      parent: 2
+  - uid: 1270
     components:
     - type: Transform
-      pos: -14.5,1.5
-      parent: 1
-  - uid: 400
+      pos: -3.5,-5.5
+      parent: 2
+  - uid: 1271
     components:
     - type: Transform
-      pos: -14.5,-5.5
-      parent: 1
-  - uid: 401
+      pos: -5.5,-5.5
+      parent: 2
+  - uid: 1272
     components:
     - type: Transform
-      pos: -14.5,-6.5
-      parent: 1
-  - uid: 402
+      pos: -7.5,-5.5
+      parent: 2
+  - uid: 1273
     components:
     - type: Transform
-      pos: -13.5,-6.5
-      parent: 1
-  - uid: 403
+      pos: -8.5,-9.5
+      parent: 2
+  - uid: 1274
     components:
     - type: Transform
-      pos: -13.5,-7.5
-      parent: 1
-  - uid: 404
+      pos: -6.5,-9.5
+      parent: 2
+  - uid: 1275
     components:
     - type: Transform
-      pos: -13.5,-8.5
-      parent: 1
-  - uid: 405
+      pos: -3.5,-9.5
+      parent: 2
+  - uid: 1276
     components:
     - type: Transform
-      pos: -14.5,-8.5
-      parent: 1
-  - uid: 406
+      pos: -1.5,-9.5
+      parent: 2
+  - uid: 1277
     components:
     - type: Transform
-      pos: -14.5,-9.5
-      parent: 1
-  - uid: 407
+      pos: -6.5,-15.5
+      parent: 2
+  - uid: 1278
     components:
     - type: Transform
-      pos: -14.5,-10.5
-      parent: 1
-  - uid: 408
+      pos: -7.5,-15.5
+      parent: 2
+  - uid: 1279
     components:
     - type: Transform
-      pos: -15.5,-10.5
-      parent: 1
-  - uid: 409
+      pos: -8.5,-15.5
+      parent: 2
+  - uid: 1280
     components:
     - type: Transform
-      pos: -15.5,-11.5
-      parent: 1
-  - uid: 410
+      pos: -8.5,-14.5
+      parent: 2
+  - uid: 1281
     components:
     - type: Transform
-      pos: -15.5,-12.5
-      parent: 1
-  - uid: 411
+      pos: -9.5,-14.5
+      parent: 2
+  - uid: 1282
     components:
     - type: Transform
-      pos: -15.5,-13.5
-      parent: 1
-  - uid: 412
+      pos: -10.5,-14.5
+      parent: 2
+  - uid: 1283
     components:
     - type: Transform
-      pos: -15.5,-14.5
-      parent: 1
-  - uid: 413
+      pos: -11.5,-14.5
+      parent: 2
+  - uid: 1284
     components:
     - type: Transform
-      pos: -15.5,-15.5
-      parent: 1
-  - uid: 414
+      pos: -12.5,-14.5
+      parent: 2
+  - uid: 1285
     components:
     - type: Transform
-      pos: -15.5,-16.5
-      parent: 1
-  - uid: 415
-    components:
-    - type: Transform
-      pos: -15.5,-17.5
-      parent: 1
-  - uid: 416
-    components:
-    - type: Transform
-      pos: -15.5,-18.5
-      parent: 1
-  - uid: 417
-    components:
-    - type: Transform
-      pos: -14.5,-18.5
-      parent: 1
-  - uid: 418
-    components:
-    - type: Transform
-      pos: -13.5,-18.5
-      parent: 1
-  - uid: 419
-    components:
-    - type: Transform
-      pos: -11.5,-18.5
-      parent: 1
-  - uid: 420
-    components:
-    - type: Transform
-      pos: -10.5,-18.5
-      parent: 1
-  - uid: 421
-    components:
-    - type: Transform
-      pos: -9.5,-18.5
-      parent: 1
-  - uid: 422
-    components:
-    - type: Transform
-      pos: -8.5,-18.5
-      parent: 1
-  - uid: 423
-    components:
-    - type: Transform
-      pos: -12.5,-18.5
-      parent: 1
-  - uid: 424
-    components:
-    - type: Transform
-      pos: -7.5,-18.5
-      parent: 1
-  - uid: 425
-    components:
-    - type: Transform
-      pos: -6.5,-18.5
-      parent: 1
-  - uid: 426
-    components:
-    - type: Transform
-      pos: -5.5,-18.5
-      parent: 1
-  - uid: 501
-    components:
-    - type: Transform
-      pos: -5.5,-19.5
-      parent: 1
-  - uid: 502
-    components:
-    - type: Transform
-      pos: -5.5,-20.5
-      parent: 1
-  - uid: 503
-    components:
-    - type: Transform
-      pos: -5.5,-21.5
-      parent: 1
-  - uid: 504
-    components:
-    - type: Transform
-      pos: -5.5,-22.5
-      parent: 1
-  - uid: 505
-    components:
-    - type: Transform
-      pos: -4.5,-22.5
-      parent: 1
-  - uid: 506
-    components:
-    - type: Transform
-      pos: -3.5,-22.5
-      parent: 1
-  - uid: 507
-    components:
-    - type: Transform
-      pos: -2.5,-22.5
-      parent: 1
-  - uid: 508
-    components:
-    - type: Transform
-      pos: -1.5,-22.5
-      parent: 1
-  - uid: 509
-    components:
-    - type: Transform
-      pos: -0.5,-22.5
-      parent: 1
-  - uid: 510
-    components:
-    - type: Transform
-      pos: 0.5,-22.5
-      parent: 1
-  - uid: 511
-    components:
-    - type: Transform
-      pos: 1.5,-22.5
-      parent: 1
-  - uid: 512
-    components:
-    - type: Transform
-      pos: 2.5,-22.5
-      parent: 1
-  - uid: 513
-    components:
-    - type: Transform
-      pos: 3.5,-22.5
-      parent: 1
-  - uid: 514
-    components:
-    - type: Transform
-      pos: 4.5,-22.5
-      parent: 1
-  - uid: 515
-    components:
-    - type: Transform
-      pos: 4.5,-21.5
-      parent: 1
-  - uid: 516
-    components:
-    - type: Transform
-      pos: 4.5,-20.5
-      parent: 1
-  - uid: 517
-    components:
-    - type: Transform
-      pos: 4.5,-19.5
-      parent: 1
-  - uid: 518
-    components:
-    - type: Transform
-      pos: 4.5,-18.5
-      parent: 1
-  - uid: 519
-    components:
-    - type: Transform
-      pos: 5.5,-18.5
-      parent: 1
-  - uid: 673
-    components:
-    - type: Transform
-      pos: -15.5,1.5
-      parent: 1
-  - uid: 674
-    components:
-    - type: Transform
-      pos: -15.5,0.5
-      parent: 1
-  - uid: 675
-    components:
-    - type: Transform
-      pos: -15.5,-0.5
-      parent: 1
-  - uid: 676
-    components:
-    - type: Transform
-      pos: -15.5,-1.5
-      parent: 1
-  - uid: 677
-    components:
-    - type: Transform
-      pos: -15.5,-2.5
-      parent: 1
-  - uid: 678
-    components:
-    - type: Transform
-      pos: -15.5,-3.5
-      parent: 1
-  - uid: 679
-    components:
-    - type: Transform
-      pos: -15.5,-4.5
-      parent: 1
-  - uid: 680
-    components:
-    - type: Transform
-      pos: -15.5,-5.5
-      parent: 1
-  - uid: 681
-    components:
-    - type: Transform
-      pos: -13.5,2.5
-      parent: 1
-  - uid: 682
-    components:
-    - type: Transform
-      pos: -11.5,2.5
-      parent: 1
-  - uid: 683
-    components:
-    - type: Transform
-      pos: -10.5,2.5
-      parent: 1
-  - uid: 684
-    components:
-    - type: Transform
-      pos: -9.5,2.5
-      parent: 1
-  - uid: 685
-    components:
-    - type: Transform
-      pos: -8.5,2.5
-      parent: 1
-  - uid: 686
-    components:
-    - type: Transform
-      pos: -7.5,2.5
-      parent: 1
-  - uid: 687
-    components:
-    - type: Transform
-      pos: -6.5,2.5
-      parent: 1
-  - uid: 688
-    components:
-    - type: Transform
-      pos: -5.5,2.5
-      parent: 1
-  - uid: 689
-    components:
-    - type: Transform
-      pos: -4.5,2.5
-      parent: 1
-  - uid: 690
-    components:
-    - type: Transform
-      pos: -12.5,2.5
-      parent: 1
-  - uid: 691
-    components:
-    - type: Transform
-      pos: -4.5,1.5
-      parent: 1
-  - uid: 692
-    components:
-    - type: Transform
-      pos: -3.5,1.5
-      parent: 1
-  - uid: 693
-    components:
-    - type: Transform
-      pos: -2.5,1.5
-      parent: 1
-  - uid: 694
-    components:
-    - type: Transform
-      pos: -1.5,1.5
-      parent: 1
-  - uid: 770
-    components:
-    - type: Transform
-      pos: 14.5,-25.5
-      parent: 1
-  - uid: 1361
-    components:
-    - type: Transform
-      pos: 13.5,-21.5
-      parent: 1
-  - uid: 1362
-    components:
-    - type: Transform
-      pos: 13.5,-22.5
-      parent: 1
-  - uid: 1363
-    components:
-    - type: Transform
-      pos: 12.5,-22.5
-      parent: 1
-  - uid: 1364
-    components:
-    - type: Transform
-      pos: 11.5,-22.5
-      parent: 1
-  - uid: 1365
-    components:
-    - type: Transform
-      pos: 10.5,-22.5
-      parent: 1
-  - uid: 1366
-    components:
-    - type: Transform
-      pos: 9.5,-22.5
-      parent: 1
-  - uid: 1367
-    components:
-    - type: Transform
-      pos: 8.5,-22.5
-      parent: 1
-  - uid: 1368
-    components:
-    - type: Transform
-      pos: 7.5,-22.5
-      parent: 1
-  - uid: 1369
-    components:
-    - type: Transform
-      pos: 6.5,-22.5
-      parent: 1
-  - uid: 1370
-    components:
-    - type: Transform
-      pos: 5.5,-22.5
-      parent: 1
-  - uid: 1371
-    components:
-    - type: Transform
-      pos: 14.5,-23.5
-      parent: 1
-  - uid: 1372
-    components:
-    - type: Transform
-      pos: 13.5,-23.5
-      parent: 1
-  - uid: 1374
-    components:
-    - type: Transform
-      pos: 14.5,-26.5
-      parent: 1
-  - uid: 1375
-    components:
-    - type: Transform
-      pos: 15.5,-26.5
-      parent: 1
-  - uid: 1376
-    components:
-    - type: Transform
-      pos: 14.5,-24.5
-      parent: 1
-  - uid: 1377
-    components:
-    - type: Transform
-      pos: 15.5,-27.5
-      parent: 1
-  - uid: 1378
-    components:
-    - type: Transform
-      pos: 16.5,-27.5
-      parent: 1
-  - uid: 1379
-    components:
-    - type: Transform
-      pos: 17.5,-27.5
-      parent: 1
-  - uid: 1380
-    components:
-    - type: Transform
-      pos: 18.5,-27.5
-      parent: 1
-  - uid: 1381
-    components:
-    - type: Transform
-      pos: 18.5,-28.5
-      parent: 1
-  - uid: 1382
-    components:
-    - type: Transform
-      pos: 17.5,-28.5
-      parent: 1
-  - uid: 1383
-    components:
-    - type: Transform
-      pos: 17.5,-29.5
-      parent: 1
-  - uid: 1384
-    components:
-    - type: Transform
-      pos: 17.5,-30.5
-      parent: 1
-  - uid: 1385
-    components:
-    - type: Transform
-      pos: 17.5,-31.5
-      parent: 1
-  - uid: 1386
-    components:
-    - type: Transform
-      pos: 18.5,-31.5
-      parent: 1
-  - uid: 1387
-    components:
-    - type: Transform
-      pos: 18.5,-32.5
-      parent: 1
-  - uid: 1388
-    components:
-    - type: Transform
-      pos: 19.5,-32.5
-      parent: 1
-  - uid: 1389
-    components:
-    - type: Transform
-      pos: 20.5,-32.5
-      parent: 1
-  - uid: 1390
-    components:
-    - type: Transform
-      pos: 21.5,-32.5
-      parent: 1
-  - uid: 1391
-    components:
-    - type: Transform
-      pos: 22.5,-32.5
-      parent: 1
-  - uid: 1392
-    components:
-    - type: Transform
-      pos: 23.5,-32.5
-      parent: 1
-  - uid: 1393
-    components:
-    - type: Transform
-      pos: 23.5,-30.5
-      parent: 1
-  - uid: 1394
-    components:
-    - type: Transform
-      pos: 23.5,-31.5
-      parent: 1
-  - uid: 1395
-    components:
-    - type: Transform
-      pos: 24.5,-31.5
-      parent: 1
-  - uid: 1396
-    components:
-    - type: Transform
-      pos: 25.5,-31.5
-      parent: 1
-  - uid: 1397
-    components:
-    - type: Transform
-      pos: 21.5,-28.5
-      parent: 1
-  - uid: 1398
-    components:
-    - type: Transform
-      pos: 21.5,-27.5
-      parent: 1
-  - uid: 1399
-    components:
-    - type: Transform
-      pos: 20.5,-27.5
-      parent: 1
-  - uid: 1400
-    components:
-    - type: Transform
-      pos: 22.5,-27.5
-      parent: 1
-  - uid: 1401
-    components:
-    - type: Transform
-      pos: 23.5,-27.5
-      parent: 1
-  - uid: 1402
-    components:
-    - type: Transform
-      pos: 24.5,-27.5
-      parent: 1
-  - uid: 1403
-    components:
-    - type: Transform
-      pos: 25.5,-27.5
-      parent: 1
-  - uid: 1404
-    components:
-    - type: Transform
-      pos: 26.5,-27.5
-      parent: 1
-  - uid: 1405
-    components:
-    - type: Transform
-      pos: 24.5,-28.5
-      parent: 1
-  - uid: 1406
-    components:
-    - type: Transform
-      pos: 25.5,-28.5
-      parent: 1
-  - uid: 1407
-    components:
-    - type: Transform
-      pos: 26.5,-28.5
-      parent: 1
-  - uid: 1408
-    components:
-    - type: Transform
-      pos: 27.5,-28.5
-      parent: 1
-  - uid: 1409
-    components:
-    - type: Transform
-      pos: 25.5,-29.5
-      parent: 1
-  - uid: 1410
-    components:
-    - type: Transform
-      pos: 26.5,-29.5
-      parent: 1
-  - uid: 1411
-    components:
-    - type: Transform
-      pos: 28.5,-28.5
-      parent: 1
-  - uid: 1412
-    components:
-    - type: Transform
-      pos: 29.5,-28.5
-      parent: 1
-  - uid: 1413
-    components:
-    - type: Transform
-      pos: 29.5,-29.5
-      parent: 1
-  - uid: 1414
-    components:
-    - type: Transform
-      pos: 30.5,-28.5
-      parent: 1
-  - uid: 1415
-    components:
-    - type: Transform
-      pos: 30.5,-29.5
-      parent: 1
-  - uid: 1416
-    components:
-    - type: Transform
-      pos: 31.5,-28.5
-      parent: 1
-  - uid: 1417
-    components:
-    - type: Transform
-      pos: 31.5,-29.5
-      parent: 1
-  - uid: 1418
-    components:
-    - type: Transform
-      pos: 31.5,-30.5
-      parent: 1
-  - uid: 1419
-    components:
-    - type: Transform
-      pos: 30.5,-30.5
-      parent: 1
-  - uid: 1420
-    components:
-    - type: Transform
-      pos: 30.5,-31.5
-      parent: 1
-  - uid: 1421
-    components:
-    - type: Transform
-      pos: 30.5,-32.5
-      parent: 1
-  - uid: 1422
-    components:
-    - type: Transform
-      pos: 30.5,-33.5
-      parent: 1
-  - uid: 1423
-    components:
-    - type: Transform
-      pos: 30.5,-34.5
-      parent: 1
-  - uid: 1424
-    components:
-    - type: Transform
-      pos: 29.5,-34.5
-      parent: 1
-  - uid: 1425
-    components:
-    - type: Transform
-      pos: 28.5,-34.5
-      parent: 1
-  - uid: 1426
-    components:
-    - type: Transform
-      pos: 27.5,-34.5
-      parent: 1
-  - uid: 1427
-    components:
-    - type: Transform
-      pos: 27.5,-33.5
-      parent: 1
-  - uid: 1428
-    components:
-    - type: Transform
-      pos: 26.5,-33.5
-      parent: 1
-  - uid: 1429
-    components:
-    - type: Transform
-      pos: 26.5,-32.5
-      parent: 1
-  - uid: 1430
-    components:
-    - type: Transform
-      pos: 25.5,-32.5
-      parent: 1
-  - uid: 1533
-    components:
-    - type: Transform
-      pos: 30.5,-27.5
-      parent: 1
-  - uid: 1534
-    components:
-    - type: Transform
-      pos: 31.5,-27.5
-      parent: 1
-  - uid: 1535
-    components:
-    - type: Transform
-      pos: 31.5,-26.5
-      parent: 1
-  - uid: 1536
-    components:
-    - type: Transform
-      pos: 31.5,-25.5
-      parent: 1
-  - uid: 1537
-    components:
-    - type: Transform
-      pos: 32.5,-25.5
-      parent: 1
-  - uid: 1538
-    components:
-    - type: Transform
-      pos: 33.5,-25.5
-      parent: 1
-  - uid: 1539
-    components:
-    - type: Transform
-      pos: 33.5,-24.5
-      parent: 1
-  - uid: 1540
-    components:
-    - type: Transform
-      pos: 34.5,-24.5
-      parent: 1
-  - uid: 1541
-    components:
-    - type: Transform
-      pos: 35.5,-24.5
-      parent: 1
-  - uid: 1542
-    components:
-    - type: Transform
-      pos: 35.5,-23.5
-      parent: 1
-  - uid: 1543
-    components:
-    - type: Transform
-      pos: 36.5,-23.5
-      parent: 1
-  - uid: 1544
-    components:
-    - type: Transform
-      pos: 37.5,-23.5
-      parent: 1
-  - uid: 1545
-    components:
-    - type: Transform
-      pos: 38.5,-23.5
-      parent: 1
-  - uid: 1546
-    components:
-    - type: Transform
-      pos: 38.5,-22.5
-      parent: 1
-  - uid: 1547
-    components:
-    - type: Transform
-      pos: 35.5,-22.5
-      parent: 1
-  - uid: 1548
-    components:
-    - type: Transform
-      pos: 35.5,-21.5
-      parent: 1
-  - uid: 1549
-    components:
-    - type: Transform
-      pos: 36.5,-21.5
-      parent: 1
-  - uid: 1550
-    components:
-    - type: Transform
-      pos: 37.5,-21.5
-      parent: 1
-  - uid: 1551
-    components:
-    - type: Transform
-      pos: 38.5,-21.5
-      parent: 1
-  - uid: 1552
-    components:
-    - type: Transform
-      pos: 36.5,-22.5
-      parent: 1
-  - uid: 1553
-    components:
-    - type: Transform
-      pos: 37.5,-22.5
-      parent: 1
-  - uid: 1554
-    components:
-    - type: Transform
-      pos: 39.5,-22.5
-      parent: 1
-  - uid: 1555
-    components:
-    - type: Transform
-      pos: 39.5,-21.5
-      parent: 1
-  - uid: 1556
-    components:
-    - type: Transform
-      pos: 37.5,-20.5
-      parent: 1
-  - uid: 1557
-    components:
-    - type: Transform
-      pos: 37.5,-19.5
-      parent: 1
-  - uid: 1558
-    components:
-    - type: Transform
-      pos: 37.5,-18.5
-      parent: 1
-  - uid: 1559
-    components:
-    - type: Transform
-      pos: 37.5,-17.5
-      parent: 1
-  - uid: 1560
-    components:
-    - type: Transform
-      pos: 37.5,-16.5
-      parent: 1
-  - uid: 1561
-    components:
-    - type: Transform
-      pos: 38.5,-20.5
-      parent: 1
-  - uid: 1562
-    components:
-    - type: Transform
-      pos: 38.5,-19.5
-      parent: 1
-  - uid: 1563
-    components:
-    - type: Transform
-      pos: 38.5,-18.5
-      parent: 1
-  - uid: 1564
-    components:
-    - type: Transform
-      pos: 38.5,-17.5
-      parent: 1
-  - uid: 1565
-    components:
-    - type: Transform
-      pos: 38.5,-16.5
-      parent: 1
-  - uid: 1566
-    components:
-    - type: Transform
-      pos: 39.5,-20.5
-      parent: 1
-  - uid: 1567
-    components:
-    - type: Transform
-      pos: 39.5,-19.5
-      parent: 1
-  - uid: 1568
-    components:
-    - type: Transform
-      pos: 39.5,-18.5
-      parent: 1
-  - uid: 1569
-    components:
-    - type: Transform
-      pos: 39.5,-17.5
-      parent: 1
-  - uid: 1570
-    components:
-    - type: Transform
-      pos: 39.5,-16.5
-      parent: 1
-  - uid: 1571
-    components:
-    - type: Transform
-      pos: 40.5,-17.5
-      parent: 1
-  - uid: 1572
-    components:
-    - type: Transform
-      pos: 41.5,-17.5
-      parent: 1
-  - uid: 1573
-    components:
-    - type: Transform
-      pos: 42.5,-17.5
-      parent: 1
-  - uid: 1574
-    components:
-    - type: Transform
-      pos: 43.5,-17.5
-      parent: 1
-  - uid: 1575
-    components:
-    - type: Transform
-      pos: 43.5,-16.5
-      parent: 1
-  - uid: 1576
-    components:
-    - type: Transform
-      pos: 43.5,-15.5
-      parent: 1
-  - uid: 1577
-    components:
-    - type: Transform
-      pos: 44.5,-17.5
-      parent: 1
-  - uid: 1578
-    components:
-    - type: Transform
-      pos: 44.5,-16.5
-      parent: 1
-  - uid: 1579
-    components:
-    - type: Transform
-      pos: 44.5,-15.5
-      parent: 1
-  - uid: 1580
-    components:
-    - type: Transform
-      pos: 45.5,-17.5
-      parent: 1
-  - uid: 1581
-    components:
-    - type: Transform
-      pos: 45.5,-16.5
-      parent: 1
-  - uid: 1582
-    components:
-    - type: Transform
-      pos: 45.5,-15.5
-      parent: 1
-  - uid: 1583
-    components:
-    - type: Transform
-      pos: 46.5,-17.5
-      parent: 1
-  - uid: 1584
-    components:
-    - type: Transform
-      pos: 46.5,-16.5
-      parent: 1
-  - uid: 1585
-    components:
-    - type: Transform
-      pos: 46.5,-15.5
-      parent: 1
-  - uid: 1586
-    components:
-    - type: Transform
-      pos: 44.5,-14.5
-      parent: 1
-  - uid: 1587
-    components:
-    - type: Transform
-      pos: 45.5,-14.5
-      parent: 1
-  - uid: 1588
-    components:
-    - type: Transform
-      pos: 46.5,-14.5
-      parent: 1
-  - uid: 1769
-    components:
-    - type: Transform
-      pos: 37.5,-15.5
-      parent: 1
-  - uid: 1770
-    components:
-    - type: Transform
-      pos: 38.5,-15.5
-      parent: 1
-  - uid: 1771
-    components:
-    - type: Transform
-      pos: 39.5,-15.5
-      parent: 1
-  - uid: 1772
-    components:
-    - type: Transform
-      pos: 40.5,-16.5
-      parent: 1
-  - uid: 1773
-    components:
-    - type: Transform
-      pos: 41.5,-16.5
-      parent: 1
-  - uid: 1774
-    components:
-    - type: Transform
-      pos: 42.5,-16.5
-      parent: 1
-  - uid: 1775
-    components:
-    - type: Transform
-      pos: 43.5,-14.5
-      parent: 1
-  - uid: 1776
-    components:
-    - type: Transform
-      pos: 44.5,-13.5
-      parent: 1
-  - uid: 2018
-    components:
-    - type: Transform
-      pos: 8.5,12.5
-      parent: 1
-  - uid: 2019
-    components:
-    - type: Transform
-      pos: 7.5,12.5
-      parent: 1
-  - uid: 2020
-    components:
-    - type: Transform
-      pos: 6.5,12.5
-      parent: 1
-  - uid: 2021
-    components:
-    - type: Transform
-      pos: 5.5,12.5
-      parent: 1
-  - uid: 2022
-    components:
-    - type: Transform
-      pos: 4.5,12.5
-      parent: 1
-  - uid: 2023
-    components:
-    - type: Transform
-      pos: 3.5,12.5
-      parent: 1
-  - uid: 2024
-    components:
-    - type: Transform
-      pos: 2.5,12.5
-      parent: 1
-  - uid: 2025
-    components:
-    - type: Transform
-      pos: 2.5,11.5
-      parent: 1
-  - uid: 2026
-    components:
-    - type: Transform
-      pos: 1.5,11.5
-      parent: 1
-  - uid: 2027
-    components:
-    - type: Transform
-      pos: 0.5,11.5
-      parent: 1
-  - uid: 2028
-    components:
-    - type: Transform
-      pos: -0.5,11.5
-      parent: 1
-  - uid: 2029
-    components:
-    - type: Transform
-      pos: -0.5,10.5
-      parent: 1
-  - uid: 2030
-    components:
-    - type: Transform
-      pos: -1.5,10.5
-      parent: 1
-  - uid: 2031
-    components:
-    - type: Transform
-      pos: -2.5,10.5
-      parent: 1
-  - uid: 2032
-    components:
-    - type: Transform
-      pos: -3.5,10.5
-      parent: 1
-  - uid: 2033
-    components:
-    - type: Transform
-      pos: -4.5,10.5
-      parent: 1
-  - uid: 2034
-    components:
-    - type: Transform
-      pos: -5.5,10.5
-      parent: 1
-  - uid: 2035
-    components:
-    - type: Transform
-      pos: -5.5,9.5
-      parent: 1
-  - uid: 2036
-    components:
-    - type: Transform
-      pos: -6.5,9.5
-      parent: 1
-  - uid: 2037
-    components:
-    - type: Transform
-      pos: -4.5,9.5
-      parent: 1
-  - uid: 2038
-    components:
-    - type: Transform
-      pos: -5.5,8.5
-      parent: 1
-  - uid: 2039
-    components:
-    - type: Transform
-      pos: -6.5,8.5
-      parent: 1
-  - uid: 2040
-    components:
-    - type: Transform
-      pos: -7.5,8.5
-      parent: 1
-  - uid: 2041
-    components:
-    - type: Transform
-      pos: -8.5,8.5
-      parent: 1
-  - uid: 2042
-    components:
-    - type: Transform
-      pos: -9.5,8.5
-      parent: 1
-  - uid: 2043
-    components:
-    - type: Transform
-      pos: -10.5,8.5
-      parent: 1
-  - uid: 2044
-    components:
-    - type: Transform
-      pos: -6.5,7.5
-      parent: 1
-  - uid: 2045
-    components:
-    - type: Transform
-      pos: -7.5,7.5
-      parent: 1
-  - uid: 2046
-    components:
-    - type: Transform
-      pos: -8.5,7.5
-      parent: 1
-  - uid: 2047
-    components:
-    - type: Transform
-      pos: -9.5,7.5
-      parent: 1
-  - uid: 2048
-    components:
-    - type: Transform
-      pos: -10.5,7.5
-      parent: 1
-  - uid: 2049
-    components:
-    - type: Transform
-      pos: -8.5,6.5
-      parent: 1
-  - uid: 2050
-    components:
-    - type: Transform
-      pos: -9.5,6.5
-      parent: 1
-  - uid: 2051
-    components:
-    - type: Transform
-      pos: -10.5,6.5
-      parent: 1
-  - uid: 2052
-    components:
-    - type: Transform
-      pos: -11.5,6.5
-      parent: 1
-  - uid: 2053
-    components:
-    - type: Transform
-      pos: -12.5,6.5
-      parent: 1
-  - uid: 2054
-    components:
-    - type: Transform
-      pos: -13.5,6.5
-      parent: 1
-  - uid: 2055
-    components:
-    - type: Transform
-      pos: -14.5,6.5
-      parent: 1
-  - uid: 2056
-    components:
-    - type: Transform
-      pos: -11.5,5.5
-      parent: 1
-  - uid: 2057
-    components:
-    - type: Transform
-      pos: -12.5,5.5
-      parent: 1
-  - uid: 2058
-    components:
-    - type: Transform
-      pos: -13.5,5.5
-      parent: 1
-  - uid: 2059
-    components:
-    - type: Transform
-      pos: -14.5,5.5
-      parent: 1
-  - uid: 2060
-    components:
-    - type: Transform
-      pos: -15.5,5.5
-      parent: 1
-  - uid: 2061
-    components:
-    - type: Transform
-      pos: -16.5,5.5
-      parent: 1
-  - uid: 2062
-    components:
-    - type: Transform
-      pos: -13.5,4.5
-      parent: 1
-  - uid: 2063
-    components:
-    - type: Transform
-      pos: -14.5,4.5
-      parent: 1
-  - uid: 2064
-    components:
-    - type: Transform
-      pos: -15.5,4.5
-      parent: 1
-  - uid: 2065
-    components:
-    - type: Transform
-      pos: -16.5,4.5
-      parent: 1
-  - uid: 2066
-    components:
-    - type: Transform
-      pos: -1.5,11.5
-      parent: 1
-  - uid: 2067
-    components:
-    - type: Transform
-      pos: -2.5,11.5
-      parent: 1
-  - uid: 2068
-    components:
-    - type: Transform
-      pos: -14.5,3.5
-      parent: 1
-  - uid: 2069
-    components:
-    - type: Transform
-      pos: -15.5,3.5
-      parent: 1
-  - uid: 2070
-    components:
-    - type: Transform
-      pos: 1.5,12.5
-      parent: 1
-  - uid: 2071
-    components:
-    - type: Transform
-      pos: 0.5,12.5
-      parent: 1
-  - uid: 2072
-    components:
-    - type: Transform
-      pos: 2.5,13.5
-      parent: 1
-  - uid: 2073
-    components:
-    - type: Transform
-      pos: 3.5,13.5
-      parent: 1
-  - uid: 2074
-    components:
-    - type: Transform
-      pos: 4.5,13.5
-      parent: 1
-  - uid: 2075
-    components:
-    - type: Transform
-      pos: 5.5,13.5
-      parent: 1
-  - uid: 2076
-    components:
-    - type: Transform
-      pos: 6.5,13.5
-      parent: 1
-  - uid: 2077
-    components:
-    - type: Transform
-      pos: 7.5,13.5
-      parent: 1
-  - uid: 2078
-    components:
-    - type: Transform
-      pos: 8.5,13.5
-      parent: 1
-  - uid: 2079
-    components:
-    - type: Transform
-      pos: 9.5,13.5
-      parent: 1
-  - uid: 2080
-    components:
-    - type: Transform
-      pos: 6.5,14.5
-      parent: 1
-  - uid: 2081
-    components:
-    - type: Transform
-      pos: 7.5,14.5
-      parent: 1
-  - uid: 2082
-    components:
-    - type: Transform
-      pos: 8.5,14.5
-      parent: 1
-  - uid: 2083
-    components:
-    - type: Transform
-      pos: 9.5,14.5
-      parent: 1
-  - uid: 2084
-    components:
-    - type: Transform
-      pos: 10.5,14.5
-      parent: 1
-  - uid: 2085
-    components:
-    - type: Transform
-      pos: 11.5,14.5
-      parent: 1
-  - uid: 2086
-    components:
-    - type: Transform
-      pos: 12.5,14.5
-      parent: 1
-  - uid: 2087
-    components:
-    - type: Transform
-      pos: 10.5,15.5
-      parent: 1
-  - uid: 2088
-    components:
-    - type: Transform
-      pos: 11.5,15.5
-      parent: 1
-  - uid: 2089
-    components:
-    - type: Transform
-      pos: 12.5,15.5
-      parent: 1
-  - uid: 2090
-    components:
-    - type: Transform
-      pos: 13.5,15.5
-      parent: 1
-  - uid: 2091
-    components:
-    - type: Transform
-      pos: 14.5,15.5
-      parent: 1
-  - uid: 2092
-    components:
-    - type: Transform
-      pos: 15.5,15.5
-      parent: 1
-  - uid: 2093
-    components:
-    - type: Transform
-      pos: 12.5,16.5
-      parent: 1
-  - uid: 2094
-    components:
-    - type: Transform
-      pos: 13.5,16.5
-      parent: 1
-  - uid: 2095
-    components:
-    - type: Transform
-      pos: 14.5,16.5
-      parent: 1
-  - uid: 2096
-    components:
-    - type: Transform
-      pos: 15.5,16.5
-      parent: 1
-  - uid: 2097
-    components:
-    - type: Transform
-      pos: 16.5,16.5
-      parent: 1
-  - uid: 2098
-    components:
-    - type: Transform
-      pos: 14.5,17.5
-      parent: 1
-  - uid: 2099
-    components:
-    - type: Transform
-      pos: 15.5,17.5
-      parent: 1
-  - uid: 2100
-    components:
-    - type: Transform
-      pos: 17.5,17.5
-      parent: 1
-  - uid: 2101
-    components:
-    - type: Transform
-      pos: 18.5,17.5
-      parent: 1
-  - uid: 2102
-    components:
-    - type: Transform
-      pos: 16.5,17.5
-      parent: 1
-  - uid: 2103
-    components:
-    - type: Transform
-      pos: 16.5,18.5
-      parent: 1
-  - uid: 2104
-    components:
-    - type: Transform
-      pos: 17.5,18.5
-      parent: 1
-  - uid: 2105
-    components:
-    - type: Transform
-      pos: 18.5,18.5
-      parent: 1
-  - uid: 2106
-    components:
-    - type: Transform
-      pos: 19.5,18.5
-      parent: 1
-  - uid: 2107
-    components:
-    - type: Transform
-      pos: 20.5,18.5
-      parent: 1
-  - uid: 2108
-    components:
-    - type: Transform
-      pos: 21.5,18.5
-      parent: 1
-  - uid: 2109
-    components:
-    - type: Transform
-      pos: 22.5,18.5
-      parent: 1
-  - uid: 2110
-    components:
-    - type: Transform
-      pos: 23.5,18.5
-      parent: 1
-  - uid: 2111
-    components:
-    - type: Transform
-      pos: 24.5,18.5
-      parent: 1
-  - uid: 2112
-    components:
-    - type: Transform
-      pos: 25.5,18.5
-      parent: 1
-  - uid: 2113
-    components:
-    - type: Transform
-      pos: 26.5,18.5
-      parent: 1
-  - uid: 2114
-    components:
-    - type: Transform
-      pos: 27.5,18.5
-      parent: 1
-  - uid: 2115
-    components:
-    - type: Transform
-      pos: 28.5,18.5
-      parent: 1
-  - uid: 2116
-    components:
-    - type: Transform
-      pos: 29.5,18.5
-      parent: 1
-  - uid: 2117
-    components:
-    - type: Transform
-      pos: 30.5,18.5
-      parent: 1
-  - uid: 2118
-    components:
-    - type: Transform
-      pos: 31.5,18.5
-      parent: 1
-  - uid: 2119
-    components:
-    - type: Transform
-      pos: 32.5,18.5
-      parent: 1
-  - uid: 2120
-    components:
-    - type: Transform
-      pos: 33.5,18.5
-      parent: 1
-  - uid: 2121
-    components:
-    - type: Transform
-      pos: 34.5,18.5
-      parent: 1
-  - uid: 2122
-    components:
-    - type: Transform
-      pos: 35.5,18.5
-      parent: 1
-  - uid: 2123
-    components:
-    - type: Transform
-      pos: 36.5,18.5
-      parent: 1
-  - uid: 2124
-    components:
-    - type: Transform
-      pos: 37.5,18.5
-      parent: 1
-  - uid: 2125
-    components:
-    - type: Transform
-      pos: 38.5,18.5
-      parent: 1
-  - uid: 2126
-    components:
-    - type: Transform
-      pos: 39.5,18.5
-      parent: 1
-  - uid: 2127
-    components:
-    - type: Transform
-      pos: 40.5,18.5
-      parent: 1
-  - uid: 2128
-    components:
-    - type: Transform
-      pos: 41.5,18.5
-      parent: 1
-  - uid: 2129
-    components:
-    - type: Transform
-      pos: 42.5,18.5
-      parent: 1
-  - uid: 2130
-    components:
-    - type: Transform
-      pos: 43.5,18.5
-      parent: 1
-  - uid: 2131
-    components:
-    - type: Transform
-      pos: 44.5,18.5
-      parent: 1
-  - uid: 2132
-    components:
-    - type: Transform
-      pos: 46.5,18.5
-      parent: 1
-  - uid: 2133
-    components:
-    - type: Transform
-      pos: 45.5,18.5
-      parent: 1
-  - uid: 2134
-    components:
-    - type: Transform
-      pos: 47.5,18.5
-      parent: 1
-  - uid: 2217
-    components:
-    - type: Transform
-      pos: 48.5,18.5
-      parent: 1
-  - uid: 2218
-    components:
-    - type: Transform
-      pos: 48.5,19.5
-      parent: 1
-- proto: WallSnowCobblebrick
-  entities:
-  - uid: 1438
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,2.5
-      parent: 1
-  - uid: 1439
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,1.5
-      parent: 1
-  - uid: 1440
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,0.5
-      parent: 1
-  - uid: 1441
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-0.5
-      parent: 1
-  - uid: 1442
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-1.5
-      parent: 1
-  - uid: 1443
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-2.5
-      parent: 1
-  - uid: 1444
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-3.5
-      parent: 1
-  - uid: 1445
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-4.5
-      parent: 1
-  - uid: 1446
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-5.5
-      parent: 1
-  - uid: 1447
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-6.5
-      parent: 1
-  - uid: 1448
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,-6.5
-      parent: 1
-  - uid: 1449
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,-7.5
-      parent: 1
-  - uid: 1450
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-7.5
-      parent: 1
-  - uid: 1451
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,-8.5
-      parent: 1
-  - uid: 1452
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,-9.5
-      parent: 1
-  - uid: 1453
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-9.5
-      parent: 1
-  - uid: 1454
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-10.5
-      parent: 1
-  - uid: 1455
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-11.5
-      parent: 1
-  - uid: 1456
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-12.5
-      parent: 1
-  - uid: 1457
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-13.5
-      parent: 1
-  - uid: 1458
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-14.5
-      parent: 1
-  - uid: 1459
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-15.5
-      parent: 1
-  - uid: 1460
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-16.5
-      parent: 1
-  - uid: 1461
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-17.5
-      parent: 1
-  - uid: 1462
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-18.5
-      parent: 1
-  - uid: 1463
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-19.5
-      parent: 1
-  - uid: 1464
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,-19.5
-      parent: 1
-  - uid: 1465
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-19.5
-      parent: 1
-  - uid: 1466
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -13.5,-19.5
-      parent: 1
-  - uid: 1467
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -12.5,-19.5
-      parent: 1
-  - uid: 1468
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -11.5,-19.5
-      parent: 1
-  - uid: 1469
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,-19.5
-      parent: 1
-  - uid: 1470
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,-19.5
-      parent: 1
-  - uid: 1471
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -8.5,-19.5
-      parent: 1
-  - uid: 1472
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-19.5
-      parent: 1
-  - uid: 1473
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-19.5
-      parent: 1
-  - uid: 1474
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-20.5
-      parent: 1
-  - uid: 1475
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-21.5
-      parent: 1
-  - uid: 1476
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-22.5
-      parent: 1
-  - uid: 1477
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-23.5
-      parent: 1
-  - uid: 1478
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-23.5
-      parent: 1
-  - uid: 1479
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-23.5
-      parent: 1
-  - uid: 1480
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-23.5
-      parent: 1
-  - uid: 1481
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-23.5
-      parent: 1
-  - uid: 1482
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-23.5
-      parent: 1
-  - uid: 1483
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-23.5
-      parent: 1
-  - uid: 1484
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-23.5
-      parent: 1
-  - uid: 1485
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-23.5
-      parent: 1
-  - uid: 1486
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-23.5
-      parent: 1
-  - uid: 1487
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-23.5
-      parent: 1
-  - uid: 1488
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-23.5
-      parent: 1
-  - uid: 1489
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-23.5
-      parent: 1
-  - uid: 1490
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-23.5
-      parent: 1
-  - uid: 1491
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-23.5
-      parent: 1
-  - uid: 1492
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-23.5
-      parent: 1
-  - uid: 1493
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,-23.5
-      parent: 1
-  - uid: 1494
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,-23.5
-      parent: 1
-  - uid: 1495
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,-23.5
-      parent: 1
-  - uid: 1496
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,-23.5
-      parent: 1
-  - uid: 1497
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,-24.5
-      parent: 1
-  - uid: 1498
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-24.5
-      parent: 1
-  - uid: 1499
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-25.5
-      parent: 1
-  - uid: 1500
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-26.5
-      parent: 1
-  - uid: 1501
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-27.5
-      parent: 1
-  - uid: 1502
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,-27.5
-      parent: 1
-  - uid: 1503
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,-28.5
-      parent: 1
-  - uid: 1504
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,-28.5
-      parent: 1
-  - uid: 1505
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,-28.5
-      parent: 1
-  - uid: 1506
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,-29.5
-      parent: 1
-  - uid: 1507
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,-30.5
-      parent: 1
-  - uid: 1508
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,-31.5
-      parent: 1
-  - uid: 1509
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,-32.5
-      parent: 1
-  - uid: 1510
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 17.5,-32.5
-      parent: 1
-  - uid: 1511
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 17.5,-33.5
-      parent: 1
-  - uid: 1512
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,-33.5
-      parent: 1
-  - uid: 1513
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,-33.5
-      parent: 1
-  - uid: 1514
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 20.5,-33.5
-      parent: 1
-  - uid: 1515
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-33.5
-      parent: 1
-  - uid: 1516
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 22.5,-33.5
-      parent: 1
-  - uid: 1517
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 23.5,-33.5
-      parent: 1
-  - uid: 1518
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 24.5,-32.5
-      parent: 1
-  - uid: 1519
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 24.5,-33.5
-      parent: 1
-  - uid: 1520
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 25.5,-33.5
-      parent: 1
-  - uid: 1521
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 25.5,-34.5
-      parent: 1
-  - uid: 1522
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 26.5,-34.5
-      parent: 1
-  - uid: 1523
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 26.5,-35.5
-      parent: 1
-  - uid: 1524
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 27.5,-35.5
-      parent: 1
-  - uid: 1525
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 28.5,-35.5
-      parent: 1
-  - uid: 1526
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 29.5,-35.5
-      parent: 1
-  - uid: 1527
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 30.5,-35.5
-      parent: 1
-  - uid: 1528
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 31.5,-35.5
-      parent: 1
-  - uid: 1529
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 31.5,-34.5
-      parent: 1
-  - uid: 1530
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 31.5,-33.5
-      parent: 1
-  - uid: 1531
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 31.5,-32.5
-      parent: 1
-  - uid: 1532
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 31.5,-31.5
-      parent: 1
-  - uid: 2135
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 43.5,19.5
-      parent: 1
-  - uid: 2136
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 25.5,19.5
-      parent: 1
-  - uid: 2137
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 26.5,19.5
-      parent: 1
-  - uid: 2138
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 24.5,19.5
-      parent: 1
-  - uid: 2139
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,19.5
-      parent: 1
-  - uid: 2140
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,19.5
-      parent: 1
-  - uid: 2141
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 23.5,19.5
-      parent: 1
-  - uid: 2142
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 20.5,19.5
-      parent: 1
-  - uid: 2143
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 22.5,19.5
-      parent: 1
-  - uid: 2144
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 17.5,19.5
-      parent: 1
-  - uid: 2145
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,19.5
-      parent: 1
-  - uid: 2146
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,19.5
-      parent: 1
-  - uid: 2147
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,19.5
-      parent: 1
-  - uid: 2148
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 45.5,19.5
-      parent: 1
-  - uid: 2149
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 46.5,19.5
-      parent: 1
-  - uid: 2150
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 44.5,19.5
-      parent: 1
-  - uid: 2151
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 42.5,19.5
-      parent: 1
-  - uid: 2152
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 40.5,19.5
-      parent: 1
-  - uid: 2153
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 41.5,19.5
-      parent: 1
-  - uid: 2154
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 38.5,19.5
-      parent: 1
-  - uid: 2155
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 39.5,19.5
-      parent: 1
-  - uid: 2156
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 36.5,19.5
-      parent: 1
-  - uid: 2157
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 37.5,19.5
-      parent: 1
-  - uid: 2158
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 34.5,19.5
-      parent: 1
-  - uid: 2159
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 35.5,19.5
-      parent: 1
-  - uid: 2160
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 32.5,19.5
-      parent: 1
-  - uid: 2161
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 33.5,19.5
-      parent: 1
-  - uid: 2162
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 30.5,19.5
-      parent: 1
-  - uid: 2163
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 31.5,19.5
-      parent: 1
-  - uid: 2164
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 29.5,19.5
-      parent: 1
-  - uid: 2165
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 28.5,19.5
-      parent: 1
-  - uid: 2166
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,18.5
-      parent: 1
-  - uid: 2167
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 27.5,19.5
-      parent: 1
-  - uid: 2168
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,18.5
-      parent: 1
-  - uid: 2169
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,18.5
-      parent: 1
-  - uid: 2170
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,17.5
-      parent: 1
-  - uid: 2171
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,17.5
-      parent: 1
-  - uid: 2172
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,16.5
-      parent: 1
-  - uid: 2173
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,17.5
-      parent: 1
-  - uid: 2174
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,16.5
-      parent: 1
-  - uid: 2175
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,16.5
-      parent: 1
-  - uid: 2176
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,15.5
-      parent: 1
-  - uid: 2177
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,15.5
-      parent: 1
-  - uid: 2178
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,15.5
-      parent: 1
-  - uid: 2179
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,15.5
-      parent: 1
-  - uid: 2180
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,15.5
-      parent: 1
-  - uid: 2181
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,14.5
-      parent: 1
-  - uid: 2182
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,14.5
-      parent: 1
-  - uid: 2183
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,14.5
-      parent: 1
-  - uid: 2184
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,14.5
-      parent: 1
-  - uid: 2185
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,14.5
-      parent: 1
-  - uid: 2186
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,13.5
-      parent: 1
-  - uid: 2187
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,13.5
-      parent: 1
-  - uid: 2188
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,13.5
-      parent: 1
-  - uid: 2189
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,12.5
-      parent: 1
-  - uid: 2190
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,12.5
-      parent: 1
-  - uid: 2191
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,12.5
-      parent: 1
-  - uid: 2192
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,12.5
-      parent: 1
-  - uid: 2193
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,11.5
-      parent: 1
-  - uid: 2194
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,11.5
-      parent: 1
-  - uid: 2195
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,11.5
-      parent: 1
-  - uid: 2196
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,11.5
-      parent: 1
-  - uid: 2197
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,10.5
-      parent: 1
-  - uid: 2198
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,10.5
-      parent: 1
-  - uid: 2199
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,9.5
-      parent: 1
-  - uid: 2200
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -8.5,9.5
-      parent: 1
-  - uid: 2201
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,9.5
-      parent: 1
-  - uid: 2202
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,9.5
-      parent: 1
-  - uid: 2203
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -11.5,9.5
-      parent: 1
-  - uid: 2204
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -11.5,8.5
-      parent: 1
-  - uid: 2205
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -11.5,7.5
-      parent: 1
-  - uid: 2206
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -12.5,7.5
-      parent: 1
-  - uid: 2207
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -13.5,7.5
-      parent: 1
-  - uid: 2208
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,7.5
-      parent: 1
-  - uid: 2209
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,7.5
-      parent: 1
-  - uid: 2210
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,6.5
-      parent: 1
-  - uid: 2211
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,6.5
-      parent: 1
-  - uid: 2212
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,6.5
-      parent: 1
-  - uid: 2213
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,5.5
-      parent: 1
-  - uid: 2214
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,4.5
-      parent: 1
-  - uid: 2215
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,3.5
-      parent: 1
-  - uid: 2216
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,3.5
-      parent: 1
-  - uid: 2219
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 47.5,19.5
-      parent: 1
-  - uid: 2314
-    components:
-    - type: Transform
-      pos: 32.5,-31.5
-      parent: 1
-  - uid: 2315
-    components:
-    - type: Transform
-      pos: 32.5,-30.5
-      parent: 1
-  - uid: 2316
-    components:
-    - type: Transform
-      pos: 32.5,-29.5
-      parent: 1
-  - uid: 2317
-    components:
-    - type: Transform
-      pos: 32.5,-28.5
-      parent: 1
-  - uid: 2318
-    components:
-    - type: Transform
-      pos: 32.5,-27.5
-      parent: 1
-  - uid: 2319
-    components:
-    - type: Transform
-      pos: 32.5,-26.5
-      parent: 1
-  - uid: 2320
-    components:
-    - type: Transform
-      pos: 33.5,-26.5
-      parent: 1
-  - uid: 2321
-    components:
-    - type: Transform
-      pos: 34.5,-26.5
-      parent: 1
-  - uid: 2322
-    components:
-    - type: Transform
-      pos: 34.5,-25.5
-      parent: 1
-  - uid: 2323
-    components:
-    - type: Transform
-      pos: 35.5,-25.5
-      parent: 1
-  - uid: 2324
-    components:
-    - type: Transform
-      pos: 36.5,-25.5
-      parent: 1
-  - uid: 2325
-    components:
-    - type: Transform
-      pos: 36.5,-24.5
-      parent: 1
-  - uid: 2326
-    components:
-    - type: Transform
-      pos: 37.5,-24.5
-      parent: 1
-  - uid: 2327
-    components:
-    - type: Transform
-      pos: 38.5,-24.5
-      parent: 1
-  - uid: 2328
-    components:
-    - type: Transform
-      pos: 39.5,-24.5
-      parent: 1
-  - uid: 2329
-    components:
-    - type: Transform
-      pos: 39.5,-23.5
-      parent: 1
-  - uid: 2330
-    components:
-    - type: Transform
-      pos: 40.5,-23.5
-      parent: 1
-  - uid: 2331
-    components:
-    - type: Transform
-      pos: 40.5,-22.5
-      parent: 1
-  - uid: 2332
-    components:
-    - type: Transform
-      pos: 40.5,-21.5
-      parent: 1
-  - uid: 2333
-    components:
-    - type: Transform
-      pos: 40.5,-20.5
-      parent: 1
-  - uid: 2334
-    components:
-    - type: Transform
-      pos: 40.5,-19.5
-      parent: 1
-  - uid: 2335
-    components:
-    - type: Transform
-      pos: 40.5,-18.5
-      parent: 1
-  - uid: 2336
-    components:
-    - type: Transform
-      pos: 41.5,-18.5
-      parent: 1
-  - uid: 2337
-    components:
-    - type: Transform
-      pos: 42.5,-18.5
-      parent: 1
-  - uid: 2338
-    components:
-    - type: Transform
-      pos: 43.5,-18.5
-      parent: 1
-  - uid: 2339
-    components:
-    - type: Transform
-      pos: 44.5,-18.5
-      parent: 1
-  - uid: 2340
-    components:
-    - type: Transform
-      pos: 45.5,-18.5
-      parent: 1
-- proto: WaterTankFull
-  entities:
-  - uid: 948
-    components:
-    - type: Transform
-      pos: -13.5,-4.5
-      parent: 1
-- proto: WeaponCapacitorRecharger
-  entities:
-  - uid: 1752
-    components:
-    - type: Transform
-      pos: 34.5,-0.5
-      parent: 1
-  - uid: 1802
-    components:
-    - type: Transform
-      pos: 37.5,-8.5
-      parent: 1
-  - uid: 1803
-    components:
-    - type: Transform
-      pos: 38.5,-10.5
-      parent: 1
-- proto: WeaponPistolViper
-  entities:
+      pos: -11.5,-15.5
+      parent: 2
   - uid: 1286
     components:
     - type: Transform
-      pos: 10.786457,-17.450405
-      parent: 1
-- proto: WeaponSprayNozzle
+      pos: -11.5,-16.5
+      parent: 2
+  - uid: 1287
+    components:
+    - type: Transform
+      pos: -8.5,-16.5
+      parent: 2
+  - uid: 1288
+    components:
+    - type: Transform
+      pos: -1.5,-18.5
+      parent: 2
+  - uid: 1289
+    components:
+    - type: Transform
+      pos: -3.5,-18.5
+      parent: 2
+  - uid: 1290
+    components:
+    - type: Transform
+      pos: 13.5,-11.5
+      parent: 2
+  - uid: 1291
+    components:
+    - type: Transform
+      pos: 13.5,-12.5
+      parent: 2
+  - uid: 1292
+    components:
+    - type: Transform
+      pos: 13.5,-14.5
+      parent: 2
+  - uid: 1293
+    components:
+    - type: Transform
+      pos: 13.5,-15.5
+      parent: 2
+  - uid: 1294
+    components:
+    - type: Transform
+      pos: 8.5,-17.5
+      parent: 2
+  - uid: 1295
+    components:
+    - type: Transform
+      pos: 7.5,-17.5
+      parent: 2
+  - uid: 1296
+    components:
+    - type: Transform
+      pos: 6.5,-17.5
+      parent: 2
+  - uid: 1297
+    components:
+    - type: Transform
+      pos: 14.5,-3.5
+      parent: 2
+  - uid: 1298
+    components:
+    - type: Transform
+      pos: 15.5,-3.5
+      parent: 2
+  - uid: 1299
+    components:
+    - type: Transform
+      pos: 16.5,-3.5
+      parent: 2
+  - uid: 1300
+    components:
+    - type: Transform
+      pos: 17.5,-3.5
+      parent: 2
+  - uid: 1301
+    components:
+    - type: Transform
+      pos: 18.5,-3.5
+      parent: 2
+  - uid: 1302
+    components:
+    - type: Transform
+      pos: 19.5,-3.5
+      parent: 2
+  - uid: 1303
+    components:
+    - type: Transform
+      pos: 20.5,-3.5
+      parent: 2
+  - uid: 1304
+    components:
+    - type: Transform
+      pos: 21.5,-3.5
+      parent: 2
+  - uid: 1305
+    components:
+    - type: Transform
+      pos: 22.5,-3.5
+      parent: 2
+  - uid: 1306
+    components:
+    - type: Transform
+      pos: 23.5,-3.5
+      parent: 2
+  - uid: 1307
+    components:
+    - type: Transform
+      pos: 24.5,-3.5
+      parent: 2
+  - uid: 1308
+    components:
+    - type: Transform
+      pos: 25.5,-3.5
+      parent: 2
+  - uid: 1309
+    components:
+    - type: Transform
+      pos: 25.5,-8.5
+      parent: 2
+  - uid: 1310
+    components:
+    - type: Transform
+      pos: 24.5,-8.5
+      parent: 2
+  - uid: 1311
+    components:
+    - type: Transform
+      pos: 23.5,-8.5
+      parent: 2
+  - uid: 1312
+    components:
+    - type: Transform
+      pos: 22.5,-8.5
+      parent: 2
+  - uid: 1313
+    components:
+    - type: Transform
+      pos: 21.5,-8.5
+      parent: 2
+  - uid: 1314
+    components:
+    - type: Transform
+      pos: 20.5,-8.5
+      parent: 2
+  - uid: 1315
+    components:
+    - type: Transform
+      pos: 19.5,-8.5
+      parent: 2
+  - uid: 1316
+    components:
+    - type: Transform
+      pos: 18.5,-8.5
+      parent: 2
+  - uid: 1317
+    components:
+    - type: Transform
+      pos: 17.5,-8.5
+      parent: 2
+  - uid: 1318
+    components:
+    - type: Transform
+      pos: 16.5,-8.5
+      parent: 2
+  - uid: 1319
+    components:
+    - type: Transform
+      pos: 15.5,-8.5
+      parent: 2
+  - uid: 1320
+    components:
+    - type: Transform
+      pos: 14.5,-8.5
+      parent: 2
+  - uid: 1321
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 34.5,-17.5
+      parent: 2
+  - uid: 1322
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 34.5,-16.5
+      parent: 2
+  - uid: 1323
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 33.5,-17.5
+      parent: 2
+  - uid: 1324
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 32.5,-17.5
+      parent: 2
+  - uid: 1325
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 31.5,-17.5
+      parent: 2
+  - uid: 1326
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 31.5,-19.5
+      parent: 2
+  - uid: 1327
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 32.5,-19.5
+      parent: 2
+  - uid: 1328
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 33.5,-19.5
+      parent: 2
+  - uid: 1329
+    components:
+    - type: Transform
+      pos: 47.5,-3.5
+      parent: 2
+  - uid: 1330
+    components:
+    - type: Transform
+      pos: 46.5,-3.5
+      parent: 2
+  - uid: 1331
+    components:
+    - type: Transform
+      pos: 45.5,-3.5
+      parent: 2
+  - uid: 1332
+    components:
+    - type: Transform
+      pos: 44.5,-3.5
+      parent: 2
+  - uid: 1333
+    components:
+    - type: Transform
+      pos: 43.5,-3.5
+      parent: 2
+  - uid: 1334
+    components:
+    - type: Transform
+      pos: 42.5,-3.5
+      parent: 2
+  - uid: 1335
+    components:
+    - type: Transform
+      pos: 41.5,-3.5
+      parent: 2
+  - uid: 1336
+    components:
+    - type: Transform
+      pos: 41.5,-5.5
+      parent: 2
+  - uid: 1337
+    components:
+    - type: Transform
+      pos: 42.5,-5.5
+      parent: 2
+  - uid: 1338
+    components:
+    - type: Transform
+      pos: 43.5,-5.5
+      parent: 2
+  - uid: 1339
+    components:
+    - type: Transform
+      pos: 44.5,-5.5
+      parent: 2
+  - uid: 1340
+    components:
+    - type: Transform
+      pos: 45.5,-5.5
+      parent: 2
+  - uid: 1341
+    components:
+    - type: Transform
+      pos: 46.5,-5.5
+      parent: 2
+  - uid: 1342
+    components:
+    - type: Transform
+      pos: 47.5,-5.5
+      parent: 2
+  - uid: 1343
+    components:
+    - type: Transform
+      pos: 43.5,-7.5
+      parent: 2
+  - uid: 1344
+    components:
+    - type: Transform
+      pos: 44.5,-7.5
+      parent: 2
+  - uid: 1345
+    components:
+    - type: Transform
+      pos: 44.5,-8.5
+      parent: 2
+  - uid: 1346
+    components:
+    - type: Transform
+      pos: 44.5,-9.5
+      parent: 2
+  - uid: 1347
+    components:
+    - type: Transform
+      pos: 44.5,-10.5
+      parent: 2
+  - uid: 1348
+    components:
+    - type: Transform
+      pos: 44.5,-11.5
+      parent: 2
+  - uid: 1349
+    components:
+    - type: Transform
+      pos: 43.5,-11.5
+      parent: 2
+  - uid: 1350
+    components:
+    - type: Transform
+      pos: 40.5,-1.5
+      parent: 2
+  - uid: 1351
+    components:
+    - type: Transform
+      pos: 38.5,-1.5
+      parent: 2
+  - uid: 1352
+    components:
+    - type: Transform
+      pos: 36.5,-4.5
+      parent: 2
+  - uid: 1353
+    components:
+    - type: Transform
+      pos: 35.5,-4.5
+      parent: 2
+  - uid: 1354
+    components:
+    - type: Transform
+      pos: 27.5,-0.5
+      parent: 2
+  - uid: 1355
+    components:
+    - type: Transform
+      pos: 27.5,0.5
+      parent: 2
+  - uid: 1356
+    components:
+    - type: Transform
+      pos: 27.5,1.5
+      parent: 2
+  - uid: 1357
+    components:
+    - type: Transform
+      pos: 27.5,2.5
+      parent: 2
+  - uid: 1358
+    components:
+    - type: Transform
+      pos: 30.5,2.5
+      parent: 2
+  - uid: 1359
+    components:
+    - type: Transform
+      pos: 30.5,-0.5
+      parent: 2
+  - uid: 1360
+    components:
+    - type: Transform
+      pos: 31.5,4.5
+      parent: 2
+- proto: SheetPlasma10
   entities:
-  - uid: 950
+  - uid: 1361
     components:
     - type: Transform
-      pos: 11.883067,-9.275236
-      parent: 1
-- proto: WeldingFuelTankFull
+      pos: -12.387239,-11.251213
+      parent: 2
+- proto: SheetPlasteel
   entities:
-  - uid: 949
+  - uid: 1362
     components:
     - type: Transform
-      pos: -11.5,0.5
-      parent: 1
-- proto: Windoor
+      pos: -12.475805,0.52586746
+      parent: 2
+- proto: SheetSteel
   entities:
-  - uid: 500
+  - uid: 1363
     components:
     - type: Transform
-      pos: 4.5,-14.5
-      parent: 1
-  - uid: 820
+      pos: -12.569555,0.43211746
+      parent: 2
+- proto: ShuttersNormal
+  entities:
+  - uid: 1364
     components:
     - type: Transform
-      pos: -2.5,-1.5
-      parent: 1
-  - uid: 1815
+      pos: 31.5,-7.5
+      parent: 2
+  - uid: 1365
+    components:
+    - type: Transform
+      pos: 30.5,-7.5
+      parent: 2
+  - uid: 1366
+    components:
+    - type: Transform
+      pos: 27.5,4.5
+      parent: 2
+  - uid: 1367
+    components:
+    - type: Transform
+      pos: 28.5,4.5
+      parent: 2
+  - uid: 1368
+    components:
+    - type: Transform
+      pos: 29.5,4.5
+      parent: 2
+  - uid: 1369
+    components:
+    - type: Transform
+      pos: 32.5,4.5
+      parent: 2
+  - uid: 1370
+    components:
+    - type: Transform
+      pos: 33.5,4.5
+      parent: 2
+- proto: SignalButton
+  entities:
+  - uid: 1371
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-18.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        94:
+        - Pressed: Toggle
+        95:
+        - Pressed: Toggle
+- proto: SignalTrigger
+  entities:
+  - uid: 1372
+    components:
+    - type: Transform
+      pos: -13.64159,-2.6691022
+      parent: 2
+  - uid: 1373
+    components:
+    - type: Transform
+      pos: -13.64159,-2.2941022
+      parent: 2
+  - uid: 1374
+    components:
+    - type: Transform
+      pos: -13.188465,-2.4191022
+      parent: 2
+- proto: SignArmory
+  entities:
+  - uid: 1375
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 38.5,-1.5
+      parent: 2
+- proto: SignAtmos
+  entities:
+  - uid: 1376
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-9.5
+      parent: 2
+- proto: SignBar
+  entities:
+  - uid: 1377
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-3.5
+      parent: 2
+- proto: SignChem
+  entities:
+  - uid: 1378
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-5.5
+      parent: 2
+- proto: SignDirectionalBridge
+  entities:
+  - uid: 1379
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-8.2
+      parent: 2
+- proto: SignDirectionalEng
+  entities:
+  - uid: 1380
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-5.2
+      parent: 2
+- proto: SignDirectionalEvac
+  entities:
+  - uid: 1381
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-8.4
+      parent: 2
+- proto: SignDirectionalMed
+  entities:
+  - uid: 1382
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-5.4
+      parent: 2
+- proto: SignDirectionalSci
+  entities:
+  - uid: 1383
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-5.6
+      parent: 2
+- proto: SignDirectionalSec
+  entities:
+  - uid: 1384
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-8.6
+      parent: 2
+- proto: SignGravity
+  entities:
+  - uid: 1385
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 33.5,-7.5
+      parent: 2
+- proto: SignJanitor
+  entities:
+  - uid: 1386
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-8.5
+      parent: 2
+- proto: SignXenobio
+  entities:
+  - uid: 1387
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-9.5
+      parent: 2
+- proto: SinkWide
+  entities:
+  - uid: 1388
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 2
+  - uid: 1389
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-14.5
+      parent: 2
+  - uid: 1390
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 2
+  - uid: 1391
+    components:
+    - type: Transform
+      pos: 6.5,-11.5
+      parent: 2
+- proto: SmallLight
+  entities:
+  - uid: 1392
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,-16.5
+      parent: 2
+  - uid: 1393
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-16.5
+      parent: 2
+  - uid: 1394
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 26.5,-17.5
+      parent: 2
+  - uid: 1395
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 27.5,-18.5
+      parent: 2
+  - uid: 1396
+    components:
+    - type: Transform
+      pos: 26.5,-19.5
+      parent: 2
+  - uid: 1397
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-18.5
+      parent: 2
+  - uid: 1398
+    components:
+    - type: Transform
+      pos: 28.5,-11.5
+      parent: 2
+  - uid: 1399
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-20.5
+      parent: 2
+  - uid: 1400
+    components:
+    - type: Transform
+      pos: 44.5,-4.5
+      parent: 2
+  - uid: 1401
+    components:
+    - type: Transform
+      pos: 0.5,-19.5
+      parent: 2
+  - uid: 1402
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-20.5
+      parent: 2
+  - uid: 1403
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-16.5
+      parent: 2
+- proto: SoapSyndie
+  entities:
+  - uid: 1404
+    components:
+    - type: Transform
+      pos: 3.5,-15.5
+      parent: 2
+- proto: SodaDispenser
+  entities:
+  - uid: 1405
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-2.5
+      parent: 2
+- proto: SpaceCash100
+  entities:
+  - uid: 1406
+    components:
+    - type: Transform
+      pos: 36.5,-10.5
+      parent: 2
+- proto: SpaceCash1000
+  entities:
+  - uid: 1407
+    components:
+    - type: Transform
+      pos: 38.5,-8.5
+      parent: 2
+- proto: SpawnMobCatKitten
+  entities:
+  - uid: 1408
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 2
+- proto: SpawnPointNukies
+  entities:
+  - uid: 1409
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 2
+  - uid: 1410
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 2
+  - uid: 1411
+    components:
+    - type: Transform
+      pos: 12.5,-0.5
+      parent: 2
+  - uid: 1412
+    components:
+    - type: Transform
+      pos: 11.5,-2.5
+      parent: 2
+  - uid: 1413
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 2
+- proto: StairDark
+  entities:
+  - uid: 1414
+    components:
+    - type: Transform
+      pos: 27.5,-9.5
+      parent: 2
+  - uid: 1415
+    components:
+    - type: Transform
+      pos: 27.5,-8.5
+      parent: 2
+- proto: Stool
+  entities:
+  - uid: 1416
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-2.5
+      parent: 2
+  - uid: 1417
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-2.5
+      parent: 2
+  - uid: 1418
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-1.5
+      parent: 2
+  - uid: 1419
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-0.5
+      parent: 2
+  - uid: 1420
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 2
+  - uid: 1421
+    components:
+    - type: Transform
+      pos: 11.5,0.5
+      parent: 2
+  - uid: 1422
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-0.5
+      parent: 2
+  - uid: 1423
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-1.5
+      parent: 2
+- proto: StoolBar
+  entities:
+  - uid: 1424
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 2
+  - uid: 1425
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 2
+  - uid: 1426
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-2.5
+      parent: 2
+- proto: StorageCanister
+  entities:
+  - uid: 1427
+    components:
+    - type: Transform
+      pos: 0.5,-14.5
+      parent: 2
+  - uid: 1428
+    components:
+    - type: Transform
+      pos: 1.5,-14.5
+      parent: 2
+- proto: SubstationBasic
+  entities:
+  - uid: 1429
+    components:
+    - type: Transform
+      pos: 36.5,-2.5
+      parent: 2
+- proto: SyndicateComputerComms
+  entities:
+  - uid: 1430
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 43.5,-9.5
+      parent: 2
+- proto: SyndicateMicrowave
+  entities:
+  - uid: 1431
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+- proto: SyndicatePersonalAI
+  entities:
+  - uid: 1432
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 2
+- proto: SyndicateSpongeBox
+  entities:
+  - uid: 1433
+    components:
+    - type: Transform
+      pos: -9.418489,-10.329338
+      parent: 2
+- proto: SyringeDermaline
+  entities:
+  - uid: 1434
+    components:
+    - type: Transform
+      pos: -1.3631997,-1.2615409
+      parent: 2
+- proto: SyringeEthylredoxrazine
+  entities:
+  - uid: 1435
+    components:
+    - type: Transform
+      pos: -1.6288247,-1.2459159
+      parent: 2
+- proto: SyringeTranexamicAcid
+  entities:
+  - uid: 1436
+    components:
+    - type: Transform
+      pos: -1.4413247,-1.0896659
+      parent: 2
+- proto: Table
+  entities:
+  - uid: 1437
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,4.5
+      parent: 2
+  - uid: 1438
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 2
+- proto: TableCounterMetal
+  entities:
+  - uid: 1439
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,1.5
-      parent: 1
-  - uid: 1816
+      parent: 2
+  - uid: 1440
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 30.5,0.5
-      parent: 1
+      parent: 2
+- proto: TablePlasmaGlass
+  entities:
+  - uid: 1441
+    components:
+    - type: Transform
+      pos: -7.5,0.5
+      parent: 2
+  - uid: 1442
+    components:
+    - type: Transform
+      pos: -11.5,-10.5
+      parent: 2
+  - uid: 1443
+    components:
+    - type: Transform
+      pos: -12.5,-10.5
+      parent: 2
+  - uid: 1444
+    components:
+    - type: Transform
+      pos: -12.5,-11.5
+      parent: 2
+  - uid: 1445
+    components:
+    - type: Transform
+      pos: -9.5,-10.5
+      parent: 2
+  - uid: 1446
+    components:
+    - type: Transform
+      pos: -13.5,-0.5
+      parent: 2
+  - uid: 1447
+    components:
+    - type: Transform
+      pos: -13.5,-1.5
+      parent: 2
+  - uid: 1448
+    components:
+    - type: Transform
+      pos: -13.5,-2.5
+      parent: 2
+  - uid: 1449
+    components:
+    - type: Transform
+      pos: -13.5,-3.5
+      parent: 2
+  - uid: 1450
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 2
+  - uid: 1451
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 2
+  - uid: 1452
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 2
+  - uid: 1453
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 2
+  - uid: 1454
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 2
+  - uid: 1455
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 2
+  - uid: 1456
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 2
+- proto: TableReinforced
+  entities:
+  - uid: 1457
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 1458
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+  - uid: 1459
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 1460
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-14.5
+      parent: 2
+  - uid: 1461
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-14.5
+      parent: 2
+  - uid: 1462
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 2
+  - uid: 1463
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 2
+  - uid: 1464
+    components:
+    - type: Transform
+      pos: 34.5,-0.5
+      parent: 2
+  - uid: 1465
+    components:
+    - type: Transform
+      pos: 34.5,0.5
+      parent: 2
+  - uid: 1466
+    components:
+    - type: Transform
+      pos: 31.5,3.5
+      parent: 2
+  - uid: 1467
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 39.5,-8.5
+      parent: 2
+  - uid: 1468
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 38.5,-8.5
+      parent: 2
+  - uid: 1469
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 37.5,-8.5
+      parent: 2
+  - uid: 1470
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 36.5,-8.5
+      parent: 2
+  - uid: 1471
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 36.5,-10.5
+      parent: 2
+  - uid: 1472
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 37.5,-10.5
+      parent: 2
+  - uid: 1473
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 38.5,-10.5
+      parent: 2
+  - uid: 1474
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 39.5,-10.5
+      parent: 2
+  - uid: 1475
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 39.5,-9.5
+      parent: 2
+  - uid: 1476
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 36.5,-9.5
+      parent: 2
+  - uid: 1477
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 41.5,-8.5
+      parent: 2
+  - uid: 1478
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 41.5,-9.5
+      parent: 2
+  - uid: 1479
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 41.5,-10.5
+      parent: 2
+- proto: TableWood
+  entities:
+  - uid: 1480
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 2
+  - uid: 1481
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 2
+  - uid: 1482
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 2
+  - uid: 1483
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 2
+  - uid: 1484
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 1485
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 2
+  - uid: 1486
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 2
+  - uid: 1487
+    components:
+    - type: Transform
+      pos: 11.5,-0.5
+      parent: 2
+  - uid: 1488
+    components:
+    - type: Transform
+      pos: 11.5,-1.5
+      parent: 2
+  - uid: 1489
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-15.5
+      parent: 2
+  - uid: 1490
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-16.5
+      parent: 2
+  - uid: 1491
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-14.5
+      parent: 2
+- proto: TimerTrigger
+  entities:
+  - uid: 1492
+    components:
+    - type: Transform
+      pos: -13.67284,-3.5597272
+      parent: 2
+  - uid: 1493
+    components:
+    - type: Transform
+      pos: -13.67284,-3.4034772
+      parent: 2
+  - uid: 1494
+    components:
+    - type: Transform
+      pos: -13.657215,-3.0909772
+      parent: 2
+- proto: ToiletEmpty
+  entities:
+  - uid: 1495
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-14.5
+      parent: 2
+  - uid: 1496
+    components:
+    - type: Transform
+      pos: 3.5,-12.5
+      parent: 2
+    - type: Toilet
+      toggleSeat: True
+- proto: ToyFigurineNukie
+  entities:
+  - uid: 1497
+    components:
+    - type: Transform
+      pos: 28.46877,-29.659956
+      parent: 2
+  - uid: 1498
+    components:
+    - type: Transform
+      pos: 29.453144,-30.503706
+      parent: 2
+  - uid: 1499
+    components:
+    - type: Transform
+      pos: 28.46877,-31.519331
+      parent: 2
+  - uid: 1500
+    components:
+    - type: Transform
+      pos: 27.609394,-30.456831
+      parent: 2
+- proto: ToyNuke
+  entities:
+  - uid: 1501
+    components:
+    - type: Transform
+      pos: 28.515644,-30.613081
+      parent: 2
+- proto: VendingMachineBooze
+  entities:
+  - uid: 1502
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 2
+- proto: VendingMachineChemicalsSyndicate
+  entities:
+  - uid: 1503
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 2
+- proto: VendingMachineCigs
+  entities:
+  - uid: 1504
+    components:
+    - type: Transform
+      pos: 12.5,2.5
+      parent: 2
+  - uid: 1505
+    components:
+    - type: Transform
+      pos: 33.5,-2.5
+      parent: 2
+- proto: VendingMachineClothing
+  entities:
+  - uid: 1506
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 2
+- proto: VendingMachineDinnerware
+  entities:
+  - uid: 1507
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 2
+- proto: VendingMachineEngivend
+  entities:
+  - uid: 1508
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 2
+- proto: VendingMachineNutri
+  entities:
+  - uid: 1509
+    components:
+    - type: Transform
+      pos: -9.5,-13.5
+      parent: 2
+- proto: VendingMachineRestockChefvend
+  entities:
+  - uid: 1510
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 2
+- proto: VendingMachineSeeds
+  entities:
+  - uid: 1511
+    components:
+    - type: Transform
+      pos: -11.5,-13.5
+      parent: 2
+- proto: VendingMachineSnackTeal
+  entities:
+  - uid: 1512
+    components:
+    - type: Transform
+      pos: 33.5,-3.5
+      parent: 2
+- proto: VendingMachineYouTool
+  entities:
+  - uid: 1513
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 2
+  - uid: 1514
+    components:
+    - type: Transform
+      pos: 35.5,-2.5
+      parent: 2
+- proto: WallPlastitanium
+  entities:
+  - uid: 1515
+    components:
+    - type: Transform
+      pos: 13.5,1.5
+      parent: 2
+  - uid: 1516
+    components:
+    - type: Transform
+      pos: 14.5,1.5
+      parent: 2
+  - uid: 1517
+    components:
+    - type: Transform
+      pos: 14.5,2.5
+      parent: 2
+  - uid: 1518
+    components:
+    - type: Transform
+      pos: 13.5,-3.5
+      parent: 2
+  - uid: 1519
+    components:
+    - type: Transform
+      pos: 12.5,-3.5
+      parent: 2
+  - uid: 1520
+    components:
+    - type: Transform
+      pos: 11.5,-3.5
+      parent: 2
+  - uid: 1521
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 2
+  - uid: 1522
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 2
+  - uid: 1523
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 2
+  - uid: 1524
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 2
+  - uid: 1525
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 2
+  - uid: 1526
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 2
+  - uid: 1527
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 2
+  - uid: 1528
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 2
+  - uid: 1529
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 2
+  - uid: 1530
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 2
+  - uid: 1531
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 2
+  - uid: 1532
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 2
+  - uid: 1533
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 2
+  - uid: 1534
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 2
+  - uid: 1535
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+  - uid: 1536
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+  - uid: 1537
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 1538
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 2
+  - uid: 1539
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 2
+  - uid: 1540
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 2
+  - uid: 1541
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 2
+  - uid: 1542
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 2
+  - uid: 1543
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 1544
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 2
+  - uid: 1545
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 2
+  - uid: 1546
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 2
+  - uid: 1547
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 2
+  - uid: 1548
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 2
+  - uid: 1549
+    components:
+    - type: Transform
+      pos: 10.5,1.5
+      parent: 2
+  - uid: 1550
+    components:
+    - type: Transform
+      pos: 11.5,1.5
+      parent: 2
+  - uid: 1551
+    components:
+    - type: Transform
+      pos: 12.5,1.5
+      parent: 2
+  - uid: 1552
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 2
+  - uid: 1553
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-4.5
+      parent: 2
+  - uid: 1554
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-4.5
+      parent: 2
+  - uid: 1555
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-7.5
+      parent: 2
+  - uid: 1556
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-8.5
+      parent: 2
+  - uid: 1557
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-8.5
+      parent: 2
+  - uid: 1558
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-8.5
+      parent: 2
+  - uid: 1559
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-8.5
+      parent: 2
+  - uid: 1560
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-9.5
+      parent: 2
+  - uid: 1561
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-10.5
+      parent: 2
+  - uid: 1562
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-10.5
+      parent: 2
+  - uid: 1563
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-10.5
+      parent: 2
+  - uid: 1564
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-10.5
+      parent: 2
+  - uid: 1565
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-10.5
+      parent: 2
+  - uid: 1566
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-9.5
+      parent: 2
+  - uid: 1567
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-10.5
+      parent: 2
+  - uid: 1568
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-7.5
+      parent: 2
+  - uid: 1569
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-10.5
+      parent: 2
+  - uid: 1570
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-10.5
+      parent: 2
+  - uid: 1571
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-10.5
+      parent: 2
+  - uid: 1572
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-9.5
+      parent: 2
+  - uid: 1573
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-9.5
+      parent: 2
+  - uid: 1574
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-8.5
+      parent: 2
+  - uid: 1575
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 2
+  - uid: 1576
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 2
+  - uid: 1577
+    components:
+    - type: Transform
+      pos: -4.5,-9.5
+      parent: 2
+  - uid: 1578
+    components:
+    - type: Transform
+      pos: -5.5,-9.5
+      parent: 2
+  - uid: 1579
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 2
+  - uid: 1580
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 2
+  - uid: 1581
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 2
+  - uid: 1582
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 2
+  - uid: 1583
+    components:
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 2
+  - uid: 1584
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 2
+  - uid: 1585
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 2
+  - uid: 1586
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 2
+  - uid: 1587
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 2
+  - uid: 1588
+    components:
+    - type: Transform
+      pos: -9.5,-5.5
+      parent: 2
+  - uid: 1589
+    components:
+    - type: Transform
+      pos: -9.5,-6.5
+      parent: 2
+  - uid: 1590
+    components:
+    - type: Transform
+      pos: -9.5,-8.5
+      parent: 2
+  - uid: 1591
+    components:
+    - type: Transform
+      pos: -9.5,-9.5
+      parent: 2
+  - uid: 1592
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 2
+  - uid: 1593
+    components:
+    - type: Transform
+      pos: -11.5,-5.5
+      parent: 2
+  - uid: 1594
+    components:
+    - type: Transform
+      pos: -12.5,-5.5
+      parent: 2
+  - uid: 1595
+    components:
+    - type: Transform
+      pos: -10.5,-9.5
+      parent: 2
+  - uid: 1596
+    components:
+    - type: Transform
+      pos: -11.5,-9.5
+      parent: 2
+  - uid: 1597
+    components:
+    - type: Transform
+      pos: -12.5,-9.5
+      parent: 2
+  - uid: 1598
+    components:
+    - type: Transform
+      pos: -12.5,-8.5
+      parent: 2
+  - uid: 1599
+    components:
+    - type: Transform
+      pos: -12.5,-7.5
+      parent: 2
+  - uid: 1600
+    components:
+    - type: Transform
+      pos: -12.5,-6.5
+      parent: 2
+  - uid: 1601
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 2
+  - uid: 1602
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 2
+  - uid: 1603
+    components:
+    - type: Transform
+      pos: -5.5,-12.5
+      parent: 2
+  - uid: 1604
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 2
+  - uid: 1605
+    components:
+    - type: Transform
+      pos: -5.5,-14.5
+      parent: 2
+  - uid: 1606
+    components:
+    - type: Transform
+      pos: -5.5,-15.5
+      parent: 2
+  - uid: 1607
+    components:
+    - type: Transform
+      pos: -5.5,-16.5
+      parent: 2
+  - uid: 1608
+    components:
+    - type: Transform
+      pos: -5.5,-17.5
+      parent: 2
+  - uid: 1609
+    components:
+    - type: Transform
+      pos: -6.5,-17.5
+      parent: 2
+  - uid: 1610
+    components:
+    - type: Transform
+      pos: -7.5,-17.5
+      parent: 2
+  - uid: 1611
+    components:
+    - type: Transform
+      pos: -8.5,-17.5
+      parent: 2
+  - uid: 1612
+    components:
+    - type: Transform
+      pos: -9.5,-17.5
+      parent: 2
+  - uid: 1613
+    components:
+    - type: Transform
+      pos: -10.5,-17.5
+      parent: 2
+  - uid: 1614
+    components:
+    - type: Transform
+      pos: -11.5,-17.5
+      parent: 2
+  - uid: 1615
+    components:
+    - type: Transform
+      pos: -12.5,-17.5
+      parent: 2
+  - uid: 1616
+    components:
+    - type: Transform
+      pos: -13.5,-17.5
+      parent: 2
+  - uid: 1617
+    components:
+    - type: Transform
+      pos: -14.5,-17.5
+      parent: 2
+  - uid: 1618
+    components:
+    - type: Transform
+      pos: -13.5,-14.5
+      parent: 2
+  - uid: 1619
+    components:
+    - type: Transform
+      pos: -13.5,-13.5
+      parent: 2
+  - uid: 1620
+    components:
+    - type: Transform
+      pos: -14.5,-16.5
+      parent: 2
+  - uid: 1621
+    components:
+    - type: Transform
+      pos: -14.5,-15.5
+      parent: 2
+  - uid: 1622
+    components:
+    - type: Transform
+      pos: -14.5,-14.5
+      parent: 2
+  - uid: 1623
+    components:
+    - type: Transform
+      pos: -14.5,-13.5
+      parent: 2
+  - uid: 1624
+    components:
+    - type: Transform
+      pos: -14.5,-12.5
+      parent: 2
+  - uid: 1625
+    components:
+    - type: Transform
+      pos: -14.5,-11.5
+      parent: 2
+  - uid: 1626
+    components:
+    - type: Transform
+      pos: -13.5,-11.5
+      parent: 2
+  - uid: 1627
+    components:
+    - type: Transform
+      pos: -13.5,-10.5
+      parent: 2
+  - uid: 1628
+    components:
+    - type: Transform
+      pos: -13.5,-9.5
+      parent: 2
+  - uid: 1629
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
+  - uid: 1630
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 1631
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 2
+  - uid: 1632
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 2
+  - uid: 1633
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-0.5
+      parent: 2
+  - uid: 1634
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-1.5
+      parent: 2
+  - uid: 1635
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-2.5
+      parent: 2
+  - uid: 1636
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-3.5
+      parent: 2
+  - uid: 1637
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 2
+  - uid: 1638
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 2
+  - uid: 1639
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 1640
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,1.5
+      parent: 2
+  - uid: 1641
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,1.5
+      parent: 2
+  - uid: 1642
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,1.5
+      parent: 2
+  - uid: 1643
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,1.5
+      parent: 2
+  - uid: 1644
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -14.5,-1.5
+      parent: 2
+  - uid: 1645
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -14.5,-3.5
+      parent: 2
+  - uid: 1646
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,0.5
+      parent: 2
+  - uid: 1647
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -14.5,-4.5
+      parent: 2
+  - uid: 1648
+    components:
+    - type: Transform
+      pos: -13.5,-5.5
+      parent: 2
+  - uid: 1649
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,1.5
+      parent: 2
+  - uid: 1650
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,1.5
+      parent: 2
+  - uid: 1651
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,1.5
+      parent: 2
+  - uid: 1652
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,1.5
+      parent: 2
+  - uid: 1653
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -14.5,-0.5
+      parent: 2
+  - uid: 1654
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -14.5,-2.5
+      parent: 2
+  - uid: 1655
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -14.5,0.5
+      parent: 2
+  - uid: 1656
+    components:
+    - type: Transform
+      pos: -2.5,-18.5
+      parent: 2
+  - uid: 1657
+    components:
+    - type: Transform
+      pos: -0.5,-18.5
+      parent: 2
+  - uid: 1658
+    components:
+    - type: Transform
+      pos: -0.5,-21.5
+      parent: 2
+  - uid: 1659
+    components:
+    - type: Transform
+      pos: -1.5,-21.5
+      parent: 2
+  - uid: 1660
+    components:
+    - type: Transform
+      pos: -2.5,-21.5
+      parent: 2
+  - uid: 1661
+    components:
+    - type: Transform
+      pos: -3.5,-21.5
+      parent: 2
+  - uid: 1662
+    components:
+    - type: Transform
+      pos: -4.5,-21.5
+      parent: 2
+  - uid: 1663
+    components:
+    - type: Transform
+      pos: -4.5,-20.5
+      parent: 2
+  - uid: 1664
+    components:
+    - type: Transform
+      pos: -4.5,-19.5
+      parent: 2
+  - uid: 1665
+    components:
+    - type: Transform
+      pos: -4.5,-18.5
+      parent: 2
+  - uid: 1666
+    components:
+    - type: Transform
+      pos: -4.5,-17.5
+      parent: 2
+  - uid: 1667
+    components:
+    - type: Transform
+      pos: 0.5,-21.5
+      parent: 2
+  - uid: 1668
+    components:
+    - type: Transform
+      pos: 0.5,-18.5
+      parent: 2
+  - uid: 1669
+    components:
+    - type: Transform
+      pos: 1.5,-18.5
+      parent: 2
+  - uid: 1670
+    components:
+    - type: Transform
+      pos: 1.5,-19.5
+      parent: 2
+  - uid: 1671
+    components:
+    - type: Transform
+      pos: 1.5,-20.5
+      parent: 2
+  - uid: 1672
+    components:
+    - type: Transform
+      pos: 1.5,-21.5
+      parent: 2
+  - uid: 1673
+    components:
+    - type: Transform
+      pos: 2.5,-18.5
+      parent: 2
+  - uid: 1674
+    components:
+    - type: Transform
+      pos: 2.5,-21.5
+      parent: 2
+  - uid: 1675
+    components:
+    - type: Transform
+      pos: 3.5,-18.5
+      parent: 2
+  - uid: 1676
+    components:
+    - type: Transform
+      pos: 3.5,-19.5
+      parent: 2
+  - uid: 1677
+    components:
+    - type: Transform
+      pos: 3.5,-20.5
+      parent: 2
+  - uid: 1678
+    components:
+    - type: Transform
+      pos: 3.5,-21.5
+      parent: 2
+  - uid: 1679
+    components:
+    - type: Transform
+      pos: 2.5,-17.5
+      parent: 2
+  - uid: 1680
+    components:
+    - type: Transform
+      pos: 3.5,-17.5
+      parent: 2
+  - uid: 1681
+    components:
+    - type: Transform
+      pos: 4.5,-17.5
+      parent: 2
+  - uid: 1682
+    components:
+    - type: Transform
+      pos: 5.5,-17.5
+      parent: 2
+  - uid: 1683
+    components:
+    - type: Transform
+      pos: 2.5,-16.5
+      parent: 2
+  - uid: 1684
+    components:
+    - type: Transform
+      pos: 2.5,-15.5
+      parent: 2
+  - uid: 1685
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 2
+  - uid: 1686
+    components:
+    - type: Transform
+      pos: 2.5,-13.5
+      parent: 2
+  - uid: 1687
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 2
+  - uid: 1688
+    components:
+    - type: Transform
+      pos: 2.5,-11.5
+      parent: 2
+  - uid: 1689
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 2
+  - uid: 1690
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 2
+  - uid: 1691
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 2
+  - uid: 1692
+    components:
+    - type: Transform
+      pos: 3.5,-11.5
+      parent: 2
+  - uid: 1693
+    components:
+    - type: Transform
+      pos: 5.5,-13.5
+      parent: 2
+  - uid: 1694
+    components:
+    - type: Transform
+      pos: 5.5,-14.5
+      parent: 2
+  - uid: 1695
+    components:
+    - type: Transform
+      pos: 5.5,-15.5
+      parent: 2
+  - uid: 1696
+    components:
+    - type: Transform
+      pos: 5.5,-16.5
+      parent: 2
+  - uid: 1697
+    components:
+    - type: Transform
+      pos: 13.5,-13.5
+      parent: 2
+  - uid: 1698
+    components:
+    - type: Transform
+      pos: 12.5,-13.5
+      parent: 2
+  - uid: 1699
+    components:
+    - type: Transform
+      pos: 11.5,-13.5
+      parent: 2
+  - uid: 1700
+    components:
+    - type: Transform
+      pos: 10.5,-13.5
+      parent: 2
+  - uid: 1701
+    components:
+    - type: Transform
+      pos: 9.5,-13.5
+      parent: 2
+  - uid: 1702
+    components:
+    - type: Transform
+      pos: 9.5,-11.5
+      parent: 2
+  - uid: 1703
+    components:
+    - type: Transform
+      pos: 9.5,-15.5
+      parent: 2
+  - uid: 1704
+    components:
+    - type: Transform
+      pos: 9.5,-16.5
+      parent: 2
+  - uid: 1705
+    components:
+    - type: Transform
+      pos: 10.5,-16.5
+      parent: 2
+  - uid: 1706
+    components:
+    - type: Transform
+      pos: 11.5,-16.5
+      parent: 2
+  - uid: 1707
+    components:
+    - type: Transform
+      pos: 12.5,-16.5
+      parent: 2
+  - uid: 1708
+    components:
+    - type: Transform
+      pos: 13.5,-16.5
+      parent: 2
+  - uid: 1709
+    components:
+    - type: Transform
+      pos: 14.5,-16.5
+      parent: 2
+  - uid: 1710
+    components:
+    - type: Transform
+      pos: 14.5,-17.5
+      parent: 2
+  - uid: 1711
+    components:
+    - type: Transform
+      pos: 13.5,-17.5
+      parent: 2
+  - uid: 1712
+    components:
+    - type: Transform
+      pos: 9.5,-17.5
+      parent: 2
+  - uid: 1713
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-13.5
+      parent: 2
+  - uid: 1714
+    components:
+    - type: Transform
+      pos: 26.5,-7.5
+      parent: 2
+  - uid: 1715
+    components:
+    - type: Transform
+      pos: 25.5,-7.5
+      parent: 2
+  - uid: 1716
+    components:
+    - type: Transform
+      pos: 21.5,-7.5
+      parent: 2
+  - uid: 1717
+    components:
+    - type: Transform
+      pos: 22.5,-7.5
+      parent: 2
+  - uid: 1718
+    components:
+    - type: Transform
+      pos: 18.5,-7.5
+      parent: 2
+  - uid: 1719
+    components:
+    - type: Transform
+      pos: 17.5,-7.5
+      parent: 2
+  - uid: 1720
+    components:
+    - type: Transform
+      pos: 26.5,-8.5
+      parent: 2
+  - uid: 1721
+    components:
+    - type: Transform
+      pos: 26.5,-9.5
+      parent: 2
+  - uid: 1722
+    components:
+    - type: Transform
+      pos: 26.5,-10.5
+      parent: 2
+  - uid: 1723
+    components:
+    - type: Transform
+      pos: 25.5,-10.5
+      parent: 2
+  - uid: 1724
+    components:
+    - type: Transform
+      pos: 26.5,-4.5
+      parent: 2
+  - uid: 1725
+    components:
+    - type: Transform
+      pos: 26.5,-3.5
+      parent: 2
+  - uid: 1726
+    components:
+    - type: Transform
+      pos: 26.5,-2.5
+      parent: 2
+  - uid: 1727
+    components:
+    - type: Transform
+      pos: 26.5,-1.5
+      parent: 2
+  - uid: 1728
+    components:
+    - type: Transform
+      pos: 27.5,-1.5
+      parent: 2
+  - uid: 1729
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 29.5,-7.5
+      parent: 2
+  - uid: 1730
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 28.5,-7.5
+      parent: 2
+  - uid: 1731
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 28.5,-8.5
+      parent: 2
+  - uid: 1732
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 28.5,-9.5
+      parent: 2
+  - uid: 1733
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 28.5,-10.5
+      parent: 2
+  - uid: 1734
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 29.5,-10.5
+      parent: 2
+  - uid: 1735
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 32.5,-10.5
+      parent: 2
+  - uid: 1736
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 32.5,-7.5
+      parent: 2
+  - uid: 1737
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 33.5,-7.5
+      parent: 2
+  - uid: 1738
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 33.5,-8.5
+      parent: 2
+  - uid: 1739
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 33.5,-9.5
+      parent: 2
+  - uid: 1740
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 33.5,-10.5
+      parent: 2
+  - uid: 1741
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 35.5,-19.5
+      parent: 2
+  - uid: 1742
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 34.5,-19.5
+      parent: 2
+  - uid: 1743
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 32.5,-11.5
+      parent: 2
+  - uid: 1744
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 31.5,-11.5
+      parent: 2
+  - uid: 1745
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 30.5,-11.5
+      parent: 2
+  - uid: 1746
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 29.5,-11.5
+      parent: 2
+  - uid: 1747
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 27.5,-15.5
+      parent: 2
+  - uid: 1748
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-15.5
+      parent: 2
+  - uid: 1749
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-17.5
+      parent: 2
+  - uid: 1750
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-19.5
+      parent: 2
+  - uid: 1751
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-21.5
+      parent: 2
+  - uid: 1752
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 27.5,-21.5
+      parent: 2
+  - uid: 1753
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 26.5,-18.5
+      parent: 2
+  - uid: 1754
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-19.5
+      parent: 2
+  - uid: 1755
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-17.5
+      parent: 2
+  - uid: 1756
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 34.5,-15.5
+      parent: 2
+  - uid: 1757
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 34.5,-10.5
+      parent: 2
+  - uid: 1758
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 34.5,-14.5
+      parent: 2
+  - uid: 1759
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 34.5,-7.5
+      parent: 2
+  - uid: 1760
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 34.5,-13.5
+      parent: 2
+  - uid: 1761
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 34.5,-12.5
+      parent: 2
+  - uid: 1762
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 34.5,-11.5
+      parent: 2
+  - uid: 1763
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 36.5,-19.5
+      parent: 2
+  - uid: 1764
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 36.5,-18.5
+      parent: 2
+  - uid: 1765
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 36.5,-17.5
+      parent: 2
+  - uid: 1766
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 36.5,-15.5
+      parent: 2
+  - uid: 1767
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 36.5,-14.5
+      parent: 2
+  - uid: 1768
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 36.5,-13.5
+      parent: 2
+  - uid: 1769
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 36.5,-16.5
+      parent: 2
+  - uid: 1770
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-15.5
+      parent: 2
+  - uid: 1771
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-21.5
+      parent: 2
+  - uid: 1772
+    components:
+    - type: Transform
+      pos: 42.5,8.5
+      parent: 2
+  - uid: 1773
+    components:
+    - type: Transform
+      pos: 26.5,8.5
+      parent: 2
+  - uid: 1774
+    components:
+    - type: Transform
+      pos: 26.5,6.5
+      parent: 2
+  - uid: 1775
+    components:
+    - type: Transform
+      pos: 26.5,5.5
+      parent: 2
+  - uid: 1776
+    components:
+    - type: Transform
+      pos: 26.5,4.5
+      parent: 2
+  - uid: 1777
+    components:
+    - type: Transform
+      pos: 26.5,7.5
+      parent: 2
+  - uid: 1778
+    components:
+    - type: Transform
+      pos: 26.5,3.5
+      parent: 2
+  - uid: 1779
+    components:
+    - type: Transform
+      pos: 27.5,3.5
+      parent: 2
+  - uid: 1780
+    components:
+    - type: Transform
+      pos: 30.5,3.5
+      parent: 2
+  - uid: 1781
+    components:
+    - type: Transform
+      pos: 30.5,4.5
+      parent: 2
+  - uid: 1782
+    components:
+    - type: Transform
+      pos: 42.5,7.5
+      parent: 2
+  - uid: 1783
+    components:
+    - type: Transform
+      pos: 41.5,8.5
+      parent: 2
+  - uid: 1784
+    components:
+    - type: Transform
+      pos: 41.5,7.5
+      parent: 2
+  - uid: 1785
+    components:
+    - type: Transform
+      pos: 41.5,5.5
+      parent: 2
+  - uid: 1786
+    components:
+    - type: Transform
+      pos: 41.5,6.5
+      parent: 2
+  - uid: 1787
+    components:
+    - type: Transform
+      pos: 41.5,3.5
+      parent: 2
+  - uid: 1788
+    components:
+    - type: Transform
+      pos: 41.5,4.5
+      parent: 2
+  - uid: 1789
+    components:
+    - type: Transform
+      pos: 41.5,1.5
+      parent: 2
+  - uid: 1790
+    components:
+    - type: Transform
+      pos: 41.5,2.5
+      parent: 2
+  - uid: 1791
+    components:
+    - type: Transform
+      pos: 41.5,0.5
+      parent: 2
+  - uid: 1792
+    components:
+    - type: Transform
+      pos: 30.5,-1.5
+      parent: 2
+  - uid: 1793
+    components:
+    - type: Transform
+      pos: 31.5,-1.5
+      parent: 2
+  - uid: 1794
+    components:
+    - type: Transform
+      pos: 33.5,-1.5
+      parent: 2
+  - uid: 1795
+    components:
+    - type: Transform
+      pos: 34.5,-4.5
+      parent: 2
+  - uid: 1796
+    components:
+    - type: Transform
+      pos: 37.5,-4.5
+      parent: 2
+  - uid: 1797
+    components:
+    - type: Transform
+      pos: 37.5,-2.5
+      parent: 2
+  - uid: 1798
+    components:
+    - type: Transform
+      pos: 37.5,-1.5
+      parent: 2
+  - uid: 1799
+    components:
+    - type: Transform
+      pos: 36.5,-1.5
+      parent: 2
+  - uid: 1800
+    components:
+    - type: Transform
+      pos: 35.5,-1.5
+      parent: 2
+  - uid: 1801
+    components:
+    - type: Transform
+      pos: 34.5,-1.5
+      parent: 2
+  - uid: 1802
+    components:
+    - type: Transform
+      pos: 34.5,-2.5
+      parent: 2
+  - uid: 1803
+    components:
+    - type: Transform
+      pos: 41.5,-2.5
+      parent: 2
+  - uid: 1804
+    components:
+    - type: Transform
+      pos: 41.5,-1.5
+      parent: 2
+  - uid: 1805
+    components:
+    - type: Transform
+      pos: 41.5,-0.5
+      parent: 2
+  - uid: 1806
+    components:
+    - type: Transform
+      pos: 42.5,2.5
+      parent: 2
+  - uid: 1807
+    components:
+    - type: Transform
+      pos: 34.5,4.5
+      parent: 2
+  - uid: 1808
+    components:
+    - type: Transform
+      pos: 34.5,3.5
+      parent: 2
+  - uid: 1809
+    components:
+    - type: Transform
+      pos: 34.5,2.5
+      parent: 2
+  - uid: 1810
+    components:
+    - type: Transform
+      pos: 35.5,2.5
+      parent: 2
+  - uid: 1811
+    components:
+    - type: Transform
+      pos: 36.5,2.5
+      parent: 2
+  - uid: 1812
+    components:
+    - type: Transform
+      pos: 37.5,2.5
+      parent: 2
+  - uid: 1813
+    components:
+    - type: Transform
+      pos: 38.5,2.5
+      parent: 2
+  - uid: 1814
+    components:
+    - type: Transform
+      pos: 39.5,2.5
+      parent: 2
+  - uid: 1815
+    components:
+    - type: Transform
+      pos: 40.5,2.5
+      parent: 2
+  - uid: 1816
+    components:
+    - type: Transform
+      pos: 35.5,1.5
+      parent: 2
+  - uid: 1817
+    components:
+    - type: Transform
+      pos: 35.5,-0.5
+      parent: 2
+  - uid: 1818
+    components:
+    - type: Transform
+      pos: 35.5,0.5
+      parent: 2
+  - uid: 1819
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 43.5,-12.5
+      parent: 2
+  - uid: 1820
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 43.5,-13.5
+      parent: 2
+  - uid: 1821
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 42.5,-13.5
+      parent: 2
+  - uid: 1822
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 42.5,-15.5
+      parent: 2
+  - uid: 1823
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 42.5,-14.5
+      parent: 2
+  - uid: 1824
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 41.5,-15.5
+      parent: 2
+  - uid: 1825
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 40.5,-15.5
+      parent: 2
+  - uid: 1826
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 40.5,-14.5
+      parent: 2
+  - uid: 1827
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 39.5,-14.5
+      parent: 2
+  - uid: 1828
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 38.5,-14.5
+      parent: 2
+  - uid: 1829
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 37.5,-14.5
+      parent: 2
+  - uid: 1830
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 40.5,-13.5
+      parent: 2
+  - uid: 1831
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 34.5,-3.5
+      parent: 2
+  - uid: 1832
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 43.5,-6.5
+      parent: 2
+- proto: WallPlastitaniumDiagonal
+  entities:
+  - uid: 1833
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 28.5,-15.5
+      parent: 2
+  - uid: 1834
+    components:
+    - type: Transform
+      pos: 24.5,-15.5
+      parent: 2
+  - uid: 1835
+    components:
+    - type: Transform
+      pos: 23.5,-16.5
+      parent: 2
+  - uid: 1836
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 23.5,-20.5
+      parent: 2
+  - uid: 1837
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 24.5,-21.5
+      parent: 2
+  - uid: 1838
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 28.5,-21.5
+      parent: 2
+  - uid: 1839
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-16.5
+      parent: 2
+  - uid: 1840
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 29.5,-20.5
+      parent: 2
+  - uid: 1841
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 28.5,-16.5
+      parent: 2
+  - uid: 1842
+    components:
+    - type: Transform
+      pos: 28.5,-20.5
+      parent: 2
+  - uid: 1843
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-20.5
+      parent: 2
+  - uid: 1844
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 24.5,-16.5
+      parent: 2
+- proto: WallReinforced
+  entities:
+  - uid: 1845
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 30.5,-19.5
+      parent: 2
+  - uid: 1846
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 30.5,-17.5
+      parent: 2
+- proto: WallRockSnow
+  entities:
+  - uid: 1847
+    components:
+    - type: Transform
+      pos: -14.5,2.5
+      parent: 2
+  - uid: 1848
+    components:
+    - type: Transform
+      pos: -14.5,1.5
+      parent: 2
+  - uid: 1849
+    components:
+    - type: Transform
+      pos: -14.5,-5.5
+      parent: 2
+  - uid: 1850
+    components:
+    - type: Transform
+      pos: -14.5,-6.5
+      parent: 2
+  - uid: 1851
+    components:
+    - type: Transform
+      pos: -13.5,-6.5
+      parent: 2
+  - uid: 1852
+    components:
+    - type: Transform
+      pos: -13.5,-7.5
+      parent: 2
+  - uid: 1853
+    components:
+    - type: Transform
+      pos: -13.5,-8.5
+      parent: 2
+  - uid: 1854
+    components:
+    - type: Transform
+      pos: -14.5,-8.5
+      parent: 2
+  - uid: 1855
+    components:
+    - type: Transform
+      pos: -14.5,-9.5
+      parent: 2
+  - uid: 1856
+    components:
+    - type: Transform
+      pos: -14.5,-10.5
+      parent: 2
+  - uid: 1857
+    components:
+    - type: Transform
+      pos: -15.5,-10.5
+      parent: 2
+  - uid: 1858
+    components:
+    - type: Transform
+      pos: -15.5,-11.5
+      parent: 2
+  - uid: 1859
+    components:
+    - type: Transform
+      pos: -15.5,-12.5
+      parent: 2
+  - uid: 1860
+    components:
+    - type: Transform
+      pos: -15.5,-13.5
+      parent: 2
+  - uid: 1861
+    components:
+    - type: Transform
+      pos: -15.5,-14.5
+      parent: 2
+  - uid: 1862
+    components:
+    - type: Transform
+      pos: -15.5,-15.5
+      parent: 2
+  - uid: 1863
+    components:
+    - type: Transform
+      pos: -15.5,-16.5
+      parent: 2
+  - uid: 1864
+    components:
+    - type: Transform
+      pos: -15.5,-17.5
+      parent: 2
+  - uid: 1865
+    components:
+    - type: Transform
+      pos: -15.5,-18.5
+      parent: 2
+  - uid: 1866
+    components:
+    - type: Transform
+      pos: -14.5,-18.5
+      parent: 2
+  - uid: 1867
+    components:
+    - type: Transform
+      pos: -13.5,-18.5
+      parent: 2
+  - uid: 1868
+    components:
+    - type: Transform
+      pos: -11.5,-18.5
+      parent: 2
+  - uid: 1869
+    components:
+    - type: Transform
+      pos: -10.5,-18.5
+      parent: 2
+  - uid: 1870
+    components:
+    - type: Transform
+      pos: -9.5,-18.5
+      parent: 2
+  - uid: 1871
+    components:
+    - type: Transform
+      pos: -8.5,-18.5
+      parent: 2
+  - uid: 1872
+    components:
+    - type: Transform
+      pos: -12.5,-18.5
+      parent: 2
+  - uid: 1873
+    components:
+    - type: Transform
+      pos: -7.5,-18.5
+      parent: 2
+  - uid: 1874
+    components:
+    - type: Transform
+      pos: -6.5,-18.5
+      parent: 2
+  - uid: 1875
+    components:
+    - type: Transform
+      pos: -5.5,-18.5
+      parent: 2
+  - uid: 1876
+    components:
+    - type: Transform
+      pos: -5.5,-19.5
+      parent: 2
+  - uid: 1877
+    components:
+    - type: Transform
+      pos: -5.5,-20.5
+      parent: 2
+  - uid: 1878
+    components:
+    - type: Transform
+      pos: -5.5,-21.5
+      parent: 2
+  - uid: 1879
+    components:
+    - type: Transform
+      pos: -5.5,-22.5
+      parent: 2
+  - uid: 1880
+    components:
+    - type: Transform
+      pos: -4.5,-22.5
+      parent: 2
+  - uid: 1881
+    components:
+    - type: Transform
+      pos: -3.5,-22.5
+      parent: 2
+  - uid: 1882
+    components:
+    - type: Transform
+      pos: -2.5,-22.5
+      parent: 2
+  - uid: 1883
+    components:
+    - type: Transform
+      pos: -1.5,-22.5
+      parent: 2
+  - uid: 1884
+    components:
+    - type: Transform
+      pos: -0.5,-22.5
+      parent: 2
+  - uid: 1885
+    components:
+    - type: Transform
+      pos: 0.5,-22.5
+      parent: 2
+  - uid: 1886
+    components:
+    - type: Transform
+      pos: 1.5,-22.5
+      parent: 2
+  - uid: 1887
+    components:
+    - type: Transform
+      pos: 2.5,-22.5
+      parent: 2
+  - uid: 1888
+    components:
+    - type: Transform
+      pos: 3.5,-22.5
+      parent: 2
+  - uid: 1889
+    components:
+    - type: Transform
+      pos: 4.5,-22.5
+      parent: 2
+  - uid: 1890
+    components:
+    - type: Transform
+      pos: 4.5,-21.5
+      parent: 2
+  - uid: 1891
+    components:
+    - type: Transform
+      pos: 4.5,-20.5
+      parent: 2
+  - uid: 1892
+    components:
+    - type: Transform
+      pos: 4.5,-19.5
+      parent: 2
+  - uid: 1893
+    components:
+    - type: Transform
+      pos: 4.5,-18.5
+      parent: 2
+  - uid: 1894
+    components:
+    - type: Transform
+      pos: 5.5,-18.5
+      parent: 2
+  - uid: 1895
+    components:
+    - type: Transform
+      pos: -15.5,1.5
+      parent: 2
+  - uid: 1896
+    components:
+    - type: Transform
+      pos: -15.5,0.5
+      parent: 2
+  - uid: 1897
+    components:
+    - type: Transform
+      pos: -15.5,-0.5
+      parent: 2
+  - uid: 1898
+    components:
+    - type: Transform
+      pos: -15.5,-1.5
+      parent: 2
+  - uid: 1899
+    components:
+    - type: Transform
+      pos: -15.5,-2.5
+      parent: 2
+  - uid: 1900
+    components:
+    - type: Transform
+      pos: -15.5,-3.5
+      parent: 2
+  - uid: 1901
+    components:
+    - type: Transform
+      pos: -15.5,-4.5
+      parent: 2
+  - uid: 1902
+    components:
+    - type: Transform
+      pos: -15.5,-5.5
+      parent: 2
+  - uid: 1903
+    components:
+    - type: Transform
+      pos: -13.5,2.5
+      parent: 2
+  - uid: 1904
+    components:
+    - type: Transform
+      pos: -11.5,2.5
+      parent: 2
+  - uid: 1905
+    components:
+    - type: Transform
+      pos: -10.5,2.5
+      parent: 2
+  - uid: 1906
+    components:
+    - type: Transform
+      pos: -9.5,2.5
+      parent: 2
+  - uid: 1907
+    components:
+    - type: Transform
+      pos: -8.5,2.5
+      parent: 2
+  - uid: 1908
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 2
+  - uid: 1909
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 2
+  - uid: 1910
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 2
+  - uid: 1911
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 2
+  - uid: 1912
+    components:
+    - type: Transform
+      pos: -12.5,2.5
+      parent: 2
+  - uid: 1913
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 2
+  - uid: 1914
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 2
+  - uid: 1915
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 2
+  - uid: 1916
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 2
+  - uid: 1917
+    components:
+    - type: Transform
+      pos: 14.5,-25.5
+      parent: 2
+  - uid: 1918
+    components:
+    - type: Transform
+      pos: 13.5,-21.5
+      parent: 2
+  - uid: 1919
+    components:
+    - type: Transform
+      pos: 13.5,-22.5
+      parent: 2
+  - uid: 1920
+    components:
+    - type: Transform
+      pos: 12.5,-22.5
+      parent: 2
+  - uid: 1921
+    components:
+    - type: Transform
+      pos: 11.5,-22.5
+      parent: 2
+  - uid: 1922
+    components:
+    - type: Transform
+      pos: 10.5,-22.5
+      parent: 2
+  - uid: 1923
+    components:
+    - type: Transform
+      pos: 9.5,-22.5
+      parent: 2
+  - uid: 1924
+    components:
+    - type: Transform
+      pos: 8.5,-22.5
+      parent: 2
+  - uid: 1925
+    components:
+    - type: Transform
+      pos: 7.5,-22.5
+      parent: 2
+  - uid: 1926
+    components:
+    - type: Transform
+      pos: 6.5,-22.5
+      parent: 2
+  - uid: 1927
+    components:
+    - type: Transform
+      pos: 5.5,-22.5
+      parent: 2
+  - uid: 1928
+    components:
+    - type: Transform
+      pos: 14.5,-23.5
+      parent: 2
+  - uid: 1929
+    components:
+    - type: Transform
+      pos: 13.5,-23.5
+      parent: 2
+  - uid: 1930
+    components:
+    - type: Transform
+      pos: 14.5,-26.5
+      parent: 2
+  - uid: 1931
+    components:
+    - type: Transform
+      pos: 15.5,-26.5
+      parent: 2
+  - uid: 1932
+    components:
+    - type: Transform
+      pos: 14.5,-24.5
+      parent: 2
+  - uid: 1933
+    components:
+    - type: Transform
+      pos: 15.5,-27.5
+      parent: 2
+  - uid: 1934
+    components:
+    - type: Transform
+      pos: 16.5,-27.5
+      parent: 2
+  - uid: 1935
+    components:
+    - type: Transform
+      pos: 17.5,-27.5
+      parent: 2
+  - uid: 1936
+    components:
+    - type: Transform
+      pos: 18.5,-27.5
+      parent: 2
+  - uid: 1937
+    components:
+    - type: Transform
+      pos: 18.5,-28.5
+      parent: 2
+  - uid: 1938
+    components:
+    - type: Transform
+      pos: 17.5,-28.5
+      parent: 2
+  - uid: 1939
+    components:
+    - type: Transform
+      pos: 17.5,-29.5
+      parent: 2
+  - uid: 1940
+    components:
+    - type: Transform
+      pos: 17.5,-30.5
+      parent: 2
+  - uid: 1941
+    components:
+    - type: Transform
+      pos: 17.5,-31.5
+      parent: 2
+  - uid: 1942
+    components:
+    - type: Transform
+      pos: 18.5,-31.5
+      parent: 2
+  - uid: 1943
+    components:
+    - type: Transform
+      pos: 18.5,-32.5
+      parent: 2
+  - uid: 1944
+    components:
+    - type: Transform
+      pos: 19.5,-32.5
+      parent: 2
+  - uid: 1945
+    components:
+    - type: Transform
+      pos: 20.5,-32.5
+      parent: 2
+  - uid: 1946
+    components:
+    - type: Transform
+      pos: 21.5,-32.5
+      parent: 2
+  - uid: 1947
+    components:
+    - type: Transform
+      pos: 22.5,-32.5
+      parent: 2
+  - uid: 1948
+    components:
+    - type: Transform
+      pos: 23.5,-32.5
+      parent: 2
+  - uid: 1949
+    components:
+    - type: Transform
+      pos: 23.5,-30.5
+      parent: 2
+  - uid: 1950
+    components:
+    - type: Transform
+      pos: 23.5,-31.5
+      parent: 2
+  - uid: 1951
+    components:
+    - type: Transform
+      pos: 24.5,-31.5
+      parent: 2
+  - uid: 1952
+    components:
+    - type: Transform
+      pos: 25.5,-31.5
+      parent: 2
+  - uid: 1953
+    components:
+    - type: Transform
+      pos: 21.5,-28.5
+      parent: 2
+  - uid: 1954
+    components:
+    - type: Transform
+      pos: 21.5,-27.5
+      parent: 2
+  - uid: 1955
+    components:
+    - type: Transform
+      pos: 20.5,-27.5
+      parent: 2
+  - uid: 1956
+    components:
+    - type: Transform
+      pos: 22.5,-27.5
+      parent: 2
+  - uid: 1957
+    components:
+    - type: Transform
+      pos: 23.5,-27.5
+      parent: 2
+  - uid: 1958
+    components:
+    - type: Transform
+      pos: 24.5,-27.5
+      parent: 2
+  - uid: 1959
+    components:
+    - type: Transform
+      pos: 25.5,-27.5
+      parent: 2
+  - uid: 1960
+    components:
+    - type: Transform
+      pos: 26.5,-27.5
+      parent: 2
+  - uid: 1961
+    components:
+    - type: Transform
+      pos: 24.5,-28.5
+      parent: 2
+  - uid: 1962
+    components:
+    - type: Transform
+      pos: 25.5,-28.5
+      parent: 2
+  - uid: 1963
+    components:
+    - type: Transform
+      pos: 26.5,-28.5
+      parent: 2
+  - uid: 1964
+    components:
+    - type: Transform
+      pos: 27.5,-28.5
+      parent: 2
+  - uid: 1965
+    components:
+    - type: Transform
+      pos: 25.5,-29.5
+      parent: 2
+  - uid: 1966
+    components:
+    - type: Transform
+      pos: 26.5,-29.5
+      parent: 2
+  - uid: 1967
+    components:
+    - type: Transform
+      pos: 28.5,-28.5
+      parent: 2
+  - uid: 1968
+    components:
+    - type: Transform
+      pos: 29.5,-28.5
+      parent: 2
+  - uid: 1969
+    components:
+    - type: Transform
+      pos: 29.5,-29.5
+      parent: 2
+  - uid: 1970
+    components:
+    - type: Transform
+      pos: 30.5,-28.5
+      parent: 2
+  - uid: 1971
+    components:
+    - type: Transform
+      pos: 30.5,-29.5
+      parent: 2
+  - uid: 1972
+    components:
+    - type: Transform
+      pos: 31.5,-28.5
+      parent: 2
+  - uid: 1973
+    components:
+    - type: Transform
+      pos: 31.5,-29.5
+      parent: 2
+  - uid: 1974
+    components:
+    - type: Transform
+      pos: 31.5,-30.5
+      parent: 2
+  - uid: 1975
+    components:
+    - type: Transform
+      pos: 30.5,-30.5
+      parent: 2
+  - uid: 1976
+    components:
+    - type: Transform
+      pos: 30.5,-31.5
+      parent: 2
+  - uid: 1977
+    components:
+    - type: Transform
+      pos: 30.5,-32.5
+      parent: 2
+  - uid: 1978
+    components:
+    - type: Transform
+      pos: 30.5,-33.5
+      parent: 2
+  - uid: 1979
+    components:
+    - type: Transform
+      pos: 30.5,-34.5
+      parent: 2
+  - uid: 1980
+    components:
+    - type: Transform
+      pos: 29.5,-34.5
+      parent: 2
+  - uid: 1981
+    components:
+    - type: Transform
+      pos: 28.5,-34.5
+      parent: 2
+  - uid: 1982
+    components:
+    - type: Transform
+      pos: 27.5,-34.5
+      parent: 2
+  - uid: 1983
+    components:
+    - type: Transform
+      pos: 27.5,-33.5
+      parent: 2
+  - uid: 1984
+    components:
+    - type: Transform
+      pos: 26.5,-33.5
+      parent: 2
+  - uid: 1985
+    components:
+    - type: Transform
+      pos: 26.5,-32.5
+      parent: 2
+  - uid: 1986
+    components:
+    - type: Transform
+      pos: 25.5,-32.5
+      parent: 2
+  - uid: 1987
+    components:
+    - type: Transform
+      pos: 30.5,-27.5
+      parent: 2
+  - uid: 1988
+    components:
+    - type: Transform
+      pos: 31.5,-27.5
+      parent: 2
+  - uid: 1989
+    components:
+    - type: Transform
+      pos: 31.5,-26.5
+      parent: 2
+  - uid: 1990
+    components:
+    - type: Transform
+      pos: 31.5,-25.5
+      parent: 2
+  - uid: 1991
+    components:
+    - type: Transform
+      pos: 32.5,-25.5
+      parent: 2
+  - uid: 1992
+    components:
+    - type: Transform
+      pos: 33.5,-25.5
+      parent: 2
+  - uid: 1993
+    components:
+    - type: Transform
+      pos: 33.5,-24.5
+      parent: 2
+  - uid: 1994
+    components:
+    - type: Transform
+      pos: 34.5,-24.5
+      parent: 2
+  - uid: 1995
+    components:
+    - type: Transform
+      pos: 35.5,-24.5
+      parent: 2
+  - uid: 1996
+    components:
+    - type: Transform
+      pos: 35.5,-23.5
+      parent: 2
+  - uid: 1997
+    components:
+    - type: Transform
+      pos: 36.5,-23.5
+      parent: 2
+  - uid: 1998
+    components:
+    - type: Transform
+      pos: 37.5,-23.5
+      parent: 2
+  - uid: 1999
+    components:
+    - type: Transform
+      pos: 38.5,-23.5
+      parent: 2
+  - uid: 2000
+    components:
+    - type: Transform
+      pos: 38.5,-22.5
+      parent: 2
+  - uid: 2001
+    components:
+    - type: Transform
+      pos: 35.5,-22.5
+      parent: 2
+  - uid: 2002
+    components:
+    - type: Transform
+      pos: 35.5,-21.5
+      parent: 2
+  - uid: 2003
+    components:
+    - type: Transform
+      pos: 36.5,-21.5
+      parent: 2
+  - uid: 2004
+    components:
+    - type: Transform
+      pos: 37.5,-21.5
+      parent: 2
+  - uid: 2005
+    components:
+    - type: Transform
+      pos: 38.5,-21.5
+      parent: 2
+  - uid: 2006
+    components:
+    - type: Transform
+      pos: 36.5,-22.5
+      parent: 2
+  - uid: 2007
+    components:
+    - type: Transform
+      pos: 37.5,-22.5
+      parent: 2
+  - uid: 2008
+    components:
+    - type: Transform
+      pos: 39.5,-22.5
+      parent: 2
+  - uid: 2009
+    components:
+    - type: Transform
+      pos: 39.5,-21.5
+      parent: 2
+  - uid: 2010
+    components:
+    - type: Transform
+      pos: 37.5,-20.5
+      parent: 2
+  - uid: 2011
+    components:
+    - type: Transform
+      pos: 37.5,-19.5
+      parent: 2
+  - uid: 2012
+    components:
+    - type: Transform
+      pos: 37.5,-18.5
+      parent: 2
+  - uid: 2013
+    components:
+    - type: Transform
+      pos: 37.5,-17.5
+      parent: 2
+  - uid: 2014
+    components:
+    - type: Transform
+      pos: 37.5,-16.5
+      parent: 2
+  - uid: 2015
+    components:
+    - type: Transform
+      pos: 38.5,-20.5
+      parent: 2
+  - uid: 2016
+    components:
+    - type: Transform
+      pos: 38.5,-19.5
+      parent: 2
+  - uid: 2017
+    components:
+    - type: Transform
+      pos: 38.5,-18.5
+      parent: 2
+  - uid: 2018
+    components:
+    - type: Transform
+      pos: 38.5,-17.5
+      parent: 2
+  - uid: 2019
+    components:
+    - type: Transform
+      pos: 38.5,-16.5
+      parent: 2
+  - uid: 2020
+    components:
+    - type: Transform
+      pos: 39.5,-20.5
+      parent: 2
+  - uid: 2021
+    components:
+    - type: Transform
+      pos: 39.5,-19.5
+      parent: 2
+  - uid: 2022
+    components:
+    - type: Transform
+      pos: 39.5,-18.5
+      parent: 2
+  - uid: 2023
+    components:
+    - type: Transform
+      pos: 39.5,-17.5
+      parent: 2
+  - uid: 2024
+    components:
+    - type: Transform
+      pos: 39.5,-16.5
+      parent: 2
+  - uid: 2025
+    components:
+    - type: Transform
+      pos: 40.5,-17.5
+      parent: 2
+  - uid: 2026
+    components:
+    - type: Transform
+      pos: 41.5,-17.5
+      parent: 2
+  - uid: 2027
+    components:
+    - type: Transform
+      pos: 42.5,-17.5
+      parent: 2
+  - uid: 2028
+    components:
+    - type: Transform
+      pos: 43.5,-17.5
+      parent: 2
+  - uid: 2029
+    components:
+    - type: Transform
+      pos: 43.5,-16.5
+      parent: 2
+  - uid: 2030
+    components:
+    - type: Transform
+      pos: 43.5,-15.5
+      parent: 2
+  - uid: 2031
+    components:
+    - type: Transform
+      pos: 44.5,-17.5
+      parent: 2
+  - uid: 2032
+    components:
+    - type: Transform
+      pos: 44.5,-16.5
+      parent: 2
+  - uid: 2033
+    components:
+    - type: Transform
+      pos: 44.5,-15.5
+      parent: 2
+  - uid: 2034
+    components:
+    - type: Transform
+      pos: 45.5,-17.5
+      parent: 2
+  - uid: 2035
+    components:
+    - type: Transform
+      pos: 45.5,-16.5
+      parent: 2
+  - uid: 2036
+    components:
+    - type: Transform
+      pos: 45.5,-15.5
+      parent: 2
+  - uid: 2037
+    components:
+    - type: Transform
+      pos: 46.5,-17.5
+      parent: 2
+  - uid: 2038
+    components:
+    - type: Transform
+      pos: 46.5,-16.5
+      parent: 2
+  - uid: 2039
+    components:
+    - type: Transform
+      pos: 46.5,-15.5
+      parent: 2
+  - uid: 2040
+    components:
+    - type: Transform
+      pos: 44.5,-14.5
+      parent: 2
+  - uid: 2041
+    components:
+    - type: Transform
+      pos: 45.5,-14.5
+      parent: 2
+  - uid: 2042
+    components:
+    - type: Transform
+      pos: 46.5,-14.5
+      parent: 2
+  - uid: 2043
+    components:
+    - type: Transform
+      pos: 37.5,-15.5
+      parent: 2
+  - uid: 2044
+    components:
+    - type: Transform
+      pos: 38.5,-15.5
+      parent: 2
+  - uid: 2045
+    components:
+    - type: Transform
+      pos: 39.5,-15.5
+      parent: 2
+  - uid: 2046
+    components:
+    - type: Transform
+      pos: 40.5,-16.5
+      parent: 2
+  - uid: 2047
+    components:
+    - type: Transform
+      pos: 41.5,-16.5
+      parent: 2
+  - uid: 2048
+    components:
+    - type: Transform
+      pos: 42.5,-16.5
+      parent: 2
+  - uid: 2049
+    components:
+    - type: Transform
+      pos: 43.5,-14.5
+      parent: 2
+  - uid: 2050
+    components:
+    - type: Transform
+      pos: 44.5,-13.5
+      parent: 2
+  - uid: 2051
+    components:
+    - type: Transform
+      pos: 8.5,12.5
+      parent: 2
+  - uid: 2052
+    components:
+    - type: Transform
+      pos: 7.5,12.5
+      parent: 2
+  - uid: 2053
+    components:
+    - type: Transform
+      pos: 6.5,12.5
+      parent: 2
+  - uid: 2054
+    components:
+    - type: Transform
+      pos: 5.5,12.5
+      parent: 2
+  - uid: 2055
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 2
+  - uid: 2056
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 2
+  - uid: 2057
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 2
+  - uid: 2058
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 2
+  - uid: 2059
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 2
+  - uid: 2060
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 2
+  - uid: 2061
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 2
+  - uid: 2062
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 2
+  - uid: 2063
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 2
+  - uid: 2064
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 2
+  - uid: 2065
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 2
+  - uid: 2066
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 2
+  - uid: 2067
+    components:
+    - type: Transform
+      pos: -5.5,10.5
+      parent: 2
+  - uid: 2068
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 2
+  - uid: 2069
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 2
+  - uid: 2070
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 2
+  - uid: 2071
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 2
+  - uid: 2072
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 2
+  - uid: 2073
+    components:
+    - type: Transform
+      pos: -7.5,8.5
+      parent: 2
+  - uid: 2074
+    components:
+    - type: Transform
+      pos: -8.5,8.5
+      parent: 2
+  - uid: 2075
+    components:
+    - type: Transform
+      pos: -9.5,8.5
+      parent: 2
+  - uid: 2076
+    components:
+    - type: Transform
+      pos: -10.5,8.5
+      parent: 2
+  - uid: 2077
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 2
+  - uid: 2078
+    components:
+    - type: Transform
+      pos: -7.5,7.5
+      parent: 2
+  - uid: 2079
+    components:
+    - type: Transform
+      pos: -8.5,7.5
+      parent: 2
+  - uid: 2080
+    components:
+    - type: Transform
+      pos: -9.5,7.5
+      parent: 2
+  - uid: 2081
+    components:
+    - type: Transform
+      pos: -10.5,7.5
+      parent: 2
+  - uid: 2082
+    components:
+    - type: Transform
+      pos: -8.5,6.5
+      parent: 2
+  - uid: 2083
+    components:
+    - type: Transform
+      pos: -9.5,6.5
+      parent: 2
+  - uid: 2084
+    components:
+    - type: Transform
+      pos: -10.5,6.5
+      parent: 2
+  - uid: 2085
+    components:
+    - type: Transform
+      pos: -11.5,6.5
+      parent: 2
+  - uid: 2086
+    components:
+    - type: Transform
+      pos: -12.5,6.5
+      parent: 2
+  - uid: 2087
+    components:
+    - type: Transform
+      pos: -13.5,6.5
+      parent: 2
+  - uid: 2088
+    components:
+    - type: Transform
+      pos: -14.5,6.5
+      parent: 2
+  - uid: 2089
+    components:
+    - type: Transform
+      pos: -11.5,5.5
+      parent: 2
+  - uid: 2090
+    components:
+    - type: Transform
+      pos: -12.5,5.5
+      parent: 2
+  - uid: 2091
+    components:
+    - type: Transform
+      pos: -13.5,5.5
+      parent: 2
+  - uid: 2092
+    components:
+    - type: Transform
+      pos: -14.5,5.5
+      parent: 2
+  - uid: 2093
+    components:
+    - type: Transform
+      pos: -15.5,5.5
+      parent: 2
+  - uid: 2094
+    components:
+    - type: Transform
+      pos: -16.5,5.5
+      parent: 2
+  - uid: 2095
+    components:
+    - type: Transform
+      pos: -13.5,4.5
+      parent: 2
+  - uid: 2096
+    components:
+    - type: Transform
+      pos: -14.5,4.5
+      parent: 2
+  - uid: 2097
+    components:
+    - type: Transform
+      pos: -15.5,4.5
+      parent: 2
+  - uid: 2098
+    components:
+    - type: Transform
+      pos: -16.5,4.5
+      parent: 2
+  - uid: 2099
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 2
+  - uid: 2100
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 2
+  - uid: 2101
+    components:
+    - type: Transform
+      pos: -14.5,3.5
+      parent: 2
+  - uid: 2102
+    components:
+    - type: Transform
+      pos: -15.5,3.5
+      parent: 2
+  - uid: 2103
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 2
+  - uid: 2104
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 2
+  - uid: 2105
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 2
+  - uid: 2106
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 2
+  - uid: 2107
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 2
+  - uid: 2108
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 2
+  - uid: 2109
+    components:
+    - type: Transform
+      pos: 6.5,13.5
+      parent: 2
+  - uid: 2110
+    components:
+    - type: Transform
+      pos: 7.5,13.5
+      parent: 2
+  - uid: 2111
+    components:
+    - type: Transform
+      pos: 8.5,13.5
+      parent: 2
+  - uid: 2112
+    components:
+    - type: Transform
+      pos: 9.5,13.5
+      parent: 2
+  - uid: 2113
+    components:
+    - type: Transform
+      pos: 6.5,14.5
+      parent: 2
+  - uid: 2114
+    components:
+    - type: Transform
+      pos: 7.5,14.5
+      parent: 2
+  - uid: 2115
+    components:
+    - type: Transform
+      pos: 8.5,14.5
+      parent: 2
+  - uid: 2116
+    components:
+    - type: Transform
+      pos: 9.5,14.5
+      parent: 2
+  - uid: 2117
+    components:
+    - type: Transform
+      pos: 10.5,14.5
+      parent: 2
+  - uid: 2118
+    components:
+    - type: Transform
+      pos: 11.5,14.5
+      parent: 2
+  - uid: 2119
+    components:
+    - type: Transform
+      pos: 12.5,14.5
+      parent: 2
+  - uid: 2120
+    components:
+    - type: Transform
+      pos: 10.5,15.5
+      parent: 2
+  - uid: 2121
+    components:
+    - type: Transform
+      pos: 11.5,15.5
+      parent: 2
+  - uid: 2122
+    components:
+    - type: Transform
+      pos: 12.5,15.5
+      parent: 2
+  - uid: 2123
+    components:
+    - type: Transform
+      pos: 13.5,15.5
+      parent: 2
+  - uid: 2124
+    components:
+    - type: Transform
+      pos: 14.5,15.5
+      parent: 2
+  - uid: 2125
+    components:
+    - type: Transform
+      pos: 15.5,15.5
+      parent: 2
+  - uid: 2126
+    components:
+    - type: Transform
+      pos: 12.5,16.5
+      parent: 2
+  - uid: 2127
+    components:
+    - type: Transform
+      pos: 13.5,16.5
+      parent: 2
+  - uid: 2128
+    components:
+    - type: Transform
+      pos: 14.5,16.5
+      parent: 2
+  - uid: 2129
+    components:
+    - type: Transform
+      pos: 15.5,16.5
+      parent: 2
+  - uid: 2130
+    components:
+    - type: Transform
+      pos: 16.5,16.5
+      parent: 2
+  - uid: 2131
+    components:
+    - type: Transform
+      pos: 14.5,17.5
+      parent: 2
+  - uid: 2132
+    components:
+    - type: Transform
+      pos: 15.5,17.5
+      parent: 2
+  - uid: 2133
+    components:
+    - type: Transform
+      pos: 17.5,17.5
+      parent: 2
+  - uid: 2134
+    components:
+    - type: Transform
+      pos: 18.5,17.5
+      parent: 2
+  - uid: 2135
+    components:
+    - type: Transform
+      pos: 16.5,17.5
+      parent: 2
+  - uid: 2136
+    components:
+    - type: Transform
+      pos: 16.5,18.5
+      parent: 2
+  - uid: 2137
+    components:
+    - type: Transform
+      pos: 17.5,18.5
+      parent: 2
+  - uid: 2138
+    components:
+    - type: Transform
+      pos: 18.5,18.5
+      parent: 2
+  - uid: 2139
+    components:
+    - type: Transform
+      pos: 19.5,18.5
+      parent: 2
+  - uid: 2140
+    components:
+    - type: Transform
+      pos: 20.5,18.5
+      parent: 2
+  - uid: 2141
+    components:
+    - type: Transform
+      pos: 21.5,18.5
+      parent: 2
+  - uid: 2142
+    components:
+    - type: Transform
+      pos: 22.5,18.5
+      parent: 2
+  - uid: 2143
+    components:
+    - type: Transform
+      pos: 23.5,18.5
+      parent: 2
+  - uid: 2144
+    components:
+    - type: Transform
+      pos: 24.5,18.5
+      parent: 2
+  - uid: 2145
+    components:
+    - type: Transform
+      pos: 25.5,18.5
+      parent: 2
+  - uid: 2146
+    components:
+    - type: Transform
+      pos: 26.5,18.5
+      parent: 2
+  - uid: 2147
+    components:
+    - type: Transform
+      pos: 27.5,18.5
+      parent: 2
+  - uid: 2148
+    components:
+    - type: Transform
+      pos: 28.5,18.5
+      parent: 2
+  - uid: 2149
+    components:
+    - type: Transform
+      pos: 29.5,18.5
+      parent: 2
+  - uid: 2150
+    components:
+    - type: Transform
+      pos: 30.5,18.5
+      parent: 2
+  - uid: 2151
+    components:
+    - type: Transform
+      pos: 31.5,18.5
+      parent: 2
+  - uid: 2152
+    components:
+    - type: Transform
+      pos: 32.5,18.5
+      parent: 2
+  - uid: 2153
+    components:
+    - type: Transform
+      pos: 33.5,18.5
+      parent: 2
+  - uid: 2154
+    components:
+    - type: Transform
+      pos: 34.5,18.5
+      parent: 2
+  - uid: 2155
+    components:
+    - type: Transform
+      pos: 35.5,18.5
+      parent: 2
+  - uid: 2156
+    components:
+    - type: Transform
+      pos: 36.5,18.5
+      parent: 2
+  - uid: 2157
+    components:
+    - type: Transform
+      pos: 37.5,18.5
+      parent: 2
+  - uid: 2158
+    components:
+    - type: Transform
+      pos: 38.5,18.5
+      parent: 2
+  - uid: 2159
+    components:
+    - type: Transform
+      pos: 39.5,18.5
+      parent: 2
+  - uid: 2160
+    components:
+    - type: Transform
+      pos: 40.5,18.5
+      parent: 2
+  - uid: 2161
+    components:
+    - type: Transform
+      pos: 41.5,18.5
+      parent: 2
+  - uid: 2162
+    components:
+    - type: Transform
+      pos: 42.5,18.5
+      parent: 2
+  - uid: 2163
+    components:
+    - type: Transform
+      pos: 43.5,18.5
+      parent: 2
+  - uid: 2164
+    components:
+    - type: Transform
+      pos: 44.5,18.5
+      parent: 2
+  - uid: 2165
+    components:
+    - type: Transform
+      pos: 46.5,18.5
+      parent: 2
+  - uid: 2166
+    components:
+    - type: Transform
+      pos: 45.5,18.5
+      parent: 2
+  - uid: 2167
+    components:
+    - type: Transform
+      pos: 47.5,18.5
+      parent: 2
+  - uid: 2168
+    components:
+    - type: Transform
+      pos: 48.5,18.5
+      parent: 2
+  - uid: 2169
+    components:
+    - type: Transform
+      pos: 48.5,19.5
+      parent: 2
+- proto: WallSnowCobblebrick
+  entities:
+  - uid: 2170
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,2.5
+      parent: 2
+  - uid: 2171
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,1.5
+      parent: 2
+  - uid: 2172
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,0.5
+      parent: 2
+  - uid: 2173
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-0.5
+      parent: 2
+  - uid: 2174
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-1.5
+      parent: 2
+  - uid: 2175
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-2.5
+      parent: 2
+  - uid: 2176
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-3.5
+      parent: 2
+  - uid: 2177
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-4.5
+      parent: 2
+  - uid: 2178
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-5.5
+      parent: 2
+  - uid: 2179
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-6.5
+      parent: 2
+  - uid: 2180
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -15.5,-6.5
+      parent: 2
+  - uid: 2181
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -15.5,-7.5
+      parent: 2
+  - uid: 2182
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-7.5
+      parent: 2
+  - uid: 2183
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -15.5,-8.5
+      parent: 2
+  - uid: 2184
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -15.5,-9.5
+      parent: 2
+  - uid: 2185
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-9.5
+      parent: 2
+  - uid: 2186
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-10.5
+      parent: 2
+  - uid: 2187
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-11.5
+      parent: 2
+  - uid: 2188
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-12.5
+      parent: 2
+  - uid: 2189
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-13.5
+      parent: 2
+  - uid: 2190
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-14.5
+      parent: 2
+  - uid: 2191
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-15.5
+      parent: 2
+  - uid: 2192
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-16.5
+      parent: 2
+  - uid: 2193
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-17.5
+      parent: 2
+  - uid: 2194
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-18.5
+      parent: 2
+  - uid: 2195
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-19.5
+      parent: 2
+  - uid: 2196
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -15.5,-19.5
+      parent: 2
+  - uid: 2197
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-19.5
+      parent: 2
+  - uid: 2198
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -13.5,-19.5
+      parent: 2
+  - uid: 2199
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,-19.5
+      parent: 2
+  - uid: 2200
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,-19.5
+      parent: 2
+  - uid: 2201
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-19.5
+      parent: 2
+  - uid: 2202
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-19.5
+      parent: 2
+  - uid: 2203
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-19.5
+      parent: 2
+  - uid: 2204
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-19.5
+      parent: 2
+  - uid: 2205
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-19.5
+      parent: 2
+  - uid: 2206
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-20.5
+      parent: 2
+  - uid: 2207
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-21.5
+      parent: 2
+  - uid: 2208
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-22.5
+      parent: 2
+  - uid: 2209
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-23.5
+      parent: 2
+  - uid: 2210
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-23.5
+      parent: 2
+  - uid: 2211
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-23.5
+      parent: 2
+  - uid: 2212
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-23.5
+      parent: 2
+  - uid: 2213
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-23.5
+      parent: 2
+  - uid: 2214
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-23.5
+      parent: 2
+  - uid: 2215
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-23.5
+      parent: 2
+  - uid: 2216
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-23.5
+      parent: 2
+  - uid: 2217
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-23.5
+      parent: 2
+  - uid: 2218
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-23.5
+      parent: 2
+  - uid: 2219
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-23.5
+      parent: 2
+  - uid: 2220
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-23.5
+      parent: 2
+  - uid: 2221
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-23.5
+      parent: 2
+  - uid: 2222
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-23.5
+      parent: 2
+  - uid: 2223
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-23.5
+      parent: 2
+  - uid: 2224
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-23.5
+      parent: 2
+  - uid: 2225
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-23.5
+      parent: 2
+  - uid: 2226
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-23.5
+      parent: 2
+  - uid: 2227
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-23.5
+      parent: 2
+  - uid: 2228
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-23.5
+      parent: 2
+  - uid: 2229
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-24.5
+      parent: 2
+  - uid: 2230
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-24.5
+      parent: 2
+  - uid: 2231
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-25.5
+      parent: 2
+  - uid: 2232
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-26.5
+      parent: 2
+  - uid: 2233
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-27.5
+      parent: 2
+  - uid: 2234
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-27.5
+      parent: 2
+  - uid: 2235
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-28.5
+      parent: 2
+  - uid: 2236
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-28.5
+      parent: 2
+  - uid: 2237
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-28.5
+      parent: 2
+  - uid: 2238
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-29.5
+      parent: 2
+  - uid: 2239
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-30.5
+      parent: 2
+  - uid: 2240
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-31.5
+      parent: 2
+  - uid: 2241
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-32.5
+      parent: 2
+  - uid: 2242
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-32.5
+      parent: 2
+  - uid: 2243
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-33.5
+      parent: 2
+  - uid: 2244
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,-33.5
+      parent: 2
+  - uid: 2245
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-33.5
+      parent: 2
+  - uid: 2246
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-33.5
+      parent: 2
+  - uid: 2247
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,-33.5
+      parent: 2
+  - uid: 2248
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,-33.5
+      parent: 2
+  - uid: 2249
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-33.5
+      parent: 2
+  - uid: 2250
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-32.5
+      parent: 2
+  - uid: 2251
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-33.5
+      parent: 2
+  - uid: 2252
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-33.5
+      parent: 2
+  - uid: 2253
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-34.5
+      parent: 2
+  - uid: 2254
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,-34.5
+      parent: 2
+  - uid: 2255
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,-35.5
+      parent: 2
+  - uid: 2256
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 27.5,-35.5
+      parent: 2
+  - uid: 2257
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 28.5,-35.5
+      parent: 2
+  - uid: 2258
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-35.5
+      parent: 2
+  - uid: 2259
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 30.5,-35.5
+      parent: 2
+  - uid: 2260
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-35.5
+      parent: 2
+  - uid: 2261
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-34.5
+      parent: 2
+  - uid: 2262
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-33.5
+      parent: 2
+  - uid: 2263
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-32.5
+      parent: 2
+  - uid: 2264
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-31.5
+      parent: 2
+  - uid: 2265
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 43.5,19.5
+      parent: 2
+  - uid: 2266
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,19.5
+      parent: 2
+  - uid: 2267
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,19.5
+      parent: 2
+  - uid: 2268
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,19.5
+      parent: 2
+  - uid: 2269
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,19.5
+      parent: 2
+  - uid: 2270
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,19.5
+      parent: 2
+  - uid: 2271
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,19.5
+      parent: 2
+  - uid: 2272
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,19.5
+      parent: 2
+  - uid: 2273
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,19.5
+      parent: 2
+  - uid: 2274
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,19.5
+      parent: 2
+  - uid: 2275
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,19.5
+      parent: 2
+  - uid: 2276
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,19.5
+      parent: 2
+  - uid: 2277
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,19.5
+      parent: 2
+  - uid: 2278
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 45.5,19.5
+      parent: 2
+  - uid: 2279
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 46.5,19.5
+      parent: 2
+  - uid: 2280
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 44.5,19.5
+      parent: 2
+  - uid: 2281
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 42.5,19.5
+      parent: 2
+  - uid: 2282
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 40.5,19.5
+      parent: 2
+  - uid: 2283
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 41.5,19.5
+      parent: 2
+  - uid: 2284
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 38.5,19.5
+      parent: 2
+  - uid: 2285
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 39.5,19.5
+      parent: 2
+  - uid: 2286
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 36.5,19.5
+      parent: 2
+  - uid: 2287
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 37.5,19.5
+      parent: 2
+  - uid: 2288
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 34.5,19.5
+      parent: 2
+  - uid: 2289
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 35.5,19.5
+      parent: 2
+  - uid: 2290
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 32.5,19.5
+      parent: 2
+  - uid: 2291
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 33.5,19.5
+      parent: 2
+  - uid: 2292
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 30.5,19.5
+      parent: 2
+  - uid: 2293
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,19.5
+      parent: 2
+  - uid: 2294
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,19.5
+      parent: 2
+  - uid: 2295
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 28.5,19.5
+      parent: 2
+  - uid: 2296
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,18.5
+      parent: 2
+  - uid: 2297
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 27.5,19.5
+      parent: 2
+  - uid: 2298
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,18.5
+      parent: 2
+  - uid: 2299
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,18.5
+      parent: 2
+  - uid: 2300
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,17.5
+      parent: 2
+  - uid: 2301
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,17.5
+      parent: 2
+  - uid: 2302
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,16.5
+      parent: 2
+  - uid: 2303
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,17.5
+      parent: 2
+  - uid: 2304
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,16.5
+      parent: 2
+  - uid: 2305
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,16.5
+      parent: 2
+  - uid: 2306
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,15.5
+      parent: 2
+  - uid: 2307
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,15.5
+      parent: 2
+  - uid: 2308
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,15.5
+      parent: 2
+  - uid: 2309
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,15.5
+      parent: 2
+  - uid: 2310
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,15.5
+      parent: 2
+  - uid: 2311
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,14.5
+      parent: 2
+  - uid: 2312
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,14.5
+      parent: 2
+  - uid: 2313
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,14.5
+      parent: 2
+  - uid: 2314
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,14.5
+      parent: 2
+  - uid: 2315
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,14.5
+      parent: 2
+  - uid: 2316
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,13.5
+      parent: 2
+  - uid: 2317
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,13.5
+      parent: 2
+  - uid: 2318
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,13.5
+      parent: 2
+  - uid: 2319
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,12.5
+      parent: 2
+  - uid: 2320
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,12.5
+      parent: 2
+  - uid: 2321
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,12.5
+      parent: 2
+  - uid: 2322
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,12.5
+      parent: 2
+  - uid: 2323
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,11.5
+      parent: 2
+  - uid: 2324
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,11.5
+      parent: 2
+  - uid: 2325
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,11.5
+      parent: 2
+  - uid: 2326
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,11.5
+      parent: 2
+  - uid: 2327
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,10.5
+      parent: 2
+  - uid: 2328
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,10.5
+      parent: 2
+  - uid: 2329
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,9.5
+      parent: 2
+  - uid: 2330
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,9.5
+      parent: 2
+  - uid: 2331
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,9.5
+      parent: 2
+  - uid: 2332
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,9.5
+      parent: 2
+  - uid: 2333
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,9.5
+      parent: 2
+  - uid: 2334
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,8.5
+      parent: 2
+  - uid: 2335
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,7.5
+      parent: 2
+  - uid: 2336
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,7.5
+      parent: 2
+  - uid: 2337
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -13.5,7.5
+      parent: 2
+  - uid: 2338
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,7.5
+      parent: 2
+  - uid: 2339
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -15.5,7.5
+      parent: 2
+  - uid: 2340
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -15.5,6.5
+      parent: 2
+  - uid: 2341
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,6.5
+      parent: 2
+  - uid: 2342
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -17.5,6.5
+      parent: 2
+  - uid: 2343
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -17.5,5.5
+      parent: 2
+  - uid: 2344
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -17.5,4.5
+      parent: 2
+  - uid: 2345
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -17.5,3.5
+      parent: 2
+  - uid: 2346
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,3.5
+      parent: 2
+  - uid: 2347
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 47.5,19.5
+      parent: 2
+  - uid: 2348
+    components:
+    - type: Transform
+      pos: 32.5,-31.5
+      parent: 2
+  - uid: 2349
+    components:
+    - type: Transform
+      pos: 32.5,-30.5
+      parent: 2
+  - uid: 2350
+    components:
+    - type: Transform
+      pos: 32.5,-29.5
+      parent: 2
+  - uid: 2351
+    components:
+    - type: Transform
+      pos: 32.5,-28.5
+      parent: 2
+  - uid: 2352
+    components:
+    - type: Transform
+      pos: 32.5,-27.5
+      parent: 2
+  - uid: 2353
+    components:
+    - type: Transform
+      pos: 32.5,-26.5
+      parent: 2
+  - uid: 2354
+    components:
+    - type: Transform
+      pos: 33.5,-26.5
+      parent: 2
+  - uid: 2355
+    components:
+    - type: Transform
+      pos: 34.5,-26.5
+      parent: 2
+  - uid: 2356
+    components:
+    - type: Transform
+      pos: 34.5,-25.5
+      parent: 2
+  - uid: 2357
+    components:
+    - type: Transform
+      pos: 35.5,-25.5
+      parent: 2
+  - uid: 2358
+    components:
+    - type: Transform
+      pos: 36.5,-25.5
+      parent: 2
+  - uid: 2359
+    components:
+    - type: Transform
+      pos: 36.5,-24.5
+      parent: 2
+  - uid: 2360
+    components:
+    - type: Transform
+      pos: 37.5,-24.5
+      parent: 2
+  - uid: 2361
+    components:
+    - type: Transform
+      pos: 38.5,-24.5
+      parent: 2
+  - uid: 2362
+    components:
+    - type: Transform
+      pos: 39.5,-24.5
+      parent: 2
+  - uid: 2363
+    components:
+    - type: Transform
+      pos: 39.5,-23.5
+      parent: 2
+  - uid: 2364
+    components:
+    - type: Transform
+      pos: 40.5,-23.5
+      parent: 2
+  - uid: 2365
+    components:
+    - type: Transform
+      pos: 40.5,-22.5
+      parent: 2
+  - uid: 2366
+    components:
+    - type: Transform
+      pos: 40.5,-21.5
+      parent: 2
+  - uid: 2367
+    components:
+    - type: Transform
+      pos: 40.5,-20.5
+      parent: 2
+  - uid: 2368
+    components:
+    - type: Transform
+      pos: 40.5,-19.5
+      parent: 2
+  - uid: 2369
+    components:
+    - type: Transform
+      pos: 40.5,-18.5
+      parent: 2
+  - uid: 2370
+    components:
+    - type: Transform
+      pos: 41.5,-18.5
+      parent: 2
+  - uid: 2371
+    components:
+    - type: Transform
+      pos: 42.5,-18.5
+      parent: 2
+  - uid: 2372
+    components:
+    - type: Transform
+      pos: 43.5,-18.5
+      parent: 2
+  - uid: 2373
+    components:
+    - type: Transform
+      pos: 44.5,-18.5
+      parent: 2
+  - uid: 2374
+    components:
+    - type: Transform
+      pos: 45.5,-18.5
+      parent: 2
+- proto: WaterTankFull
+  entities:
+  - uid: 2375
+    components:
+    - type: Transform
+      pos: -13.5,-4.5
+      parent: 2
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 2376
+    components:
+    - type: Transform
+      pos: 34.5,-0.5
+      parent: 2
+  - uid: 2377
+    components:
+    - type: Transform
+      pos: 37.5,-8.5
+      parent: 2
+  - uid: 2378
+    components:
+    - type: Transform
+      pos: 38.5,-10.5
+      parent: 2
+- proto: WeaponPistolViper
+  entities:
+  - uid: 2379
+    components:
+    - type: Transform
+      pos: 10.786457,-17.450405
+      parent: 2
+- proto: WeaponSprayNozzle
+  entities:
+  - uid: 2380
+    components:
+    - type: Transform
+      pos: 11.883067,-9.275236
+      parent: 2
+- proto: WeldingFuelTankFull
+  entities:
+  - uid: 2381
+    components:
+    - type: Transform
+      pos: -11.5,0.5
+      parent: 2
+- proto: Windoor
+  entities:
+  - uid: 2382
+    components:
+    - type: Transform
+      pos: 4.5,-14.5
+      parent: 2
+  - uid: 2383
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 2384
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 30.5,1.5
+      parent: 2
+  - uid: 2385
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 30.5,0.5
+      parent: 2
 - proto: WindowDirectional
   entities:
-  - uid: 498
+  - uid: 2386
     components:
     - type: Transform
       pos: 3.5,-14.5
-      parent: 1
-  - uid: 754
+      parent: 2
+  - uid: 2387
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-13.5
-      parent: 1
-  - uid: 821
+      parent: 2
+  - uid: 2388
     components:
     - type: Transform
       pos: -1.5,-1.5
-      parent: 1
-  - uid: 822
+      parent: 2
+  - uid: 2389
     components:
     - type: Transform
       pos: -3.5,-1.5
-      parent: 1
+      parent: 2
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 549
+  - uid: 2390
     components:
     - type: Transform
       pos: 1.5,-14.5
-      parent: 1
-  - uid: 550
+      parent: 2
+  - uid: 2391
     components:
     - type: Transform
       pos: 0.5,-14.5
-      parent: 1
+      parent: 2
 - proto: Wrench
   entities:
-  - uid: 450
+  - uid: 2392
     components:
     - type: Transform
       pos: -4.438742,-14.360842
-      parent: 1
+      parent: 2
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-  - uid: 795
+  - uid: 2393
     components:
     - type: Transform
       pos: -12.48534,0.4715228
-      parent: 1
+      parent: 2
+  - uid: 2394
+    components:
+    - type: Transform
+      pos: -10.090788,-3.0192807
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
 - proto: Zipties
   entities:
-  - uid: 1753
+  - uid: 2395
     components:
     - type: Transform
       pos: 31.5,-0.5
-      parent: 1
+      parent: 2
 ...

--- a/Resources/Maps/Goobstation/Shuttles/infiltrator.yml
+++ b/Resources/Maps/Goobstation/Shuttles/infiltrator.yml
@@ -25,7 +25,7 @@ entities:
   - uid: 2
     components:
     - type: MetaData
-      name: grid
+      name: Infiltrator
     - type: Transform
       pos: -2.5547404,-0.85075015
       parent: 1
@@ -461,990 +461,1001 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,0.5
       parent: 2
-- proto: BoxHandcuff
+- proto: BoxFolderNuclearCodes
   entities:
   - uid: 50
+    components:
+    - type: Transform
+      pos: 8.515652,3.538541
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+- proto: BoxHandcuff
+  entities:
+  - uid: 51
     components:
     - type: Transform
       pos: 7.4232526,1.7930057
       parent: 2
 - proto: C4
   entities:
-  - uid: 51
+  - uid: 52
     components:
     - type: Transform
       pos: 8.407627,2.2383182
       parent: 2
-  - uid: 52
+  - uid: 53
     components:
     - type: Transform
       pos: 8.75919,1.9805057
       parent: 2
-  - uid: 53
+  - uid: 54
     components:
     - type: Transform
       pos: 8.431065,1.5820682
       parent: 2
 - proto: CableApcExtension
   entities:
-  - uid: 54
+  - uid: 55
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 2
-  - uid: 55
+  - uid: 56
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 2
-  - uid: 56
+  - uid: 57
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 2
-  - uid: 57
+  - uid: 58
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 2
-  - uid: 58
+  - uid: 59
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 2
-  - uid: 59
+  - uid: 60
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 2
-  - uid: 60
+  - uid: 61
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 2
-  - uid: 61
+  - uid: 62
     components:
     - type: Transform
       pos: 6.5,0.5
       parent: 2
-  - uid: 62
+  - uid: 63
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 2
-  - uid: 63
+  - uid: 64
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 2
-  - uid: 64
+  - uid: 65
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 2
-  - uid: 65
+  - uid: 66
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 2
-  - uid: 66
+  - uid: 67
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 2
-  - uid: 67
+  - uid: 68
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 2
-  - uid: 68
+  - uid: 69
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 2
-  - uid: 69
+  - uid: 70
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 2
-  - uid: 70
+  - uid: 71
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 2
-  - uid: 71
+  - uid: 72
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 2
-  - uid: 72
+  - uid: 73
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 2
-  - uid: 73
+  - uid: 74
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 2
-  - uid: 74
+  - uid: 75
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 2
-  - uid: 75
+  - uid: 76
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 2
-  - uid: 76
+  - uid: 77
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 2
-  - uid: 77
+  - uid: 78
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 2
-  - uid: 78
+  - uid: 79
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 2
-  - uid: 79
+  - uid: 80
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 2
-  - uid: 80
+  - uid: 81
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 2
-  - uid: 81
+  - uid: 82
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 2
-  - uid: 82
+  - uid: 83
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 2
-  - uid: 83
+  - uid: 84
     components:
     - type: Transform
       pos: 9.5,-1.5
       parent: 2
-  - uid: 84
+  - uid: 85
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 2
-  - uid: 85
+  - uid: 86
     components:
     - type: Transform
       pos: 8.5,-3.5
       parent: 2
-  - uid: 86
+  - uid: 87
     components:
     - type: Transform
       pos: 8.5,-4.5
       parent: 2
-  - uid: 87
+  - uid: 88
     components:
     - type: Transform
       pos: 8.5,-5.5
       parent: 2
-  - uid: 88
+  - uid: 89
     components:
     - type: Transform
       pos: 8.5,-6.5
       parent: 2
-  - uid: 89
+  - uid: 90
     components:
     - type: Transform
       pos: 8.5,-7.5
       parent: 2
-  - uid: 90
+  - uid: 91
     components:
     - type: Transform
       pos: 8.5,-8.5
       parent: 2
-  - uid: 91
+  - uid: 92
     components:
     - type: Transform
       pos: 8.5,-9.5
       parent: 2
-  - uid: 92
+  - uid: 93
     components:
     - type: Transform
       pos: 7.5,-6.5
       parent: 2
-  - uid: 93
+  - uid: 94
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 2
-  - uid: 94
+  - uid: 95
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 2
-  - uid: 95
+  - uid: 96
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 2
-  - uid: 96
+  - uid: 97
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 2
-  - uid: 97
+  - uid: 98
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 2
-  - uid: 98
+  - uid: 99
     components:
     - type: Transform
       pos: -3.5,-8.5
       parent: 2
-  - uid: 99
+  - uid: 100
     components:
     - type: Transform
       pos: -3.5,-7.5
       parent: 2
-  - uid: 100
+  - uid: 101
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 2
-  - uid: 101
+  - uid: 102
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 2
-  - uid: 102
+  - uid: 103
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 2
-  - uid: 103
+  - uid: 104
     components:
     - type: Transform
       pos: 8.5,-10.5
       parent: 2
-  - uid: 104
+  - uid: 105
     components:
     - type: Transform
       pos: 8.5,-11.5
       parent: 2
-  - uid: 105
+  - uid: 106
     components:
     - type: Transform
       pos: 8.5,-12.5
       parent: 2
-  - uid: 106
+  - uid: 107
     components:
     - type: Transform
       pos: 9.5,-12.5
       parent: 2
-  - uid: 107
+  - uid: 108
     components:
     - type: Transform
       pos: 7.5,-12.5
       parent: 2
-  - uid: 108
+  - uid: 109
     components:
     - type: Transform
       pos: 8.5,-13.5
       parent: 2
-  - uid: 109
+  - uid: 110
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 2
-  - uid: 110
+  - uid: 111
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 2
-  - uid: 111
+  - uid: 112
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 2
-  - uid: 112
+  - uid: 113
     components:
     - type: Transform
       pos: -3.5,-13.5
       parent: 2
-  - uid: 113
+  - uid: 114
     components:
     - type: Transform
       pos: -2.5,-12.5
       parent: 2
-  - uid: 114
+  - uid: 115
     components:
     - type: Transform
       pos: -4.5,-12.5
       parent: 2
-  - uid: 115
+  - uid: 116
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 2
-  - uid: 116
+  - uid: 117
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 2
-  - uid: 117
+  - uid: 118
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 2
-  - uid: 118
+  - uid: 119
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 2
-  - uid: 119
+  - uid: 120
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 2
-  - uid: 120
+  - uid: 121
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 2
-  - uid: 121
+  - uid: 122
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 2
-  - uid: 122
+  - uid: 123
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 2
-  - uid: 123
+  - uid: 124
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 2
-  - uid: 124
+  - uid: 125
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 2
-  - uid: 125
+  - uid: 126
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 2
-  - uid: 126
+  - uid: 127
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 2
-  - uid: 127
+  - uid: 128
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 2
-  - uid: 128
+  - uid: 129
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 2
-  - uid: 129
+  - uid: 130
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 2
-  - uid: 130
+  - uid: 131
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 2
-  - uid: 131
+  - uid: 132
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 2
-  - uid: 132
+  - uid: 133
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 2
-  - uid: 133
+  - uid: 134
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 2
-  - uid: 134
+  - uid: 135
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 2
-  - uid: 135
+  - uid: 136
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 2
-  - uid: 136
+  - uid: 137
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 2
-  - uid: 137
+  - uid: 138
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 2
-  - uid: 138
+  - uid: 139
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 2
-  - uid: 139
+  - uid: 140
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 2
-  - uid: 140
+  - uid: 141
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 2
-  - uid: 141
+  - uid: 142
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 2
-  - uid: 142
+  - uid: 143
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 2
-  - uid: 143
+  - uid: 144
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 2
-  - uid: 144
+  - uid: 145
     components:
     - type: Transform
       pos: 3.5,13.5
       parent: 2
-  - uid: 145
+  - uid: 146
     components:
     - type: Transform
       pos: 4.5,13.5
       parent: 2
-  - uid: 146
+  - uid: 147
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 2
-  - uid: 147
+  - uid: 148
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 2
-  - uid: 148
+  - uid: 149
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 2
-  - uid: 149
+  - uid: 150
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 2
-  - uid: 150
+  - uid: 151
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 2
-  - uid: 151
+  - uid: 152
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
-  - uid: 152
+  - uid: 153
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 2
-  - uid: 153
+  - uid: 154
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 2
-  - uid: 154
+  - uid: 155
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 2
-  - uid: 155
+  - uid: 156
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 2
-  - uid: 156
+  - uid: 157
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 2
-  - uid: 157
+  - uid: 158
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 2
-  - uid: 158
+  - uid: 159
     components:
     - type: Transform
       pos: 8.5,7.5
       parent: 2
 - proto: CableHV
   entities:
-  - uid: 159
+  - uid: 160
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 2
-  - uid: 160
+  - uid: 161
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 2
-  - uid: 161
+  - uid: 162
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 2
-  - uid: 162
+  - uid: 163
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 2
-  - uid: 163
+  - uid: 164
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 2
-  - uid: 164
+  - uid: 165
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 2
-  - uid: 165
+  - uid: 166
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 2
-  - uid: 166
+  - uid: 167
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 2
-  - uid: 167
+  - uid: 168
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 2
-  - uid: 168
+  - uid: 169
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 2
-  - uid: 169
+  - uid: 170
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 2
-  - uid: 170
+  - uid: 171
     components:
     - type: Transform
       pos: 6.5,-4.5
       parent: 2
-  - uid: 171
+  - uid: 172
     components:
     - type: Transform
       pos: 6.5,-5.5
       parent: 2
-  - uid: 172
+  - uid: 173
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 2
-  - uid: 173
+  - uid: 174
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 2
-  - uid: 174
+  - uid: 175
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 2
-  - uid: 175
+  - uid: 176
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 2
 - proto: CableMV
   entities:
-  - uid: 176
+  - uid: 177
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 2
-  - uid: 177
+  - uid: 178
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 2
-  - uid: 178
+  - uid: 179
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 2
-  - uid: 179
+  - uid: 180
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 2
-  - uid: 180
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 2
   - uid: 181
     components:
     - type: Transform
-      pos: 2.5,-0.5
+      pos: 2.5,-1.5
       parent: 2
   - uid: 182
     components:
     - type: Transform
-      pos: 2.5,0.5
+      pos: 2.5,-0.5
       parent: 2
   - uid: 183
     components:
     - type: Transform
-      pos: 2.5,-1.5
+      pos: 2.5,0.5
       parent: 2
   - uid: 184
     components:
     - type: Transform
-      pos: 3.5,-1.5
+      pos: 2.5,-1.5
       parent: 2
   - uid: 185
     components:
     - type: Transform
-      pos: 4.5,-1.5
+      pos: 3.5,-1.5
       parent: 2
   - uid: 186
     components:
     - type: Transform
-      pos: 5.5,-1.5
+      pos: 4.5,-1.5
       parent: 2
   - uid: 187
     components:
     - type: Transform
-      pos: 6.5,-1.5
+      pos: 5.5,-1.5
       parent: 2
   - uid: 188
     components:
     - type: Transform
-      pos: 6.5,0.5
+      pos: 6.5,-1.5
       parent: 2
   - uid: 189
     components:
     - type: Transform
-      pos: 6.5,-2.5
+      pos: 6.5,0.5
       parent: 2
   - uid: 190
     components:
     - type: Transform
-      pos: 6.5,-4.5
+      pos: 6.5,-2.5
       parent: 2
   - uid: 191
     components:
     - type: Transform
-      pos: 6.5,-3.5
+      pos: 6.5,-4.5
       parent: 2
   - uid: 192
     components:
     - type: Transform
-      pos: 7.5,-4.5
+      pos: 6.5,-3.5
       parent: 2
   - uid: 193
     components:
     - type: Transform
-      pos: 8.5,-4.5
+      pos: 7.5,-4.5
       parent: 2
   - uid: 194
     components:
     - type: Transform
-      pos: 8.5,-3.5
+      pos: 8.5,-4.5
       parent: 2
   - uid: 195
     components:
     - type: Transform
-      pos: 1.5,-1.5
+      pos: 8.5,-3.5
       parent: 2
   - uid: 196
     components:
     - type: Transform
-      pos: 0.5,-1.5
+      pos: 1.5,-1.5
       parent: 2
   - uid: 197
     components:
     - type: Transform
-      pos: -0.5,-1.5
+      pos: 0.5,-1.5
       parent: 2
   - uid: 198
     components:
     - type: Transform
-      pos: -1.5,-1.5
+      pos: -0.5,-1.5
       parent: 2
   - uid: 199
     components:
     - type: Transform
-      pos: -1.5,-2.5
+      pos: -1.5,-1.5
       parent: 2
   - uid: 200
     components:
     - type: Transform
-      pos: -1.5,-3.5
+      pos: -1.5,-2.5
       parent: 2
   - uid: 201
     components:
     - type: Transform
-      pos: -1.5,-4.5
+      pos: -1.5,-3.5
       parent: 2
   - uid: 202
     components:
     - type: Transform
-      pos: -2.5,-4.5
+      pos: -1.5,-4.5
       parent: 2
   - uid: 203
     components:
     - type: Transform
-      pos: -3.5,-4.5
+      pos: -2.5,-4.5
       parent: 2
   - uid: 204
     components:
     - type: Transform
-      pos: -3.5,-3.5
+      pos: -3.5,-4.5
       parent: 2
   - uid: 205
     components:
     - type: Transform
-      pos: 1.5,0.5
+      pos: -3.5,-3.5
       parent: 2
   - uid: 206
     components:
     - type: Transform
-      pos: 3.5,0.5
+      pos: 1.5,0.5
       parent: 2
   - uid: 207
     components:
     - type: Transform
-      pos: 3.5,1.5
+      pos: 3.5,0.5
       parent: 2
   - uid: 208
     components:
     - type: Transform
-      pos: 3.5,2.5
+      pos: 3.5,1.5
       parent: 2
   - uid: 209
     components:
     - type: Transform
-      pos: 1.5,1.5
+      pos: 3.5,2.5
       parent: 2
   - uid: 210
     components:
     - type: Transform
-      pos: 1.5,2.5
+      pos: 1.5,1.5
       parent: 2
   - uid: 211
     components:
     - type: Transform
-      pos: 2.5,2.5
+      pos: 1.5,2.5
       parent: 2
   - uid: 212
     components:
     - type: Transform
-      pos: 2.5,3.5
+      pos: 2.5,2.5
       parent: 2
   - uid: 213
     components:
     - type: Transform
-      pos: 2.5,4.5
+      pos: 2.5,3.5
       parent: 2
   - uid: 214
     components:
     - type: Transform
-      pos: 3.5,4.5
+      pos: 2.5,4.5
       parent: 2
   - uid: 215
     components:
     - type: Transform
-      pos: 4.5,4.5
+      pos: 3.5,4.5
       parent: 2
   - uid: 216
     components:
     - type: Transform
-      pos: 5.5,4.5
+      pos: 4.5,4.5
       parent: 2
   - uid: 217
     components:
     - type: Transform
-      pos: 1.5,4.5
+      pos: 5.5,4.5
       parent: 2
   - uid: 218
     components:
     - type: Transform
-      pos: 0.5,4.5
+      pos: 1.5,4.5
       parent: 2
   - uid: 219
     components:
     - type: Transform
-      pos: -0.5,4.5
+      pos: 0.5,4.5
       parent: 2
   - uid: 220
     components:
     - type: Transform
-      pos: -1.5,4.5
+      pos: -0.5,4.5
       parent: 2
   - uid: 221
     components:
     - type: Transform
-      pos: 6.5,4.5
+      pos: -1.5,4.5
       parent: 2
   - uid: 222
     components:
     - type: Transform
-      pos: 6.5,3.5
+      pos: 6.5,4.5
       parent: 2
   - uid: 223
     components:
     - type: Transform
-      pos: 6.5,2.5
+      pos: 6.5,3.5
       parent: 2
   - uid: 224
     components:
     - type: Transform
-      pos: 6.5,1.5
+      pos: 6.5,2.5
       parent: 2
   - uid: 225
     components:
     - type: Transform
-      pos: 6.5,0.5
+      pos: 6.5,1.5
       parent: 2
   - uid: 226
     components:
     - type: Transform
-      pos: -1.5,3.5
+      pos: 6.5,0.5
       parent: 2
   - uid: 227
     components:
     - type: Transform
-      pos: -1.5,2.5
+      pos: -1.5,3.5
       parent: 2
   - uid: 228
     components:
     - type: Transform
-      pos: -1.5,1.5
+      pos: -1.5,2.5
       parent: 2
   - uid: 229
     components:
     - type: Transform
-      pos: -1.5,0.5
+      pos: -1.5,1.5
       parent: 2
   - uid: 230
     components:
     - type: Transform
-      pos: 1.5,-4.5
+      pos: -1.5,0.5
       parent: 2
   - uid: 231
     components:
     - type: Transform
-      pos: 0.5,-4.5
+      pos: 1.5,-4.5
       parent: 2
   - uid: 232
     components:
     - type: Transform
-      pos: 2.5,6.5
+      pos: 0.5,-4.5
       parent: 2
   - uid: 233
     components:
     - type: Transform
-      pos: 2.5,7.5
+      pos: 2.5,6.5
       parent: 2
   - uid: 234
     components:
     - type: Transform
-      pos: 2.5,8.5
+      pos: 2.5,7.5
       parent: 2
   - uid: 235
     components:
     - type: Transform
-      pos: 2.5,9.5
+      pos: 2.5,8.5
       parent: 2
   - uid: 236
     components:
     - type: Transform
-      pos: 2.5,10.5
+      pos: 2.5,9.5
       parent: 2
   - uid: 237
     components:
     - type: Transform
-      pos: 2.5,11.5
+      pos: 2.5,10.5
       parent: 2
   - uid: 238
     components:
     - type: Transform
-      pos: 2.5,12.5
+      pos: 2.5,11.5
       parent: 2
   - uid: 239
     components:
     - type: Transform
-      pos: 2.5,5.5
+      pos: 2.5,12.5
       parent: 2
   - uid: 240
     components:
     - type: Transform
-      pos: 1.5,12.5
+      pos: 2.5,5.5
       parent: 2
   - uid: 241
     components:
     - type: Transform
-      pos: 0.5,12.5
+      pos: 1.5,12.5
       parent: 2
   - uid: 242
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 2
+  - uid: 243
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 2
 - proto: CableTerminal
   entities:
-  - uid: 243
+  - uid: 244
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-4.5
       parent: 2
-  - uid: 244
+  - uid: 245
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1452,91 +1463,91 @@ entities:
       parent: 2
 - proto: Catwalk
   entities:
-  - uid: 248
+  - uid: 246
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 2
-  - uid: 249
+  - uid: 247
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 2
-  - uid: 250
+  - uid: 248
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 2
-  - uid: 251
+  - uid: 249
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 2
-  - uid: 252
+  - uid: 250
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 2
-  - uid: 253
+  - uid: 251
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 2
-  - uid: 257
+  - uid: 252
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,4.5
       parent: 2
-  - uid: 258
+  - uid: 253
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-5.5
       parent: 2
-  - uid: 259
+  - uid: 254
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-7.5
       parent: 2
-  - uid: 260
+  - uid: 255
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-6.5
       parent: 2
-  - uid: 261
+  - uid: 256
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-7.5
       parent: 2
-  - uid: 262
+  - uid: 257
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-6.5
       parent: 2
-  - uid: 263
+  - uid: 258
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-5.5
       parent: 2
-  - uid: 590
+  - uid: 259
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 2
-  - uid: 593
+  - uid: 260
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,4.5
       parent: 2
-  - uid: 599
+  - uid: 261
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1544,20 +1555,20 @@ entities:
       parent: 2
 - proto: Cautery
   entities:
-  - uid: 264
+  - uid: 262
     components:
     - type: Transform
       pos: -0.6122134,-4.820427
       parent: 2
 - proto: ChairOfficeDark
   entities:
-  - uid: 265
+  - uid: 263
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,13.5
       parent: 2
-  - uid: 266
+  - uid: 264
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1565,31 +1576,31 @@ entities:
       parent: 2
 - proto: ChairPilotSeat
   entities:
-  - uid: 267
+  - uid: 265
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,5.5
       parent: 2
-  - uid: 268
+  - uid: 266
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,4.5
       parent: 2
-  - uid: 269
+  - uid: 267
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,4.5
       parent: 2
-  - uid: 270
+  - uid: 268
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 2
-  - uid: 271
+  - uid: 269
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1597,21 +1608,21 @@ entities:
       parent: 2
 - proto: CheapRollerBed
   entities:
-  - uid: 272
+  - uid: 270
     components:
     - type: Transform
       pos: -2.510651,-4.539177
       parent: 2
 - proto: ClothingOuterHardsuitSyndicateDurathread
   entities:
-  - uid: 273
+  - uid: 271
     components:
     - type: Transform
       pos: -0.54308534,5.539448
       parent: 2
 - proto: ComputerCrewMonitoring
   entities:
-  - uid: 274
+  - uid: 272
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1619,7 +1630,7 @@ entities:
       parent: 2
 - proto: ComputerCriminalRecords
   entities:
-  - uid: 275
+  - uid: 273
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1627,14 +1638,14 @@ entities:
       parent: 2
 - proto: ComputerIFFSyndicate
   entities:
-  - uid: 276
+  - uid: 274
     components:
     - type: Transform
       pos: 1.5,14.5
       parent: 2
 - proto: ComputerMedicalRecords
   entities:
-  - uid: 277
+  - uid: 275
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1642,140 +1653,140 @@ entities:
       parent: 2
 - proto: ComputerShuttleSyndie
   entities:
-  - uid: 278
+  - uid: 276
     components:
     - type: Transform
       pos: 2.5,14.5
       parent: 2
 - proto: CrowbarRed
   entities:
-  - uid: 279
+  - uid: 277
     components:
     - type: Transform
       pos: -0.44933534,5.445698
       parent: 2
 - proto: DoubleEmergencyNitrogenTankFilled
   entities:
-  - uid: 280
+  - uid: 278
     components:
     - type: Transform
       pos: -4.3939404,-0.66514474
       parent: 2
-  - uid: 281
+  - uid: 279
     components:
     - type: Transform
       pos: 9.645123,-0.73545724
       parent: 2
 - proto: DoubleEmergencyOxygenTankFilled
   entities:
-  - uid: 282
+  - uid: 280
     components:
     - type: Transform
       pos: -4.5345654,-0.45420724
       parent: 2
-  - uid: 283
+  - uid: 281
     components:
     - type: Transform
       pos: 9.38731,-0.45420724
       parent: 2
 - proto: EpinephrineChemistryBottle
   entities:
-  - uid: 284
+  - uid: 282
     components:
     - type: Transform
       pos: -4.526276,-7.2344894
       parent: 2
 - proto: ExplosivePayload
   entities:
-  - uid: 285
+  - uid: 283
     components:
     - type: Transform
       pos: 9.547621,-8.148552
       parent: 2
 - proto: FoodBoxDonut
   entities:
-  - uid: 286
+  - uid: 284
     components:
     - type: Transform
       pos: 0.53503966,14.4985695
       parent: 2
 - proto: Gauze
   entities:
-  - uid: 287
+  - uid: 285
     components:
     - type: Transform
       pos: -0.49502587,-5.2657394
       parent: 2
 - proto: GravityGeneratorMini
   entities:
-  - uid: 288
+  - uid: 286
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 2
 - proto: Grille
   entities:
-  - uid: 289
+  - uid: 287
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 2
-  - uid: 290
+  - uid: 288
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 2
-  - uid: 291
+  - uid: 289
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 2
-  - uid: 292
+  - uid: 290
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 2
-  - uid: 293
+  - uid: 291
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 2
-  - uid: 294
+  - uid: 292
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 2
-  - uid: 295
+  - uid: 293
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,4.5
       parent: 2
-  - uid: 296
+  - uid: 294
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,2.5
       parent: 2
-  - uid: 297
+  - uid: 295
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,2.5
       parent: 2
-  - uid: 298
+  - uid: 296
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,4.5
       parent: 2
-  - uid: 299
+  - uid: 297
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,5.5
       parent: 2
-  - uid: 300
+  - uid: 298
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1783,52 +1794,52 @@ entities:
       parent: 2
 - proto: Gyroscope
   entities:
-  - uid: 301
+  - uid: 299
     components:
     - type: Transform
       pos: 8.5,-11.5
       parent: 2
-  - uid: 302
+  - uid: 300
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 2
 - proto: HandheldHealthAnalyzer
   entities:
-  - uid: 303
+  - uid: 301
     components:
     - type: Transform
       pos: -0.44815087,-4.398552
       parent: 2
 - proto: Hemostat
   entities:
-  - uid: 304
+  - uid: 302
     components:
     - type: Transform
       pos: -2.3934636,-10.445427
       parent: 2
 - proto: LargeBeaker
   entities:
-  - uid: 305
+  - uid: 303
     components:
     - type: Transform
       pos: -4.4559636,-6.461052
       parent: 2
 - proto: LiquidOxygenCanister
   entities:
-  - uid: 306
+  - uid: 304
     components:
     - type: Transform
       pos: 9.5,-4.5
       parent: 2
-  - uid: 307
+  - uid: 305
     components:
     - type: Transform
       pos: 9.5,-5.5
       parent: 2
 - proto: MachineFrame
   entities:
-  - uid: 308
+  - uid: 306
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1836,72 +1847,58 @@ entities:
       parent: 2
 - proto: MachineFrameDestroyed
   entities:
-  - uid: 309
+  - uid: 307
     components:
     - type: Transform
       pos: 8.5,-10.5
       parent: 2
 - proto: MedicalBed
   entities:
-  - uid: 310
+  - uid: 308
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 2
-  - uid: 311
+  - uid: 309
     components:
     - type: Transform
       pos: -4.5,-5.5
       parent: 2
 - proto: MedkitCombatFilled
   entities:
-  - uid: 312
+  - uid: 310
     components:
     - type: Transform
       pos: -1.4090884,-8.289177
       parent: 2
-  - uid: 313
+  - uid: 311
     components:
     - type: Transform
       pos: -0.9637759,-8.570427
       parent: 2
-  - uid: 314
+  - uid: 312
     components:
     - type: Transform
       pos: -0.5419009,-8.289177
       parent: 2
 - proto: NuclearBomb
   entities:
-  - uid: 315
+  - uid: 313
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,1.5
       parent: 2
-- proto: NukeCodePaper
-  entities:
-  - uid: 316
-    components:
-    - type: Transform
-      pos: 8.458004,3.5654695
-      parent: 2
-- proto: NukeCodePaperStation
-  entities:
-  - uid: 317
-    components:
-    - type: Transform
-      pos: 8.5751915,3.213907
-      parent: 2
 - proto: OperatingTable
   entities:
-  - uid: 318
+  - uid: 314
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 2
 - proto: PaperOffice
   entities:
-  - uid: 319
+  - uid: 315
     components:
     - type: Transform
       pos: 8.404715,2.9624357
@@ -1915,10 +1912,8 @@ entities:
         Congratulations on hopping onto a new revision of our Infiltrator ship, made in collaboration with CyberSun.
 
 
-        You have been provided with both the station codes, and for your own nuke. Don't ask why, just be happy we've went through all this trouble to give you TWO chances to blow up the station, in case some random assistant decides that the nuke needs to feel some fresh space wind.
-
-
         - John Station, Gorlex Marauders Representative
+
 
 
     - type: Physics
@@ -1926,109 +1921,109 @@ entities:
       linearDamping: 0
 - proto: PlastitaniumWindow
   entities:
-  - uid: 320
+  - uid: 316
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,11.5
       parent: 2
-  - uid: 321
+  - uid: 317
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,11.5
       parent: 2
-  - uid: 322
+  - uid: 318
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,11.5
       parent: 2
-  - uid: 323
+  - uid: 319
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,14.5
       parent: 2
-  - uid: 324
+  - uid: 320
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,13.5
       parent: 2
-  - uid: 325
+  - uid: 321
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,12.5
       parent: 2
-  - uid: 326
+  - uid: 322
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,12.5
       parent: 2
-  - uid: 327
+  - uid: 323
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,13.5
       parent: 2
-  - uid: 328
+  - uid: 324
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,14.5
       parent: 2
-  - uid: 329
+  - uid: 325
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,11.5
       parent: 2
-  - uid: 330
+  - uid: 326
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,11.5
       parent: 2
-  - uid: 331
+  - uid: 327
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,15.5
       parent: 2
-  - uid: 332
+  - uid: 328
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,15.5
       parent: 2
-  - uid: 333
+  - uid: 329
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,15.5
       parent: 2
-  - uid: 334
+  - uid: 330
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,15.5
       parent: 2
-  - uid: 335
+  - uid: 331
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,15.5
       parent: 2
-  - uid: 336
+  - uid: 332
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,15.5
       parent: 2
-  - uid: 337
+  - uid: 333
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2036,49 +2031,49 @@ entities:
       parent: 2
 - proto: PlushieNuke
   entities:
-  - uid: 338
+  - uid: 334
     components:
     - type: Transform
       pos: -2.416901,-5.3594894
       parent: 2
 - proto: PosterContrabandC20r
   entities:
-  - uid: 339
+  - uid: 335
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 2
 - proto: PosterContrabandEnlistGorlex
   entities:
-  - uid: 340
+  - uid: 336
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 2
 - proto: PosterContrabandFreeSyndicateEncryptionKey
   entities:
-  - uid: 341
+  - uid: 337
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 2
 - proto: PosterContrabandFunPolice
   entities:
-  - uid: 342
+  - uid: 338
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 2
 - proto: PowerCellHigh
   entities:
-  - uid: 343
+  - uid: 339
     components:
     - type: Transform
       pos: 5.610121,-8.382927
       parent: 2
 - proto: PowerCellRecharger
   entities:
-  - uid: 344
+  - uid: 340
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2086,135 +2081,135 @@ entities:
       parent: 2
 - proto: Poweredlight
   entities:
-  - uid: 345
+  - uid: 341
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 2
-  - uid: 346
+  - uid: 342
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 2
-  - uid: 347
+  - uid: 343
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-4.5
       parent: 2
-  - uid: 348
+  - uid: 344
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-6.5
       parent: 2
-  - uid: 349
+  - uid: 345
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-7.5
       parent: 2
-  - uid: 350
+  - uid: 346
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-10.5
       parent: 2
-  - uid: 351
+  - uid: 347
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 2
-  - uid: 352
+  - uid: 348
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-10.5
       parent: 2
-  - uid: 353
+  - uid: 349
     components:
     - type: Transform
       pos: 9.5,-4.5
       parent: 2
-  - uid: 354
+  - uid: 350
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,4.5
       parent: 2
-  - uid: 355
+  - uid: 351
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,4.5
       parent: 2
-  - uid: 356
+  - uid: 352
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,1.5
       parent: 2
-  - uid: 357
+  - uid: 353
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,1.5
       parent: 2
-  - uid: 358
+  - uid: 354
     components:
     - type: Transform
       pos: 0.5,14.5
       parent: 2
-  - uid: 359
+  - uid: 355
     components:
     - type: Transform
       pos: 4.5,14.5
       parent: 2
 - proto: PoweredSmallLight
   entities:
-  - uid: 360
+  - uid: 356
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-2.5
       parent: 2
-  - uid: 361
+  - uid: 357
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-2.5
       parent: 2
-  - uid: 362
+  - uid: 358
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,0.5
       parent: 2
-  - uid: 363
+  - uid: 359
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,0.5
       parent: 2
-  - uid: 364
+  - uid: 360
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,6.5
       parent: 2
-  - uid: 365
+  - uid: 361
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,6.5
       parent: 2
-  - uid: 366
+  - uid: 362
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,7.5
       parent: 2
-  - uid: 367
+  - uid: 363
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2222,95 +2217,95 @@ entities:
       parent: 2
 - proto: Rack
   entities:
-  - uid: 368
+  - uid: 364
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 2
-  - uid: 369
+  - uid: 365
     components:
     - type: Transform
       pos: 9.5,-0.5
       parent: 2
-  - uid: 370
+  - uid: 366
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 2
-  - uid: 371
+  - uid: 367
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-5.5
       parent: 2
-  - uid: 372
+  - uid: 368
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 2
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 373
+  - uid: 369
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 2
-  - uid: 374
+  - uid: 370
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 2
-  - uid: 375
+  - uid: 371
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 2
-  - uid: 376
+  - uid: 372
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 2
-  - uid: 377
+  - uid: 373
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 2
-  - uid: 378
+  - uid: 374
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 2
-  - uid: 379
+  - uid: 375
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,5.5
       parent: 2
-  - uid: 380
+  - uid: 376
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,5.5
       parent: 2
-  - uid: 381
+  - uid: 377
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,4.5
       parent: 2
-  - uid: 382
+  - uid: 378
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,2.5
       parent: 2
-  - uid: 383
+  - uid: 379
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,2.5
       parent: 2
-  - uid: 384
+  - uid: 380
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2318,28 +2313,28 @@ entities:
       parent: 2
 - proto: RemoteSignaller
   entities:
-  - uid: 385
+  - uid: 381
     components:
     - type: Transform
       pos: 9.313246,-7.5157394
       parent: 2
 - proto: SawAdvanced
   entities:
-  - uid: 386
+  - uid: 382
     components:
     - type: Transform
       pos: -4.432526,-9.343864
       parent: 2
 - proto: ScalpelAdvanced
   entities:
-  - uid: 387
+  - uid: 383
     components:
     - type: Transform
       pos: -4.4559636,-10.351677
       parent: 2
 - proto: SignElectricalMed
   entities:
-  - uid: 388
+  - uid: 384
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2347,7 +2342,7 @@ entities:
       parent: 2
 - proto: SignEngine
   entities:
-  - uid: 389
+  - uid: 385
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2355,7 +2350,7 @@ entities:
       parent: 2
 - proto: SignEngineering
   entities:
-  - uid: 390
+  - uid: 386
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2363,320 +2358,320 @@ entities:
       parent: 2
 - proto: SignMedical
   entities:
-  - uid: 391
+  - uid: 387
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 2
 - proto: SignSpace
   entities:
-  - uid: 392
+  - uid: 388
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 2
-  - uid: 393
+  - uid: 389
     components:
     - type: Transform
       pos: 8.5,-0.5
       parent: 2
 - proto: SMESBasic
   entities:
-  - uid: 394
+  - uid: 390
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 2
-  - uid: 395
+  - uid: 391
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 2
 - proto: SubstationBasic
   entities:
-  - uid: 396
+  - uid: 392
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 2
 - proto: SuitStorageEVASyndicate
   entities:
-  - uid: 397
+  - uid: 393
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 2
-  - uid: 398
+  - uid: 394
     components:
     - type: Transform
       pos: 9.5,-2.5
       parent: 2
-  - uid: 399
+  - uid: 395
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 2
-  - uid: 400
+  - uid: 396
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 2
-  - uid: 401
+  - uid: 397
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 2
-  - uid: 402
+  - uid: 398
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 2
 - proto: SyndicateComputerComms
   entities:
-  - uid: 403
+  - uid: 399
     components:
     - type: Transform
       pos: 3.5,14.5
       parent: 2
 - proto: SyndicatePersonalAI
   entities:
-  - uid: 404
+  - uid: 400
     components:
     - type: Transform
       pos: -0.44933534,14.615757
       parent: 2
 - proto: SyndieMiniBomb
   entities:
-  - uid: 405
+  - uid: 401
     components:
     - type: Transform
       pos: 7.8451276,1.5586307
       parent: 2
-  - uid: 406
+  - uid: 402
     components:
     - type: Transform
       pos: 7.54044,1.3008182
       parent: 2
 - proto: TableReinforced
   entities:
-  - uid: 407
+  - uid: 403
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-6.5
       parent: 2
-  - uid: 408
+  - uid: 404
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-7.5
       parent: 2
-  - uid: 409
+  - uid: 405
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-8.5
       parent: 2
-  - uid: 410
+  - uid: 406
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-8.5
       parent: 2
-  - uid: 411
+  - uid: 407
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-8.5
       parent: 2
-  - uid: 412
+  - uid: 408
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-4.5
       parent: 2
-  - uid: 413
+  - uid: 409
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-5.5
       parent: 2
-  - uid: 414
+  - uid: 410
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-8.5
       parent: 2
-  - uid: 415
+  - uid: 411
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-8.5
       parent: 2
-  - uid: 416
+  - uid: 412
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-9.5
       parent: 2
-  - uid: 417
+  - uid: 413
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-10.5
       parent: 2
-  - uid: 418
+  - uid: 414
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-10.5
       parent: 2
-  - uid: 419
+  - uid: 415
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-7.5
       parent: 2
-  - uid: 420
+  - uid: 416
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-6.5
       parent: 2
-  - uid: 421
+  - uid: 417
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,1.5
       parent: 2
-  - uid: 422
+  - uid: 418
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,1.5
       parent: 2
-  - uid: 423
+  - uid: 419
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,2.5
       parent: 2
-  - uid: 424
+  - uid: 420
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,3.5
       parent: 2
-  - uid: 425
+  - uid: 421
     components:
     - type: Transform
       pos: 0.5,14.5
       parent: 2
-  - uid: 426
+  - uid: 422
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 2
-  - uid: 427
+  - uid: 423
     components:
     - type: Transform
       pos: 4.5,14.5
       parent: 2
-  - uid: 428
+  - uid: 424
     components:
     - type: Transform
       pos: 5.5,14.5
       parent: 2
 - proto: TelecomServer
   entities:
-  - uid: 429
+  - uid: 425
     components:
     - type: Transform
       pos: 7.5,-10.5
       parent: 2
 - proto: Thruster
   entities:
-  - uid: 430
+  - uid: 426
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-13.5
       parent: 2
-  - uid: 431
+  - uid: 427
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-13.5
       parent: 2
-  - uid: 432
+  - uid: 428
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-12.5
       parent: 2
-  - uid: 433
+  - uid: 429
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-12.5
       parent: 2
-  - uid: 434
+  - uid: 430
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-12.5
       parent: 2
-  - uid: 435
+  - uid: 431
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-12.5
       parent: 2
-  - uid: 436
+  - uid: 432
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-11.5
       parent: 2
-  - uid: 437
+  - uid: 433
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-11.5
       parent: 2
-  - uid: 438
+  - uid: 434
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-11.5
       parent: 2
-  - uid: 439
+  - uid: 435
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 2
-  - uid: 440
+  - uid: 436
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 2
-  - uid: 441
+  - uid: 437
     components:
     - type: Transform
       pos: 7.5,8.5
       parent: 2
-  - uid: 442
+  - uid: 438
     components:
     - type: Transform
       pos: 8.5,8.5
       parent: 2
-  - uid: 443
+  - uid: 439
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,6.5
       parent: 2
-  - uid: 444
+  - uid: 440
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2684,21 +2679,21 @@ entities:
       parent: 2
 - proto: ToolboxSyndicateFilled
   entities:
-  - uid: 445
+  - uid: 441
     components:
     - type: Transform
       pos: 6.4773083,-8.289177
       parent: 2
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 446
+  - uid: 442
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 2
 - proto: VendingMachineYouTool
   entities:
-  - uid: 447
+  - uid: 443
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2706,843 +2701,843 @@ entities:
       parent: 2
 - proto: WallPlastitanium
   entities:
-  - uid: 448
+  - uid: 444
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-2.5
       parent: 2
-  - uid: 449
+  - uid: 445
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 2
-  - uid: 450
+  - uid: 446
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 2
-  - uid: 451
+  - uid: 447
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 2
-  - uid: 452
+  - uid: 448
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-0.5
       parent: 2
-  - uid: 453
+  - uid: 449
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 2
-  - uid: 454
+  - uid: 450
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-3.5
       parent: 2
-  - uid: 455
+  - uid: 451
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-2.5
       parent: 2
-  - uid: 456
+  - uid: 452
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-3.5
       parent: 2
-  - uid: 457
+  - uid: 453
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-3.5
       parent: 2
-  - uid: 458
+  - uid: 454
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-4.5
       parent: 2
-  - uid: 459
+  - uid: 455
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-5.5
       parent: 2
-  - uid: 460
+  - uid: 456
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-6.5
       parent: 2
-  - uid: 461
+  - uid: 457
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-7.5
       parent: 2
-  - uid: 462
+  - uid: 458
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-8.5
       parent: 2
-  - uid: 463
+  - uid: 459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-9.5
       parent: 2
-  - uid: 464
+  - uid: 460
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-10.5
       parent: 2
-  - uid: 465
+  - uid: 461
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-10.5
       parent: 2
-  - uid: 466
+  - uid: 462
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-10.5
       parent: 2
-  - uid: 467
+  - uid: 463
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-10.5
       parent: 2
-  - uid: 468
+  - uid: 464
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-10.5
       parent: 2
-  - uid: 469
+  - uid: 465
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-9.5
       parent: 2
-  - uid: 470
+  - uid: 466
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-8.5
       parent: 2
-  - uid: 471
+  - uid: 467
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-7.5
       parent: 2
-  - uid: 472
+  - uid: 468
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-6.5
       parent: 2
-  - uid: 473
+  - uid: 469
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-5.5
       parent: 2
-  - uid: 474
+  - uid: 470
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 2
-  - uid: 475
+  - uid: 471
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 2
-  - uid: 476
+  - uid: 472
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-3.5
       parent: 2
-  - uid: 477
+  - uid: 473
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-9.5
       parent: 2
-  - uid: 478
+  - uid: 474
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-9.5
       parent: 2
-  - uid: 479
+  - uid: 475
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-10.5
       parent: 2
-  - uid: 480
+  - uid: 476
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-11.5
       parent: 2
-  - uid: 481
+  - uid: 477
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-11.5
       parent: 2
-  - uid: 482
+  - uid: 478
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-12.5
       parent: 2
-  - uid: 483
+  - uid: 479
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-13.5
       parent: 2
-  - uid: 484
+  - uid: 480
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-12.5
       parent: 2
-  - uid: 485
+  - uid: 481
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-12.5
       parent: 2
-  - uid: 486
+  - uid: 482
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-13.5
       parent: 2
-  - uid: 487
+  - uid: 483
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-11.5
       parent: 2
-  - uid: 488
+  - uid: 484
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-11.5
       parent: 2
-  - uid: 489
+  - uid: 485
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-10.5
       parent: 2
-  - uid: 490
+  - uid: 486
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-9.5
       parent: 2
-  - uid: 491
+  - uid: 487
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-8.5
       parent: 2
-  - uid: 492
+  - uid: 488
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-7.5
       parent: 2
-  - uid: 493
+  - uid: 489
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-6.5
       parent: 2
-  - uid: 494
+  - uid: 490
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-5.5
       parent: 2
-  - uid: 495
+  - uid: 491
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-4.5
       parent: 2
-  - uid: 496
+  - uid: 492
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-3.5
       parent: 2
-  - uid: 497
+  - uid: 493
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-2.5
       parent: 2
-  - uid: 498
+  - uid: 494
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-4.5
       parent: 2
-  - uid: 499
+  - uid: 495
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-5.5
       parent: 2
-  - uid: 500
+  - uid: 496
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-6.5
       parent: 2
-  - uid: 501
+  - uid: 497
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-3.5
       parent: 2
-  - uid: 502
+  - uid: 498
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-7.5
       parent: 2
-  - uid: 503
+  - uid: 499
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-8.5
       parent: 2
-  - uid: 504
+  - uid: 500
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-9.5
       parent: 2
-  - uid: 505
+  - uid: 501
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-10.5
       parent: 2
-  - uid: 506
+  - uid: 502
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-11.5
       parent: 2
-  - uid: 507
+  - uid: 503
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-11.5
       parent: 2
-  - uid: 508
+  - uid: 504
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-12.5
       parent: 2
-  - uid: 509
+  - uid: 505
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-13.5
       parent: 2
-  - uid: 510
+  - uid: 506
     components:
     - type: Transform
       pos: 8.5,-12.5
       parent: 2
-  - uid: 511
+  - uid: 507
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-13.5
       parent: 2
-  - uid: 512
+  - uid: 508
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-12.5
       parent: 2
-  - uid: 513
+  - uid: 509
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-11.5
       parent: 2
-  - uid: 514
+  - uid: 510
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-11.5
       parent: 2
-  - uid: 515
+  - uid: 511
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-10.5
       parent: 2
-  - uid: 516
+  - uid: 512
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-9.5
       parent: 2
-  - uid: 517
+  - uid: 513
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-9.5
       parent: 2
-  - uid: 518
+  - uid: 514
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-3.5
       parent: 2
-  - uid: 519
+  - uid: 515
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-3.5
       parent: 2
-  - uid: 520
+  - uid: 516
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-2.5
       parent: 2
-  - uid: 521
+  - uid: 517
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-0.5
       parent: 2
-  - uid: 522
+  - uid: 518
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-0.5
       parent: 2
-  - uid: 523
+  - uid: 519
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,0.5
       parent: 2
-  - uid: 524
+  - uid: 520
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,0.5
       parent: 2
-  - uid: 525
+  - uid: 521
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,0.5
       parent: 2
-  - uid: 526
+  - uid: 522
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,0.5
       parent: 2
-  - uid: 527
+  - uid: 523
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,0.5
       parent: 2
-  - uid: 528
+  - uid: 524
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 2
-  - uid: 529
+  - uid: 525
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 2
-  - uid: 530
+  - uid: 526
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,5.5
       parent: 2
-  - uid: 531
+  - uid: 527
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,5.5
       parent: 2
-  - uid: 532
+  - uid: 528
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,1.5
       parent: 2
-  - uid: 533
+  - uid: 529
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 2
-  - uid: 534
+  - uid: 530
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,0.5
       parent: 2
-  - uid: 535
+  - uid: 531
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 2
-  - uid: 536
+  - uid: 532
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 2
-  - uid: 537
+  - uid: 533
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 2
-  - uid: 538
+  - uid: 534
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-3.5
       parent: 2
-  - uid: 539
+  - uid: 535
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,5.5
       parent: 2
-  - uid: 540
+  - uid: 536
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,4.5
       parent: 2
-  - uid: 541
+  - uid: 537
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,3.5
       parent: 2
-  - uid: 542
+  - uid: 538
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,1.5
       parent: 2
-  - uid: 543
+  - uid: 539
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 2
-  - uid: 544
+  - uid: 540
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,1.5
       parent: 2
-  - uid: 545
+  - uid: 541
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,2.5
       parent: 2
-  - uid: 546
+  - uid: 542
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,3.5
       parent: 2
-  - uid: 547
+  - uid: 543
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,4.5
       parent: 2
-  - uid: 548
+  - uid: 544
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,5.5
       parent: 2
-  - uid: 549
+  - uid: 545
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,1.5
       parent: 2
-  - uid: 550
+  - uid: 546
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,0.5
       parent: 2
-  - uid: 551
+  - uid: 547
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,6.5
       parent: 2
-  - uid: 552
+  - uid: 548
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,6.5
       parent: 2
-  - uid: 553
+  - uid: 549
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,6.5
       parent: 2
-  - uid: 554
+  - uid: 550
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,6.5
       parent: 2
-  - uid: 555
+  - uid: 551
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,6.5
       parent: 2
-  - uid: 556
+  - uid: 552
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,6.5
       parent: 2
-  - uid: 557
+  - uid: 553
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,6.5
       parent: 2
-  - uid: 558
+  - uid: 554
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,6.5
       parent: 2
-  - uid: 559
+  - uid: 555
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,11.5
       parent: 2
-  - uid: 560
+  - uid: 556
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,10.5
       parent: 2
-  - uid: 561
+  - uid: 557
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,9.5
       parent: 2
-  - uid: 562
+  - uid: 558
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,8.5
       parent: 2
-  - uid: 563
+  - uid: 559
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,7.5
       parent: 2
-  - uid: 564
+  - uid: 560
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,10.5
       parent: 2
-  - uid: 565
+  - uid: 561
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,9.5
       parent: 2
-  - uid: 566
+  - uid: 562
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,8.5
       parent: 2
-  - uid: 567
+  - uid: 563
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,7.5
       parent: 2
-  - uid: 568
+  - uid: 564
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 2
-  - uid: 569
+  - uid: 565
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 2
-  - uid: 570
+  - uid: 566
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
-  - uid: 571
+  - uid: 567
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 2
-  - uid: 572
+  - uid: 568
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 2
-  - uid: 573
+  - uid: 569
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 2
-  - uid: 574
+  - uid: 570
     components:
     - type: Transform
       pos: 8.5,7.5
       parent: 2
-  - uid: 575
+  - uid: 571
     components:
     - type: Transform
       pos: 9.5,7.5
       parent: 2
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 576
+  - uid: 572
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 2
-  - uid: 577
+  - uid: 573
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,0.5
       parent: 2
-  - uid: 578
+  - uid: 574
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-11.5
       parent: 2
-  - uid: 579
+  - uid: 575
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-11.5
       parent: 2
-  - uid: 580
+  - uid: 576
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-13.5
       parent: 2
-  - uid: 581
+  - uid: 577
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-13.5
       parent: 2
-  - uid: 582
+  - uid: 578
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-13.5
       parent: 2
-  - uid: 583
+  - uid: 579
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-13.5
       parent: 2
-  - uid: 584
+  - uid: 580
     components:
     - type: Transform
       pos: -1.5,15.5
       parent: 2
-  - uid: 585
+  - uid: 581
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,15.5
       parent: 2
-  - uid: 586
+  - uid: 582
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,11.5
       parent: 2
-  - uid: 587
+  - uid: 583
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,11.5
       parent: 2
-  - uid: 588
+  - uid: 584
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 2
-  - uid: 589
+  - uid: 585
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3550,49 +3545,49 @@ entities:
       parent: 2
 - proto: WeaponTurretSyndicate
   entities:
-  - uid: 245
+  - uid: 586
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,1.5
       parent: 2
-  - uid: 246
+  - uid: 587
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 2
-  - uid: 247
+  - uid: 588
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-0.5
       parent: 2
-  - uid: 254
+  - uid: 589
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,4.5
       parent: 2
-  - uid: 255
+  - uid: 590
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,10.5
       parent: 2
-  - uid: 256
+  - uid: 591
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,10.5
       parent: 2
-  - uid: 591
+  - uid: 592
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 2
-  - uid: 592
+  - uid: 593
     components:
     - type: Transform
       rot: 1.5707963267948966 rad

--- a/Resources/Maps/Goobstation/Shuttles/infiltrator.yml
+++ b/Resources/Maps/Goobstation/Shuttles/infiltrator.yml
@@ -33,19 +33,19 @@ entities:
       chunks:
         0,0:
           ind: 0,0
-          tiles: ggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAVwAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAggAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAVwAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAXAAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: ggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAVwAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAVwAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAXAAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         0,-1:
           ind: 0,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAgQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAggAAAAAAggAAAAAAVwAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVwAAAAAAggAAAAAAggAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVwAAAAAAggAAAAAAggAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVwAAAAAAggAAAAAAggAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAggAAAAAAXAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVwAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAggAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAggAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVwAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAggAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAgQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAggAAAAAAggAAAAAAVwAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVwAAAAAAggAAAAAAggAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVwAAAAAAggAAAAAAggAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVwAAAAAAggAAAAAAggAAAAAAXAAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAggAAAAAAXAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVwAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVwAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAggAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAgQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAVwAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAXAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAggAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAgQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAVwAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAXAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAA
           version: 6
         -1,0:
           ind: -1,0
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAA
           version: 6
     - type: Broadphase
     - type: Physics
@@ -191,47 +191,47 @@ entities:
     - type: RadiationGridResistance
 - proto: AirlockExternalGlassNukeopLocked
   entities:
-  - uid: 104
+  - uid: 3
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 2
-  - uid: 105
+  - uid: 4
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 2
 - proto: AirlockExternalNukeopLocked
   entities:
-  - uid: 553
+  - uid: 5
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 2
-  - uid: 554
+  - uid: 6
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 2
-  - uid: 555
+  - uid: 7
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 2
-  - uid: 556
+  - uid: 8
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 2
 - proto: AirlockExternalShuttleNukeopLocked
   entities:
-  - uid: 592
+  - uid: 9
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-1.5
       parent: 2
-  - uid: 593
+  - uid: 10
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -239,187 +239,187 @@ entities:
       parent: 2
 - proto: AirlockSyndicateNukeopLocked
   entities:
-  - uid: 106
+  - uid: 11
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 2
-  - uid: 108
+  - uid: 12
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 2
-  - uid: 109
+  - uid: 13
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 2
-  - uid: 119
+  - uid: 14
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 2
-  - uid: 120
+  - uid: 15
     components:
     - type: Transform
       pos: 6.5,-3.5
       parent: 2
-  - uid: 288
+  - uid: 16
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 2
-  - uid: 289
+  - uid: 17
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,3.5
       parent: 2
-  - uid: 290
+  - uid: 18
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,1.5
       parent: 2
-  - uid: 291
+  - uid: 19
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,1.5
       parent: 2
-  - uid: 292
+  - uid: 20
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,5.5
       parent: 2
-  - uid: 578
+  - uid: 21
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 2
 - proto: AmeController
   entities:
-  - uid: 164
+  - uid: 22
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 2
 - proto: AmeJar
   entities:
-  - uid: 167
+  - uid: 23
     components:
     - type: Transform
       pos: 1.2544969,-5.311164
       parent: 2
-  - uid: 168
+  - uid: 24
     components:
     - type: Transform
       pos: 1.4654344,-5.545539
       parent: 2
-  - uid: 169
+  - uid: 25
     components:
     - type: Transform
       pos: 1.7701219,-5.2877264
       parent: 2
 - proto: AmeShielding
   entities:
-  - uid: 152
+  - uid: 26
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 2
-  - uid: 153
+  - uid: 27
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 2
-  - uid: 154
+  - uid: 28
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 2
-  - uid: 155
+  - uid: 29
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 2
-  - uid: 156
+  - uid: 30
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 2
-  - uid: 157
+  - uid: 31
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 2
-  - uid: 158
+  - uid: 32
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 2
-  - uid: 159
+  - uid: 33
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 2
-  - uid: 160
+  - uid: 34
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 2
-  - uid: 161
+  - uid: 35
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 2
-  - uid: 162
+  - uid: 36
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 2
-  - uid: 163
+  - uid: 37
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 2
 - proto: APCBasic
   entities:
-  - uid: 312
+  - uid: 38
     components:
     - type: Transform
       pos: 8.5,-3.5
       parent: 2
-  - uid: 313
+  - uid: 39
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 2
-  - uid: 314
+  - uid: 40
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 2
-  - uid: 317
+  - uid: 41
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,0.5
       parent: 2
-  - uid: 318
+  - uid: 42
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,0.5
       parent: 2
-  - uid: 432
+  - uid: 43
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-4.5
       parent: 2
-  - uid: 504
+  - uid: 44
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -427,13 +427,13 @@ entities:
       parent: 2
 - proto: AtmosDeviceFanTiny
   entities:
-  - uid: 4
+  - uid: 45
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-1.5
       parent: 2
-  - uid: 5
+  - uid: 46
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -441,7 +441,7 @@ entities:
       parent: 2
 - proto: BaseComputer
   entities:
-  - uid: 539
+  - uid: 47
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -449,13 +449,13 @@ entities:
       parent: 2
 - proto: BlastDoorOpen
   entities:
-  - uid: 307
+  - uid: 48
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,0.5
       parent: 2
-  - uid: 308
+  - uid: 49
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -463,576 +463,678 @@ entities:
       parent: 2
 - proto: BoxHandcuff
   entities:
-  - uid: 550
+  - uid: 50
     components:
     - type: Transform
       pos: 7.4232526,1.7930057
       parent: 2
 - proto: C4
   entities:
-  - uid: 547
+  - uid: 51
     components:
     - type: Transform
       pos: 8.407627,2.2383182
       parent: 2
-  - uid: 548
+  - uid: 52
     components:
     - type: Transform
       pos: 8.75919,1.9805057
       parent: 2
-  - uid: 549
+  - uid: 53
     components:
     - type: Transform
       pos: 8.431065,1.5820682
       parent: 2
 - proto: CableApcExtension
   entities:
-  - uid: 329
+  - uid: 54
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 2
-  - uid: 372
+  - uid: 55
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 2
-  - uid: 373
+  - uid: 56
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 2
-  - uid: 374
+  - uid: 57
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 2
-  - uid: 375
+  - uid: 58
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 2
-  - uid: 376
+  - uid: 59
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 2
-  - uid: 377
+  - uid: 60
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 2
-  - uid: 378
+  - uid: 61
     components:
     - type: Transform
       pos: 6.5,0.5
       parent: 2
-  - uid: 379
+  - uid: 62
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 2
-  - uid: 380
+  - uid: 63
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 2
-  - uid: 381
+  - uid: 64
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 2
-  - uid: 382
+  - uid: 65
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 2
-  - uid: 383
+  - uid: 66
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 2
-  - uid: 384
+  - uid: 67
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 2
-  - uid: 385
+  - uid: 68
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 2
-  - uid: 386
+  - uid: 69
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 2
-  - uid: 387
+  - uid: 70
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 2
-  - uid: 388
+  - uid: 71
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 2
-  - uid: 389
+  - uid: 72
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 2
-  - uid: 390
+  - uid: 73
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 2
-  - uid: 391
+  - uid: 74
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 2
-  - uid: 392
+  - uid: 75
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 2
-  - uid: 393
+  - uid: 76
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 2
-  - uid: 394
+  - uid: 77
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 2
-  - uid: 395
+  - uid: 78
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 2
-  - uid: 396
+  - uid: 79
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 2
-  - uid: 397
+  - uid: 80
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 2
-  - uid: 398
+  - uid: 81
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 2
-  - uid: 399
+  - uid: 82
     components:
     - type: Transform
       pos: 7.5,-1.5
       parent: 2
-  - uid: 400
+  - uid: 83
     components:
     - type: Transform
       pos: 9.5,-1.5
       parent: 2
-  - uid: 401
+  - uid: 84
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 2
-  - uid: 402
+  - uid: 85
     components:
     - type: Transform
       pos: 8.5,-3.5
       parent: 2
-  - uid: 403
+  - uid: 86
     components:
     - type: Transform
       pos: 8.5,-4.5
       parent: 2
-  - uid: 404
+  - uid: 87
     components:
     - type: Transform
       pos: 8.5,-5.5
       parent: 2
-  - uid: 405
+  - uid: 88
     components:
     - type: Transform
       pos: 8.5,-6.5
       parent: 2
-  - uid: 406
+  - uid: 89
     components:
     - type: Transform
       pos: 8.5,-7.5
       parent: 2
-  - uid: 407
+  - uid: 90
     components:
     - type: Transform
       pos: 8.5,-8.5
       parent: 2
-  - uid: 408
+  - uid: 91
     components:
     - type: Transform
       pos: 8.5,-9.5
       parent: 2
-  - uid: 409
+  - uid: 92
     components:
     - type: Transform
       pos: 7.5,-6.5
       parent: 2
-  - uid: 410
+  - uid: 93
     components:
     - type: Transform
       pos: 6.5,-6.5
       parent: 2
-  - uid: 411
+  - uid: 94
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 2
-  - uid: 412
+  - uid: 95
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 2
-  - uid: 413
+  - uid: 96
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 2
-  - uid: 414
+  - uid: 97
     components:
     - type: Transform
       pos: -3.5,-6.5
       parent: 2
-  - uid: 415
+  - uid: 98
     components:
     - type: Transform
       pos: -3.5,-8.5
       parent: 2
-  - uid: 416
+  - uid: 99
     components:
     - type: Transform
       pos: -3.5,-7.5
       parent: 2
-  - uid: 417
+  - uid: 100
     components:
     - type: Transform
       pos: -3.5,-9.5
       parent: 2
-  - uid: 418
+  - uid: 101
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 2
-  - uid: 419
+  - uid: 102
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 2
-  - uid: 420
+  - uid: 103
     components:
     - type: Transform
       pos: 8.5,-10.5
       parent: 2
-  - uid: 421
+  - uid: 104
     components:
     - type: Transform
       pos: 8.5,-11.5
       parent: 2
-  - uid: 422
+  - uid: 105
     components:
     - type: Transform
       pos: 8.5,-12.5
       parent: 2
-  - uid: 423
+  - uid: 106
     components:
     - type: Transform
       pos: 9.5,-12.5
       parent: 2
-  - uid: 424
+  - uid: 107
     components:
     - type: Transform
       pos: 7.5,-12.5
       parent: 2
-  - uid: 425
+  - uid: 108
     components:
     - type: Transform
       pos: 8.5,-13.5
       parent: 2
-  - uid: 426
+  - uid: 109
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 2
-  - uid: 427
+  - uid: 110
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 2
-  - uid: 428
+  - uid: 111
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 2
-  - uid: 429
+  - uid: 112
     components:
     - type: Transform
       pos: -3.5,-13.5
       parent: 2
-  - uid: 430
+  - uid: 113
     components:
     - type: Transform
       pos: -2.5,-12.5
       parent: 2
-  - uid: 431
+  - uid: 114
     components:
     - type: Transform
       pos: -4.5,-12.5
       parent: 2
-  - uid: 435
+  - uid: 115
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 2
-  - uid: 436
+  - uid: 116
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 2
-  - uid: 437
+  - uid: 117
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 2
-  - uid: 438
+  - uid: 118
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 2
-  - uid: 439
+  - uid: 119
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 2
-  - uid: 440
+  - uid: 120
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 2
-  - uid: 441
+  - uid: 121
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 2
-  - uid: 442
+  - uid: 122
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 2
-  - uid: 443
+  - uid: 123
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 2
-  - uid: 444
+  - uid: 124
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 2
-  - uid: 445
+  - uid: 125
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 2
-  - uid: 446
+  - uid: 126
     components:
     - type: Transform
       pos: 3.5,-11.5
       parent: 2
-  - uid: 516
+  - uid: 127
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 2
-  - uid: 517
+  - uid: 128
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 2
-  - uid: 518
+  - uid: 129
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 2
-  - uid: 519
+  - uid: 130
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 2
-  - uid: 520
+  - uid: 131
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 2
-  - uid: 521
+  - uid: 132
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 2
-  - uid: 522
+  - uid: 133
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 2
-  - uid: 523
+  - uid: 134
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 2
-  - uid: 524
+  - uid: 135
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 2
-  - uid: 525
+  - uid: 136
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 2
-  - uid: 526
+  - uid: 137
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 2
-  - uid: 527
+  - uid: 138
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 2
-  - uid: 528
+  - uid: 139
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 2
-  - uid: 529
+  - uid: 140
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 2
-  - uid: 530
+  - uid: 141
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 2
-  - uid: 531
+  - uid: 142
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 2
-  - uid: 532
+  - uid: 143
     components:
     - type: Transform
       pos: 2.5,13.5
       parent: 2
-  - uid: 533
+  - uid: 144
     components:
     - type: Transform
       pos: 3.5,13.5
       parent: 2
-  - uid: 534
+  - uid: 145
     components:
     - type: Transform
       pos: 4.5,13.5
       parent: 2
-  - uid: 535
+  - uid: 146
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 2
-  - uid: 594
+  - uid: 147
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 2
-  - uid: 595
+  - uid: 148
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 2
-  - uid: 596
+  - uid: 149
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 2
-  - uid: 597
+  - uid: 150
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 2
-  - uid: 598
+  - uid: 151
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
-  - uid: 599
+  - uid: 152
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 2
-  - uid: 600
+  - uid: 153
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 2
-  - uid: 601
+  - uid: 154
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 2
-  - uid: 602
+  - uid: 155
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 2
-  - uid: 603
+  - uid: 156
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 2
-  - uid: 604
+  - uid: 157
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 2
-  - uid: 605
+  - uid: 158
     components:
     - type: Transform
       pos: 8.5,7.5
       parent: 2
 - proto: CableHV
   entities:
-  - uid: 179
+  - uid: 159
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 2
-  - uid: 180
+  - uid: 160
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 2
-  - uid: 181
+  - uid: 161
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 2
-  - uid: 182
+  - uid: 162
     components:
     - type: Transform
       pos: 2.5,-2.5
+      parent: 2
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 2
+  - uid: 164
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 2
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 2
+  - uid: 166
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 2
+  - uid: 167
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 2
+  - uid: 168
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 2
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 2
+  - uid: 170
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 2
+  - uid: 171
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 2
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 2
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 2
+  - uid: 174
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 2
+  - uid: 175
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 2
+- proto: CableMV
+  entities:
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 2
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 2
+  - uid: 178
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 2
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 180
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 2
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 2
+  - uid: 182
+    components:
+    - type: Transform
+      pos: 2.5,0.5
       parent: 2
   - uid: 183
     components:
@@ -1062,12 +1164,12 @@ entities:
   - uid: 188
     components:
     - type: Transform
-      pos: 6.5,-2.5
+      pos: 6.5,0.5
       parent: 2
   - uid: 189
     components:
     - type: Transform
-      pos: 6.5,-3.5
+      pos: 6.5,-2.5
       parent: 2
   - uid: 190
     components:
@@ -1077,374 +1179,272 @@ entities:
   - uid: 191
     components:
     - type: Transform
-      pos: 6.5,-5.5
-      parent: 2
-  - uid: 194
-    components:
-    - type: Transform
-      pos: 5.5,-5.5
-      parent: 2
-  - uid: 195
-    components:
-    - type: Transform
-      pos: 5.5,-4.5
-      parent: 2
-  - uid: 196
-    components:
-    - type: Transform
-      pos: 4.5,-4.5
-      parent: 2
-  - uid: 197
-    components:
-    - type: Transform
-      pos: 3.5,-4.5
-      parent: 2
-- proto: CableMV
-  entities:
-  - uid: 315
-    components:
-    - type: Transform
-      pos: 2.5,-4.5
-      parent: 2
-  - uid: 316
-    components:
-    - type: Transform
-      pos: 3.5,-4.5
-      parent: 2
-  - uid: 319
-    components:
-    - type: Transform
-      pos: 2.5,-3.5
-      parent: 2
-  - uid: 320
-    components:
-    - type: Transform
-      pos: 2.5,-2.5
-      parent: 2
-  - uid: 321
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 2
-  - uid: 322
-    components:
-    - type: Transform
-      pos: 2.5,-0.5
-      parent: 2
-  - uid: 323
-    components:
-    - type: Transform
-      pos: 2.5,0.5
-      parent: 2
-  - uid: 324
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 2
-  - uid: 325
-    components:
-    - type: Transform
-      pos: 3.5,-1.5
-      parent: 2
-  - uid: 326
-    components:
-    - type: Transform
-      pos: 4.5,-1.5
-      parent: 2
-  - uid: 327
-    components:
-    - type: Transform
-      pos: 5.5,-1.5
-      parent: 2
-  - uid: 328
-    components:
-    - type: Transform
-      pos: 6.5,-1.5
-      parent: 2
-  - uid: 330
-    components:
-    - type: Transform
-      pos: 6.5,0.5
-      parent: 2
-  - uid: 331
-    components:
-    - type: Transform
-      pos: 6.5,-2.5
-      parent: 2
-  - uid: 332
-    components:
-    - type: Transform
-      pos: 6.5,-4.5
-      parent: 2
-  - uid: 333
-    components:
-    - type: Transform
       pos: 6.5,-3.5
       parent: 2
-  - uid: 334
+  - uid: 192
     components:
     - type: Transform
       pos: 7.5,-4.5
       parent: 2
-  - uid: 335
+  - uid: 193
     components:
     - type: Transform
       pos: 8.5,-4.5
       parent: 2
-  - uid: 336
+  - uid: 194
     components:
     - type: Transform
       pos: 8.5,-3.5
       parent: 2
-  - uid: 337
+  - uid: 195
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 2
-  - uid: 338
+  - uid: 196
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 2
-  - uid: 339
+  - uid: 197
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 2
-  - uid: 340
+  - uid: 198
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 2
-  - uid: 341
+  - uid: 199
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 2
-  - uid: 342
+  - uid: 200
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 2
-  - uid: 343
+  - uid: 201
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 2
-  - uid: 344
+  - uid: 202
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 2
-  - uid: 345
+  - uid: 203
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 2
-  - uid: 346
+  - uid: 204
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 2
-  - uid: 347
+  - uid: 205
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 2
-  - uid: 348
+  - uid: 206
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 2
-  - uid: 349
+  - uid: 207
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 2
-  - uid: 350
+  - uid: 208
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 2
-  - uid: 351
+  - uid: 209
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 2
-  - uid: 352
+  - uid: 210
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 2
-  - uid: 353
+  - uid: 211
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 2
-  - uid: 354
+  - uid: 212
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 2
-  - uid: 355
+  - uid: 213
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 2
-  - uid: 356
+  - uid: 214
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 2
-  - uid: 357
+  - uid: 215
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 2
-  - uid: 358
+  - uid: 216
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 2
-  - uid: 359
+  - uid: 217
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 2
-  - uid: 360
+  - uid: 218
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 2
-  - uid: 361
+  - uid: 219
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 2
-  - uid: 362
+  - uid: 220
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 2
-  - uid: 363
+  - uid: 221
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 2
-  - uid: 364
+  - uid: 222
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 2
-  - uid: 365
+  - uid: 223
     components:
     - type: Transform
       pos: 6.5,2.5
       parent: 2
-  - uid: 366
+  - uid: 224
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 2
-  - uid: 367
+  - uid: 225
     components:
     - type: Transform
       pos: 6.5,0.5
       parent: 2
-  - uid: 368
+  - uid: 226
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 2
-  - uid: 369
+  - uid: 227
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 2
-  - uid: 370
+  - uid: 228
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 2
-  - uid: 371
+  - uid: 229
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 2
-  - uid: 433
+  - uid: 230
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 2
-  - uid: 434
+  - uid: 231
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 2
-  - uid: 505
+  - uid: 232
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 2
-  - uid: 506
+  - uid: 233
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 2
-  - uid: 507
+  - uid: 234
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 2
-  - uid: 508
+  - uid: 235
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 2
-  - uid: 509
+  - uid: 236
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 2
-  - uid: 510
+  - uid: 237
     components:
     - type: Transform
       pos: 2.5,11.5
       parent: 2
-  - uid: 511
+  - uid: 238
     components:
     - type: Transform
       pos: 2.5,12.5
       parent: 2
-  - uid: 512
+  - uid: 239
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 2
-  - uid: 513
+  - uid: 240
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 2
-  - uid: 514
+  - uid: 241
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 2
-  - uid: 515
+  - uid: 242
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 2
 - proto: CableTerminal
   entities:
-  - uid: 192
+  - uid: 243
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-4.5
       parent: 2
-  - uid: 193
+  - uid: 244
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1452,139 +1452,112 @@ entities:
       parent: 2
 - proto: Catwalk
   entities:
-  - uid: 121
-    components:
-    - type: Transform
-      pos: -1.5,-1.5
-      parent: 2
-  - uid: 122
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 2
-  - uid: 123
-    components:
-    - type: Transform
-      pos: 6.5,-1.5
-      parent: 2
-  - uid: 173
+  - uid: 248
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 2
-  - uid: 174
+  - uid: 249
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 2
-  - uid: 175
+  - uid: 250
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 2
-  - uid: 176
+  - uid: 251
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 2
-  - uid: 177
+  - uid: 252
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 2
-  - uid: 178
+  - uid: 253
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 2
-  - uid: 275
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,5.5
-      parent: 2
-  - uid: 276
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,5.5
-      parent: 2
-  - uid: 310
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,3.5
-      parent: 2
-  - uid: 495
+  - uid: 257
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,9.5
+      pos: 1.5,4.5
       parent: 2
-  - uid: 496
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,8.5
-      parent: 2
-  - uid: 497
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,7.5
-      parent: 2
-  - uid: 498
+  - uid: 258
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-5.5
       parent: 2
-  - uid: 499
+  - uid: 259
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-7.5
       parent: 2
-  - uid: 500
+  - uid: 260
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-6.5
       parent: 2
-  - uid: 501
+  - uid: 261
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-7.5
       parent: 2
-  - uid: 502
+  - uid: 262
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-6.5
       parent: 2
-  - uid: 503
+  - uid: 263
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-5.5
       parent: 2
+  - uid: 590
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 2
+  - uid: 593
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 599
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 2
 - proto: Cautery
   entities:
-  - uid: 238
+  - uid: 264
     components:
     - type: Transform
       pos: -0.6122134,-4.820427
       parent: 2
 - proto: ChairOfficeDark
   entities:
-  - uid: 589
+  - uid: 265
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,13.5
       parent: 2
-  - uid: 591
+  - uid: 266
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1592,31 +1565,31 @@ entities:
       parent: 2
 - proto: ChairPilotSeat
   entities:
-  - uid: 451
+  - uid: 267
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,5.5
       parent: 2
-  - uid: 452
+  - uid: 268
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,4.5
       parent: 2
-  - uid: 453
+  - uid: 269
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,4.5
       parent: 2
-  - uid: 588
+  - uid: 270
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 2
-  - uid: 590
+  - uid: 271
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1624,21 +1597,21 @@ entities:
       parent: 2
 - proto: CheapRollerBed
   entities:
-  - uid: 231
+  - uid: 272
     components:
     - type: Transform
       pos: -2.510651,-4.539177
       parent: 2
 - proto: ClothingOuterHardsuitSyndicateDurathread
   entities:
-  - uid: 586
+  - uid: 273
     components:
     - type: Transform
       pos: -0.54308534,5.539448
       parent: 2
 - proto: ComputerCrewMonitoring
   entities:
-  - uid: 536
+  - uid: 274
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1646,7 +1619,7 @@ entities:
       parent: 2
 - proto: ComputerCriminalRecords
   entities:
-  - uid: 538
+  - uid: 275
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1654,14 +1627,14 @@ entities:
       parent: 2
 - proto: ComputerIFFSyndicate
   entities:
-  - uid: 540
+  - uid: 276
     components:
     - type: Transform
       pos: 1.5,14.5
       parent: 2
 - proto: ComputerMedicalRecords
   entities:
-  - uid: 537
+  - uid: 277
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1669,140 +1642,140 @@ entities:
       parent: 2
 - proto: ComputerShuttleSyndie
   entities:
-  - uid: 541
+  - uid: 278
     components:
     - type: Transform
       pos: 2.5,14.5
       parent: 2
 - proto: CrowbarRed
   entities:
-  - uid: 587
+  - uid: 279
     components:
     - type: Transform
       pos: -0.44933534,5.445698
       parent: 2
 - proto: DoubleEmergencyNitrogenTankFilled
   entities:
-  - uid: 150
+  - uid: 280
     components:
     - type: Transform
       pos: -4.3939404,-0.66514474
       parent: 2
-  - uid: 151
+  - uid: 281
     components:
     - type: Transform
       pos: 9.645123,-0.73545724
       parent: 2
 - proto: DoubleEmergencyOxygenTankFilled
   entities:
-  - uid: 148
+  - uid: 282
     components:
     - type: Transform
       pos: -4.5345654,-0.45420724
       parent: 2
-  - uid: 149
+  - uid: 283
     components:
     - type: Transform
       pos: 9.38731,-0.45420724
       parent: 2
 - proto: EpinephrineChemistryBottle
   entities:
-  - uid: 240
+  - uid: 284
     components:
     - type: Transform
       pos: -4.526276,-7.2344894
       parent: 2
 - proto: ExplosivePayload
   entities:
-  - uid: 209
+  - uid: 285
     components:
     - type: Transform
       pos: 9.547621,-8.148552
       parent: 2
 - proto: FoodBoxDonut
   entities:
-  - uid: 580
+  - uid: 286
     components:
     - type: Transform
       pos: 0.53503966,14.4985695
       parent: 2
 - proto: Gauze
   entities:
-  - uid: 236
+  - uid: 287
     components:
     - type: Transform
       pos: -0.49502587,-5.2657394
       parent: 2
 - proto: GravityGeneratorMini
   entities:
-  - uid: 170
+  - uid: 288
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 2
 - proto: Grille
   entities:
-  - uid: 10
+  - uid: 289
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 2
-  - uid: 78
+  - uid: 290
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 2
-  - uid: 107
+  - uid: 291
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 2
-  - uid: 110
+  - uid: 292
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 2
-  - uid: 111
+  - uid: 293
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 2
-  - uid: 112
-    components:
-    - type: Transform
-      pos: -2.5,-3.5
-      parent: 2
-  - uid: 293
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,4.5
-      parent: 2
   - uid: 294
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,2.5
+      pos: -2.5,-3.5
       parent: 2
   - uid: 295
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 0.5,2.5
+      pos: 4.5,4.5
       parent: 2
   - uid: 296
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 0.5,4.5
+      pos: 4.5,2.5
       parent: 2
   - uid: 297
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.5,5.5
+      pos: 0.5,2.5
       parent: 2
   - uid: 298
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 2
+  - uid: 299
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,5.5
+      parent: 2
+  - uid: 300
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1810,52 +1783,52 @@ entities:
       parent: 2
 - proto: Gyroscope
   entities:
-  - uid: 98
+  - uid: 301
     components:
     - type: Transform
       pos: 8.5,-11.5
       parent: 2
-  - uid: 99
+  - uid: 302
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 2
 - proto: HandheldHealthAnalyzer
   entities:
-  - uid: 237
+  - uid: 303
     components:
     - type: Transform
       pos: -0.44815087,-4.398552
       parent: 2
 - proto: Hemostat
   entities:
-  - uid: 243
+  - uid: 304
     components:
     - type: Transform
       pos: -2.3934636,-10.445427
       parent: 2
 - proto: LargeBeaker
   entities:
-  - uid: 239
+  - uid: 305
     components:
     - type: Transform
       pos: -4.4559636,-6.461052
       parent: 2
 - proto: LiquidOxygenCanister
   entities:
-  - uid: 199
+  - uid: 306
     components:
     - type: Transform
       pos: 9.5,-4.5
       parent: 2
-  - uid: 200
+  - uid: 307
     components:
     - type: Transform
       pos: 9.5,-5.5
       parent: 2
 - proto: MachineFrame
   entities:
-  - uid: 205
+  - uid: 308
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1863,43 +1836,43 @@ entities:
       parent: 2
 - proto: MachineFrameDestroyed
   entities:
-  - uid: 206
+  - uid: 309
     components:
     - type: Transform
       pos: 8.5,-10.5
       parent: 2
 - proto: MedicalBed
   entities:
-  - uid: 228
+  - uid: 310
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 2
-  - uid: 229
+  - uid: 311
     components:
     - type: Transform
       pos: -4.5,-5.5
       parent: 2
 - proto: MedkitCombatFilled
   entities:
-  - uid: 233
+  - uid: 312
     components:
     - type: Transform
       pos: -1.4090884,-8.289177
       parent: 2
-  - uid: 234
+  - uid: 313
     components:
     - type: Transform
       pos: -0.9637759,-8.570427
       parent: 2
-  - uid: 235
+  - uid: 314
     components:
     - type: Transform
       pos: -0.5419009,-8.289177
       parent: 2
 - proto: NuclearBomb
   entities:
-  - uid: 447
+  - uid: 315
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1907,28 +1880,28 @@ entities:
       parent: 2
 - proto: NukeCodePaper
   entities:
-  - uid: 448
+  - uid: 316
     components:
     - type: Transform
       pos: 8.458004,3.5654695
       parent: 2
 - proto: NukeCodePaperStation
   entities:
-  - uid: 449
+  - uid: 317
     components:
     - type: Transform
       pos: 8.5751915,3.213907
       parent: 2
 - proto: OperatingTable
   entities:
-  - uid: 244
+  - uid: 318
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 2
 - proto: PaperOffice
   entities:
-  - uid: 450
+  - uid: 319
     components:
     - type: Transform
       pos: 8.404715,2.9624357
@@ -1953,109 +1926,109 @@ entities:
       linearDamping: 0
 - proto: PlastitaniumWindow
   entities:
-  - uid: 464
+  - uid: 320
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,11.5
       parent: 2
-  - uid: 465
+  - uid: 321
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,11.5
       parent: 2
-  - uid: 466
+  - uid: 322
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,11.5
       parent: 2
-  - uid: 467
+  - uid: 323
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,14.5
       parent: 2
-  - uid: 468
+  - uid: 324
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,13.5
       parent: 2
-  - uid: 469
+  - uid: 325
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,12.5
       parent: 2
-  - uid: 470
+  - uid: 326
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,12.5
       parent: 2
-  - uid: 471
+  - uid: 327
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,13.5
       parent: 2
-  - uid: 472
+  - uid: 328
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,14.5
       parent: 2
-  - uid: 473
+  - uid: 329
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,11.5
       parent: 2
-  - uid: 475
+  - uid: 330
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,11.5
       parent: 2
-  - uid: 476
+  - uid: 331
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,15.5
       parent: 2
-  - uid: 477
+  - uid: 332
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,15.5
       parent: 2
-  - uid: 478
+  - uid: 333
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,15.5
       parent: 2
-  - uid: 479
+  - uid: 334
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,15.5
       parent: 2
-  - uid: 480
+  - uid: 335
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,15.5
       parent: 2
-  - uid: 481
+  - uid: 336
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,15.5
       parent: 2
-  - uid: 482
+  - uid: 337
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2063,49 +2036,49 @@ entities:
       parent: 2
 - proto: PlushieNuke
   entities:
-  - uid: 232
+  - uid: 338
     components:
     - type: Transform
       pos: -2.416901,-5.3594894
       parent: 2
 - proto: PosterContrabandC20r
   entities:
-  - uid: 581
+  - uid: 339
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 2
 - proto: PosterContrabandEnlistGorlex
   entities:
-  - uid: 582
+  - uid: 340
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 2
 - proto: PosterContrabandFreeSyndicateEncryptionKey
   entities:
-  - uid: 583
+  - uid: 341
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 2
 - proto: PosterContrabandFunPolice
   entities:
-  - uid: 584
+  - uid: 342
     components:
     - type: Transform
       pos: 4.5,9.5
       parent: 2
 - proto: PowerCellHigh
   entities:
-  - uid: 213
+  - uid: 343
     components:
     - type: Transform
       pos: 5.610121,-8.382927
       parent: 2
 - proto: PowerCellRecharger
   entities:
-  - uid: 212
+  - uid: 344
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2113,135 +2086,135 @@ entities:
       parent: 2
 - proto: Poweredlight
   entities:
-  - uid: 144
+  - uid: 345
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 2
-  - uid: 145
+  - uid: 346
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 2
-  - uid: 249
+  - uid: 347
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-4.5
       parent: 2
-  - uid: 250
+  - uid: 348
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-6.5
       parent: 2
-  - uid: 251
+  - uid: 349
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-7.5
       parent: 2
-  - uid: 252
+  - uid: 350
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-10.5
       parent: 2
-  - uid: 253
+  - uid: 351
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 2
-  - uid: 254
+  - uid: 352
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-10.5
       parent: 2
-  - uid: 255
+  - uid: 353
     components:
     - type: Transform
       pos: 9.5,-4.5
       parent: 2
-  - uid: 284
+  - uid: 354
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,4.5
       parent: 2
-  - uid: 285
+  - uid: 355
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,4.5
       parent: 2
-  - uid: 286
+  - uid: 356
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,1.5
       parent: 2
-  - uid: 287
+  - uid: 357
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,1.5
       parent: 2
-  - uid: 575
+  - uid: 358
     components:
     - type: Transform
       pos: 0.5,14.5
       parent: 2
-  - uid: 576
+  - uid: 359
     components:
     - type: Transform
       pos: 4.5,14.5
       parent: 2
 - proto: PoweredSmallLight
   entities:
-  - uid: 146
+  - uid: 360
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-2.5
       parent: 2
-  - uid: 147
+  - uid: 361
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-2.5
       parent: 2
-  - uid: 256
+  - uid: 362
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,0.5
       parent: 2
-  - uid: 257
+  - uid: 363
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,0.5
       parent: 2
-  - uid: 462
+  - uid: 364
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,6.5
       parent: 2
-  - uid: 463
+  - uid: 365
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,6.5
       parent: 2
-  - uid: 573
+  - uid: 366
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,7.5
       parent: 2
-  - uid: 574
+  - uid: 367
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2249,95 +2222,95 @@ entities:
       parent: 2
 - proto: Rack
   entities:
-  - uid: 102
+  - uid: 368
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 2
-  - uid: 103
+  - uid: 369
     components:
     - type: Transform
       pos: 9.5,-0.5
       parent: 2
-  - uid: 166
+  - uid: 370
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 2
-  - uid: 230
+  - uid: 371
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-5.5
       parent: 2
-  - uid: 585
+  - uid: 372
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 2
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 113
+  - uid: 373
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 2
-  - uid: 114
+  - uid: 374
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 2
-  - uid: 115
+  - uid: 375
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 2
-  - uid: 116
+  - uid: 376
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 2
-  - uid: 117
+  - uid: 377
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 2
-  - uid: 118
+  - uid: 378
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 2
-  - uid: 299
+  - uid: 379
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,5.5
       parent: 2
-  - uid: 300
+  - uid: 380
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,5.5
       parent: 2
-  - uid: 301
+  - uid: 381
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,4.5
       parent: 2
-  - uid: 302
+  - uid: 382
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,2.5
       parent: 2
-  - uid: 303
+  - uid: 383
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,2.5
       parent: 2
-  - uid: 304
+  - uid: 384
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2345,28 +2318,28 @@ entities:
       parent: 2
 - proto: RemoteSignaller
   entities:
-  - uid: 208
+  - uid: 385
     components:
     - type: Transform
       pos: 9.313246,-7.5157394
       parent: 2
 - proto: SawAdvanced
   entities:
-  - uid: 241
+  - uid: 386
     components:
     - type: Transform
       pos: -4.432526,-9.343864
       parent: 2
 - proto: ScalpelAdvanced
   entities:
-  - uid: 242
+  - uid: 387
     components:
     - type: Transform
       pos: -4.4559636,-10.351677
       parent: 2
 - proto: SignElectricalMed
   entities:
-  - uid: 311
+  - uid: 388
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2374,7 +2347,7 @@ entities:
       parent: 2
 - proto: SignEngine
   entities:
-  - uid: 260
+  - uid: 389
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2382,7 +2355,7 @@ entities:
       parent: 2
 - proto: SignEngineering
   entities:
-  - uid: 246
+  - uid: 390
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2390,320 +2363,320 @@ entities:
       parent: 2
 - proto: SignMedical
   entities:
-  - uid: 245
+  - uid: 391
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 2
 - proto: SignSpace
   entities:
-  - uid: 247
+  - uid: 392
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 2
-  - uid: 248
+  - uid: 393
     components:
     - type: Transform
       pos: 8.5,-0.5
       parent: 2
 - proto: SMESBasic
   entities:
-  - uid: 171
+  - uid: 394
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 2
-  - uid: 172
+  - uid: 395
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 2
 - proto: SubstationBasic
   entities:
-  - uid: 165
+  - uid: 396
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 2
 - proto: SuitStorageEVASyndicate
   entities:
-  - uid: 100
+  - uid: 397
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 2
-  - uid: 101
+  - uid: 398
     components:
     - type: Transform
       pos: 9.5,-2.5
       parent: 2
-  - uid: 277
+  - uid: 399
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 2
-  - uid: 278
+  - uid: 400
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 2
-  - uid: 279
+  - uid: 401
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 2
-  - uid: 280
+  - uid: 402
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 2
 - proto: SyndicateComputerComms
   entities:
-  - uid: 542
+  - uid: 403
     components:
     - type: Transform
       pos: 3.5,14.5
       parent: 2
 - proto: SyndicatePersonalAI
   entities:
-  - uid: 579
+  - uid: 404
     components:
     - type: Transform
       pos: -0.44933534,14.615757
       parent: 2
 - proto: SyndieMiniBomb
   entities:
-  - uid: 551
+  - uid: 405
     components:
     - type: Transform
       pos: 7.8451276,1.5586307
       parent: 2
-  - uid: 552
+  - uid: 406
     components:
     - type: Transform
       pos: 7.54044,1.3008182
       parent: 2
 - proto: TableReinforced
   entities:
-  - uid: 201
+  - uid: 407
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-6.5
       parent: 2
-  - uid: 202
+  - uid: 408
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-7.5
       parent: 2
-  - uid: 203
+  - uid: 409
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-8.5
       parent: 2
-  - uid: 210
+  - uid: 410
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-8.5
       parent: 2
-  - uid: 211
+  - uid: 411
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-8.5
       parent: 2
-  - uid: 219
+  - uid: 412
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-4.5
       parent: 2
-  - uid: 220
+  - uid: 413
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-5.5
       parent: 2
-  - uid: 221
+  - uid: 414
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-8.5
       parent: 2
-  - uid: 222
+  - uid: 415
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-8.5
       parent: 2
-  - uid: 223
+  - uid: 416
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-9.5
       parent: 2
-  - uid: 224
+  - uid: 417
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-10.5
       parent: 2
-  - uid: 225
+  - uid: 418
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-10.5
       parent: 2
-  - uid: 226
+  - uid: 419
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-7.5
       parent: 2
-  - uid: 227
+  - uid: 420
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-6.5
       parent: 2
-  - uid: 271
+  - uid: 421
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,1.5
       parent: 2
-  - uid: 272
+  - uid: 422
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,1.5
       parent: 2
-  - uid: 273
+  - uid: 423
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,2.5
       parent: 2
-  - uid: 274
+  - uid: 424
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,3.5
       parent: 2
-  - uid: 543
+  - uid: 425
     components:
     - type: Transform
       pos: 0.5,14.5
       parent: 2
-  - uid: 544
+  - uid: 426
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 2
-  - uid: 545
+  - uid: 427
     components:
     - type: Transform
       pos: 4.5,14.5
       parent: 2
-  - uid: 546
+  - uid: 428
     components:
     - type: Transform
       pos: 5.5,14.5
       parent: 2
 - proto: TelecomServer
   entities:
-  - uid: 204
+  - uid: 429
     components:
     - type: Transform
       pos: 7.5,-10.5
       parent: 2
 - proto: Thruster
   entities:
-  - uid: 131
+  - uid: 430
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-13.5
       parent: 2
-  - uid: 132
+  - uid: 431
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,-13.5
       parent: 2
-  - uid: 133
+  - uid: 432
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-12.5
       parent: 2
-  - uid: 134
+  - uid: 433
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-12.5
       parent: 2
-  - uid: 135
+  - uid: 434
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-12.5
       parent: 2
-  - uid: 136
+  - uid: 435
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-12.5
       parent: 2
-  - uid: 137
+  - uid: 436
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-11.5
       parent: 2
-  - uid: 138
+  - uid: 437
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-11.5
       parent: 2
-  - uid: 139
+  - uid: 438
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-11.5
       parent: 2
-  - uid: 565
+  - uid: 439
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 2
-  - uid: 566
+  - uid: 440
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 2
-  - uid: 567
+  - uid: 441
     components:
     - type: Transform
       pos: 7.5,8.5
       parent: 2
-  - uid: 568
+  - uid: 442
     components:
     - type: Transform
       pos: 8.5,8.5
       parent: 2
-  - uid: 569
+  - uid: 443
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,6.5
       parent: 2
-  - uid: 570
+  - uid: 444
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2711,21 +2684,21 @@ entities:
       parent: 2
 - proto: ToolboxSyndicateFilled
   entities:
-  - uid: 214
+  - uid: 445
     components:
     - type: Transform
       pos: 6.4773083,-8.289177
       parent: 2
 - proto: VendingMachineTankDispenserEVA
   entities:
-  - uid: 281
+  - uid: 446
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 2
 - proto: VendingMachineYouTool
   entities:
-  - uid: 198
+  - uid: 447
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -2733,920 +2706,915 @@ entities:
       parent: 2
 - proto: WallPlastitanium
   entities:
-  - uid: 3
+  - uid: 448
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-2.5
       parent: 2
-  - uid: 6
+  - uid: 449
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-0.5
       parent: 2
-  - uid: 7
+  - uid: 450
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,0.5
       parent: 2
-  - uid: 8
+  - uid: 451
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 2
-  - uid: 9
+  - uid: 452
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-0.5
       parent: 2
-  - uid: 11
+  - uid: 453
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-3.5
       parent: 2
-  - uid: 12
+  - uid: 454
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-3.5
       parent: 2
-  - uid: 13
+  - uid: 455
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-2.5
       parent: 2
-  - uid: 14
+  - uid: 456
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-3.5
       parent: 2
-  - uid: 15
+  - uid: 457
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-3.5
       parent: 2
-  - uid: 16
+  - uid: 458
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-4.5
       parent: 2
-  - uid: 17
+  - uid: 459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-5.5
       parent: 2
-  - uid: 18
+  - uid: 460
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-6.5
       parent: 2
-  - uid: 19
+  - uid: 461
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-7.5
       parent: 2
-  - uid: 20
+  - uid: 462
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-8.5
       parent: 2
-  - uid: 21
+  - uid: 463
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-9.5
       parent: 2
-  - uid: 22
+  - uid: 464
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-10.5
       parent: 2
-  - uid: 23
+  - uid: 465
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-10.5
       parent: 2
-  - uid: 24
+  - uid: 466
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-10.5
       parent: 2
-  - uid: 25
+  - uid: 467
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-10.5
       parent: 2
-  - uid: 26
+  - uid: 468
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-10.5
       parent: 2
-  - uid: 27
+  - uid: 469
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-9.5
       parent: 2
-  - uid: 28
+  - uid: 470
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-8.5
       parent: 2
-  - uid: 29
+  - uid: 471
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-7.5
       parent: 2
-  - uid: 30
+  - uid: 472
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-6.5
       parent: 2
-  - uid: 31
+  - uid: 473
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-5.5
       parent: 2
-  - uid: 32
+  - uid: 474
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 2
-  - uid: 33
+  - uid: 475
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 2
-  - uid: 34
+  - uid: 476
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-3.5
       parent: 2
-  - uid: 35
+  - uid: 477
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-9.5
       parent: 2
-  - uid: 36
+  - uid: 478
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-9.5
       parent: 2
-  - uid: 37
+  - uid: 479
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-10.5
       parent: 2
-  - uid: 38
+  - uid: 480
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-11.5
       parent: 2
-  - uid: 39
+  - uid: 481
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-11.5
       parent: 2
-  - uid: 40
+  - uid: 482
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-12.5
       parent: 2
-  - uid: 41
+  - uid: 483
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-13.5
       parent: 2
-  - uid: 42
+  - uid: 484
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-12.5
       parent: 2
-  - uid: 43
+  - uid: 485
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-12.5
       parent: 2
-  - uid: 44
+  - uid: 486
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-13.5
       parent: 2
-  - uid: 45
+  - uid: 487
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-11.5
       parent: 2
-  - uid: 46
+  - uid: 488
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-11.5
       parent: 2
-  - uid: 47
+  - uid: 489
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-10.5
       parent: 2
-  - uid: 48
+  - uid: 490
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-9.5
       parent: 2
-  - uid: 49
+  - uid: 491
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-8.5
       parent: 2
-  - uid: 50
+  - uid: 492
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-7.5
       parent: 2
-  - uid: 51
+  - uid: 493
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-6.5
       parent: 2
-  - uid: 52
+  - uid: 494
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-5.5
       parent: 2
-  - uid: 53
+  - uid: 495
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-4.5
       parent: 2
-  - uid: 54
+  - uid: 496
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-3.5
       parent: 2
-  - uid: 55
+  - uid: 497
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-2.5
       parent: 2
-  - uid: 56
+  - uid: 498
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-4.5
       parent: 2
-  - uid: 57
+  - uid: 499
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-5.5
       parent: 2
-  - uid: 58
+  - uid: 500
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-6.5
       parent: 2
-  - uid: 59
+  - uid: 501
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-3.5
       parent: 2
-  - uid: 60
+  - uid: 502
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-7.5
       parent: 2
-  - uid: 61
+  - uid: 503
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-8.5
       parent: 2
-  - uid: 62
+  - uid: 504
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-9.5
       parent: 2
-  - uid: 63
+  - uid: 505
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-10.5
       parent: 2
-  - uid: 64
+  - uid: 506
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-11.5
       parent: 2
-  - uid: 65
+  - uid: 507
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-11.5
       parent: 2
-  - uid: 66
+  - uid: 508
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-12.5
       parent: 2
-  - uid: 67
+  - uid: 509
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-13.5
       parent: 2
-  - uid: 68
+  - uid: 510
     components:
     - type: Transform
       pos: 8.5,-12.5
       parent: 2
-  - uid: 69
+  - uid: 511
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-13.5
       parent: 2
-  - uid: 70
+  - uid: 512
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-12.5
       parent: 2
-  - uid: 71
+  - uid: 513
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-11.5
       parent: 2
-  - uid: 72
+  - uid: 514
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-11.5
       parent: 2
-  - uid: 73
+  - uid: 515
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-10.5
       parent: 2
-  - uid: 74
+  - uid: 516
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-9.5
       parent: 2
-  - uid: 75
+  - uid: 517
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-9.5
       parent: 2
-  - uid: 76
+  - uid: 518
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,-3.5
       parent: 2
-  - uid: 77
+  - uid: 519
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-3.5
       parent: 2
-  - uid: 79
+  - uid: 520
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-2.5
       parent: 2
-  - uid: 80
+  - uid: 521
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-0.5
       parent: 2
-  - uid: 81
+  - uid: 522
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-0.5
       parent: 2
-  - uid: 83
+  - uid: 523
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,0.5
       parent: 2
-  - uid: 84
+  - uid: 524
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,0.5
       parent: 2
-  - uid: 85
+  - uid: 525
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,0.5
       parent: 2
-  - uid: 86
+  - uid: 526
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,0.5
       parent: 2
-  - uid: 87
+  - uid: 527
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,0.5
       parent: 2
-  - uid: 88
+  - uid: 528
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,0.5
       parent: 2
-  - uid: 89
+  - uid: 529
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 2
-  - uid: 90
+  - uid: 530
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,5.5
       parent: 2
-  - uid: 91
+  - uid: 531
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,5.5
       parent: 2
-  - uid: 92
+  - uid: 532
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,1.5
       parent: 2
-  - uid: 93
+  - uid: 533
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 2
-  - uid: 94
+  - uid: 534
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,0.5
       parent: 2
-  - uid: 95
+  - uid: 535
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 2
-  - uid: 96
+  - uid: 536
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,0.5
       parent: 2
-  - uid: 258
+  - uid: 537
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 2
-  - uid: 259
+  - uid: 538
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-3.5
       parent: 2
-  - uid: 261
+  - uid: 539
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,5.5
       parent: 2
-  - uid: 262
+  - uid: 540
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,4.5
       parent: 2
-  - uid: 263
+  - uid: 541
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,3.5
       parent: 2
-  - uid: 264
+  - uid: 542
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,1.5
       parent: 2
-  - uid: 265
+  - uid: 543
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,2.5
       parent: 2
-  - uid: 266
+  - uid: 544
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,1.5
       parent: 2
-  - uid: 267
+  - uid: 545
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,2.5
       parent: 2
-  - uid: 268
+  - uid: 546
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,3.5
       parent: 2
-  - uid: 269
+  - uid: 547
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,4.5
       parent: 2
-  - uid: 270
+  - uid: 548
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,5.5
       parent: 2
-  - uid: 305
+  - uid: 549
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,1.5
       parent: 2
-  - uid: 306
+  - uid: 550
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,0.5
       parent: 2
-  - uid: 454
+  - uid: 551
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,6.5
       parent: 2
-  - uid: 455
+  - uid: 552
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,6.5
       parent: 2
-  - uid: 456
+  - uid: 553
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,6.5
       parent: 2
-  - uid: 457
+  - uid: 554
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,6.5
       parent: 2
-  - uid: 458
+  - uid: 555
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,6.5
       parent: 2
-  - uid: 459
+  - uid: 556
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,6.5
       parent: 2
-  - uid: 460
+  - uid: 557
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,6.5
       parent: 2
-  - uid: 461
+  - uid: 558
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,6.5
       parent: 2
-  - uid: 474
+  - uid: 559
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,11.5
       parent: 2
-  - uid: 487
+  - uid: 560
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,10.5
       parent: 2
-  - uid: 488
+  - uid: 561
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,9.5
       parent: 2
-  - uid: 489
+  - uid: 562
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,8.5
       parent: 2
-  - uid: 490
+  - uid: 563
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,7.5
       parent: 2
-  - uid: 491
+  - uid: 564
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,10.5
       parent: 2
-  - uid: 492
+  - uid: 565
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,9.5
       parent: 2
-  - uid: 493
+  - uid: 566
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,8.5
       parent: 2
-  - uid: 494
+  - uid: 567
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,7.5
       parent: 2
-  - uid: 557
+  - uid: 568
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 2
-  - uid: 558
+  - uid: 569
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 2
-  - uid: 559
+  - uid: 570
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
-  - uid: 560
+  - uid: 571
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 2
-  - uid: 561
+  - uid: 572
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 2
-  - uid: 562
+  - uid: 573
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 2
-  - uid: 563
+  - uid: 574
     components:
     - type: Transform
       pos: 8.5,7.5
       parent: 2
-  - uid: 564
+  - uid: 575
     components:
     - type: Transform
       pos: 9.5,7.5
       parent: 2
 - proto: WallPlastitaniumDiagonal
   entities:
-  - uid: 82
+  - uid: 576
     components:
     - type: Transform
       pos: -5.5,0.5
       parent: 2
-  - uid: 97
+  - uid: 577
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,0.5
       parent: 2
-  - uid: 129
+  - uid: 578
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-11.5
       parent: 2
-  - uid: 130
+  - uid: 579
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-11.5
       parent: 2
-  - uid: 140
+  - uid: 580
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-13.5
       parent: 2
-  - uid: 141
+  - uid: 581
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-13.5
       parent: 2
-  - uid: 142
+  - uid: 582
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,-13.5
       parent: 2
-  - uid: 143
+  - uid: 583
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-13.5
       parent: 2
-  - uid: 483
+  - uid: 584
     components:
     - type: Transform
       pos: -1.5,15.5
       parent: 2
-  - uid: 484
+  - uid: 585
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,15.5
       parent: 2
-  - uid: 485
+  - uid: 586
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,11.5
       parent: 2
-  - uid: 486
+  - uid: 587
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,11.5
       parent: 2
-  - uid: 571
+  - uid: 588
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 2
-  - uid: 572
+  - uid: 589
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,8.5
       parent: 2
-- proto: WeaponTurretSyndicateDisposable
+- proto: WeaponTurretSyndicate
   entities:
-  - uid: 124
+  - uid: 245
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-1.5
+      rot: -1.5707963267948966 rad
+      pos: 10.5,1.5
       parent: 2
-  - uid: 125
+  - uid: 246
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-1.5
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-0.5
       parent: 2
-  - uid: 126
+  - uid: 247
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-0.5
       parent: 2
-  - uid: 127
+  - uid: 254
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,0.5
+      rot: 1.5707963267948966 rad
+      pos: 1.5,4.5
       parent: 2
-  - uid: 128
+  - uid: 255
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-1.5
+      rot: -1.5707963267948966 rad
+      pos: -0.5,10.5
       parent: 2
-  - uid: 282
+  - uid: 256
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,5.5
+      rot: -1.5707963267948966 rad
+      pos: 5.5,10.5
       parent: 2
-  - uid: 283
+  - uid: 591
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,5.5
+      rot: -1.5707963267948966 rad
+      pos: -5.5,1.5
       parent: 2
-  - uid: 309
+  - uid: 592
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,3.5
-      parent: 2
-  - uid: 577
-    components:
-    - type: Transform
-      pos: 2.5,8.5
+      rot: 1.5707963267948966 rad
+      pos: 3.5,4.5
       parent: 2
 - proto: WelderIndustrial
   entities:
-  - uid: 207
+  - uid: 594
     components:
     - type: Transform
       pos: 9.571058,-6.742302
       parent: 2
 - proto: WeldingFuelTankFull
   entities:
-  - uid: 215
+  - uid: 595
     components:
     - type: Transform
       pos: 7.5,-8.5
       parent: 2
 - proto: Windoor
   entities:
-  - uid: 216
+  - uid: 596
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3654,13 +3622,13 @@ entities:
       parent: 2
 - proto: WindowDirectional
   entities:
-  - uid: 217
+  - uid: 597
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-9.5
       parent: 2
-  - uid: 218
+  - uid: 598
     components:
     - type: Transform
       rot: 3.141592653589793 rad


### PR DESCRIPTION
## About the PR
- Added hotplate, electolyzer and centrifuge to nukie med.
- Added directional sighs for easier navigating.
- Removed RCD.
- Added intellicard and intercom electronics for interactions with AI.
- Shuttle turrets not disposable anymore, Their amount inside the shuttle decreased and they don't block the passage. Moved outside turrets from shuttle walls. Added two more turrets near north entrance.
- Axe moved from inaccessible air chamber to fireaxe case with nukeops access (You can find it near atmos).
- Two papers of codes replaced with nuke codes folder on shuttle.

:cl:
- tweak: Nukie planet medbay now has more tools
- tweak: The nukie planet now has signs for easier navigation
- tweak: The nuke code papers now come in a folder
- tweak: Nukies now get an intellicard and intercom electronics to interact with AI
- fix: The nukie planet's fire axe is now accessible
- fix: The nukie shuttle's turrets are not disposable anymore, and there aren't as many of them.
