### PR TITLE
Fixed merc web vest contraband level

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -21,7 +21,7 @@
 
 #Mercenary web vest
 - type: entity
-  parent: [ClothingOuterVestWeb, BaseMinorContraband] #web vest so it should have some pockets for ammo
+  parent: [ClothingOuterStorageBase, BaseMajorContraband] #web vest so it should have some pockets for ammo
   id: ClothingOuterVestWebMerc
   name: merc web vest
   description: A high-quality armored vest made from a hard synthetic material. It's surprisingly flexible and light, despite formidable armor plating.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -21,7 +21,7 @@
 
 #Mercenary web vest
 - type: entity
-  parent: [ClothingOuterStorageBase, BaseMajorContraband] #web vest so it should have some pockets for ammo
+  parent: [ClothingOuterStorageBase, BaseMajorContraband] #web vest so it should have some pockets for ammo \\ Goobstation - issue #733 fix, changed from minor to major contraband
   id: ClothingOuterVestWebMerc
   name: merc web vest
   description: A high-quality armored vest made from a hard synthetic material. It's surprisingly flexible and light, despite formidable armor plating.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed the Mercenary web vest showing as syndicate contraband due to adopting its parent's contraband status

## Why / Balance
Isn't a syndicate specific item, shouldn't have syndicate status

## Technical details
Changed parent from ClothingOuterVestWeb to ClothingOuterStorageBase

## Media
![373638926-dfdd7664-ea7e-49ef-ad7b-e50a066c8fc6](https://github.com/user-attachments/assets/b719460b-c2cb-4f53-8e96-1c927b06346f)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


**Changelog**
- tweak: Changed Merc web vest from minor contraband to major contraband
- fix: Fixed Merc web vest being marked as a syndicate item



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Reclassified the mercenary web vest as major contraband, enhancing its significance in the inventory system.

- **Bug Fixes**
	- Corrected the parent attributes for the `ClothingOuterVestWebMerc` entity to reflect accurate classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->