### PR TITLE
Remove Maximum Nuclear Operative Count

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -134,7 +134,7 @@
     - prefRoles: [ Nukeops ]
       fallbackRoles: [ NukeopsCommander, NukeopsMedic ]
       spawnerPrototype: SpawnPointNukeopsOperative
-      max: 3
+      #max: 3 - Goobstation / 古布空间站 - 没有限制的核特工
       playerRatio: 10
       startingGear: SyndicateOperativeGearFull
       roleLoadout:

--- a/Resources/Prototypes/_Goobstation/GameRules/Dynamic/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/Dynamic/roundstart.yml
@@ -33,7 +33,7 @@
       lateJoinAdditional: true
       mindRoles:
       - MindRoleTraitor
-      
+
 - type: entity
   parent: BaseTraitorRuleDynamic
   id: TraitorDynamicMedium
@@ -54,7 +54,7 @@
       lateJoinAdditional: true
       mindRoles:
       - MindRoleTraitor
-      
+
 - type: entity
   parent: BaseTraitorRuleDynamic
   id: TraitorDynamicHigh
@@ -77,7 +77,7 @@
       lateJoinAdditional: true
       mindRoles:
       - MindRoleTraitor
-      
+
 # Thief (Spy wyci) - Low Threat Solo, Side Antag
 - type: entity
   parent: BaseGameRuleDynamic
@@ -115,7 +115,7 @@
       briefing:
         sound: "/Audio/Misc/thief_greeting.ogg"
 
-# Changeling - Medium Threat Solo 
+# Changeling - Medium Threat Solo
 - type: entity
   parent: BaseGameRuleDynamic
   id: ChangelingDynamicLow
@@ -159,7 +159,7 @@
     scalingCost: 23
   - type: ChangelingRule
   - type: GameRule
-    minPlayers: 20 # Changelings are great low pop antags but it doesn't work for dynamic that well :[ 
+    minPlayers: 20 # Changelings are great low pop antags but it doesn't work for dynamic that well :[
   - type: AntagObjectives
     objectives:
     - ChangelingStealDNAObjective
@@ -324,7 +324,7 @@
     - prefRoles: [ Nukeops ]
       fallbackRoles: [ NukeopsCommander, NukeopsMedic ]
       spawnerPrototype: SpawnPointNukeopsOperative
-      max: 3
+      #max: 3 - Goobstation / 古布空间站 - 没有限制的核特工
       playerRatio: 10
       startingGear: SyndicateOperativeGearFull
       roleLoadout:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

没有限制的核特工，他们很糟糕

Removed maximum count of nuclear operatives- it's bad.

Causes big issues on high pop.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 圓周率覆盆子314
- tweak: Removed the arbitrary nukie limit, high-pop nukies should have a chance now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new game rules and entities, including `InactivityTimeRestart`, `MaxTimeRestart`, and `Sandbox`.
	- Added new antagonist roles: `TraitorDynamicMedium` and `TraitorDynamicHigh`, enhancing gameplay diversity.
	- Updated respawn timing in `DeathMatch31` from 10 seconds to 5 seconds.
  
- **Bug Fixes**
	- Commented out the `max` parameter for the `Nukeops` entity, indicating potential adjustments in player limits. 

- **Documentation**
	- Enhanced comments for clarity on game rules and entity functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->