### PR TITLE
SEPERATE NTR AND BSO ACCESS

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/_Goobstation/prototypes/access/accesses.ftl
@@ -1,0 +1,2 @@
+id-card-access-level-ntr = Nanotrasen Representative
+id-card-access-level-bso = Blueshield Officer

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
@@ -287,22 +287,6 @@
   - type: AccessReader
     access: [["CentralCommand"]]
 
-- type: entity # GOOBSTATION - TOO LAZY TO MAKE A FILE IN GOOBSTATION FOLDER
-  parent: DoorElectronics
-  id: DoorElectronicsNTR
-  suffix: NanotrasenRepresentative, Locked
-  components:
-  - type: AccessReader
-    access: [["NanotrasenRepresentative"]]
-
-- type: entity # GOOBSTATION - TOO LAZY TO MAKE A FILE IN GOOBSTATION FOLDER
-  parent: DoorElectronics
-  id: DoorElectronicsBSO
-  suffix: BlueshieldOfficer, Locked
-  components:
-  - type: AccessReader
-    access: [["BlueshieldOfficer"]]
-
 - type: entity
   parent: DoorElectronics
   id: DoorElectronicsExternal

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/door_access.yml
@@ -287,6 +287,22 @@
   - type: AccessReader
     access: [["CentralCommand"]]
 
+- type: entity # GOOBSTATION - TOO LAZY TO MAKE A FILE IN GOOBSTATION FOLDER
+  parent: DoorElectronics
+  id: DoorElectronicsNTR
+  suffix: NanotrasenRepresentative, Locked
+  components:
+  - type: AccessReader
+    access: [["NanotrasenRepresentative"]]
+
+- type: entity # GOOBSTATION - TOO LAZY TO MAKE A FILE IN GOOBSTATION FOLDER
+  parent: DoorElectronics
+  id: DoorElectronicsBSO
+  suffix: BlueshieldOfficer, Locked
+  components:
+  - type: AccessReader
+    access: [["BlueshieldOfficer"]]
+
 - type: entity
   parent: DoorElectronics
   id: DoorElectronicsExternal

--- a/Resources/Prototypes/_Goobstation/Access/centcomm.yml
+++ b/Resources/Prototypes/_Goobstation/Access/centcomm.yml
@@ -1,0 +1,7 @@
+- type: accessLevel
+  id: NanotrasenRepresentative
+  name: id-card-access-level-ntr
+
+- type: accessLevel
+  id: BlueshieldOfficer
+  name: id-card-access-level-bso

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/Electronics/door_access.yml
@@ -5,3 +5,19 @@
   components:
   - type: AccessReader
     access: [["CentralCommand"], [Captain]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsNTR
+  suffix: NanotrasenRepresentative, Locked
+  components:
+  - type: AccessReader
+    access: [["NanotrasenRepresentative"]]
+
+- type: entity
+  parent: DoorElectronics
+  id: DoorElectronicsBSO
+  suffix: BlueshieldOfficer, Locked
+  components:
+  - type: AccessReader
+    access: [["BlueshieldOfficer"]]

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Doors/Airlocks/access.yml
@@ -1,3 +1,5 @@
+# CC locked
+
 - type: entity
   parent: AirlockCentralCommand
   id: AirlockCentralCommandCommandLocked
@@ -16,6 +18,8 @@
     containers:
       board: [ DoorElectronicsCommand ]
 
+# CC/cap locked
+
 - type: entity
   parent: AirlockCommand
   id: AirlockCommandCommandLocked
@@ -33,3 +37,43 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsCentralCommandCaptain ]
+
+# BSO locked
+
+- type: entity
+  parent: AirlockCentralCommand
+  id: AirlockBlueshieldOfficerCommandLocked
+  suffix: Blueshield, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsBSO ]
+
+- type: entity
+  parent: AirlockCentralCommandGlass
+  id: AirlockBlueshieldOfficerCommandGlassLocked
+  suffix: Blueshield, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsBSO ]
+
+# NTR locked
+
+- type: entity
+  parent: AirlockCentralCommand
+  id: AirlockNanotrasenRepresentativeCommandLocked
+  suffix: NTRep, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsNTR ]
+
+- type: entity
+  parent: AirlockCentralCommandGlass
+  id: AirlockNanotrasenRepresentativeCommandGlassLocked
+  suffix: NTRep, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsNTR ]

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -7,7 +7,7 @@
   - type: Sprite
     sprite: _Goobstation/Structures/Storage/closet.rsi
   - type: AccessReader
-    access: [["CentralCommand"]]
+    access: [["BlueshieldOfficer"]]
   - type: EntityStorageVisuals
     stateBaseClosed: bso
     stateDoorOpen: bso_open
@@ -22,7 +22,7 @@
   - type: Sprite
     sprite: _Goobstation/Structures/Storage/closet.rsi
   - type: AccessReader
-    access: [["CentralCommand"]]
+    access: [["NanotrasenRepresentative"]]
   - type: EntityStorageVisuals
     stateBaseClosed: ntr
     stateDoorOpen: ntr_open

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -33,6 +33,7 @@
   - Research
   - Command
   - CentralCommand
+  - BlueshieldOfficer
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
@@ -26,6 +26,7 @@
   - Medical
   - Research  
   - Command
+  - NanotrasenRepresentative
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
NTR and BSO lockers are now separate access

## Why / Balance
metagrudging

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
https://cdn.discordapp.com/attachments/1202734573247795303/1304638224890859673/2024-11-08_21-39-51.mp4?ex=67301e87&is=672ecd07&hm=f6f8c8ec46c963e87c0eec3b19a266ab16c1410300240380dc8bb062ee7d2297&

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: NTrep and BSO are separate access now (currently only affects their lockers)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added access levels for "Nanotrasen Representative" and "Blueshield Officer" roles.
	- Introduced new door electronics entities for enhanced access control.
	- Expanded airlock command system with new locked states for various roles.
	- Updated job configurations for "Blueshield Officer" and "Nanotrasen Representative" to include new access entries and special abilities.

- **Bug Fixes**
	- Corrected access permissions for lockers associated with "Blueshield Officer" and "Nanotrasen Representative."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->