### PR TITLE
Fix Yowies not spawning with survival boxes + other changes

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/accent/bogan.ftl
+++ b/Resources/Locale/en-US/_Goobstation/accent/bogan.ftl
@@ -5,7 +5,7 @@ accent-bogan-prefix-4 = Mmmmm,
 
 accent-bogan-suffix-1 = , cunt.
 accent-bogan-suffix-2 = , fuckin' oath.
-accent-bogan-suffix-3 = , fuck oath cunt.
+accent-bogan-suffix-3 = , fuckin' oath cunt.
 accent-bogan-suffix-4 = , ya fuckin druggo.
 accent-bogan-suffix-5 = , you fucking drug addict.
 
@@ -27,8 +27,8 @@ accent-bogan-words-replace-5 = fuckin' skitz
 accent-bogan-words-6 = cool
 accent-bogan-words-replace-6 = skiz
 
-accent-bogan-words-7 = what
-accent-bogan-words-replace-7 = whuddyatalkinabeet
+accent-bogan-words-7 = what?
+accent-bogan-words-replace-7 = whuddyatalkinabeet?
 
 accent-bogan-words-8 = weed
 accent-bogan-words-replace-8 = yoweed
@@ -129,7 +129,7 @@ accent-bogan-words-replace-39 = me
 accent-bogan-words-40 = ok
 accent-bogan-words-replace-40 = no worries
 
-accent-bogan-words-41 = break
+accent-bogan-words-41 = smoke
 accent-bogan-words-replace-41 = smoko
 
 accent-bogan-words-42 = friend

--- a/Resources/Locale/en-US/_Goobstation/accent/bogan.ftl
+++ b/Resources/Locale/en-US/_Goobstation/accent/bogan.ftl
@@ -5,7 +5,7 @@ accent-bogan-prefix-4 = Mmmmm,
 
 accent-bogan-suffix-1 = , cunt.
 accent-bogan-suffix-2 = , fuckin' oath.
-accent-bogan-suffix-3 = , fuckin' oath cunt.
+accent-bogan-suffix-3 = , fuck oath cunt.
 accent-bogan-suffix-4 = , ya fuckin druggo.
 accent-bogan-suffix-5 = , you fucking drug addict.
 
@@ -27,8 +27,8 @@ accent-bogan-words-replace-5 = fuckin' skitz
 accent-bogan-words-6 = cool
 accent-bogan-words-replace-6 = skiz
 
-accent-bogan-words-7 = what?
-accent-bogan-words-replace-7 = whuddyatalkinabeet?
+accent-bogan-words-7 = what
+accent-bogan-words-replace-7 = whuddyatalkinabeet
 
 accent-bogan-words-8 = weed
 accent-bogan-words-replace-8 = yoweed
@@ -129,7 +129,7 @@ accent-bogan-words-replace-39 = me
 accent-bogan-words-40 = ok
 accent-bogan-words-replace-40 = no worries
 
-accent-bogan-words-41 = smoke
+accent-bogan-words-41 = break
 accent-bogan-words-replace-41 = smoko
 
 accent-bogan-words-42 = friend

--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -24,7 +24,6 @@
     - Harpy
     - Gingerbread
     - Rodentia
-    - Yowie
 
 - type: loadoutEffectGroup
   id: EffectSpeciesVox

--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -24,6 +24,7 @@
     - Harpy
     - Gingerbread
     - Rodentia
+    - Yowie
 
 - type: loadoutEffectGroup
   id: EffectSpeciesVox

--- a/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
@@ -30,3 +30,4 @@
     Cold: 0.7  # Fur = Keep warm
     Bloodloss: 0.9
     Poison: 0.5 # Should be more resistant to toxin
+    Radiation : 0.7 # Engie yowies need some help against anti-rads

--- a/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
@@ -30,4 +30,3 @@
     Cold: 0.7  # Fur = Keep warm
     Bloodloss: 0.9
     Poison: 0.5 # Should be more resistant to toxin
-    Radiation : 0.7 # Engie yowies need some help against anti-rads

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/yowie.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/yowie.yml
@@ -50,6 +50,16 @@
 - type: entity
   parent: BaseSpeciesDummy
   id: MobYowieDummy
+  categories: [ HideSpawnMenu ]
   components:
   - type: HumanoidAppearance
-    species: Yowie
+    species: Diona
+  - type: Inventory
+    templateId: diona
+    femaleDisplacements:
+      jumpsuit:
+        sizeMaps:
+          32:
+            sprite: Mobs/Species/Human/displacement.rsi
+            state: jumpsuit-female
+ 


### PR DESCRIPTION

## About the PR
Fixed some Yowie grievances and stuff

**Changelog**

:cl:
- fix: Yowie's spawn with survival boxes now
- fix: Fixed some bogan accent annoyances
- add: Yowie's are now more rad proof


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced Bogan accent localization with updated colloquial expressions for a more authentic feel.
  - Added the `Yowie` species to the `OxygenBreather` loadout effect group, expanding gameplay options.
  - Introduced radiation resistance for the `Yowie` damage modifier set, improving gameplay dynamics.
  - Updated properties for the `MobYowieDummy` entity, including new inventory features and appearance adjustments.

- **Bug Fixes**
  - Minor formatting adjustments for improved file consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->