### PR TITLE
Kettle Fix (Bridge Button & Chemistry Sink)

### DIFF
--- a/Resources/Maps/_Goobstation/kettle.yml
+++ b/Resources/Maps/_Goobstation/kettle.yml
@@ -13065,7 +13065,7 @@ entities:
       pos: -5.5,-58.5
       parent: 82
     - type: Door
-      secondsUntilStateChange: -990.1326
+      secondsUntilStateChange: -1740.5632
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -137089,8 +137089,6 @@ entities:
         - Pressed: Toggle
         21623:
         - Pressed: Toggle
-        10525:
-        - Pressed: Toggle
   - uid: 26135
     components:
     - type: Transform
@@ -138915,6 +138913,11 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -34.5,-44.5
+      parent: 82
+  - uid: 26491
+    components:
+    - type: Transform
+      pos: -34.5,-26.5
       parent: 82
 - proto: Skub
   entities:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
For Kettle map only.
I fixed the button on the bridge to stop toggling the bridge door when lockdown is initiated.
I also added a chemistry sink because it was mentioned and there are no sinks in chem.
Fixes #864 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The bridge button shouldn't be opening the door, it just doesn't make sense and I think it was an accident that wasn't corrected at the time.
The sink in chemistry makes it so chem doesn't have to steal the water tank from hydroponics or go maintenance searching for one.

## Technical details
<!-- Summary of code changes for easier review. -->
No code changes were made, just used a multitool on the door to fix it and added the sink entity to Chemistry. I tested it and a video is attached.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://youtu.be/SlPp1RPtGI8
Before:
![image](https://github.com/user-attachments/assets/ec7d8ead-3005-49f5-ab7b-5e156f666b84)
After:
![image](https://github.com/user-attachments/assets/4cea2460-22d9-48a6-af17-33810994998a)
Added Sink:
![image](https://github.com/user-attachments/assets/f3f1a1be-457f-472f-92be-e8958a466b52)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added sink to Chemistry on Kettle.
- fix: Kettle's lockdown button no longer opens/closes the door, only the blast doors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new entity with updated positioning for enhanced gameplay dynamics.
  
- **Improvements**
	- Adjusted door state transition timing for better user experience.
  
- **Bug Fixes**
	- Removed outdated toggle state entry to streamline interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->