### PR TITLE
Kill crawling fights

### DIFF
--- a/Content.Shared/Damage/Systems/RequireProjectileTargetSystem.cs
+++ b/Content.Shared/Damage/Systems/RequireProjectileTargetSystem.cs
@@ -11,6 +11,7 @@ namespace Content.Shared.Damage.Components;
 public sealed class RequireProjectileTargetSystem : EntitySystem
 {
     [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
 
     public override void Initialize()
     {
@@ -38,6 +39,10 @@ public sealed class RequireProjectileTargetSystem : EntitySystem
 
             // Goobstation - Crawling
             if (TryComp<StandingStateComponent>(shooter, out var standingState) && standingState.CurrentState != StandingState.Standing)
+                return;
+
+            // Goobstation - Crawling
+            if (_mobState.IsAlive(args.OurEntity))
                 return;
 
             if (!_container.IsEntityOrParentInContainer(shooter.Value))


### PR DESCRIPTION
## About the PR
Now you'll always hit crawling people if they alive

## Why / Balance
Crawling fights are:
1. Unfunny
2. Not dynamic
3. Looks stupid
4. Literally CS double ducks

:cl:
- tweak: Now you'll always hit crawling people if they alive.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced collision prevention logic by incorporating entity state checks, ensuring that actions are only processed for alive entities.

- **Bug Fixes**
	- Improved handling of collision events to prevent unnecessary processing for entities that are not alive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->