### PR TITLE
fix borg limbs and make borg legs good

### DIFF
--- a/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
@@ -50,6 +50,12 @@ public partial class SharedBodySystem
             _slots.AddItemSlot(ent, ent.Comp.ContainerName, ent.Comp.ItemInsertionSlot);
             Dirty(ent, ent.Comp);
         }
+        // Shitmed Change Start
+        foreach (var connection in ent.Comp.Children.Keys)
+        {
+            Containers.EnsureContainer<ContainerSlot>(ent, GetPartSlotContainerId(connection));
+        }
+        // Shitmed Change End
     }
 
     private void OnBodyPartRemove(Entity<BodyPartComponent> ent, ref ComponentRemove args)

--- a/Resources/Prototypes/Body/Parts/silicon.yml
+++ b/Resources/Prototypes/Body/Parts/silicon.yml
@@ -91,7 +91,9 @@
     tags:
     - Trash
     - BorgLeg
-  - type: MovementBodyPart # Shitmed Change
+  - type: MovementBodyPart # Shitmed Change: 25% speed boost
+    walkSpeed: 3.125
+    sprintSpeed: 5.625
 
 - type: entity
   id: BaseBorgLegRight
@@ -111,7 +113,9 @@
     tags:
     - Trash
     - BorgLeg
-  - type: MovementBodyPart # Shitmed Change
+  - type: MovementBodyPart # Shitmed Change: 25% speed boost
+    walkSpeed: 3.125
+    sprintSpeed: 5.625
 
 - type: entity
   id: BaseBorgHead

--- a/Resources/Prototypes/Body/Parts/silicon.yml
+++ b/Resources/Prototypes/Body/Parts/silicon.yml
@@ -44,6 +44,11 @@
   - type: BodyPart
     partType: Arm # Shitmed Change
     symmetry: Left
+    toolName: "a left arm" # Shitmed Change
+    children: # Shitmed Change
+      left hand:
+        id: "left hand"
+        type: Hand
   - type: Tag
     tags:
     - Trash
@@ -58,6 +63,11 @@
   - type: BodyPart
     partType: Arm # Shitmed Change
     symmetry: Right
+    toolName: "a right arm" # Shitmed Change
+    children: # Shitmed Change
+      right hand:
+        id: "right hand"
+        type: Hand
   - type: Tag
     tags:
     - Trash
@@ -72,6 +82,11 @@
   - type: BodyPart
     partType: Leg
     symmetry: Left
+    toolName: "a left leg" # Shitmed Change
+    children: # Shitmed Change
+      left foot:
+        id: "left foot"
+        type: Foot
   - type: Tag
     tags:
     - Trash
@@ -87,6 +102,11 @@
   - type: BodyPart
     partType: Leg
     symmetry: Right
+    toolName: "a right leg" # Shitmed Change
+    children: # Shitmed Change
+      right foot:
+        id: "right foot"
+        type: Foot
   - type: Tag
     tags:
     - Trash
@@ -101,6 +121,7 @@
   components:
   - type: BodyPart
     partType: Head
+    toolName: "a head" # Shitmed Change
   - type: Tag
     tags:
     - Trash
@@ -114,6 +135,7 @@
   components:
   - type: BodyPart
     partType: Torso
+    toolName: "a torso" # Shitmed Change
   - type: Tag
     tags:
     - Trash


### PR DESCRIPTION
## About the PR
you can now attach hands/feet

borg legs also make you 25% faster now

## Why / Balance
Body Modder Transformed +13
I asked for this.

## Technical details
shitcode only initializes body not bodypart

## Media
![01:52:28](https://github.com/user-attachments/assets/4d995434-ad1f-41ae-945f-318d606e483c)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed not being able to install hands onto cyborg arms.
- tweak: Cyborg legs make you 25% faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced definitions for cyborg body parts, including tool names and child entities for hands and feet.
	- Updated movement speeds for legs, providing a 25% speed boost for walking and sprinting.

- **Improvements**
	- Added sound paths for the SurgeryTool component, improving functionality and user experience.
	- Improved management of body parts with new event handling for initialization, removal, and enabling/disabling actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->