### PR TITLE
EG-4 fix-ening

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/weapons/gun.ftl
+++ b/Resources/Locale/en-US/_Goobstation/weapons/gun.ftl
@@ -1,0 +1,2 @@
+# EnergyGunComponent
+energygun-examine-fire-mode = Set to {$mode} bolt.

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -76,7 +76,7 @@
   name: EG-4 energy revolver
   parent: [ BaseWeaponBatterySmall, BaseCentcommContraband ]
   id: WeaponEnergyRevolver
-  description: A highly advabced energy revolver capable of firing both lethal and disabling bullets.
+  description: A highly advanced energy revolver capable of firing both lethal and disabling bullets.
   components:
   - type: Sprite
     sprite: _Goobstation/Objects/Weapons/Guns/Battery/erevolver.rsi
@@ -112,7 +112,7 @@
     fireModes:
     - proto: BulletDisabler
       fireCost: 100
-      name: disable
+      name: disabling
       state: disabler
     - proto: BulletEnergyGunMagnum
       fireCost: 225
@@ -134,4 +134,4 @@
     - Sidearm
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 35
+    autoRechargeRate: 40


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Updated the EG-4 (and X-01 by proxy):
- Fixed a spelling mistake
- Buffed the auto-recharge on the EG-4
- added locales for examining.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The EG-4 now has a recharge on par with Captain's laser pistol, due to feedback on it not being fast enough.
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/30c78a81-2162-4bea-9a80-6fb1635318bd)
![image](https://github.com/user-attachments/assets/b8193d57-9631-49e9-89df-37c3570f93d1)
![image](https://github.com/user-attachments/assets/0e633425-34e5-4775-b0b1-03727fdbfc86)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: the X-01 Multiphase and the EG-4 energy revolver now show their fire mode when examined.
- tweak: Buffed the Auto-recharge rate of the EG-4 energy revolver.
- fix: Fixed spelling mistake when examining the EG-4 energy revolver.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new string entry for examining the fire mode of the energy gun, allowing for dynamic display of the current mode.

- **Bug Fixes**
	- Corrected a typographical error in the description of the EG-4 energy revolver.
	- Updated the fire mode name from "disable" to "disabling" for clarity.

- **Improvements**
	- Increased the auto-recharge rate of the BatterySelfRecharger component for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->