### PR TITLE
last resort fix

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/changeling/abilities/changeling.ftl
+++ b/Resources/Locale/en-US/_Goobstation/changeling/abilities/changeling.ftl
@@ -55,3 +55,5 @@ changeling-chameleon-start = You adapt your skin to the environment
 changeling-chameleon-end = Your skin is losing it's translucency
 
 changeling-hivemind-start = You tune your brainwaves to match the hivemind frequency
+
+changeling-lastresort-activate = CURRENT BODY WILL BE LOST! Use it again to confirm.

--- a/Resources/Prototypes/_Goobstation/Changeling/Actions/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Actions/changeling.yml
@@ -515,9 +515,11 @@
   description: Abandon your current body and escape in the form of a headslug. Costs 20 chemicals.
   categories: [ HideSpawnMenu ]
   components:
+  - type: ConfirmableAction
+    popup: changeling-lastresort-activate
   - type: InstantAction
-    useDelay: 5
     checkCanInteract: false
+    checkConsciousness: false
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Changeling/changeling_abilities.rsi


### PR DESCRIPTION
## About the PR
Changeling last resort ability can be used in dead state.

## Why / Balance
John told me to do so.
I told him that i am to lazy to fix it.
And i fixed it.

## Technical details
{{Technical details}}

**Changelog**
- fix: Changeling last resort ability can be used even in dead state and also will require confirmation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new "last resort" ability for changeling characters, requiring user confirmation before activation.
- **User Interaction Improvements**
	- Added a confirmation popup for the "last resort" action to enhance player engagement.
- **Behavior Changes**
	- Removed the action delay for the "last resort," altering how quickly players can execute this ability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->