### PR TITLE
Nukies nerf

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1490,7 +1490,7 @@
   productEntity: ClothingBackpackDuffelSyndicateHardsuitBundle
   cost:
     # Goobstation - Telecrystal rework
-    Telecrystal: 40
+    Telecrystal: 50
   categories:
   - UplinkWearables
   saleLimit: 1 # WD EDIT
@@ -1502,7 +1502,8 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Armor/syndie-raid.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateRaidBundle
   cost:
-    Telecrystal: 30 # Goobstation
+    # Goobstation - Telecrystal rework
+    Telecrystal: 50
   categories:
   - UplinkWearables
   conditions:
@@ -1520,7 +1521,7 @@
   productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
   cost:
     # Goobstation - Telecrystal rework
-    Telecrystal: 70
+    Telecrystal: 75
   categories:
   - UplinkWearables
   saleLimit: 1 # WD EDIT
@@ -1533,7 +1534,7 @@
   productEntity: CrateCybersunJuggernautBundle
   cost:
     # Goobstation - Telecrystal rework
-    Telecrystal: 100
+    Telecrystal: 75
   categories:
   - UplinkWearables
   saleLimit: 1 # WD EDIT

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -323,5 +323,6 @@
   - type: Damageable #Goobstation - Ion Damage
     damageContainer: Silicon
     damageModifierSet: SiliconProtected
-  - type: ExplosionResistance
+  - type: ExplosionResistance #Goobstation - Ion Damage
     damageCoefficient: 0.5
+  - type: FlashImmunity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -947,6 +947,7 @@
     damage:
       types:
         Heat: 2
+        Ion: 4 #Goobstation
     soundHit:
       collection: WeakHit
     forceSound: true

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -63,7 +63,7 @@
   id: SyndicateOperativeGearFull
   parent: SyndicateOperativeGearFullNoUplink
   equipment:
-    pocket2: BaseUplinkRadio250TC # Goobstation - Telecrystal rework
+    pocket2: BaseUplinkRadio225TC # Goobstation - Telecrystal rework
 
 #Nuclear Operative Commander Gear
 - type: startingGear

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/syndicate.yml
@@ -73,12 +73,12 @@
 #this uplink MUST be used for nukeops, as it has the tag for filtering the listing.
 - type: entity
   parent: BaseUplinkRadio
-  id: BaseUplinkRadio250TC
-  suffix: 250 TC, NukeOps
+  id: BaseUplinkRadio225TC
+  suffix: 225 TC, NukeOps
   components:
   - type: Store
     balance:
-      Telecrystal: 250
+      Telecrystal: 225
   - type: Tag
     tags:
     - NukeOpsUplink


### PR DESCRIPTION
## About the PR
Decreased base nukie TC from 250 to 225.
Increased bloodred suit, raid suit and elite tc cost (40 -> 50, 30 -> 50, 70 -> 75)
Decreased jug suit cost from 100 to 75.
Disabler SMG projectiles deals 4 ion damage (forgot to add this in ion damage PR)
Assault borg got flash protection (because it costs 375 tc)

## Why / Balance
Nukies have too much TC after Duke Nukies update.
Calculations:
![image](https://github.com/user-attachments/assets/ca1c92e9-794a-41d2-956d-d3e1f0d2b7ab)

**Changelog**
:cl:
- tweak: Syndicate borgs got flash protection.
- tweak: Nuke ops now gain 225 TC instead of 250 TC. Increased price for all nukie armor.
- fixed: Fixed disabler SMG dealt no Ion damage.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced new damage type "Ion" for projectiles.
  - Added "FlashImmunity" to enhance cyborg resilience against flash effects.

- **Changes**
  - Adjusted costs for several product bundles, including increases and decreases in Telecrystal values.
  - Updated configurations for Syndicate Operative gear, reducing telecrystal allocations and modifying related identifiers. 

These changes enhance gameplay balance and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->