### PR TITLE
Changeling metashield

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
@@ -33,10 +33,10 @@
 
   ## Changelings
 
-  In the eyes of the public, changeling are an exterminated predatory lifeform and their existence on the station is shielded.
-  This metashield prohibits players from crew bloodtesting.
+  In the eyes of the public, changelings are an exterminated predatory lifeform and their potential existence on the station is shielded.
+  This metashield prohibits players from crew bloodtesting until the metashield is revealed.
   
-  The knowledge of changelings ability to change their appearance and their possibility to resurrect from dead state is not shielded.
+  Knowledge about the abilities of changelings is not shielded.
 
   The revealing condition for this shield is any of the following:
   - discovering a hollowed body

--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
@@ -31,6 +31,20 @@
   - a War Ops announcement
   - being a nuclear operative
 
+  ## Changelings
+
+  Changeling in the eyes of the public are extinct creatures and no one would believe they could appear on the station is shielded.
+  This metashield prohibits players from bloodtesting.
+  
+  Despite this, many people know about changeling ability to change their appearance, impossibility of gibbing the body and stasis ability is not shielded.
+
+  The revealing condition for this shield is any of the following:
+  - discovering a hollowed body
+  - witnessing changeling use their non-stealth abilities (not stings or passive abilities)
+  - witnessing someone trying to absord a body
+  - witnessing someone changing it's appearance
+  - being a changeling
+
   ## Implanted Implants
 
   Implanted implants are shielded.

--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
@@ -33,16 +33,16 @@
 
   ## Changelings
 
-  Changeling in the eyes of the public are extinct creatures and no one would believe they could appear on the station is shielded.
-  This metashield prohibits players from bloodtesting.
+  In the eyes of the public, changeling are an exterminated predatory lifeform and their existence on the station is shielded.
+  This metashield prohibits players from crew bloodtesting.
   
-  Despite this, many people know about changeling ability to change their appearance, impossibility of gibbing the body and stasis ability is not shielded.
+  The knowledge of changelings ability to change their appearance and their possibility to resurrect from dead state is not shielded.
 
   The revealing condition for this shield is any of the following:
   - discovering a hollowed body
   - witnessing changeling use their non-stealth abilities (not stings or passive abilities)
-  - witnessing someone trying to absord a body
-  - witnessing someone changing it's appearance
+  - witnessing someone trying to absorb a body
+  - witnessing someone changing its appearance
   - being a changeling
 
   ## Implanted Implants

--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR4Metashield.xml
@@ -42,7 +42,7 @@
   - discovering a hollowed body
   - witnessing changeling use their non-stealth abilities (not stings or passive abilities)
   - witnessing someone trying to absorb a body
-  - witnessing someone changing its appearance
+  - witnessing someone changing their appearance
   - being a changeling
 
   ## Implanted Implants


### PR DESCRIPTION
## About the PR
Adds changeling in metashield rules

:cl:
- tweak: Updated Metashield rule for changeling




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new section on "Changelings" in the roleplay rules, clarifying their shielded nature and interaction guidelines for players.
	- Specified conditions under which players may gain knowledge about Changelings, including their abilities and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->