### PR TITLE
Give important antagonists playtime requirements

### DIFF
--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -6,7 +6,10 @@
   objective: roles-antag-rev-head-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 18000 # 10h
+    time: 54000 # 15h
+  - !type:DepartmentTimeRequirement
+  department: command
+  time: 36000 #10 hrs
   guides: [ Revolutionaries ]
 
 - type: antag

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -4,6 +4,9 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-rev-head-objective
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 18000 # 10h
   guides: [ Revolutionaries ]
 
 - type: antag

--- a/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
@@ -4,4 +4,9 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-changeling-description
+  - !type:DepartmentTimeRequirement
+  department: Security
+  time: 36000 #10 hrs
+  - !type:OverallPlaytimeRequirement
+  time: 108000 #30 hrs
   guides: [ Changelings ]

--- a/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
@@ -4,6 +4,12 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-heretic-description
+  - !type:DepartmentTimeRequirement
+  department: Medical
+  time: 36000 #10 hrs
+  - !type:DepartmentTimeRequirement
+  department: Security
+  time: 36000 #10 hrs
   guides: [ Heretics ]
 
 - type: startingGear


### PR DESCRIPTION
## About the PR
Ling, Heretic, and Headrev receive playtime requirements.

## Why / Balance
I consistently see these roles insta SSD, or not know how to play the said role (Headrev not knowing how to flash, heretic not knowing how to get organs, ect.) Adding these playtime requirements will push players to branch out to more jobs besides tider and learn to play said roles before rolling them. Will also help fix the lack of sec and command.