### PR TITLE
Fix rummage

### DIFF
--- a/Content.Shared/RatKing/SharedRatKingSystem.cs
+++ b/Content.Shared/RatKing/SharedRatKingSystem.cs
@@ -33,6 +33,7 @@ public abstract class SharedRatKingSystem : EntitySystem
 
         SubscribeLocalEvent<RatKingServantComponent, ComponentShutdown>(OnServantShutdown);
 
+        SubscribeLocalEvent<RatKingRummageableComponent, ComponentInit>(OnComponentInit); // Goobstation
         SubscribeLocalEvent<RatKingRummageableComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerb);
         SubscribeLocalEvent<RatKingRummageableComponent, RatKingRummageDoAfterEvent>(OnDoAfterComplete);
     }
@@ -104,6 +105,13 @@ public abstract class SharedRatKingSystem : EntitySystem
         _action.StartUseDelay(component.ActionOrderFollowEntity);
         _action.StartUseDelay(component.ActionOrderCheeseEmEntity);
         _action.StartUseDelay(component.ActionOrderLooseEntity);
+    }
+
+    // Goobstation
+    public void OnComponentInit(EntityUid uid, RatKingRummageableComponent component, ComponentInit args)
+    {
+        component.LastLooted = _gameTiming.CurTime;
+        Dirty(uid, component);
     }
 
     private void OnGetVerb(EntityUid uid, RatKingRummageableComponent component, GetVerbsEvent<AlternativeVerb> args)


### PR DESCRIPTION
## About the PR
(https://discord.com/channels/1202734573247795300/1284621766458609674)
Starts cooldown on comp init

:cl:
- fix: Disposal unit rummage cooldown now start on spawn to prevent rodentia abuse.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new event subscription for tracking the last loot time in the Rat King component, enhancing gameplay mechanics related to looting and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->