### PR TITLE
Fix: Preferred cyborg naming 

### DIFF
--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.CCVar;
 using Content.Shared.Clothing;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Prototypes;
+using Content.Shared.NameIdentifier;
 using Content.Shared.PDA;
 using Content.Shared.Preferences;
 using Content.Shared.Preferences.Loadouts;
@@ -140,7 +141,11 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
             // #Goobstation - Borg Preferred Name
             if (profile != null && prototype.JobEntity == "PlayerBorgGeneric")
             {
-                _metaSystem.SetEntityName(jobEntity, profile.BorgName);
+                var name = profile.BorgName;
+                if (TryComp<NameIdentifierComponent>(jobEntity, out var nameIdentifier))
+                    name = $"{name} {nameIdentifier.FullIdentifier}";
+
+                _metaSystem.SetEntityName(jobEntity, name);
             }
             return jobEntity;
         }


### PR DESCRIPTION
## About the PR
Preferred cyborg names now respects name identifier.  This will also fix negative string length in borg bui making it work again.
Resolves #800 

# Media
https://github.com/user-attachments/assets/c036ba46-9b28-4fb1-bb5a-9208143942e5

**Changelog**
:cl:
- fix: Fixed borg UI not be able to eject anything from borg.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced naming functionality for player characters, specifically for `Borg` entities, resulting in more descriptive names.
  
- **Bug Fixes**
	- Improved logic for setting entity names by incorporating additional context when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->