### PR TITLE
Mail loc fix

### DIFF
--- a/Resources/Locale/en-US/_NF/mail/mail.ftl
+++ b/Resources/Locale/en-US/_NF/mail/mail.ftl
@@ -1,7 +1,7 @@
 mail-large-item-name-unaddressed = package
 mail-large-item-name-addressed = package ({$recipient})
 mail-large-desc-far = A large package.
-mail-large-desc-close = A large package addressed to {CAPITALIZE($name)}, {$job}. Last known location: {$station}.
+mail-large-desc-close = A large package addressed to {CAPITALIZE($name)}, {$job}.
 
 ### Frontier: mailtestbulk
 command-mailtestbulk = Sends one of each type of parcel to a given mail teleporter.  Implicitly calls mailnow.


### PR DESCRIPTION
## About the PR
Removed frontier's $station in loc file that was used for stations.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified description for large mail items in the English (US) locale, enhancing clarity for users.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->