### PR TITLE
Remove OD from Barozine

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -515,13 +515,6 @@
         damage:
           types:
             Heat: 0.5
-      - !type:HealthChange
-        conditions:
-          - !type:ReagentThreshold
-            min: 30
-        damage:
-          types:
-            Poison: 3
       - !type:ChemVomit
         probability: 0.15
         conditions:


### PR DESCRIPTION
## About the PR
Remove barozine OD because it's an instant win button.

## Why / Balance
you can kill anyone for free (no counter) with 3 space pens


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced several new reagents: Opporozidone, Necrosol, Aloxadone, Mannitol, Psicodine, PotassiumIodide, and Haloperidol.
  
- **Improvements**
	- Enhanced effects and conditions for existing reagents, including Barozine, Epinephrine, Ambuzol, AmbuzolPlus, Necrosol, and Aloxadone.
	- New functionalities for curing zombie infections and effects applicable to dead entities have been added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->