### PR TITLE
Fixed changeling armor not equipping regardless of worn equipment

### DIFF
--- a/Content.IntegrationTests/Tests/_Goobstation/Changeling/ChangelingArmorTests.cs
+++ b/Content.IntegrationTests/Tests/_Goobstation/Changeling/ChangelingArmorTests.cs
@@ -1,0 +1,81 @@
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Content.Server.Actions;
+using Content.Server.Antag;
+using Content.Server.Changeling;
+using Content.Server.GameTicking;
+using Content.Server.GameTicking.Rules;
+using Content.Server.Mind;
+using Content.Shared.Actions;
+using Content.Shared.Changeling;
+using Content.Shared.Clothing.EntitySystems;
+using Content.Shared.Inventory;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Timing;
+
+namespace Content.IntegrationTests.Tests._Goobstation.Changeling;
+
+[TestFixture]
+public sealed class ChangelingArmorTest
+{
+    [Test]
+    public async Task TestChangelingChitinousArmor()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Dirty = true,
+            InLobby = false,
+            DummyTicker = false,
+        });
+
+        var server = pair.Server;
+        var testMap = await pair.CreateTestMap();
+        var ticker = server.System<GameTicker>();
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var timing = server.ResolveDependency<IGameTiming>();
+
+        var lingSys = entMan.System<ChangelingSystem>();
+        var antagSys = entMan.System<AntagSelectionSystem>();
+        var mindSys = entMan.System<MindSystem>();
+        var actionSys = entMan.System<ActionsSystem>();
+        var invSys = entMan.System<InventorySystem>();
+
+        Assert.That(ticker.RunLevel, Is.EqualTo(GameRunLevel.InRound));
+
+        await server.WaitAssertion(() =>
+        {
+            // Spawn a urist
+            var urist = entMan.SpawnEntity("MobHuman", testMap.GridCoords);
+            Assert.That(urist.IsValid());
+
+            // Make urist a changeling
+            var changeling = entMan.AddComponent<ChangelingComponent>(urist);
+            changeling.TotalAbsorbedEntities += 10;
+            changeling.MaxChemicals = 1000;
+            changeling.Chemicals = 1000;
+
+            server.RunTicks(5);
+
+            // Give urist chitinous armor action
+            var armorActionEnt = actionSys.AddAction(urist, "ActionToggleChitinousArmor");
+            Assert.That(armorActionEnt, Is.Not.Null);
+            Entity<InstantActionComponent> armorAction = (armorActionEnt.Value, entMan.GetComponent<InstantActionComponent>(armorActionEnt.Value));
+            ChangelingActionComponent lingAction = entMan.GetComponent<ChangelingActionComponent>(armorActionEnt.Value);
+
+            // Armor up
+            actionSys.PerformAction(urist, null, armorAction, armorAction.Comp, armorAction.Comp.BaseEvent, timing.CurTime);
+
+            server.RunTicks(5);
+
+            Assert.That(invSys.TryGetSlotEntity(urist, "outerClothing", out var outerClothing));
+            Assert.That(outerClothing, Is.Not.Null);
+            Assert.That(entMan.GetComponent<MetaDataComponent>(outerClothing.Value).EntityPrototype!.ID, Is.EqualTo(lingSys.ArmorPrototype.Id));
+
+            Assert.That(invSys.TryGetSlotEntity(urist, "head", out var head));
+            Assert.That(head, Is.Not.Null);
+            Assert.That(entMan.GetComponent<MetaDataComponent>(head.Value).EntityPrototype!.ID, Is.EqualTo(lingSys.ArmorHelmetPrototype.Id));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/_Goobstation/Changeling/ChangelingArmorTests.cs
+++ b/Content.IntegrationTests/Tests/_Goobstation/Changeling/ChangelingArmorTests.cs
@@ -42,38 +42,211 @@ public sealed class ChangelingArmorTest
 
         Assert.That(ticker.RunLevel, Is.EqualTo(GameRunLevel.InRound));
 
-        await server.WaitAssertion(() =>
+        EntityUid urist = EntityUid.Invalid;
+        ChangelingComponent changeling = null;
+        Entity<InstantActionComponent> armorAction = (EntityUid.Invalid, null);
+
+        await server.WaitPost(() =>
         {
             // Spawn a urist
-            var urist = entMan.SpawnEntity("MobHuman", testMap.GridCoords);
-            Assert.That(urist.IsValid());
+            urist = entMan.SpawnEntity("MobHuman", testMap.GridCoords);
 
             // Make urist a changeling
-            var changeling = entMan.AddComponent<ChangelingComponent>(urist);
+            changeling = entMan.AddComponent<ChangelingComponent>(urist);
             changeling.TotalAbsorbedEntities += 10;
             changeling.MaxChemicals = 1000;
             changeling.Chemicals = 1000;
 
-            server.RunTicks(5);
-
             // Give urist chitinous armor action
             var armorActionEnt = actionSys.AddAction(urist, "ActionToggleChitinousArmor");
-            Assert.That(armorActionEnt, Is.Not.Null);
-            Entity<InstantActionComponent> armorAction = (armorActionEnt.Value, entMan.GetComponent<InstantActionComponent>(armorActionEnt.Value));
-            ChangelingActionComponent lingAction = entMan.GetComponent<ChangelingActionComponent>(armorActionEnt.Value);
+            armorAction = (armorActionEnt.Value, entMan.GetComponent<InstantActionComponent>(armorActionEnt.Value));
+            actionSys.SetUseDelay(armorAction, null);
 
             // Armor up
             actionSys.PerformAction(urist, null, armorAction, armorAction.Comp, armorAction.Comp.BaseEvent, timing.CurTime);
+        });
 
-            server.RunTicks(5);
+        await server.WaitRunTicks(5);
 
-            Assert.That(invSys.TryGetSlotEntity(urist, "outerClothing", out var outerClothing));
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(invSys.TryGetSlotEntity(urist, "outerClothing", out var outerClothing), Is.True);
             Assert.That(outerClothing, Is.Not.Null);
             Assert.That(entMan.GetComponent<MetaDataComponent>(outerClothing.Value).EntityPrototype!.ID, Is.EqualTo(lingSys.ArmorPrototype.Id));
 
             Assert.That(invSys.TryGetSlotEntity(urist, "head", out var head));
             Assert.That(head, Is.Not.Null);
             Assert.That(entMan.GetComponent<MetaDataComponent>(head.Value).EntityPrototype!.ID, Is.EqualTo(lingSys.ArmorHelmetPrototype.Id));
+        });
+
+        await server.WaitPost(() =>
+        {
+            // Armor down
+            actionSys.PerformAction(urist, null, armorAction, armorAction.Comp, armorAction.Comp.BaseEvent, timing.CurTime);
+        });
+
+        await server.WaitRunTicks(5);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(invSys.TryGetSlotEntity(urist, "outerClothing", out var outerClothing), Is.False);
+                Assert.That(entMan.TryGetComponent<MetaDataComponent>(outerClothing, out var meta), Is.False);
+                Assert.That(meta?.EntityPrototype, Is.Null);
+            });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(invSys.TryGetSlotEntity(urist, "head", out var head), Is.False);
+                Assert.That(entMan.TryGetComponent<MetaDataComponent>(head, out var meta), Is.False);
+                Assert.That(meta?.EntityPrototype, Is.Null);
+            });
+        });
+
+        const string mercHelmet = "ClothingHeadHelmetMerc";
+
+        await server.WaitPost(() =>
+        {
+            // Equip helmet
+            var helm = entMan.SpawnEntity(mercHelmet, testMap.GridCoords);
+            Assert.That(invSys.TryEquip(urist, helm, "head", force: true));
+
+            // Try to armor up, should fail due to helmet and not equip anything
+            actionSys.PerformAction(urist, null, armorAction, armorAction.Comp, armorAction.Comp.BaseEvent, timing.CurTime);
+        });
+
+        await server.WaitRunTicks(5);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(invSys.TryGetSlotEntity(urist, "outerClothing", out var outerClothing), Is.False);
+                Assert.That(entMan.TryGetComponent<MetaDataComponent>(outerClothing, out var meta), Is.False);
+                Assert.That(meta?.EntityPrototype, Is.Null);
+            });
+
+            Assert.That(invSys.TryGetSlotEntity(urist, "head", out var head));
+            Assert.That(head, Is.Not.Null);
+            Assert.That(entMan.GetComponent<MetaDataComponent>(head.Value).EntityPrototype!.ID, Is.EqualTo(mercHelmet));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task TestChangelingSpacesuit()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Dirty = true,
+            InLobby = false,
+            DummyTicker = false,
+        });
+
+        var server = pair.Server;
+        var testMap = await pair.CreateTestMap();
+        var ticker = server.System<GameTicker>();
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var timing = server.ResolveDependency<IGameTiming>();
+
+        var lingSys = entMan.System<ChangelingSystem>();
+        var antagSys = entMan.System<AntagSelectionSystem>();
+        var mindSys = entMan.System<MindSystem>();
+        var actionSys = entMan.System<ActionsSystem>();
+        var invSys = entMan.System<InventorySystem>();
+
+        Assert.That(ticker.RunLevel, Is.EqualTo(GameRunLevel.InRound));
+
+        EntityUid urist = EntityUid.Invalid;
+        ChangelingComponent changeling = null;
+        Entity<InstantActionComponent> armorAction = (EntityUid.Invalid, null);
+
+        await server.WaitPost(() =>
+        {
+            // Spawn a urist
+            urist = entMan.SpawnEntity("MobHuman", testMap.GridCoords);
+
+            // Make urist a changeling
+            changeling = entMan.AddComponent<ChangelingComponent>(urist);
+            changeling.TotalAbsorbedEntities += 10;
+            changeling.MaxChemicals = 1000;
+            changeling.Chemicals = 1000;
+
+            // Give urist chitinous armor action
+            var armorActionEnt = actionSys.AddAction(urist, "ActionToggleSpacesuit");
+            armorAction = (armorActionEnt.Value, entMan.GetComponent<InstantActionComponent>(armorActionEnt.Value));
+            actionSys.SetUseDelay(armorAction, null);
+
+            // Armor up
+            actionSys.PerformAction(urist, null, armorAction, armorAction.Comp, armorAction.Comp.BaseEvent, timing.CurTime);
+        });
+
+        await server.WaitRunTicks(5);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(invSys.TryGetSlotEntity(urist, "outerClothing", out var outerClothing), Is.True);
+            Assert.That(outerClothing, Is.Not.Null);
+            Assert.That(entMan.GetComponent<MetaDataComponent>(outerClothing.Value).EntityPrototype!.ID, Is.EqualTo(lingSys.SpacesuitPrototype.Id));
+
+            Assert.That(invSys.TryGetSlotEntity(urist, "head", out var head));
+            Assert.That(head, Is.Not.Null);
+            Assert.That(entMan.GetComponent<MetaDataComponent>(head.Value).EntityPrototype!.ID, Is.EqualTo(lingSys.SpacesuitHelmetPrototype.Id));
+        });
+
+        await server.WaitPost(() =>
+        {
+            // Armor down
+            actionSys.PerformAction(urist, null, armorAction, armorAction.Comp, armorAction.Comp.BaseEvent, timing.CurTime);
+        });
+
+        await server.WaitRunTicks(5);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(invSys.TryGetSlotEntity(urist, "outerClothing", out var outerClothing), Is.False);
+                Assert.That(entMan.TryGetComponent<MetaDataComponent>(outerClothing, out var meta), Is.False);
+                Assert.That(meta?.EntityPrototype, Is.Null);
+            });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(invSys.TryGetSlotEntity(urist, "head", out var head), Is.False);
+                Assert.That(entMan.TryGetComponent<MetaDataComponent>(head, out var meta), Is.False);
+                Assert.That(meta?.EntityPrototype, Is.Null);
+            });
+        });
+
+        const string mercHelmet = "ClothingHeadHelmetMerc";
+
+        await server.WaitPost(() =>
+        {
+            // Equip helmet
+            var helm = entMan.SpawnEntity(mercHelmet, testMap.GridCoords);
+            Assert.That(invSys.TryEquip(urist, helm, "head", force: true));
+
+            // Try to armor up, should fail due to helmet and not equip anything
+            actionSys.PerformAction(urist, null, armorAction, armorAction.Comp, armorAction.Comp.BaseEvent, timing.CurTime);
+        });
+
+        await server.WaitRunTicks(5);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(invSys.TryGetSlotEntity(urist, "outerClothing", out var outerClothing), Is.False);
+                Assert.That(entMan.TryGetComponent<MetaDataComponent>(outerClothing, out var meta), Is.False);
+                Assert.That(meta?.EntityPrototype, Is.Null);
+            });
+
+            Assert.That(invSys.TryGetSlotEntity(urist, "head", out var head));
+            Assert.That(head, Is.Not.Null);
+            Assert.That(entMan.GetComponent<MetaDataComponent>(head.Value).EntityPrototype!.ID, Is.EqualTo(mercHelmet));
         });
 
         await pair.CleanReturnAsync();

--- a/Content.IntegrationTests/Tests/_Goobstation/Changeling/ChangelingArmorTests.cs
+++ b/Content.IntegrationTests/Tests/_Goobstation/Changeling/ChangelingArmorTests.cs
@@ -1,14 +1,10 @@
-using System.Linq;
-using System.Runtime.CompilerServices;
 using Content.Server.Actions;
 using Content.Server.Antag;
 using Content.Server.Changeling;
 using Content.Server.GameTicking;
-using Content.Server.GameTicking.Rules;
 using Content.Server.Mind;
 using Content.Shared.Actions;
 using Content.Shared.Changeling;
-using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.Inventory;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Timing;
@@ -19,7 +15,9 @@ namespace Content.IntegrationTests.Tests._Goobstation.Changeling;
 public sealed class ChangelingArmorTest
 {
     [Test]
-    public async Task TestChangelingChitinousArmor()
+    [TestCase("ActionToggleChitinousArmor", "ChangelingClothingOuterArmor", "ChangelingClothingHeadHelmet")]
+    [TestCase("ActionToggleSpacesuit", "ChangelingClothingOuterHardsuit", "ChangelingClothingHeadHelmetHardsuit")]
+    public async Task TestChangelingFullArmor(string actionProto, string outerProto, string helmetProto)
     {
         await using var pair = await PoolManager.GetServerClient(new PoolSettings
         {
@@ -58,7 +56,7 @@ public sealed class ChangelingArmorTest
             changeling.Chemicals = 1000;
 
             // Give urist chitinous armor action
-            var armorActionEnt = actionSys.AddAction(urist, "ActionToggleChitinousArmor");
+            var armorActionEnt = actionSys.AddAction(urist, actionProto);
             armorAction = (armorActionEnt.Value, entMan.GetComponent<InstantActionComponent>(armorActionEnt.Value));
             actionSys.SetUseDelay(armorAction, null);
 
@@ -72,128 +70,11 @@ public sealed class ChangelingArmorTest
         {
             Assert.That(invSys.TryGetSlotEntity(urist, "outerClothing", out var outerClothing), Is.True);
             Assert.That(outerClothing, Is.Not.Null);
-            Assert.That(entMan.GetComponent<MetaDataComponent>(outerClothing.Value).EntityPrototype!.ID, Is.EqualTo(lingSys.ArmorPrototype.Id));
+            Assert.That(entMan.GetComponent<MetaDataComponent>(outerClothing.Value).EntityPrototype!.ID, Is.EqualTo(outerProto));
 
             Assert.That(invSys.TryGetSlotEntity(urist, "head", out var head));
             Assert.That(head, Is.Not.Null);
-            Assert.That(entMan.GetComponent<MetaDataComponent>(head.Value).EntityPrototype!.ID, Is.EqualTo(lingSys.ArmorHelmetPrototype.Id));
-        });
-
-        await server.WaitPost(() =>
-        {
-            // Armor down
-            actionSys.PerformAction(urist, null, armorAction, armorAction.Comp, armorAction.Comp.BaseEvent, timing.CurTime);
-        });
-
-        await server.WaitRunTicks(5);
-
-        await server.WaitAssertion(() =>
-        {
-            Assert.Multiple(() =>
-            {
-                Assert.That(invSys.TryGetSlotEntity(urist, "outerClothing", out var outerClothing), Is.False);
-                Assert.That(entMan.TryGetComponent<MetaDataComponent>(outerClothing, out var meta), Is.False);
-                Assert.That(meta?.EntityPrototype, Is.Null);
-            });
-
-            Assert.Multiple(() =>
-            {
-                Assert.That(invSys.TryGetSlotEntity(urist, "head", out var head), Is.False);
-                Assert.That(entMan.TryGetComponent<MetaDataComponent>(head, out var meta), Is.False);
-                Assert.That(meta?.EntityPrototype, Is.Null);
-            });
-        });
-
-        const string mercHelmet = "ClothingHeadHelmetMerc";
-
-        await server.WaitPost(() =>
-        {
-            // Equip helmet
-            var helm = entMan.SpawnEntity(mercHelmet, testMap.GridCoords);
-            Assert.That(invSys.TryEquip(urist, helm, "head", force: true));
-
-            // Try to armor up, should fail due to helmet and not equip anything
-            actionSys.PerformAction(urist, null, armorAction, armorAction.Comp, armorAction.Comp.BaseEvent, timing.CurTime);
-        });
-
-        await server.WaitRunTicks(5);
-
-        await server.WaitAssertion(() =>
-        {
-            Assert.Multiple(() =>
-            {
-                Assert.That(invSys.TryGetSlotEntity(urist, "outerClothing", out var outerClothing), Is.False);
-                Assert.That(entMan.TryGetComponent<MetaDataComponent>(outerClothing, out var meta), Is.False);
-                Assert.That(meta?.EntityPrototype, Is.Null);
-            });
-
-            Assert.That(invSys.TryGetSlotEntity(urist, "head", out var head));
-            Assert.That(head, Is.Not.Null);
-            Assert.That(entMan.GetComponent<MetaDataComponent>(head.Value).EntityPrototype!.ID, Is.EqualTo(mercHelmet));
-        });
-
-        await pair.CleanReturnAsync();
-    }
-
-    [Test]
-    public async Task TestChangelingSpacesuit()
-    {
-        await using var pair = await PoolManager.GetServerClient(new PoolSettings
-        {
-            Dirty = true,
-            InLobby = false,
-            DummyTicker = false,
-        });
-
-        var server = pair.Server;
-        var testMap = await pair.CreateTestMap();
-        var ticker = server.System<GameTicker>();
-        var entMan = server.ResolveDependency<IEntityManager>();
-        var timing = server.ResolveDependency<IGameTiming>();
-
-        var lingSys = entMan.System<ChangelingSystem>();
-        var antagSys = entMan.System<AntagSelectionSystem>();
-        var mindSys = entMan.System<MindSystem>();
-        var actionSys = entMan.System<ActionsSystem>();
-        var invSys = entMan.System<InventorySystem>();
-
-        Assert.That(ticker.RunLevel, Is.EqualTo(GameRunLevel.InRound));
-
-        EntityUid urist = EntityUid.Invalid;
-        ChangelingComponent changeling = null;
-        Entity<InstantActionComponent> armorAction = (EntityUid.Invalid, null);
-
-        await server.WaitPost(() =>
-        {
-            // Spawn a urist
-            urist = entMan.SpawnEntity("MobHuman", testMap.GridCoords);
-
-            // Make urist a changeling
-            changeling = entMan.AddComponent<ChangelingComponent>(urist);
-            changeling.TotalAbsorbedEntities += 10;
-            changeling.MaxChemicals = 1000;
-            changeling.Chemicals = 1000;
-
-            // Give urist chitinous armor action
-            var armorActionEnt = actionSys.AddAction(urist, "ActionToggleSpacesuit");
-            armorAction = (armorActionEnt.Value, entMan.GetComponent<InstantActionComponent>(armorActionEnt.Value));
-            actionSys.SetUseDelay(armorAction, null);
-
-            // Armor up
-            actionSys.PerformAction(urist, null, armorAction, armorAction.Comp, armorAction.Comp.BaseEvent, timing.CurTime);
-        });
-
-        await server.WaitRunTicks(5);
-
-        await server.WaitAssertion(() =>
-        {
-            Assert.That(invSys.TryGetSlotEntity(urist, "outerClothing", out var outerClothing), Is.True);
-            Assert.That(outerClothing, Is.Not.Null);
-            Assert.That(entMan.GetComponent<MetaDataComponent>(outerClothing.Value).EntityPrototype!.ID, Is.EqualTo(lingSys.SpacesuitPrototype.Id));
-
-            Assert.That(invSys.TryGetSlotEntity(urist, "head", out var head));
-            Assert.That(head, Is.Not.Null);
-            Assert.That(entMan.GetComponent<MetaDataComponent>(head.Value).EntityPrototype!.ID, Is.EqualTo(lingSys.SpacesuitHelmetPrototype.Id));
+            Assert.That(entMan.GetComponent<MetaDataComponent>(head.Value).EntityPrototype!.ID, Is.EqualTo(helmetProto));
         });
 
         await server.WaitPost(() =>

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
@@ -291,8 +291,7 @@ public sealed partial class ChangelingSystem : EntitySystem
         if (!TryUseAbility(uid, comp, args))
             return;
 
-        if (!TryToggleItem(uid, ArmorPrototype, comp, "outerClothing")
-        || !TryToggleItem(uid, ArmorHelmetPrototype, comp, "head"))
+        if (!TryToggleArmor(uid, comp, [(ArmorHelmetPrototype, "head"), (ArmorPrototype, "outerClothing")]))
         {
             _popup.PopupEntity(Loc.GetString("changeling-equip-armor-fail"), uid, uid);
             comp.Chemicals += Comp<ChangelingActionComponent>(args.Action).ChemicalCost;
@@ -439,7 +438,7 @@ public sealed partial class ChangelingSystem : EntitySystem
         PlayMeatySound(target, comp);
     }
     public void OnLayEgg(EntityUid uid, ChangelingComponent comp, ref StingLayEggsEvent args)
-    {     
+    {
         var target = args.Target;
 
         if (!_mobState.IsDead(target))
@@ -474,7 +473,7 @@ public sealed partial class ChangelingSystem : EntitySystem
 
         EnsureComp<AbsorbedComponent>(target);
         var dmg = new DamageSpecifier(_proto.Index(AbsorbedDamageGroup), 200);
-        _damage.TryChangeDamage(target, dmg, false, false);           
+        _damage.TryChangeDamage(target, dmg, false, false);
         _blood.ChangeBloodReagent(target, "FerrochromicAcid");
         _blood.SpillAllSolutions(target);
 
@@ -605,9 +604,9 @@ public sealed partial class ChangelingSystem : EntitySystem
         comp.IsInLastResort = true;
 
         var newUid = TransformEntity(
-            uid, 
-            protoId: "MobHeadcrab", 
-            comp: comp, 
+            uid,
+            protoId: "MobHeadcrab",
+            comp: comp,
             dropInventory: true,
             transferDamage: false);
 
@@ -652,8 +651,7 @@ public sealed partial class ChangelingSystem : EntitySystem
         if (!TryUseAbility(uid, comp, args))
             return;
 
-        if (!TryToggleItem(uid, SpacesuitPrototype, comp, "outerClothing")
-        || !TryToggleItem(uid, SpacesuitHelmetPrototype, comp, "head"))
+        if (!TryToggleArmor(uid, comp, [(SpacesuitHelmetPrototype, "head"), (SpacesuitPrototype, "outerClothing")]))
         {
             _popup.PopupEntity(Loc.GetString("changeling-equip-armor-fail"), uid, uid);
             comp.Chemicals += Comp<ChangelingActionComponent>(args.Action).ChemicalCost;

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
@@ -375,17 +375,12 @@ public sealed partial class ChangelingSystem : EntitySystem
 
         return true;
     }
-    public bool TryToggleItem(EntityUid uid, EntProtoId proto, ChangelingComponent comp, string? clothingSlot = null)
+    public bool TryToggleItem(EntityUid uid, EntProtoId proto, ChangelingComponent comp)
     {
         if (!comp.Equipment.TryGetValue(proto.Id, out var item) && item == null)
         {
             item = Spawn(proto, Transform(uid).Coordinates);
-            if (clothingSlot != null && !_inventory.TryEquip(uid, (EntityUid) item, clothingSlot, force: true))
-            {
-                QueueDel(item);
-                return false;
-            }
-            else if (!_hands.TryForcePickupAnyHand(uid, (EntityUid) item))
+            if (!_hands.TryForcePickupAnyHand(uid, (EntityUid) item))
             {
                 _popup.PopupEntity(Loc.GetString("changeling-fail-hands"), uid, uid);
                 QueueDel(item);
@@ -400,6 +395,41 @@ public sealed partial class ChangelingSystem : EntitySystem
         comp.Equipment.Remove(proto.Id);
 
         return true;
+    }
+
+    public bool TryToggleArmor(EntityUid uid, ChangelingComponent comp, (EntProtoId, string)[] armors)
+    {
+        if (comp.ActiveArmor == null)
+        {
+            // Equip armor
+            var newArmor = new List<EntityUid>();
+            var coords = Transform(uid).Coordinates;
+            foreach (var (proto, slot) in armors)
+            {
+                EntityUid armor = EntityManager.SpawnEntity(proto, coords);
+                if (!_inventory.TryEquip(uid, armor, slot, force: true))
+                {
+                    Del(armor);
+                    foreach (var delArmor in newArmor)
+                        Del(delArmor);
+
+                    return false;
+                }
+                newArmor.Add(armor);
+            }
+
+            comp.ActiveArmor = newArmor;
+            return true;
+        }
+        else
+        {
+            // Unequip armor
+            foreach (var armor in comp.ActiveArmor)
+                QueueDel(armor);
+
+            comp.ActiveArmor = null!;
+            return true;
+        }
     }
 
     public bool TryStealDNA(EntityUid uid, EntityUid target, ChangelingComponent comp, bool countObjective = false)
@@ -464,11 +494,11 @@ public sealed partial class ChangelingSystem : EntitySystem
         return comp;
     }
     private EntityUid? TransformEntity(
-        EntityUid uid, 
-        TransformData? data = null, 
-        EntProtoId? protoId = null, 
-        ChangelingComponent? comp = null, 
-        bool dropInventory = false, 
+        EntityUid uid,
+        TransformData? data = null,
+        EntProtoId? protoId = null,
+        ChangelingComponent? comp = null,
+        bool dropInventory = false,
         bool transferDamage = true,
         bool persistentDna = false)
     {
@@ -494,7 +524,7 @@ public sealed partial class ChangelingSystem : EntitySystem
             RevertOnDeath = false
         };
 
-        
+
         var newUid = _polymorph.PolymorphEntity(uid, config);
 
         if (newUid == null)
@@ -566,7 +596,7 @@ public sealed partial class ChangelingSystem : EntitySystem
         EntityUid? newUid = null;
         if (sting)
             newUid = TransformEntity(target, data: data, persistentDna: persistentDna);
-        else 
+        else
         {
             comp.IsInLesserForm = false;
             newUid = TransformEntity(target, data: data, comp: comp, persistentDna: persistentDna);
@@ -638,7 +668,7 @@ public sealed partial class ChangelingSystem : EntitySystem
 
         if (!args.DamageIncreased)
             return;
-        
+
         target.Damage.ClampMax(200); // we never die. UNLESS??
     }
 

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
@@ -377,7 +377,7 @@ public sealed partial class ChangelingSystem : EntitySystem
     }
     public bool TryToggleItem(EntityUid uid, EntProtoId proto, ChangelingComponent comp)
     {
-        if (!comp.Equipment.TryGetValue(proto.Id, out var item) && item == null)
+        if (!comp.Equipment.TryGetValue(proto.Id, out var item))
         {
             item = Spawn(proto, Transform(uid).Coordinates);
             if (!_hands.TryForcePickupAnyHand(uid, (EntityUid) item))
@@ -409,9 +409,9 @@ public sealed partial class ChangelingSystem : EntitySystem
                 EntityUid armor = EntityManager.SpawnEntity(proto, coords);
                 if (!_inventory.TryEquip(uid, armor, slot, force: true))
                 {
-                    Del(armor);
+                    QueueDel(armor);
                     foreach (var delArmor in newArmor)
-                        Del(delArmor);
+                        QueueDel(delArmor);
 
                     return false;
                 }

--- a/Content.Shared/_Goobstation/Changeling/ChangelingComponent.cs
+++ b/Content.Shared/_Goobstation/Changeling/ChangelingComponent.cs
@@ -54,6 +54,7 @@ public sealed partial class ChangelingComponent : Component
 
     public bool IsInLastResort = false;
 
+    public List<EntityUid>? ActiveArmor = null;
 
     public Dictionary<string, EntityUid?> Equipment = new();
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

This PR fixes the changeling's chitinous armor and space suit abilities. Previously, when attempting to use them, they would display overlapping popup errors and simply do nothing, even if the changeling was wearing absolutely nothing.

This PR also includes an additional integration test to check the behavior of ling armor and space suit in the future. 

## Technical details
<!-- Summary of code changes for easier review. -->

`ChangelingComponent` now contains a new field named `ActiveArmor`, which contains all the entities that make up the changeling's current armor. This is used to determine whether a changeling is toggling armor on or off.

The clothing code of `ChangelingSystem.TryToggleItem` was split into a new method `ChangelingSystem.TryToggleArmor` for handling armor separate from other equipment.


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- fix: Fixed changeling armor refusing to equip regardless of your current equipment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced integration tests for changeling armor functionality, ensuring correct equipment interactions.
	- Enhanced the changeling system with improved ability handling and clearer player feedback through popup messages.
	- Increased maximum biomass capacity for changelings from 30 to 100.

- **Bug Fixes**
	- Adjusted logic for armor toggling and damage application to ensure accurate gameplay mechanics.

- **Documentation**
	- Updated class and method declarations to reflect new features and changes in functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->