### PR TITLE
Revert "Remove sentience from clean and medi bot (#32383)"

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -258,6 +258,8 @@
   - type: Construction
     graph: CleanBot
     node: bot
+  - type: SentienceTarget
+    flavorKind: station-event-random-sentience-flavor-mechanical
   - type: Absorbent
     pickupAmount: 10
   - type: UseDelay
@@ -344,6 +346,8 @@
   - type: Construction
     graph: MediBot
     node: bot
+  - type: SentienceTarget
+    flavorKind: station-event-random-sentience-flavor-mechanical
   - type: Anchorable
   - type: InteractionPopup
     interactSuccessString: petting-success-medibot


### PR DESCRIPTION
This reverts commit bc76cd876f61839c519bf35bd09bb6a2f23b5c44.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
lets silicons be sentient from the random sentience event again

though we might want to think about this one because sentient medibots are unable to do anything (noobtrap) and ghosting from a sentient bot bricks it

could consider only giving random sentience back to cleanbots

## Why / Balance
being a bot is fun

## Media
untested

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Random sentience events can target cleanbots and medibots once again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `SentienceTarget` component for `MobCleanBot` and `MobMedibot`, enhancing their functionality with a new `flavorKind` property.
  
- **Entity Modifications**
	- Improved alignment of the `Construction` component for both `MobCleanBot` and `MobMedibot` while maintaining existing entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->