### PR TITLE
refactor scram and BSC (#896 alternative)

### DIFF
--- a/Content.Server/_Goobstation/Heretic/EntitySystems/HereticBladeSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/HereticBladeSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Body.Systems;
 using Content.Server.Heretic.Components;
+using Content.Server.Teleportation;
 using Content.Server.Temperature.Components;
 using Content.Server.Temperature.Systems;
 using Content.Shared.Damage;
@@ -41,9 +42,7 @@ public sealed partial class HereticBladeSystem : EntitySystem
     [Dependency] private readonly DamageableSystem _damage = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly TemperatureSystem _temp = default!;
-
-    private EntityQuery<PhysicsComponent> _physicsQuery;
-    private HashSet<Entity<MapGridComponent>> _targetGrids = [];
+    [Dependency] private readonly TeleportSystem _teleport = default!;
 
     public void ApplySpecialEffect(EntityUid performer, EntityUid target)
     {
@@ -91,7 +90,6 @@ public sealed partial class HereticBladeSystem : EntitySystem
     {
         base.Initialize();
 
-        _physicsQuery = GetEntityQuery<PhysicsComponent>();
         SubscribeLocalEvent<HereticBladeComponent, UseInHandEvent>(OnInteract);
         SubscribeLocalEvent<HereticBladeComponent, ExaminedEvent>(OnExamine);
         SubscribeLocalEvent<HereticBladeComponent, MeleeHitEvent>(OnMeleeHit);
@@ -102,33 +100,28 @@ public sealed partial class HereticBladeSystem : EntitySystem
         if (!TryComp<HereticComponent>(args.User, out var heretic))
             return;
 
-        var xform = Transform(args.User);
-        // 250 because for some reason it counts "10" as 1 tile
-        var targetCoords = SelectRandomTileInRange(xform, 250f);
-        var queuedel = true;
-
-        // void path exxclusive
+        // void path exclusive
         if (heretic.CurrentPath == "Void" && heretic.PathStage >= 7)
         {
             var look = _lookupSystem.GetEntitiesInRange<HereticCombatMarkComponent>(Transform(ent).Coordinates, 15f);
             if (look.Count > 0)
             {
-                targetCoords = Transform(look.ToList()[0]).Coordinates;
-                queuedel = false;
+                var targetCoords = Transform(look.ToList()[0]).Coordinates;
+                _xform.SetCoordinates(args.User, targetCoords);
             }
         }
-
-        if (targetCoords != null)
+        else
         {
-            _xform.SetCoordinates(args.User, targetCoords.Value);
-            _audio.PlayPvs(new SoundPathSpecifier("/Audio/Effects/tesla_consume.ogg"), args.User);
-            args.Handled = true;
+            if (!TryComp<RandomTeleportComponent>(ent, out var rtp))
+                return;
+
+            _teleport.RandomTeleport(args.User, rtp);
+            QueueDel(ent);
         }
 
-        _popup.PopupEntity(Loc.GetString("heretic-blade-use"), args.User, args.User);
+        _audio.PlayPvs(new SoundPathSpecifier("/Audio/Effects/tesla_consume.ogg"), args.User);
 
-        if (queuedel)
-            QueueDel(ent);
+        args.Handled = true;
     }
 
     private void OnExamine(Entity<HereticBladeComponent> ent, ref ExaminedEvent args)
@@ -163,83 +156,4 @@ public sealed partial class HereticBladeSystem : EntitySystem
                 ApplySpecialEffect(args.User, hit);
         }
     }
-
-    private EntityCoordinates? SelectRandomTileInRange(TransformComponent userXform, float radius)
-    {
-        var userCoords = userXform.Coordinates.ToMap(EntityManager, _xform);
-        _targetGrids.Clear();
-        _lookupSystem.GetEntitiesInRange(userCoords, radius, _targetGrids);
-        Entity<MapGridComponent>? targetGrid = null;
-
-        if (_targetGrids.Count == 0)
-            return null;
-
-        // Give preference to the grid the entity is currently on.
-        // This does not guarantee that if the probability fails that the owner's grid won't be picked.
-        // In reality the probability is higher and depends on the number of grids.
-        if (userXform.GridUid != null && TryComp<MapGridComponent>(userXform.GridUid, out var gridComp))
-        {
-            var userGrid = new Entity<MapGridComponent>(userXform.GridUid.Value, gridComp);
-            if (_random.Prob(0.5f))
-            {
-                _targetGrids.Remove(userGrid);
-                targetGrid = userGrid;
-            }
-        }
-
-        if (targetGrid == null)
-            targetGrid = _random.GetRandom().PickAndTake(_targetGrids);
-
-        EntityCoordinates? targetCoords = null;
-
-        do
-        {
-            var valid = false;
-
-            var range = (float) Math.Sqrt(radius);
-            var box = Box2.CenteredAround(userCoords.Position, new Vector2(range, range));
-            var tilesInRange = _mapSystem.GetTilesEnumerator(targetGrid.Value.Owner, targetGrid.Value.Comp, box, false);
-            var tileList = new ValueList<Vector2i>();
-
-            while (tilesInRange.MoveNext(out var tile))
-            {
-                tileList.Add(tile.GridIndices);
-            }
-
-            while (tileList.Count != 0)
-            {
-                var tile = tileList.RemoveSwap(_random.Next(tileList.Count));
-                valid = true;
-                foreach (var entity in _mapSystem.GetAnchoredEntities(targetGrid.Value.Owner, targetGrid.Value.Comp,
-                             tile))
-                {
-                    if (!_physicsQuery.TryGetComponent(entity, out var body))
-                        continue;
-
-                    if (body.BodyType != BodyType.Static ||
-                        !body.Hard ||
-                        (body.CollisionLayer & (int) CollisionGroup.MobMask) == 0)
-                        continue;
-
-                    valid = false;
-                    break;
-                }
-
-                if (valid)
-                {
-                    targetCoords = new EntityCoordinates(targetGrid.Value.Owner,
-                        _mapSystem.TileCenterToVector(targetGrid.Value, tile));
-                    break;
-                }
-            }
-
-            if (valid || _targetGrids.Count == 0) // if we don't do the check here then PickAndTake will blow up on an empty set.
-                break;
-
-            targetGrid = _random.GetRandom().PickAndTake(_targetGrids);
-        } while (true);
-
-        return targetCoords;
-    }
-
 }

--- a/Content.Server/_Goobstation/Teleportation/Components/RandomTeleportComponent.cs
+++ b/Content.Server/_Goobstation/Teleportation/Components/RandomTeleportComponent.cs
@@ -15,5 +15,15 @@ public partial class RandomTeleportComponent : Component
     /// </summary>
     [DataField] public MinMax Radius = new MinMax(10, 20);
 
+    /// <summary>
+    ///     How many times to try to pick the destination. Larger number means the teleport is more likely to be safe.
+    /// </summary>
+    [DataField] public int TeleportAttempts = 10;
+
+    /// <summary>
+    ///     Will try harder to find a safe teleport.
+    /// </summary>
+    [DataField] public bool ForceSafeTeleport = true;
+
     [DataField] public ProtoId<SoundCollectionPrototype> TeleportSounds = "sparks";
 }

--- a/Content.Server/_Goobstation/Teleportation/Components/RandomTeleportComponent.cs
+++ b/Content.Server/_Goobstation/Teleportation/Components/RandomTeleportComponent.cs
@@ -1,25 +1,19 @@
+using Content.Shared.Destructible.Thresholds;
 using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Teleportation;
 
 /// <summary>
-/// Component to store parameters for entities that teleport randomly.
+///     Component to store parameters for entities that teleport randomly.
 /// </summary>
-[RegisterComponent]
-public sealed partial class RandomTeleportComponent : Component
+[RegisterComponent, Virtual]
+public partial class RandomTeleportComponent : Component
 {
     /// <summary>
-    /// Up to how far to teleport the user
+    ///     Up to how far to teleport the user in tiles.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float TeleportRadius = 100f;
+    [DataField] public MinMax Radius = new MinMax(10, 20);
 
-    /// <summary>
-    /// How many times to check for a valid tile to teleport to, higher number means less teleports into walls or open space
-    /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public int TeleportAttempts = 20;
-
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public SoundSpecifier TeleportSound = new SoundPathSpecifier("/Audio/Effects/teleport_arrival.ogg");
+    [DataField] public ProtoId<SoundCollectionPrototype> TeleportSounds = "sparks";
 }

--- a/Content.Server/_Goobstation/Teleportation/Components/RandomTeleportOnUseComponent.cs
+++ b/Content.Server/_Goobstation/Teleportation/Components/RandomTeleportOnUseComponent.cs
@@ -3,14 +3,13 @@ using Robust.Shared.Prototypes;
 namespace Content.Server.Teleportation;
 
 /// <summary>
-/// Entity that will randomly teleport the user when used in hand.
+///     Entity that will randomly teleport the user when used in hand.
 /// </summary>
 [RegisterComponent]
-public sealed partial class RandomTeleportOnUseComponent : Component
+public sealed partial class RandomTeleportOnUseComponent : RandomTeleportComponent
 {
     /// <summary>
-    /// Whether to consume this item on use; consumes only one if it's a stack
+    ///     Whether to consume this item on use; consumes only one if it's a stack
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public bool ConsumeOnUse = true;
+    [DataField] public bool ConsumeOnUse = true;
 }

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -140,7 +140,7 @@
   - type: InstantAction
     checkCanInteract: false
     # charges: 2 # Goobstation - Scrambler buff
-    useDelay: 120 # Goobstation - Scrambler buff, Goobstation - Fix scram
+    useDelay: 300 # Goobstation - Scrambler buff, Goobstation - Fix scram
     itemIconStyle: BigAction
     priority: -20
     icon:

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -140,7 +140,7 @@
   - type: InstantAction
     checkCanInteract: false
     # charges: 2 # Goobstation - Scrambler buff
-    useDelay: 300 # Goobstation - Scrambler buff, Goobstation - Fix scram
+    useDelay: 120 # Goobstation - Scrambler buff, Goobstation - Fix scram
     itemIconStyle: BigAction
     priority: -20
     icon:

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -188,6 +188,9 @@
       implantAction: ActionActivateScramImplant
     - type: TriggerImplantAction
     - type: RandomTeleport
+      radius:
+        min: 10
+        max: 100
 
 - type: entity
   parent: BaseSubdermalImplant

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Materials/materials.yml
@@ -24,10 +24,10 @@
   - type: PhysicalComposition
     materialComposition:
       BSCrystal: 100
-  - type: RandomTeleport
-    teleportRadius: 150
-    teleportAttempts: 1 # you're going to brazil
   - type: RandomTeleportOnUse
+    radius:
+      min: 2
+      max: 5
 
 - type: entity
   parent: MaterialBSCrystal

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/heretic_blades.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Weapons/Melee/heretic_blades.yml
@@ -21,6 +21,7 @@
     size: Normal
     sprite: _Goobstation/Heretic/Blades/blade_blade-inhand.rsi
   - type: ItemToggle
+  - type: RandomTeleport
 
 - type: entity
   parent: HereticBladeBase

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/sheet.yml
@@ -3,6 +3,6 @@
   result: MaterialBSCrystal1
   completetime: 2
   materials:
-    Glass: 500
-    Plasma: 500
-    Diamond: 100
+    Glass: 50
+    Plasma: 50
+    Diamond: 10

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/sheet.yml
@@ -3,6 +3,7 @@
   result: MaterialBSCrystal1
   completetime: 2
   materials:
+    Gold: 25
+    Silver: 25
     Glass: 50
     Plasma: 50
-    Diamond: 10


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
#896, but:
- scram implant max range stays as 100
- cooldown stays as 5 minutes
- goes back to the tries implementation, but ensures you never teleport to open space

## Why / Balance
see #896
why choose this or #896? here:
- the tries implementation (this PR) is much more performant than tile enumeration (#896)
- scram was initially supposed to teleport you over very long ranges and i think it's more fun this way
- the tries implementation code is less readable than tile enumeration, but i don't believe it really matters

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The scram implant will no longer teleport you into open space or very close to your original position.