### PR TITLE
buff ores to deltav values

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -37,7 +37,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawGold: 100
+      RawGold: 300 # Goobstation - was 100
   - type: Extractable
     grindableSolutionName: goldore
   - type: SolutionContainerManager
@@ -99,7 +99,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawIron: 100
+      RawIron: 200 # Goobstation - was 100
   - type: Extractable
     grindableSolutionName: ironore
   - type: SolutionContainerManager
@@ -130,7 +130,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawPlasma: 100
+      RawPlasma: 500 # Goobstation - was 100
   - type: PointLight
     radius: 1.2
     energy: 0.6
@@ -166,7 +166,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawSilver: 100
+      RawSilver: 300 # Goobstation - was 100
   - type: Extractable
     grindableSolutionName: silverore
   - type: SolutionContainerManager
@@ -197,7 +197,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawQuartz: 100
+      RawQuartz: 200 # Goobstation - was 100
   - type: Extractable
     grindableSolutionName: quartzore
   - type: SolutionContainerManager
@@ -228,7 +228,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawUranium: 100
+      RawUranium: 300 # Goobstation - was 100
   - type: PointLight
     radius: 1.2
     energy: 0.8
@@ -323,7 +323,7 @@
           Quantity: 0.1
   - type: PhysicalComposition
     materialComposition:
-      Coal: 100
+      Coal: 200 # Goobstation - was 100
 
 - type: entity
   parent: Coal


### PR DESCRIPTION
## About the PR
buffs ore from [DeltaV #1721](https://github.com/DeltaV-Station/Delta-v/pull/1721)

## Why / Balance
to incentivize salv to actually mine
these values have been used on deltav for a while and they work well

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Rebalanced mining so all ore is worth more.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased resource quantities for various ore types to enhance gameplay balance, including:
		- GoldOre: RawGold increased to 300
		- SteelOre: RawIron increased to 200
		- PlasmaOre: RawPlasma increased to 500
		- SilverOre: RawSilver increased to 300
		- SpaceQuartz: RawQuartz increased to 200
		- UraniumOre: RawUranium increased to 300
		- Coal: Coal quantity increased to 200

<!-- end of auto-generated comment: release notes by coderabbit.ai -->