### PR TITLE
Revert "Emag works as laws board for syndicate lawset on AI (#637)"

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/emag.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/emag.yml
@@ -12,8 +12,6 @@
   - type: Item
     sprite: Objects/Tools/emag.rsi
     storedRotation: -90
-  - type: SiliconLawProvider #Goobstation
-    laws: SyndicateStatic
 
 - type: entity
   parent: EmagUnlimited


### PR DESCRIPTION
## About the PR
Feature was added on goob with AI. Now, game have Antimov lawboard, so we don't need this because it's too OP and makes antimov useless.

:cl:
- remove: EMAG no longer works as Syndicate lawboard for AI upload.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated `Emag` entity with new `LimitedCharges` and `AutoRecharge` components for enhanced functionality.
- **Changes**
	- Removed the `SiliconLawProvider` component from `EmagUnlimited`, streamlining its structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->