### PR TITLE
Give important antagonists playtime requirements

### DIFF
--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -6,7 +6,10 @@
   objective: roles-antag-rev-head-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 18000 # 10h
+  time: 54000 # 15h
+  - !type:DepartmentTimeRequirement
+  department: command
+  time: 36000 #10 hrs
   guides: [ Revolutionaries ]
 
 - type: antag

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -4,6 +4,9 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-rev-head-objective
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 18000 # 10h
   guides: [ Revolutionaries ]
 
 - type: antag

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -6,7 +6,7 @@
   objective: roles-antag-rev-head-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-  time: 54000 # 10h
+  time: 36000 # 10h
   - !type:DepartmentTimeRequirement
   guides: [ Revolutionaries ]
 

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -8,7 +8,7 @@
     - !type:OverallPlaytimeRequirement
     time: 36000 # 10h
     - !type:DepartmentTimeRequirement
-    guides: [ Revolutionaries ]
+  guides: [ Revolutionaries ]
 
 - type: antag
   id: Rev

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -6,8 +6,7 @@
   objective: roles-antag-rev-head-objective
   requirements:
     - !type:OverallPlaytimeRequirement
-    time: 36000 # 10h
-    - !type:DepartmentTimeRequirement
+      time: 36000 # 10h
   guides: [ Revolutionaries ]
 
 - type: antag

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -6,10 +6,8 @@
   objective: roles-antag-rev-head-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-  time: 54000 # 15h
+  time: 54000 # 10h
   - !type:DepartmentTimeRequirement
-  department: command
-  time: 36000 #10 hrs
   guides: [ Revolutionaries ]
 
 - type: antag

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -5,10 +5,10 @@
   setPreference: true
   objective: roles-antag-rev-head-objective
   requirements:
-  - !type:OverallPlaytimeRequirement
-  time: 36000 # 10h
-  - !type:DepartmentTimeRequirement
-  guides: [ Revolutionaries ]
+    - !type:OverallPlaytimeRequirement
+    time: 36000 # 10h
+    - !type:DepartmentTimeRequirement
+    guides: [ Revolutionaries ]
 
 - type: antag
   id: Rev

--- a/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
@@ -4,8 +4,8 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-changeling-description
-  - !type:DepartmentTimeRequirement
   requirements:
-    department: Security
-    time: 18000 #5 hrs
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 18000 #5 hrs
   guides: [ Changelings ]

--- a/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
@@ -6,6 +6,6 @@
   objective: roles-antag-changeling-description
   - !type:DepartmentTimeRequirement
   requirements:
-  department: Security
-  time: 18000 #5 hrs
-  guides: [ Changelings ]
+    department: Security
+    time: 18000 #5 hrs
+    guides: [ Changelings ]

--- a/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
@@ -7,7 +7,5 @@
   - !type:DepartmentTimeRequirement
   requirements:
   department: Security
-  time: 36000 #10 hrs
-  - !type:OverallPlaytimeRequirement
-  time: 108000 #30 hrs
+  time: 18000 #5 hrs
   guides: [ Changelings ]

--- a/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
@@ -4,4 +4,10 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-changeling-description
+  - !type:DepartmentTimeRequirement
+  requirements:
+  department: Security
+  time: 36000 #10 hrs
+  - !type:OverallPlaytimeRequirement
+  time: 108000 #30 hrs
   guides: [ Changelings ]

--- a/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
@@ -8,4 +8,4 @@
   requirements:
     department: Security
     time: 18000 #5 hrs
-    guides: [ Changelings ]
+  guides: [ Changelings ]

--- a/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
@@ -7,10 +7,10 @@
   requirements:
   - !type:DepartmentTimeRequirement
   department: Security
-  time: 36000 # 10h
+  time: 18000 # 5h
   - !type:DepartmentTimeRequirement
   department: Medical
-  time: 36000 # 10h
+  time: 18000 # 5h
   guides: [ Heretics ]
 
 - type: startingGear

--- a/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
@@ -4,6 +4,13 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-heretic-description
+  requirements:
+  - !type:DepartmentTimeRequirement
+  department: Security
+  time: 36000 # 10h
+  - !type:DepartmentTimeRequirement
+  department: Medical
+  time: 36000 # 10h
   guides: [ Heretics ]
 
 - type: startingGear

--- a/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
@@ -5,12 +5,12 @@
   setPreference: true
   objective: roles-antag-heretic-description
   requirements:
-  - !type:DepartmentTimeRequirement
-  department: Security
-  time: 18000 # 5h
-  - !type:DepartmentTimeRequirement
-  department: Medical
-  time: 18000 # 5h
+    - !type:DepartmentTimeRequirement
+    department: Security
+    time: 18000 # 5h
+    - !type:DepartmentTimeRequirement
+    department: Medical
+    time: 18000 # 5h
   guides: [ Heretics ]
 
 - type: startingGear

--- a/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
@@ -6,11 +6,11 @@
   objective: roles-antag-heretic-description
   requirements:
     - !type:DepartmentTimeRequirement
-    department: Security
-    time: 18000 # 5h
+      department: Security
+      time: 18000 # 5h
     - !type:DepartmentTimeRequirement
-    department: Medical
-    time: 18000 # 5h
+      department: Medical
+      time: 18000 # 5h
   guides: [ Heretics ]
 
 - type: startingGear


### PR DESCRIPTION
About the PR
Ling, Heretic, and Headrev receive playtime requirements.

Why / Balance
I consistently see these roles insta SSD, or not know how to play the said role (Headrev not knowing how to flash, heretic not knowing how to get organs, ect.) Adding these playtime requirements will push players to branch out to more jobs besides tider and learn to play said roles before rolling them. Will also help fix the lack of sec and command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new playtime requirements for the `HeadRev`, `Changeling`, and `Heretic` antag roles, enhancing eligibility criteria.
	- `HeadRev` role now requires 10 hours of overall playtime and additional time in the command department.
	- `Changeling` role requires 5 hours in the Security department.
	- `Heretic` role requires 5 hours in both Security and Medical departments, along with the inclusion of the `OrganHumanHeart` in starting gear.

- **Bug Fixes**
	- Corrected formatting issue in the `Heretic` role's starting gear section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->