### PR TITLE
Adds EE Run/Build Scripts.

### DIFF
--- a/Scripts/bat/!README.txt
+++ b/Scripts/bat/!README.txt
@@ -1,0 +1,25 @@
+buildAllDebug
+    Builds all projects with debug configuration
+buildAllRelease
+    Builds all projects with release configuration
+buildAllTools
+    Builds all projects with tools configuration
+
+The debug vs release build is simply what people develop in vs the actual server.
+The release build contains various optimizations, while the debug build contains debugging tools.
+If you're mapping, use the release or tools build as it will run smoother with less crashes.
+
+
+runQuickAll
+    Runs the client and server without building
+runQuickClient
+    Runs the client without building
+runQuickServer
+    Runs the server without building
+
+runTests
+    Runs the unit tests, makes sure various C# systems work as intended
+runTestsIntegration
+    Runs the integration tests, makes sure various C# systems work as intended
+runTestsYAML
+    Runs the YAML linter and finds issues with the YAML files that you probably wouldn't otherwise

--- a/Scripts/bat/buildAllDebug.bat
+++ b/Scripts/bat/buildAllDebug.bat
@@ -1,0 +1,7 @@
+@echo off
+cd ../../
+
+call git submodule update --init --recursive
+call dotnet build -c Debug
+
+pause

--- a/Scripts/bat/buildAllRelease.bat
+++ b/Scripts/bat/buildAllRelease.bat
@@ -1,0 +1,7 @@
+@echo off
+cd ../../
+
+call git submodule update --init --recursive
+call dotnet build -c Release
+
+pause

--- a/Scripts/bat/buildAllTools.bat
+++ b/Scripts/bat/buildAllTools.bat
@@ -1,0 +1,7 @@
+@echo off
+cd ../../
+
+call git submodule update --init --recursive
+call dotnet build -c Tools
+
+pause

--- a/Scripts/bat/runQuickAll.bat
+++ b/Scripts/bat/runQuickAll.bat
@@ -1,0 +1,6 @@
+@echo off
+
+start runQuickServer.bat %*
+start runQuickClient.bat %*
+
+exit

--- a/Scripts/bat/runQuickClient.bat
+++ b/Scripts/bat/runQuickClient.bat
@@ -1,0 +1,6 @@
+@echo off
+cd ../../
+
+call dotnet run --project Content.Client --no-build %*
+
+pause

--- a/Scripts/bat/runQuickServer.bat
+++ b/Scripts/bat/runQuickServer.bat
@@ -1,0 +1,6 @@
+@echo off
+cd ../../
+
+call dotnet run --project Content.Server --no-build %*
+
+pause

--- a/Scripts/bat/runTests.bat
+++ b/Scripts/bat/runTests.bat
@@ -1,0 +1,8 @@
+cd ..\..\
+
+mkdir Scripts\logs
+
+del Scripts\logs\Content.Tests.log
+dotnet test Content.Tests/Content.Tests.csproj -c DebugOpt -- NUnit.ConsoleOut=0 > Scripts\logs\Content.Tests.log
+
+pause

--- a/Scripts/bat/runTestsIntegration.bat
+++ b/Scripts/bat/runTestsIntegration.bat
@@ -1,0 +1,8 @@
+cd ..\..\
+
+mkdir Scripts\logs
+
+del Scripts\logs\Content.IntegrationTests.log
+dotnet test Content.IntegrationTests/Content.IntegrationTests.csproj -c DebugOpt -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed > Scripts\logs\Content.IntegrationTests.log
+
+pause

--- a/Scripts/bat/runTestsYAML.bat
+++ b/Scripts/bat/runTestsYAML.bat
@@ -1,0 +1,8 @@
+cd ..\..\
+
+mkdir Scripts\logs
+
+del Scripts\logs\Content.YAMLLinter.log
+dotnet run --project Content.YAMLLinter/Content.YAMLLinter.csproj -c DebugOpt -- NUnit.ConsoleOut=0 > Scripts\logs\Content.YAMLLinter.log
+
+pause

--- a/Scripts/sh/!README.txt
+++ b/Scripts/sh/!README.txt
@@ -1,0 +1,25 @@
+buildAllDebug
+    Builds all projects with debug configuration
+buildAllRelease
+    Builds all projects with release configuration
+buildAllTools
+    Builds all projects with tools configuration
+
+The debug vs release build is simply what people develop in vs the actual server.
+The release build contains various optimizations, while the debug build contains debugging tools.
+If you're mapping, use the release or tools build as it will run smoother with less crashes.
+
+
+runQuickAll
+    Runs the client and server without building
+runQuickClient
+    Runs the client without building
+runQuickServer
+    Runs the server without building
+
+runTests
+    Runs the unit tests, makes sure various C# systems work as intended
+runTestsIntegration
+    Runs the integration tests, makes sure various C# systems work as intended
+runTestsYAML
+    Runs the YAML linter and finds issues with the YAML files that you probably wouldn't otherwise

--- a/Scripts/sh/buildAllDebug.sh
+++ b/Scripts/sh/buildAllDebug.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+# make sure to start from script dir
+if [ "$(dirname $0)" != "." ]; then
+    cd "$(dirname $0)"
+fi
+
+cd ../../
+
+git submodule update --init --recursive
+dotnet build -c Debug

--- a/Scripts/sh/buildAllRelease.sh
+++ b/Scripts/sh/buildAllRelease.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+# make sure to start from script dir
+if [ "$(dirname $0)" != "." ]; then
+    cd "$(dirname $0)"
+fi
+
+cd ../../
+
+git submodule update --init --recursive
+dotnet build -c Release

--- a/Scripts/sh/buildAllTools.sh
+++ b/Scripts/sh/buildAllTools.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+# make sure to start from script dir
+if [ "$(dirname $0)" != "." ]; then
+    cd "$(dirname $0)"
+fi
+
+cd ../../
+
+git submodule update --init --recursive
+dotnet build -c Tools

--- a/Scripts/sh/runQuickAll.sh
+++ b/Scripts/sh/runQuickAll.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+# make sure to start from script dir
+if [ "$(dirname $0)" != "." ]; then
+    cd "$(dirname $0)"
+fi
+
+sh -e runQuickServer.sh &
+sh -e runQuickClient.sh
+
+exit

--- a/Scripts/sh/runQuickClient.sh
+++ b/Scripts/sh/runQuickClient.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+# make sure to start from script dir
+if [ "$(dirname $0)" != "." ]; then
+    cd "$(dirname $0)"
+fi
+
+cd ../../
+dotnet run --project Content.Client --no-build

--- a/Scripts/sh/runQuickServer.sh
+++ b/Scripts/sh/runQuickServer.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+# make sure to start from script dir
+if [ "$(dirname $0)" != "." ]; then
+    cd "$(dirname $0)"
+fi
+
+cd ../../
+dotnet run --project Content.Server --no-build

--- a/Scripts/sh/runTests.sh
+++ b/Scripts/sh/runTests.sh
@@ -1,0 +1,9 @@
+cd ../../
+
+mkdir Scripts/logs
+
+rm Scripts/logs/Content.Tests.log
+dotnet test Content.Tests/Content.Tests.csproj -c DebugOpt -- NUnit.ConsoleOut=0 > Scripts/logs/Content.Tests.log
+
+echo "Tests complete. Press enter to continue."
+read

--- a/Scripts/sh/runTestsIntegration.sh
+++ b/Scripts/sh/runTestsIntegration.sh
@@ -1,0 +1,9 @@
+cd ../../
+
+mkdir Scripts/logs
+
+rm Scripts/logs/Content.IntegrationTests.log
+dotnet test Content.IntegrationTests/Content.IntegrationTests.csproj -c DebugOpt -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed > Scripts/logs/Content.IntegrationTests.log
+
+echo "Tests complete. Press enter to continue."
+read

--- a/Scripts/sh/runTestsYAML.sh
+++ b/Scripts/sh/runTestsYAML.sh
@@ -1,0 +1,9 @@
+cd ../../
+
+mkdir Scripts/logs
+
+rm Scripts/logs/Content.YAMLLinter.log
+dotnet run --project Content.YAMLLinter/Content.YAMLLinter.csproj -c DebugOpt -- NUnit.ConsoleOut=0 > Scripts/logs/Content.YAMLLinter.log
+
+echo "Tests complete. Press enter to continue."
+read


### PR DESCRIPTION
## About the PR
Added the scripts folder from EE to the game files. In practice this means that instead of having to make commands to run both the client and server at once without building, you can just comfortably run your choice of ./buildall[debug/tools/release] and ./runquick[client/server/all].

## Why / Balance
QOL


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: Mocho
- add: Added EE build/run scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced multiple batch and shell scripts for building projects in different configurations (Debug, Release, Tools).
	- Added scripts for running client and server applications without recompilation.
	- Implemented testing scripts for unit tests, integration tests, and YAML linting.

- **Documentation**
	- Updated `!README.txt` files to include new commands and clarify build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->