### PR TITLE
Fixed some Ritual of Knowledge items not working

### DIFF
--- a/Content.IntegrationTests/Tests/_Goobstation/Heretic/RitualKnowledgeTests.cs
+++ b/Content.IntegrationTests/Tests/_Goobstation/Heretic/RitualKnowledgeTests.cs
@@ -60,6 +60,7 @@ public sealed class RitualKnowledgeTests
             // Loop through every entity prototype and assemble a used tags set
             var usedTags = new HashSet<string>();
 
+            // Ensure that every tag is used by a non-abstract entity
             foreach (var entProto in protoMan.EnumeratePrototypes<EntityPrototype>())
             {
                 if (entProto.Abstract)
@@ -71,9 +72,8 @@ public sealed class RitualKnowledgeTests
                 }
             }
 
-            // Ensure that every tag has a valid item
             var unusedTags = dataset.Except(usedTags).ToHashSet();
-            Assert.That(unusedTags, Is.Empty);
+            Assert.That(unusedTags, Is.Empty, $"The following ritual item tags are not used by any obtainable entity prototypes: {string.Join(", ", unusedTags)}");
         });
 
         await pair.CleanReturnAsync();

--- a/Content.IntegrationTests/Tests/_Goobstation/Heretic/RitualKnowledgeTests.cs
+++ b/Content.IntegrationTests/Tests/_Goobstation/Heretic/RitualKnowledgeTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Linq;
+using Content.Server.Heretic.Ritual;
+using Content.Shared.Dataset;
+using Content.Shared.Tag;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests._Goobstation.Heretic;
+
+[TestFixture, TestOf(typeof(RitualKnowledgeBehavior))]
+public sealed class RitualKnowledgeTests
+{
+    [Test]
+    public async Task ValidateEligibleTags()
+    {
+        // As far as I can tell, there's no annotation to validate
+        // a dataset of tag prototype IDs, so we'll have to do it
+        // in a test fixture. Sad.
+
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            // Get the eligible tags prototype
+            var dataset = protoMan.Index<DatasetPrototype>(RitualKnowledgeBehavior.EligibleTagsDataset);
+
+            // Validate that every value is a valid tag
+            Assert.Multiple(() =>
+            {
+                foreach (var tagId in dataset.Values)
+                {
+                    Assert.That(protoMan.TryIndex<TagPrototype>(tagId, out var tagProto), Is.True, $"\"{tagId}\" is not a valid tag prototype ID");
+                }
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ValidateTagsHaveItems()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+        var compFactory = server.ResolveDependency<IComponentFactory>();
+
+        await server.WaitAssertion(() =>
+        {
+            // Get the eligible tags prototype
+            var dataset = protoMan.Index<DatasetPrototype>(RitualKnowledgeBehavior.EligibleTagsDataset).Values.ToHashSet();
+
+            // Loop through every entity prototype and assemble a used tags set
+            var usedTags = new HashSet<string>();
+
+            foreach (var entProto in protoMan.EnumeratePrototypes<EntityPrototype>())
+            {
+                if (entProto.Abstract)
+                    continue;
+
+                if (entProto.TryGetComponent<TagComponent>(out var tags, compFactory))
+                {
+                    usedTags.UnionWith(tags.Tags.Select(t => t.Id));
+                }
+            }
+
+            // Ensure that every tag has a valid item
+            var unusedTags = dataset.Except(usedTags).ToHashSet();
+            Assert.That(unusedTags, Is.Empty);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Knowledge.cs
+++ b/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Knowledge.cs
@@ -20,6 +20,9 @@ public sealed partial class RitualKnowledgeBehavior : RitualCustomBehavior
     private EntityLookupSystem _lookup = default!;
     private HereticSystem _heretic = default!;
 
+    [ValidatePrototypeId<DatasetPrototype>]
+    public const string EligibleTagsDataset = "EligibleTags";
+
     // this is basically a ripoff from hereticritualsystem
     public override bool Execute(RitualData args, out string? outstr)
     {
@@ -33,7 +36,7 @@ public sealed partial class RitualKnowledgeBehavior : RitualCustomBehavior
         // generate new set of tags
         if (requiredTags.Count == 0)
             for (int i = 0; i < 4; i++)
-                requiredTags.Add(_rand.Pick(_prot.Index<DatasetPrototype>("EligibleTags").Values), 1);
+                requiredTags.Add(_rand.Pick(_prot.Index<DatasetPrototype>(EligibleTagsDataset).Values), 1);
 
         var lookup = _lookup.GetEntitiesInRange(args.Platform, .75f);
         var missingList = new List<string>();

--- a/Resources/Prototypes/Entities/Objects/Devices/geiger.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/geiger.yml
@@ -34,4 +34,7 @@
     - type: PhysicalComposition
       materialComposition:
         Plastic: 100
+    - type: Tag # goob edit
+      tags:
+        - GeigerCounter
 

--- a/Resources/Prototypes/_Goobstation/Datasets/tags.yml
+++ b/Resources/Prototypes/_Goobstation/Datasets/tags.yml
@@ -15,7 +15,7 @@
   - Airlock
   - AirSensor
   - Ambrosia
-  - ApprisalTool
+  - AppraisalTool
   - Arrow
   - ArtifactFragment
   - Banana


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->

This PR fixes two items that would cause the Ritual of Knowledge to fail, the appraisal tool and the geiger counter.

The appraisal tool is tagged with `AppraisalTool`, but the tag in EligibleTags read `ApprisalTool`. This was corrected, and a new test was added to ensure that all values in EligibleTags are valid tag prototype IDs.

`GeigerCounter` was a valid tag defined in EligibleTags, but no item was tagged with it. This tag was added to the `GeigerCounter` entity, and a new test was added to ensure that all eligible tags had associated non-abstract entity prototypes.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/fb08a10c-6af1-494c-b52e-e27aa17464c6)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- fix: Geiger counters and appraisal tools should now work in rituals


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added integration tests for the `RitualKnowledgeBehavior`, ensuring tag validity and item association.
	- Introduced a new `Tag` component for the `GeigerCounter` entity to enhance categorization.

- **Bug Fixes**
	- Corrected a typo in the tag name from "ApprisalTool" to "AppraisalTool" and adjusted tag indentation for consistency.

- **Chores**
	- Improved maintainability by introducing a constant for the eligible tags dataset in the `RitualKnowledgeBehavior`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->