### PR TITLE
Station Deletion fast fix

### DIFF
--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -182,14 +182,6 @@ namespace Content.Server.Explosion.EntitySystems
 
         private void HandleDeleteTrigger(EntityUid uid, DeleteOnTriggerComponent component, TriggerEvent args)
         {
-            //Goobstation - bluespace lifeline implanter
-            if (TryComp(uid, out TransformComponent? xform) && xform.ParentUid != null)
-            {
-                EntityManager.QueueDeleteEntity(xform.ParentUid);
-                args.Handled = true;
-                return;
-            }
-
             EntityManager.QueueDeleteEntity(uid);
             args.Handled = true;
         }

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -55,4 +55,4 @@
     back:
     - BoxSurvivalSlots
     - Flash
-    - BluespaceLifelineImplanter
+    - DeathAcidifierImplanter #BluespaceLifelineImplanter


### PR DESCRIPTION
## About the PR


:cl:
- fix: fix station deletion bug



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the blueshield officer role to include the Death Acidifier Implanter as a tool option, replacing the Bluespace Lifeline Implanter.
  
- **Bug Fixes**
	- Improved entity deletion process by simplifying the trigger handling, ensuring more efficient removal of entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->