### PR TITLE
Fix crawling throwing and turret shooting

### DIFF
--- a/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
@@ -202,7 +202,7 @@ public sealed partial class NPCCombatSystem
                 return;
             }
 
-            _gun.AttemptShoot(uid, gunUid, gun, targetCordinates);
+            _gun.AttemptShoot(uid, gunUid, gun, targetCordinates, comp.Target);
         }
     }
 }

--- a/Content.Shared/Damage/Components/RequireProjectileTargetComponent.cs
+++ b/Content.Shared/Damage/Components/RequireProjectileTargetComponent.cs
@@ -11,4 +11,8 @@ public sealed partial class RequireProjectileTargetComponent : Component
 {
     [DataField, AutoNetworkedField]
     public bool Active = true;
+
+    // Goobstation - Crawl fix
+    [DataField, AutoNetworkedField]
+    public bool IgnoreThrow = false;
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -215,6 +215,15 @@ public abstract partial class SharedGunSystem : EntitySystem
         gun.ShotCounter = 0;
     }
 
+    // Goobstation - Crawling turret fix
+    public void AttemptShoot(EntityUid user, EntityUid gunUid, GunComponent gun, EntityCoordinates toCoordinates, EntityUid target)
+    {
+        gun.Target = target;
+        gun.ShootCoordinates = toCoordinates;
+        AttemptShoot(user, gunUid, gun);
+        gun.ShotCounter = 0;
+    }
+
     /// <summary>
     /// Shoots by assuming the gun is the user at default coordinates.
     /// </summary>

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/base_structuretables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/base_structuretables.yml
@@ -40,6 +40,7 @@
     footstepSoundCollection:
       collection: FootstepHull
   - type: RequireProjectileTarget # Goobstation - Crawling
+    ignoreThrow: true
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
@@ -111,6 +111,7 @@
     graph: Table
     node: CounterWoodFrame
   - type: RequireProjectileTarget # Goobstation - Crawling
+    ignoreThrow: true
 
 - type: entity
   id: CounterMetalFrame


### PR DESCRIPTION
## About the PR
Fix crawl fix throwing bug 
Fixed turret can't shoot lying people
Resolves: #656

**Changelog**

:cl:
- fix: Fixed throwing objects collision with tables
- fix: Fixed turrets couldn't shoot lying people 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property, `IgnoreThrow`, allowing certain entities to ignore projectile throw actions.
	- Enhanced collision prevention logic for projectiles, improving gameplay interactions.
	- Added functionality for targeted shooting in the gun system, enhancing shooting accuracy.

- **Bug Fixes**
	- Adjustments made to projectile targeting mechanics, particularly for crawling gameplay.

- **Configuration Changes**
	- Updated entity configurations to include `ignoreThrow: true` for specific furniture types, affecting how they interact with thrown projectiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->