### PR TITLE
Fix mid round nukies 

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/Dynamic/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/Dynamic/midround.yml
@@ -272,6 +272,16 @@
       startingGear: SyndicateLoneOperativeGearFull
       roleLoadout:
       - RoleSurvivalNukie
+      components:
+      - type: NukeOperative
+      - type: RandomMetadata
+        nameSegments: [names_death_commando] # goob edit
+      - type: NpcFactionMember
+        factions:
+        - Syndicate
+      mindComponents:
+      - type: NukeopsRole
+        prototype: Nukeops
 
 # Rat King Spawn
 - type: entity


### PR DESCRIPTION
## About the PR
Resolves: #730 
Added required nukies components

## Media
https://github.com/user-attachments/assets/a81fc9dd-fde8-453f-a0d5-bdbd964a4d83

:cl:
- fix: Fixed midround nukies weren't count as real syndicate members



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced various new midround roles, including Traitors, Changelings, Heretics, and more, each with unique gameplay mechanics.
	- Enhanced gameplay dynamics with new entities like Skeletons, Dragons, and Zombies, adding depth and variety to midround events.
	- Improved the complexity and functionality of existing roles, such as the Lone Operative, with additional components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->