### PR TITLE
Proper bluespace lifeline implant fix

### DIFF
--- a/Content.Server/_Goobstation/Explosion/Components/DeleteParentOnTriggerComponent.cs
+++ b/Content.Server/_Goobstation/Explosion/Components/DeleteParentOnTriggerComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Server._Goobstation.Explosion.Components;
+
+/// <summary>
+/// Deletes entity parent on <see cref="TriggerEvent"/>
+/// </summary>
+[RegisterComponent]
+public sealed partial class DeleteParentOnTriggerComponent : Component
+{
+}

--- a/Content.Server/_Goobstation/Explosion/EntitySystems/GoobTriggerSystem.cs
+++ b/Content.Server/_Goobstation/Explosion/EntitySystems/GoobTriggerSystem.cs
@@ -1,0 +1,23 @@
+using Content.Server._Goobstation.Explosion.Components;
+using Content.Server.Explosion.EntitySystems;
+
+namespace Content.Server._Goobstation.Explosion.EntitySystems;
+
+public sealed partial class GoobTriggerSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DeleteParentOnTriggerComponent, TriggerEvent>(HandleDeleteParentTrigger);
+    }
+
+    private void HandleDeleteParentTrigger(Entity<DeleteParentOnTriggerComponent> entity, ref TriggerEvent args)
+    {
+        if (!TryComp<TransformComponent>(entity, out var xform))
+            return;
+
+        EntityManager.QueueDeleteEntity(xform.ParentUid);
+        args.Handled = true;
+    }
+}

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/subdermal_implants.yml
@@ -12,7 +12,7 @@
     mobState:
     - Dead
   - type: TriggerImplantAction
-  - type: DeleteOnTrigger
+  - type: DeleteParentOnTrigger
   - type: SpawnOnTrigger
     proto: BluespaceLifeline
   - type: Tag

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -55,4 +55,4 @@
     back:
     - BoxSurvivalSlots
     - Flash
-    - DeathAcidifierImplanter #BluespaceLifelineImplanter
+    - BluespaceLifelineImplanter


### PR DESCRIPTION
## About the PR
Added DeleteParentOnTrigger component to prevent station deletion.

:cl:
- fix: Fixed BSO bluespace lifeline implant



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `DeleteParentOnTriggerComponent` to enable parent entity deletion upon trigger events.
	- Added the `GoobTriggerSystem` to manage trigger events related to the new component.
  
- **Changes**
	- Updated the `BluespaceLifelineImplant` to utilize the new `DeleteParentOnTrigger` component.
	- Modified the `BlueshieldOfficer` job configuration to replace the `DeathAcidifierImplanter` with the `BluespaceLifelineImplanter` in starting gear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->