### PR TITLE
Minor stuff fixes

### DIFF
--- a/Content.Shared/_White/Standing/SharedLayingDownSystem.cs
+++ b/Content.Shared/_White/Standing/SharedLayingDownSystem.cs
@@ -124,7 +124,6 @@ public abstract class SharedLayingDownSystem : EntitySystem
 
         var args = new DoAfterArgs(EntityManager, uid, layingDown.StandingUpTime, new StandingUpDoAfterEvent(), uid)
         {
-            BreakOnDamage = true,
             BreakOnHandChange = false,
             RequireCanInteract = false
         };

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/harpy.yml
@@ -29,6 +29,11 @@
         type: HumanoidMarkingModifierBoundUserInterface
       enum.StrippingUiKey.Key:
         type: StrippableBoundUserInterface
+      # Goobstation - changelings
+      enum.StoreUiKey.Key:
+        type: StoreBoundUserInterface
+      enum.HereticLivingHeartKey.Key: # goob edit - heretics
+        type: LivingHeartMenuBoundUserInterface
   - type: Sprite
     scale: 0.9, 0.9
     layers:

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -34,6 +34,11 @@
         type: HumanoidMarkingModifierBoundUserInterface
       enum.StrippingUiKey.Key:
         type: StrippableBoundUserInterface
+      # Goobstation - changelings
+      enum.StoreUiKey.Key:
+        type: StoreBoundUserInterface
+      enum.HereticLivingHeartKey.Key: # goob edit - heretics
+        type: LivingHeartMenuBoundUserInterface
   # to prevent bag open/honk spam
   - type: UseDelay
     delay: 0.5

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/cores.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/cores.yml
@@ -33,6 +33,8 @@
     timeToDecay: 600
     startPrice: 10000
     endPrice: 200
+  - type: MovedByPressure #Goob - space wind moment
+    enabled: false 
 
 - type: entity
   parent: BaseAnomalyCore

--- a/Resources/Prototypes/_Goobstation/Entities/Supermatter/supermatter.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Supermatter/supermatter.yml
@@ -68,3 +68,5 @@
     - type: WarpPoint
       follow: true
       location: supermatter
+    - type: StealTarget
+      stealGroup: SupermatterSliver # uses to verify sm existense on map

--- a/Resources/Prototypes/_Goobstation/Objectives/traitor.yml
+++ b/Resources/Prototypes/_Goobstation/Objectives/traitor.yml
@@ -59,6 +59,7 @@
   - type: Objective
     difficulty: 3.5
   - type: StealCondition
+    verifyMapExistence: true
     stealGroup: SupermatterSliver
     objectiveNoOwnerText: objective-condition-steal-smsliver-title
     descriptionText: objective-condition-steal-smsliver-description

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: mail RPDS
-  parent: WeaponLauncherChinaLake
+  parent: [BaseCargoContraband, WeaponLauncherChinaLake]
   id: WeaponMailLake
   description: Rap(b?)id Parcel Delivery System
   components:


### PR DESCRIPTION
## About the PR
- Fixed heretic/lings uis on harpy and slime (minor bug :trollface:)
- Fixed RPDS contraband group
- Anomaly cores not movable by pressure anymore (this fix anomaly cores flying zillion tiles away from following target)
- Added SM objective check
- Standing up doafter not breaking by damage anymore (You'll be able to escape goliath perma-stun now)

:cl:
- fix: Fixed heretic and ling ui on Hapry and Slime.
- fix: Fixed RPDS contraband group
- fix: Fixed anomaly cores flying away from following target
- fix: SM objective now check SM existence
- tweak: Standing up doafter not breaking by damage anymore



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced interaction capabilities for Harpy and Slime entities with new user interface components.
	- Introduced new actions for Harpy, allowing for musical interactions and voice customization.
	- Added a `MovedByPressure` component to the Base Anomaly Core entity, expanding its functionality.
	- New `StealTarget` component added to the Supermatter entity for improved interaction verification.
	- Introduced new objectives for players, including random traitor and person kill objectives.

- **Bug Fixes**
	- Refined conditions for toggling standing states and movement speed adjustments for entities.

- **Changes**
	- Updated parent class for "mail RPDS" to inherit from multiple classes, enhancing its functionality.
	- Modified existing objective to include a verification step for map existence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->