### PR TITLE
return pen embeddability

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -26,12 +26,7 @@
         maxDistance: 2
   - type: UseDelay
     delay: 1.5
-
-- type: entity
-  parent: Pen
-  id: PenEmbeddable
-  abstract: true
-  components:
+  # Goobstation - Return pen embeddability
   - type: EmbeddableProjectile
     offset: 0.3,0.0
     removalTime: 0.0
@@ -58,7 +53,8 @@
 
 - type: entity
   id: BaseAdvancedPen
-  parent: PenEmbeddable
+  # Goobstation - Return pen embeddability
+  parent: Pen
   abstract: true
   components:
   - type: Tag
@@ -104,7 +100,8 @@
 
 - type: entity
   name: captain's fountain pen
-  parent: PenEmbeddable
+  # Goobstation - Return pen embeddability
+  parent: Pen
   id: PenCap
   description: A luxurious fountain pen for the captain of the station.
   components:
@@ -113,7 +110,8 @@
 
 - type: entity
   name: hop's fountain pen
-  parent: PenEmbeddable
+  # Goobstation - Return pen embeddability
+  parent: Pen
   id: PenHop
   description: A luxurious fountain pen for the hop of the station.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
@@ -1,7 +1,8 @@
 - type: entity
   name: pen
   suffix: Exploding
-  parent: PenEmbeddable
+  # Goobstation - Return pen embeddability
+  parent: Pen
   description: A dark ink pen.
   id: PenExploding
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
makes all pens embeddable once more

note that i have a similar PR up for wizden (https://github.com/space-wizards/space-station-14/pull/32831), this PR is in case that one doesn't go through so goob can still have it

## Why / Balance
funny and couldn't reasonably affect balance

## Technical details
adds embeddability to Pen and reparents things to it from PenEmbeddable

## Media
untested but should work

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
PenEmbeddable is no more, Pen instead embeds by default now

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: All pens may now embed on throw.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new entity, the "PenExplodingBox," which includes unique attributes and functionality.
- **Improvements**
	- Updated the parentage of multiple pen entities to enhance their classification under the unified `Pen` entity.
	- Added a new description for the "luxury pen" entity for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->