### PR TITLE
wet floor sign allows suit storage

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -115,7 +115,7 @@
 - type: entity
   name: wet floor sign
   id: WetFloorSign
-  parent: ClothingOuterBase
+  parent: [ClothingOuterBase, AllowSuitStorageClothing]
   description: Caution! Wet Floor!
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
if you wear a wet floor sign you can now put things on your suit storage slot
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
without this the only way non sec can have access to suit storage is if they break into a sec outpost and hack the secdrobe, if there even is one, to take a regular armor vest, or take a hardsuit. this gives crew and antagonists a low risk way of obtaining suit storage without having much armor while remaining mobile

and it has armor values, so it should be considered armor in this way

weapons like rifles and spears have slings on their sprite when you wear it on suit storage, but suddenly doesn't work when you don't have an armor vest on. (perhaps this can be solved by adding a sling item and craftable makeshift sling that allows you to wear guns and spears on the suit storage slot regardless of outerclothing?

## Media
![image](https://github.com/user-attachments/assets/629c741e-1ae1-4244-a748-5ad8be188b81)
![image](https://github.com/user-attachments/assets/6c9b1b91-f6c7-412c-96b8-57cb91d6ca2d)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: JoeHammad
- tweak: wet floor signs, when worn, now allows suit storage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `advanced mop` with enhanced functionalities for water reagent management.
	- Added a `golden plunger` with illumination effects.
	- Defined a new `Wet Floor Sign Mine Explosive` with explosive properties.
	- Expanded the definitions of janitorial items, including `damp rag` and `wet floor sign` with updated functionalities.
  
These updates enhance gameplay by adding new items and improving existing ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->