### PR TITLE
Change Secret Weights

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,17 +1,18 @@
 - type: weightedRandom # All dual antag gamemodes are goobstation
   id: Secret
   weights:
-    Traitor: 0.40 # Goobstation
-    Changeling: 0.11 # Goobstation unique antag
-    Traitorling: 0.05 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
-    Nukeops: 0.20 # Goobstation
-    NukeTraitor: 0.01
-    NukeLing: 0.01
-    Revolutionary: 0.10 # Maybe 0.04 after wiz/cult? Goobstation
-    RevTraitor: 0.02
-    RevLing: 0.01
-    Zombie: 0.04 # Maybe 0.03 after wiz/cult? Goobstation
-    Survival: 0.05 # Maybe 0.03 after wiz/cult? aGoobstation
+    Traitor: 1 # Goobstation
+    Changeling: 0.5 # Goobstation
+    Nukeops: 0.25 # Goobstation
+    Revolutionary: 0.25 # Goobstation
+    Zombie: 0.1 # Goobstation
+    Survival: 0.05 # Goobstation
+    #Dualmodes
+    Traitorling: 0.5 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
+    RevTraitor: 0.25
+    RevLing: 0.25
+    NukeTraitor: 0.1
+    NukeLing: 0.1
   #  KesslerSyndrome: 0.01 # Goobstation - remove kessler
   # Wizard: 0.05
   # Cult: 0.05

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,8 +1,8 @@
 - type: weightedRandom # All dual antag gamemodes are goobstation
   id: Secret
   weights:
-    Traitor: 0.20 # Goobstation
-    Changeling: 0.20 # Goobstation
+    Traitor: 0.25 # Goobstation
+    Changeling: 0.15 # Goobstation
     Nukeops: 0.10 # Goobstation
     Revolutionary: 0.10 # Goobstation
     Zombie: 0.05 # Goobstation

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,18 +1,17 @@
 - type: weightedRandom # All dual antag gamemodes are goobstation
   id: Secret
   weights:
-    Traitor: 1 # Goobstation
-    Changeling: 0.5 # Goobstation
-    Nukeops: 0.25 # Goobstation
-    Revolutionary: 0.25 # Goobstation
-    Zombie: 0.1 # Goobstation
-    Survival: 0.05 # Goobstation
+    Traitor: 0.20 # Goobstation
+    Changeling: 0.20 # Goobstation
+    Nukeops: 0.10 # Goobstation
+    Revolutionary: 0.10 # Goobstation
+    Zombie: 0.05 # Goobstation
     #Dualmodes
-    Traitorling: 0.5 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
-    RevTraitor: 0.25
-    RevLing: 0.25
-    NukeTraitor: 0.1
-    NukeLing: 0.1
+    Traitorling: 0.15 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
+    RevTraitor: 0.05
+    RevLing: 0.05
+    NukeTraitor: 0.05
+    NukeLing: 0.05
   #  KesslerSyndrome: 0.01 # Goobstation - remove kessler
   # Wizard: 0.05
   # Cult: 0.05

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -6,6 +6,7 @@
     Nukeops: 0.10 # Goobstation
     Revolutionary: 0.10 # Goobstation
     Zombie: 0.05 # Goobstation
+    Survival: 0.01 # Goobstation
     #Dualmodes
     Traitorling: 0.15 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
     RevTraitor: 0.05


### PR DESCRIPTION
## About the PR
Changed secret weights.
- Traitor, Lings: 0.25, 0,15 - stealth mode without involving all station. Should be played more often
- Nukies, Revs: 0.10 - involve most station crew. Should be played rarer
- Zombie: 0.05 - zondbe. no skills, no funny :(

Dual modes check player count so their weight shouldn't be low:
- Traitorlings: 0.15 - contains both stealth antags.
- RevLings, RevTraitors, NukeLings, NukeTraitors - 0.05 - contains antags that involve most of the station and stealth antags that can work together. Should be rarer because hard for station.

## Why / Balance
Nukies gamemode roll too often. Many players want to play new antags like heretics or lings and not nukies 5 rounds in a row.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced new antagonist types, including Traitorling, RevTraitor, RevLing, NukeTraitor, and NukeLing, with adjusted weights for enhanced gameplay balance.

- **Bug Fixes**
	- Adjusted weights for existing antagonist types (Traitor, Changeling, Nukeops, Survival) to improve game dynamics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->