### PR TITLE
make gambling ids actually work

### DIFF
--- a/Content.Server/Access/Systems/IdCardSystem.cs
+++ b/Content.Server/Access/Systems/IdCardSystem.cs
@@ -31,14 +31,31 @@ public sealed class IdCardSystem : SharedIdCardSystem
     private void OnMicrowaved(EntityUid uid, IdCardComponent component, BeingMicrowavedEvent args)
     {
         if (!component.CanMicrowave || !TryComp<MicrowaveComponent>(args.Microwave, out var micro) || micro.Broken)
-            return;   
+            return;
 
         if (TryComp<AccessComponent>(uid, out var access))
         {
             float randomPick = _random.NextFloat();
 
+            //basically, it does a small check to decide if its mango is to blow up -Space
+
+            //roll microwave exploding -Space
+            if (!micro.CanMicrowaveIdsSafely)
+            {
+                float explodeCheck = _random.NextFloat();
+
+                if (explodeCheck <= micro.ExplosionChance)
+                {
+                    _microwave.Explode((args.Microwave, micro));
+                    return;
+                }
+
+            }
+
+            // then continue like normal -Space
+
             // if really unlucky, burn card
-            if (randomPick <= 0.15f)
+            if (randomPick <= 0.10f)
             {
                 TryComp(uid, out TransformComponent? transformComponent);
                 if (transformComponent != null)
@@ -54,15 +71,9 @@ public sealed class IdCardSystem : SharedIdCardSystem
                 return;
             }
 
-            //Explode if the microwave can't handle it
-            if (!micro.CanMicrowaveIdsSafely)
-            {
-                _microwave.Explode((args.Microwave, micro));
-                return;
-            }
 
             // If they're unlucky, brick their ID
-            if (randomPick <= 0.25f)
+            if (randomPick <= 0.4f)
             {
                 _popupSystem.PopupEntity(Loc.GetString("id-card-component-microwave-bricked", ("id", uid)), uid);
 

--- a/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
@@ -7,7 +7,7 @@
   - type: Microwave
     capacity: 10
     canMicrowaveIdsSafely: false # Goobstation
-    explosionChance: 0.4 # Goobstation
+    explosionChance: .25 # Goobstation
   - type: Appearance
   - type: GenericVisualizer
     visuals:
@@ -119,7 +119,7 @@
     cookTimeMultiplier: 0.5
     capacity: 10
     canMicrowaveIdsSafely: false
-    explosionChance: 0.15 # Goobstation
+    explosionChance: 0.10 # Goobstation
   - type: Sprite
     sprite: Structures/Machines/microwave_syndie.rsi
     drawdepth: SmallObjects


### PR DESCRIPTION
## About the PR
Fixes microwaves exploding, now fixed so it will have a chance to explode OR mess with the ids and change accesses like it was supposed to.

## Why / Balance
Before it would only explode or burn the id. Which removes the whole system of gambling ids in the first place. Now you can gamble with way more risk and annoy hop for ids!

## Technical details
-Added an if statement in front of the access changing to check if it rolls the microwave exploding. Then afterwards it will normally do the ifs to mess with the id.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in game showcase.

## Breaking changes

**Changelog**

:cl:
- fix: Microwave gambling will actually let you get accesses now
- tweak: Chance for IDs to sizzle increased
- tweak: Microwave exploding chances decreased overall



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an explosion mechanic when microwaving ID cards, with adjusted probabilities for card damage.
  
- **Bug Fixes**
	- Reduced explosion risk for microwaves by modifying the `explosionChance` attributes.

These changes enhance user experience by adding new interactions and refining existing mechanics related to ID card usage in microwaves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->