### PR TITLE
Buff Medical due to Shitmed Changes

### DIFF
--- a/Content.Server/Medical/Components/HealingComponent.cs
+++ b/Content.Server/Medical/Components/HealingComponent.cs
@@ -43,13 +43,13 @@ namespace Content.Server.Medical.Components
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("delay")]
-        public float Delay = 3f;
+        public float Delay = 2f; //Was 3f, changed due to Surgery Changes (Goobstation)
 
         /// <summary>
         /// Delay multiplier when healing yourself.
         /// </summary>
         [DataField("selfHealPenaltyMultiplier")]
-        public float SelfHealPenaltyMultiplier = 3f;
+        public float SelfHealPenaltyMultiplier = 2f; //Was 3f, changed due to Surgery Changes (Goobstation)
 
         /// <summary>
         ///     Sound played on healing begin

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -35,7 +35,7 @@
         Heat: -15
         Cold: -15
         Shock: -15
-        Caustic: -4.5 #Was 5 per type, 1.5 caustic, Buffed due to surgery changes (Goobstation)
+        Caustic: -4.5 #Was 5 per type & 1.5 caustic, Buffed due to surgery changes (Goobstation)
     healingBeginSound:
       path: "/Audio/Items/Medical/ointment_begin.ogg"
     healingEndSound:
@@ -83,10 +83,10 @@
       - Biological
     damage:
       types:
-        Heat: -25
-        Cold: -25
-        Shock: -25
-        Caustic: -25 #Was 10 per type, Buffed due to surgery changes (Goobstation)
+        Heat: -20
+        Cold: -20
+        Shock: -20
+        Caustic: -20 #Was 10 per type, Buffed due to surgery changes (Goobstation)
     healingBeginSound:
       path: "/Audio/Items/Medical/ointment_begin.ogg"
     healingEndSound:
@@ -172,7 +172,7 @@
       - Biological
     damage:
       groups:
-        Brute: -75 # was 10 for each, 25 for each type in the group, Buffed due to surgery changes (Goobstation)
+        Brute: -60 # was 10 for each, now 20 for each type in the group, Buffed due to surgery changes (Goobstation)
     bloodlossModifier: -10 # a suture should stop ongoing bleeding
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"
@@ -210,8 +210,8 @@
       - Biological
     damage:
       types:
-        Bloodloss: -0.5 #lowers bloodloss damage
-    ModifyBloodLevel: 30 #used to restore 5% blood per use, now restores about 10% blood per use on standard Buffed due to surgery changes (Goobstation)
+        Bloodloss: -5 #lowers bloodloss damage, was .5 buffed to 5 due to Surgery Changes (Goobstation)
+    ModifyBloodLevel: 30 #used to restore 5% blood per use, now restores about 10% blood per use on standard Buffed due to Surgery Changes (Goobstation)
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"
     healingEndSound:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -35,16 +35,16 @@
         Heat: -15
         Cold: -15
         Shock: -15
-        Caustic: -4.5 #Was 5 per type & 1.5 caustic, Buffed due to surgery changes (Goobstation)
+        Caustic: -10 #Was 5 per type & 1.5 caustic, Buffed due to limb damage changes (Goobstation)
     healingBeginSound:
       path: "/Audio/Items/Medical/ointment_begin.ogg"
     healingEndSound:
       path: "/Audio/Items/Medical/ointment_end.ogg"
   - type: Stack
     stackType: Ointment
-    count: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
+    count: 15 #Was 10, Buffed due to limb damage changes (Goobstation)
   - type: StackPrice
-    price: 10 #Was 5, now 10, Buffed due to surgery changes (Goobstation)
+    price: 10 #Was 5, Buffed due to surgery changes (Goobstation)
 
 - type: entity
   id: Ointment1
@@ -86,16 +86,16 @@
         Heat: -20
         Cold: -20
         Shock: -20
-        Caustic: -20 #Was 10 per type, Buffed due to surgery changes (Goobstation)
+        Caustic: -20 #Was 10 per type, Buffed due to limb damage changes (Goobstation)
     healingBeginSound:
       path: "/Audio/Items/Medical/ointment_begin.ogg"
     healingEndSound:
       path: "/Audio/Items/Medical/ointment_end.ogg"
   - type: Stack
     stackType: RegenerativeMesh
-    count: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
+    count: 15 #Was 10, Buffed due to limb damage changes (Goobstation)
   - type: StackPrice
-    price: 40 #Was 20, now 40, Buffed due to surgery changes (Goobstation)
+    price: 40 #Was 20, Buffed due to limb damage changes (Goobstation)
 
 - type: entity
   id: OintmentAdvanced1
@@ -123,16 +123,16 @@
       - Biological
     damage:
       groups:
-        Brute: -45 # was 5 for each, now 15 for each type in the group, Buffed due to surgery changes (Goobstation)
+        Brute: -45 # was 5 for each, Buffed due to limb damage changes (Goobstation)
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"
     healingEndSound:
       path: "/Audio/Items/Medical/brutepack_end.ogg"
   - type: Stack
     stackType: Brutepack
-    count: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
+    count: 15 #Was 10, Buffed due to limb damage changes (Goobstation)
   - type: StackPrice
-    price: 10 #Was 5, now 10, Buffed due to surgery changes (Goobstation)
+    price: 10 #Was 5, Buffed due to limb damage changes (Goobstation)
 
 - type: entity
   id: Brutepack1
@@ -180,9 +180,9 @@
       path: "/Audio/Items/Medical/brutepack_end.ogg"
   - type: Stack
     stackType: MedicatedSuture
-    count: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
+    count: 15 #Was 10, Buffed due to surgery changes (Goobstation)
   - type: StackPrice
-    price: 40 #Was 20, now 40, Buffed due to surgery changes (Goobstation)
+    price: 40 #Was 20, Buffed due to limb damage changes (Goobstation)
 
 - type: entity
   id: BrutepackAdvanced1
@@ -218,9 +218,9 @@
       path: "/Audio/Items/Medical/brutepack_end.ogg"
   - type: Stack
     stackType: Bloodpack
-    count: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
+    count: 15 #Was 10, Buffed due to limb damage changes (Goobstation)
   - type: StackPrice
-    price: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
+    price: 20 #Was 10, Buffed due to limb damage changes (Goobstation)
 
 - type: entity
   parent: Bloodpack
@@ -277,7 +277,7 @@
     damage:
       types:
         Slash: -15 # Was 5
-        Piercing: -20 # Was 10, Buffed due to surgery changes (Goobstation)
+        Piercing: -20 # Was 10, Buffed due to limb damage changes (Goobstation)
     bloodlossModifier: -10
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"
@@ -285,9 +285,9 @@
       path: "/Audio/Items/Medical/brutepack_end.ogg"
   - type: Stack
     stackType: Gauze
-    count: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
+    count: 15 #Was 10, Buffed due to limb damage changes (Goobstation)
   - type: StackPrice
-    price: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
+    price: 20 #Was 10, Buffed due to limb damage changes (Goobstation)
 
 - type: entity
   id: Gauze1
@@ -317,7 +317,7 @@
     state: cream
   - type: Stack
     stackType: AloeCream
-    count: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
+    count: 15 #Was 10, Buffed due to limb damage changes (Goobstation)
 
 - type: entity
   parent: BaseHealingItem

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -210,8 +210,8 @@
       - Biological
     damage:
       types:
-        Bloodloss: -5 #lowers bloodloss damage, was .5 buffed to 5 due to Surgery Changes (Goobstation)
-    ModifyBloodLevel: 30 #used to restore 5% blood per use, now restores about 10% blood per use on standard Buffed due to Surgery Changes (Goobstation)
+        Bloodloss: -2.5 #lowers bloodloss damage, was .5 buffed to 5 due to Limb Damage Changes (Goobstation)
+    ModifyBloodLevel: 30 #used to restore 5% blood per use, now restores about 10% blood per use on standard Buffed due to Limb Damage Changes (Goobstation)
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"
     healingEndSound:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -42,9 +42,9 @@
       path: "/Audio/Items/Medical/ointment_end.ogg"
   - type: Stack
     stackType: Ointment
-    count: 10
+    count: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
   - type: StackPrice
-    price: 5
+    price: 10 #Was 5, now 10, Buffed due to surgery changes (Goobstation)
 
 - type: entity
   id: Ointment1
@@ -93,9 +93,9 @@
       path: "/Audio/Items/Medical/ointment_end.ogg"
   - type: Stack
     stackType: RegenerativeMesh
-    count: 10
+    count: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
   - type: StackPrice
-    price: 20
+    price: 40 #Was 20, now 40, Buffed due to surgery changes (Goobstation)
 
 - type: entity
   id: OintmentAdvanced1
@@ -130,9 +130,9 @@
       path: "/Audio/Items/Medical/brutepack_end.ogg"
   - type: Stack
     stackType: Brutepack
-    count: 10
+    count: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
   - type: StackPrice
-    price: 5
+    price: 10 #Was 5, now 10, Buffed due to surgery changes (Goobstation)
 
 - type: entity
   id: Brutepack1
@@ -180,9 +180,9 @@
       path: "/Audio/Items/Medical/brutepack_end.ogg"
   - type: Stack
     stackType: MedicatedSuture
-    count: 10
+    count: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
   - type: StackPrice
-    price: 20
+    price: 40 #Was 20, now 40, Buffed due to surgery changes (Goobstation)
 
 - type: entity
   id: BrutepackAdvanced1
@@ -218,9 +218,9 @@
       path: "/Audio/Items/Medical/brutepack_end.ogg"
   - type: Stack
     stackType: Bloodpack
-    count: 10
+    count: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
   - type: StackPrice
-    price: 10
+    price: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
 
 - type: entity
   parent: Bloodpack
@@ -285,9 +285,9 @@
       path: "/Audio/Items/Medical/brutepack_end.ogg"
   - type: Stack
     stackType: Gauze
-    count: 10
+    count: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
   - type: StackPrice
-    price: 10
+    price: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
 
 - type: entity
   id: Gauze1
@@ -317,7 +317,7 @@
     state: cream
   - type: Stack
     stackType: AloeCream
-    count: 10
+    count: 20 #Was 10, now 20, Buffed due to surgery changes (Goobstation)
 
 - type: entity
   parent: BaseHealingItem

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -32,10 +32,10 @@
       - Biological
     damage:
       types:
-        Heat: -5
-        Cold: -5
-        Shock: -5
-        Caustic: -1.5
+        Heat: -15
+        Cold: -15
+        Shock: -15
+        Caustic: -4.5 #Was 5 per type, 1.5 caustic, Buffed due to surgery changes (Goobstation)
     healingBeginSound:
       path: "/Audio/Items/Medical/ointment_begin.ogg"
     healingEndSound:
@@ -83,10 +83,10 @@
       - Biological
     damage:
       types:
-        Heat: -10
-        Cold: -10
-        Shock: -10
-        Caustic: -10
+        Heat: -25
+        Cold: -25
+        Shock: -25
+        Caustic: -25 #Was 10 per type, Buffed due to surgery changes (Goobstation)
     healingBeginSound:
       path: "/Audio/Items/Medical/ointment_begin.ogg"
     healingEndSound:
@@ -123,7 +123,7 @@
       - Biological
     damage:
       groups:
-        Brute: -15 # 5 for each type in the group
+        Brute: -45 # was 5 for each, now 15 for each type in the group, Buffed due to surgery changes (Goobstation)
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"
     healingEndSound:
@@ -172,7 +172,7 @@
       - Biological
     damage:
       groups:
-        Brute: -30 # 10 for each type in the group
+        Brute: -75 # was 10 for each, 25 for each type in the group, Buffed due to surgery changes (Goobstation)
     bloodlossModifier: -10 # a suture should stop ongoing bleeding
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"
@@ -211,7 +211,7 @@
     damage:
       types:
         Bloodloss: -0.5 #lowers bloodloss damage
-    ModifyBloodLevel: 15 #restores about 5% blood per use on standard humanoids.
+    ModifyBloodLevel: 30 #used to restore 5% blood per use, now restores about 10% blood per use on standard Buffed due to surgery changes (Goobstation)
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"
     healingEndSound:
@@ -276,8 +276,8 @@
       - Biological
     damage:
       types:
-        Slash: -5
-        Piercing: -10
+        Slash: -15 # Was 5
+        Piercing: -20 # Was 10, Buffed due to surgery changes (Goobstation)
     bloodlossModifier: -10
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -30,7 +30,7 @@
       - !type:HealthChange
         damage:
           types:
-            Poison: -1
+            Poison: -1.5 # Was 1, Slight Buff as it should heal for half the amount as Dip or Stelli(GoobStation)
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -140,7 +140,7 @@
       - !type:HealthChange
         damage:
           groups:
-            Brute: -2
+            Brute: -2.5 # Was 2, Buffed due to limb damage changes(GoobStation)
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -223,9 +223,9 @@
       - !type:HealthChange
         damage:
           types:
-            Heat: -1.5
-            Shock: -1.5
-            Cold: -1.5
+            Heat: -2
+            Shock: -2 
+            Cold: -2 # Was 1.5, Buffed due to limb damage changes(GoobStation)
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -323,8 +323,8 @@
             Asphyxiation: -3
             Poison: -0.5
           groups:
-            Brute: -0.5
-            Burn: -0.5
+            Brute: -1
+            Burn: -1 # Was .5, Buffed due to limb damage changes(GoobStation)
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -446,9 +446,9 @@
       - !type:HealthChange
         damage:
           types:
-            Heat: -0.33
-            Shock: -0.33
-            Cold: -0.33
+            Heat: -0.5
+            Shock: -0.5
+            Cold: -0.5 # Was .33, Buffed due to limb damage changes(GoobStation)
       - !type:SatiateThirst
         factor: -10
         conditions:
@@ -762,9 +762,9 @@
             Brute: -1
           types:
             Poison: -0.5 ##Should be about what it was when it healed the toxin group
-            Heat: -0.33
-            Shock: -0.33
-            Cold: -0.33
+            Heat: -0.5
+            Shock: -0.5
+            Cold: -0.5 # Was .33, Buffed due to limb damage changes(GoobStation)
 
 - type: reagent
   id: Lipozine
@@ -796,10 +796,10 @@
       - !type:HealthChange
         damage:
           groups:
-            Burn: -2
-            Toxin: -2
-            Airloss: -2
-            Brute: -2
+            Burn: -3
+            Toxin: -3
+            Airloss: -3
+            Brute: -3 # Was 2, Buffed due to limb damage changes(GoobStation)
 
 - type: reagent
   id: Ultravasculine
@@ -981,7 +981,7 @@
       - !type:HealthChange
         damage:
           types:
-            Slash: -3
+            Slash: -4 # Was 3, Buffed due to limb damage changes(GoobStation)
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -1028,7 +1028,7 @@
       - !type:HealthChange
         damage:
           types:
-            Blunt: -3.5
+            Blunt: -4 # Was 3, Buffed due to limb damage changes(GoobStation)
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
+ Buffed applicable medication heal values.
+ Buffed applicable medication stack sizes.
+ Slightly buffed dylovene, burn, and brute chems.
+ Buffed applicable medication doAfter delay from 3s to 2s.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This change was made with the advent of the new Limb Damage system. This PR seeks to achieve making SS14 Medical more equivalent to SS13 Medical when it comes to healing damage values.

This was done as Bruise Packs and Ointment only heal 5 Brute or 5 Burn respectively when applied to a limb. When each limb has a 100 Crit threshold, this can make it extremely hard even with surgery to heal limbs in the absence of Chemicals.

Furthermore on higher pop, this will lead to people burning through applicable meds even faster than before Limb Damage was implemented.

## Technical details
<!-- Summary of code changes for easier review. -->
Mostly YML Value Changes and 2 float val changes for DoAfters. Commented old value and reason for change on each.

<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Should values be overtuned, they can be reduced in a future PR or before this PR is merged.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Increased applicable medication heal values.
- tweak: Increased stack size of applicable medications.
- tweak: Slightly increased dylovene, burn, and brute chemicals heal values.
- tweak: Decreased Medical item application time from 3s to 2s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced healing items with increased effectiveness and new entities introduced.
  
- **Adjustments**
	- Healing item damage values have been significantly increased for various items, improving their in-game utility.
	- Stack counts for several healing items have been increased from 10 to 15, and prices have been adjusted accordingly.
  
- **Rebalancing**
	- Reagents have undergone a comprehensive rebalancing, with many damage values increased to enhance their impact in gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->