### PR TITLE
Revert security helmet buff

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -63,11 +63,10 @@
   - type: Armor #This is intentionally not spaceproof, when the time comes to port the values from SS13 this should be buffed from what it was.
     modifiers:
       coefficients:
-        Blunt: 0.80
-        Slash: 0.80
-        Piercing: 0.80
-        Heat: 0.80
-        Radiation: 0.80
+        Blunt: 0.85
+        Slash: 0.85
+        Piercing: 0.85
+        Heat: 0.85
         Caustic: 0.95
   - type: ExplosionResistance
     damageCoefficient: 0.75

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -9,10 +9,10 @@
   - type: Armor #Values seem to let the user survive one extra hit if attacked consistently.
     modifiers:
       coefficients:
-        Blunt: 0.85
-        Slash: 0.85
-        Piercing: 0.85
-        Heat: 0.85
+        Blunt: 0.9
+        Slash: 0.9
+        Piercing: 0.9
+        Heat: 0.9
   - type: Tag
     tags:
     - WhitelistChameleon

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -15,9 +15,9 @@
   - type: Armor #Based on /tg/ but slightly compensated to fit the fact that armor stacks in SS14.
     modifiers:
       coefficients:
-        Blunt: 0.70
-        Slash: 0.70
-        Piercing: 0.70 #Can save you, but bullets will still hurt. Will take about 10 shots from a Viper before critting, as opposed to 7 while unarmored and 16~ with a bulletproof vest.
+        Blunt: 0.65
+        Slash: 0.65
+        Piercing: 0.67 #Can save you, but bullets will still hurt. Will take about 10 shots from a Viper before critting, as opposed to 7 while unarmored and 16~ with a bulletproof vest.
         Heat: 0.80
   - type: ExplosionResistance
     damageCoefficient: 0.90

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -15,9 +15,9 @@
   - type: Armor #Based on /tg/ but slightly compensated to fit the fact that armor stacks in SS14.
     modifiers:
       coefficients:
-        Blunt: 0.65
-        Slash: 0.65
-        Piercing: 0.67 #Can save you, but bullets will still hurt. Will take about 10 shots from a Viper before critting, as opposed to 7 while unarmored and 16~ with a bulletproof vest.
+        Blunt: 0.70
+        Slash: 0.70
+        Piercing: 0.70 #Can save you, but bullets will still hurt. Will take about 10 shots from a Viper before critting, as opposed to 7 while unarmored and 16~ with a bulletproof vest.
         Heat: 0.80
   - type: ExplosionResistance
     damageCoefficient: 0.90


### PR DESCRIPTION
Partially reverts Goob-Station/Goob-Station#573

the helmet is on par with the fucking raid suit, (buffing the raid suit to compensate would just make raid suit users even tankier when they dont need to be, 65% resistances for about 30-40 TC by the way) and dont forget to check out that comment
![image](https://github.com/user-attachments/assets/d8ab2b69-8698-4ea8-9823-6d5fc8d331d2)
and helmets generally aren't supposed to be better than hardsuit helmets in the first place (the raid suit and SWAT helmets dont count because the raid suit is purchasable by nukies and the SWAT helmet is currently unobtainable)
![image](https://github.com/user-attachments/assets/c435e65e-4c7d-4996-8046-81f6cf19795f)

the following is no longer true to the nature of the PR anymore, i originally wanted to de-buff the armor vest values too, but penguin forced me to keep them

the armor also didnt need a buff since more specialized armors are available (riot suits and bulletproof vests). and an extra 3% pierce gives me pain because it doesnt follow the 5% convention

penguin also asked me to nerf the swat helmet

:cl: JoeHammad
- Tweak: Un-buffed security helmet armor values, it is no longer on par with the RAID SUIT HELMET
- Tweak: Nerfed the SWAT helmet (available to BSO) so it is now on par with the raid suit helmet (why the fuck did it resist radiation?)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced damage resistance for helmets, improving protection against Blunt, Slash, Piercing, and Heat damage.
	- Increased armor resistance coefficients for Outer Clothing, boosting effectiveness against Blunt, Slash, and Piercing damage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->