### PR TITLE
remove stamina cost from mining drill

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -57,6 +57,7 @@
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"
     attackRate: 4
+    heavyStaminaCost: 0 # GoobStation: Mining drill is for mining
     damage:
       groups:
         Brute: 3


### PR DESCRIPTION
## About the PR
title

## Why / Balance
so you can actually fucking mine without killing yourself
it has next to no damage so its useless for combat

**Changelog**
:cl:
- fix: Fixed mining drills stunlocking you.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new melee weapon, the **WeaponCrusherGlaive**, enhancing gameplay options.
	- Added a **heavyStaminaCost** attribute to the **Mining Drill**, clarifying its operational cost.

- **Improvements**
	- Enhanced definitions for existing melee weapons, improving clarity and functionality within the game.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->