### PR TITLE
removes salvage, a cargo tech can do the same job

### DIFF
--- a/Resources/Prototypes/Maps/bagel.yml
+++ b/Resources/Prototypes/Maps/bagel.yml
@@ -54,7 +54,6 @@
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -54,7 +54,6 @@
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/cog.yml
+++ b/Resources/Prototypes/Maps/cog.yml
@@ -54,7 +54,6 @@
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -56,7 +56,6 @@
             #supply
             CargoTechnician: [ 3, 3 ]
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 2, 2 ]
             #civilian
             Passenger: [ -1, -1 ]
             Clown: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/fland.yml
+++ b/Resources/Prototypes/Maps/fland.yml
@@ -55,7 +55,6 @@
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -53,7 +53,6 @@
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/meta.yml
+++ b/Resources/Prototypes/Maps/meta.yml
@@ -53,7 +53,6 @@
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/oasis.yml
+++ b/Resources/Prototypes/Maps/oasis.yml
@@ -58,7 +58,6 @@
             Lawyer: [ 3, 3 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -52,7 +52,6 @@
             Lawyer: [ 1, 1 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -50,7 +50,6 @@
             Lawyer: [ 1, 1 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/reach.yml
+++ b/Resources/Prototypes/Maps/reach.yml
@@ -21,8 +21,7 @@
             Captain: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
             SecurityOfficer: [ 1, 3 ]
-            CargoTechnician: [ 1, 1 ]
-            SalvageSpecialist: [ 1, 1 ]
+            CargoTechnician: [ 1, 2 ] #fcuk salvg
             Bartender: [ 1, 1 ]
             Botanist: [ 1, 1 ]
             Chef: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -55,7 +55,6 @@
             SecurityCadet: [ 4, 4 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 1, 3 ]
             CargoTechnician: [ 2, 2 ]
             #civillian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/Maps/train.yml
+++ b/Resources/Prototypes/Maps/train.yml
@@ -55,7 +55,6 @@
             Lawyer: [ 1, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
             #civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/atlas.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/atlas.yml
@@ -51,7 +51,6 @@
             Detective: [ 1, 1 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civillian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/cluster.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/cluster.yml
@@ -54,7 +54,6 @@
             SecurityCadet: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 2, 2 ]
             CargoTechnician: [ 2, 2 ]
             #civillian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/europa.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/europa.yml
@@ -54,7 +54,6 @@
             #supply
             CargoTechnician: [ 3, 3 ]
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
             #civilian
             Passenger: [ -1, -1 ]
             Clown: [ 1, 1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/flandhighpop.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/flandhighpop.yml
@@ -55,7 +55,6 @@
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/flandhighpop.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/flandhighpop.yml
@@ -55,7 +55,7 @@
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            CargoTechnician: [ 4, 4 ]
+            CargoTechnician: [ -1, -1 ]
             #civilian
             Passenger: [ -1, -1 ]
             Clown: [ 1, 1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/flandhighpop.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/flandhighpop.yml
@@ -55,7 +55,7 @@
             Lawyer: [ 2, 2 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            CargoTechnician: [ -1, -1 ]
+            CargoTechnician: [ -1, -1 ] # this has a merge conflict for some reason
             #civilian
             Passenger: [ -1, -1 ]
             Clown: [ 1, 1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/oasishighpop.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/oasishighpop.yml
@@ -56,7 +56,6 @@
             Lawyer: [ 3, 3 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 4, 4 ]
             #civilian
             Passenger: [ -1, -1 ]

--- a/Resources/Prototypes/_Goobstation/Maps/origin.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/origin.yml
@@ -55,7 +55,6 @@
             SecurityCadet: [ 2, 4 ]
             #supply
             Quartermaster: [ 1, 1 ]
-            SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 5, 5 ]
             #civillian
             Passenger: [ -1, -1 ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
fuck salvage fucking powergaming motherfuckerskdfm making shittles not interacting with the station

## Why / Balance
## Media
## Requirements
## Breaking changes
**Changelog**

- removed fun

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Removal of the `SalvageSpecialist` job from multiple game maps, streamlining job availability for players.
	- Increased maximum availability for the `CargoTechnician` job on the "Reach" map.

- **Bug Fixes**
	- Adjusted job availability for `CargoTechnician` and `Passenger` roles in the "Fland Installation" high population map.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->