### PR TITLE
Ion damage

### DIFF
--- a/Resources/Locale/en-US/Goobstation/damage/damage-groups.ftl
+++ b/Resources/Locale/en-US/Goobstation/damage/damage-groups.ftl
@@ -1,1 +1,1 @@
-damage-group-burn = Electronic
+damage-group-electronic = Electronic

--- a/Resources/Locale/en-US/Goobstation/damage/damage-groups.ftl
+++ b/Resources/Locale/en-US/Goobstation/damage/damage-groups.ftl
@@ -1,0 +1,2 @@
+damage-group-burn = Electronic
+damage-type-ion = Ion

--- a/Resources/Locale/en-US/Goobstation/damage/damage-groups.ftl
+++ b/Resources/Locale/en-US/Goobstation/damage/damage-groups.ftl
@@ -1,2 +1,1 @@
 damage-group-burn = Electronic
-damage-type-ion = Ion

--- a/Resources/Locale/en-US/Goobstation/damage/damage-types.ftl
+++ b/Resources/Locale/en-US/Goobstation/damage/damage-types.ftl
@@ -1,0 +1,1 @@
+damage-type-ion = Ion

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1080,7 +1080,7 @@
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-borg-assault }
   cost:
     # Goobstation - Telecrystal rework
-    Telecrystal: 325
+    Telecrystal: 350
   categories:
     - UplinkAllies
   conditions:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1080,7 +1080,7 @@
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-borg-assault }
   cost:
     # Goobstation - Telecrystal rework
-    Telecrystal: 350
+    Telecrystal: 375
   categories:
     - UplinkAllies
   conditions:

--- a/Resources/Prototypes/Damage/containers.yml
+++ b/Resources/Prototypes/Damage/containers.yml
@@ -28,6 +28,7 @@
   id: Silicon
   supportedGroups:
     - Brute
+    - Electronic #Goobstation
   supportedTypes:
     - Heat
     - Shock

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -71,7 +71,6 @@
     impactEffect: BulletImpactEffectBlueDisabler
     damage:
       types:
-        Cold: 7.5
-        Heat: 5
+        Ion: 20
     soundHit:
       collection: MeatLaserImpact

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -166,6 +166,7 @@
   - type: LockedWiresPanel
   - type: Damageable
     damageContainer: Silicon
+    damageModifierSet: Silicon #Goobstation - Iondamage
   - type: Destructible
     thresholds:
     - trigger:
@@ -317,3 +318,8 @@
       Unsexed: UnisexSiliconSyndicate
   - type: PointLight
     color: "#dd200b"
+  - type: Damageable #Goobstation - Ion Damage
+    damageContainer: Silicon
+    damageModifierSet: SiliconProtected 
+  - type: ExplosionResistance
+    damageCoefficient: 0.5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -821,7 +821,7 @@
       name: lethal
       state: lethal
     - proto: BulletEnergyGunIon
-      fireCost: 275
+      fireCost: 200
       name: ion
       state: special
   - type: MagazineVisuals

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -821,7 +821,7 @@
       name: lethal
       state: lethal
     - proto: BulletEnergyGunIon
-      fireCost: 400
+      fireCost: 275
       name: ion
       state: special
   - type: MagazineVisuals

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -82,6 +82,7 @@
     types:
       Heat: 10
       Radiation: 10
+      Ion: 15 #Goobstation
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_xray

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -235,6 +235,7 @@
     damage:
       types:
         Heat: 5
+        Ion: 10 #Goobstation
     soundHit:
       collection: WeakHit
     forceSound: true
@@ -275,6 +276,7 @@
     damage:
       types:
         Heat: 1
+        Ion: 5 #Goobstation
     soundHit:
       collection: WeakHit
     forceSound: true

--- a/Resources/Prototypes/Goobstation/Damage/groups.yml
+++ b/Resources/Prototypes/Goobstation/Damage/groups.yml
@@ -1,0 +1,5 @@
+- type: damageGroup
+  id: Electronic
+  name: damage-group-electronic
+  damageTypes:
+    - Ion

--- a/Resources/Prototypes/Goobstation/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Goobstation/Damage/modifier_sets.yml
@@ -1,5 +1,7 @@
 - type: damageModifierSet
   id: Silicon
+  coefficients:
+    Heat: 0.8
   flatReductions:
     Blunt: 5
     Slash: 5

--- a/Resources/Prototypes/Goobstation/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Goobstation/Damage/modifier_sets.yml
@@ -1,0 +1,23 @@
+- type: damageModifierSet
+  id: Silicon
+  coefficients:
+    Blunt: 0.9
+    Slash: 0.9
+    Piercing: 0.9
+    Heat: 0.8
+  flatReductions:
+    Blunt: 5
+    Slash: 5
+    Piercing: 5
+
+- type: damageModifierSet
+  id: SiliconProtected
+  coefficients:
+    Blunt: 0.6
+    Slash: 0.6
+    Piercing: 0.6
+    Heat: 0.5
+  flatReductions:
+    Blunt: 10
+    Slash: 5
+    Piercing: 5

--- a/Resources/Prototypes/Goobstation/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Goobstation/Damage/modifier_sets.yml
@@ -1,10 +1,5 @@
 - type: damageModifierSet
   id: Silicon
-  coefficients:
-    Blunt: 0.9
-    Slash: 0.9
-    Piercing: 0.9
-    Heat: 0.8
   flatReductions:
     Blunt: 5
     Slash: 5
@@ -18,6 +13,6 @@
     Piercing: 0.6
     Heat: 0.5
   flatReductions:
-    Blunt: 10
+    Blunt: 5
     Slash: 5
     Piercing: 5

--- a/Resources/Prototypes/Goobstation/Damage/types.yml
+++ b/Resources/Prototypes/Goobstation/Damage/types.yml
@@ -1,0 +1,5 @@
+- type: damageType
+  id: Ion
+  name: damage-type-ion
+  armorCoefficientPrice: 1
+  armorFlatPrice: 1


### PR DESCRIPTION
## About the PR
Added Ion damage and Electronic damage group.
Works only on borgs for now.

Weapons with ion damage:
- X-01 Ion mode will deal 20 ion damage instead of cold damage.
- Disabler and Disabler SMG will deal 10/5 ion damage
- X-ray deal 15 ion damage

All borgs got protection:
All NT borgs now have 5 flat brute damage and 20% heat damage resistance. 
Syndicate assault borg now have 5 + 40% brute damage, 50% heat damage, 50% explosive damage resistance. 
Electro and Ion damage won't be reduced.

Syndicate borg price increased from 325 to 375 tc.

## Why / Balance
X-01 ion mode looks boring with just cold damage + borgs weren't feel like threat to anyone without any protection. 

## Technical details
<!-- Summary of code changes for easier review. -->

## Media

https://github.com/user-attachments/assets/c0ba78eb-e34f-4ad2-8110-99f934780535

:cl:
- add: Added new damage type - Ion. Some disabling weapons can now make this damage. Most electonic creatures are weak against this type of damage.
- add: All borgs get slight damage resistance for brute and heat damage. Syndicate borgs get more protection.
- tweak: X-01 Ion mode now deal Ion damage instead of cold damage.
- tweak: Syndicate assault borg price increased from 325 to 375 tc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added localization support for "Electronic" and "Ion" damage types, enhancing user experience for English-speaking users.
	- Introduced a new damage group for electronic damage, improving gameplay mechanics.
	- Enhanced weapon mechanics by adding "Ion" as a new damage type across various projectiles and weapons.

- **Gameplay Adjustments**
	- Increased the cost of specific in-game items to balance gameplay.
	- Modified the damage handling for Cyborg entities, improving their resilience against various damage types.

- **Performance Enhancements**
	- Adjusted fire costs for certain weapons to improve usability and effectiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->