### PR TITLE
let RD teleporter work crossgrid

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/hand_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/hand_teleporter.yml
@@ -9,6 +9,7 @@
     layers:
     - state: icon
   - type: HandTeleporter
+    allowPortalsOnDifferentGrids: true
   - type: Tag
     tags:
     - HighRiskItem

--- a/Resources/Prototypes/Entities/Objects/Devices/hand_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/hand_teleporter.yml
@@ -9,6 +9,7 @@
     layers:
     - state: icon
   - type: HandTeleporter
+    # Goobstation - Let RD teleporter work crossgrid
     allowPortalsOnDifferentGrids: true
   - type: Tag
     tags:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
title, lets the portals be on different grids

## Why / Balance
more interaction variety and lets it be more useful, though will be used to make portals to/from grids such as ATS and evac, like it has been before, which i think is maybe fine? since you can only have the portals link one pair of places at once

should be merged if ATS being portalled to from cargo is fine

## Media
tested, works

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The hand teleporter may now have portals placed on differing grids.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the Hand Teleporter's capabilities by allowing it to create portals across different grids.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->