### PR TITLE
Medglasses flash protection

### DIFF
--- a/Resources/Prototypes/Goobstation/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Goobstation/Entities/Clothing/Eyes/glasses.yml
@@ -1,8 +1,8 @@
 - type: entity
-  parent: [ClothingEyesBase, ShowMedicalIcons]
-  id: ClothingEyesGlassesMedical
-  name: medglasses
-  description: Sunglasses with a medical hud
+  parent: [ClothingEyesBase, ShowSecurityIcons, ShowMedicalIcons]
+  id: ClothingEyesGlassesMedSec
+  name: medsecglasses
+  description: Sunglasses with a medical and security hud
   components:
   - type: Sprite
     sprite: Goobstation/Clothing/Eyes/Glasses/medglasses.rsi

--- a/Resources/Prototypes/Goobstation/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Goobstation/Entities/Clothing/Eyes/glasses.yml
@@ -8,6 +8,9 @@
     sprite: Goobstation/Clothing/Eyes/Glasses/medglasses.rsi
   - type: Clothing
     sprite: Goobstation/Clothing/Eyes/Glasses/medglasses.rsi
+  - type: FlashImmunity
+  - type: EyeProtection
+    protectionTime: 5
   - type: Tag
     tags:
     - WhitelistChameleon

--- a/Resources/Prototypes/Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -45,7 +45,7 @@
     back: ClothingBackpack
     jumpsuit: ClothingUniformJumpsuitBlueshieldOfficer
     shoes: ClothingShoesBootsJackFilled
-    eyes: ClothingEyesGlassesMedical
+    eyes: ClothingEyesGlassesMedSec
     gloves: ClothingHandsGlovesCombat
     outerClothing: ClothingBlueshieldArmourVest
     id: ERTSecurityPDA


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds flash protection to medglasses (i forgotteded)

## Media

https://github.com/user-attachments/assets/743c689b-dcdf-498a-9eda-45ddd39964a9


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Medglasses are now Medsecglasses.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new attributes for glasses: `FlashImmunity` and `EyeProtection`.
	- `EyeProtection` now includes a `protectionTime` property set to 5, enhancing gameplay related to vision and environmental hazards.
	- Updated eyewear for the "blueshield officer" role to a more specialized design, reflecting enhanced security features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->