### PR TITLE
billions must flip

### DIFF
--- a/Resources/Prototypes/_Goobstation/Actions/emotes.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/emotes.yml
@@ -1,10 +1,12 @@
 - type: emote
   id: Flip
   name: chat-emote-name-flip
-  category: Hands
   chatMessages: ["chat-emote-msg-flip"]
   chatTriggers:
   - flip
+  - flips
+  - flips.
+  - flips!
   - does a flip
   - does a flip.
   - does a flip!
@@ -13,7 +15,6 @@
 - type: emote
   id: Spin
   name: chat-emote-name-spin
-  category: Hands
   chatMessages: ["chat-emote-msg-spin"]
   chatTriggers:
   - spin
@@ -25,7 +26,6 @@
 - type: emote
   id: Jump
   name: chat-emote-name-jump
-  category: Hands
   chatMessages: ["chat-emote-msg-jump"]
   chatTriggers:
   - jump


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
made flip/spin/jump generic, also gave more verbs to flip

## Why / Balance
all sentient mobs should be able to do this not just ones with hands  
this means fish too

## Technical details
no fuck you go read the code yourself

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: router
- fix: All mobs can now flip, not just ones with hands
- tweak: You can now also use *flips to access the flip emote.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded chat triggers for the `Flip` emote to include `flips`, `flips.`, and `flips!`.
- **Bug Fixes**
	- Removed the `category` field from emotes for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->