### PR TITLE
give nukies jackboots

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -48,7 +48,7 @@
     ears: ClothingHeadsetAltSyndicate
     gloves: ClothingHandsGlovesCombat
     #outerClothing: ClothingOuterHardsuitSyndie # goobstation - duke nukies
-    shoes: ClothingShoesBootsCombatFilled
+    shoes: ClothingShoesBootsJackFilled
     id: SyndiPDA
     pocket1: DoubleEmergencyOxygenTankFilled
     pocket2: PlushieCarp

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -48,7 +48,7 @@
     ears: ClothingHeadsetAltSyndicate
     gloves: ClothingHandsGlovesCombat
     #outerClothing: ClothingOuterHardsuitSyndie # goobstation - duke nukies
-    shoes: ClothingShoesBootsJackFilled
+    shoes: ClothingShoesBootsJackFilled # goobstation
     id: SyndiPDA
     pocket1: DoubleEmergencyOxygenTankFilled
     pocket2: PlushieCarp


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Gave nukies jackboots
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
since jacks got buffed, combat boots are now a direct downgrade
this gives nukies a choice between buying noslips or having less slowdown with damage


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: nukies now get jackboots by default, except for the medic who keeps their magboots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated character equipment for nukeops, changing footwear to enhance appearance and functionality.
- **Bug Fixes**
	- Corrected the footwear type to align with gameplay aesthetics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->