### PR TITLE
AI job role for highpop Fland

### DIFF
--- a/Resources/Prototypes/_Goobstation/Maps/flandhighpop.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/flandhighpop.yml
@@ -45,7 +45,6 @@
             ResearchDirector: [ 1, 1 ]
             Scientist: [ 10, 10 ]
             ResearchAssistant: [ -1, -1 ]
-            Borg: [ 4, 4 ]
             #security
             HeadOfSecurity: [ 1, 1 ]
             Warden: [ 1, 1 ]
@@ -62,3 +61,6 @@
             Clown: [ 2, 2 ]
             Mime: [ 2, 2 ]
             Musician: [ 3, 3 ]
+            #silicon
+            StationAi: [ 1, 1 ]
+            Borg: [ 4, 4 ]


### PR DESCRIPTION
## About the PR
added StationAi into the flandhighpop prototype

## Why / Balance
Fland has mapped AI but it cant spawn anyway (only in highpop version)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: AI can spawn in highpop Fland

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new job category "#silicon" in the game map "FlandHighPop," adding roles for "StationAi" and "Borg."
	- Expanded gameplay dynamics with new job options for players.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->