### PR TITLE
Shitmed Surgery Popups (EE Port)

### DIFF
--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -10,6 +10,7 @@ using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.DoAfter;
+using Content.Shared.IdentityManagement;
 using Content.Shared._Shitmed.Medical.Surgery.Conditions;
 using Content.Shared._Shitmed.Medical.Surgery.Effects.Step;
 using Content.Shared._Shitmed.Medical.Surgery.Steps;
@@ -646,7 +647,21 @@ public abstract partial class SharedSurgerySystem
             BreakOnHandChange = true,
         };
 
-        _doAfter.TryStartDoAfter(doAfter);
+        if (_doAfter.TryStartDoAfter(doAfter))
+        {
+            var userName = Identity.Entity(user, EntityManager);
+            var targetName = Identity.Entity(ent.Owner, EntityManager);
+
+            var locName = $"surgery-popup-procedure-{args.Surgery}-step-{args.Step}";
+            var locResult = Loc.GetString(locName,
+                ("user", userName), ("target", targetName), ("part", part));
+
+            if (locResult == locName)
+                locResult = Loc.GetString($"surgery-popup-step-{args.Step}",
+                    ("user", userName), ("target", targetName), ("part", part));
+
+            _popup.PopupEntity(locResult, user);
+        }
     }
 
     private (Entity<SurgeryComponent> Surgery, int Step)? GetNextStep(EntityUid body, EntityUid part, Entity<SurgeryComponent?> surgery, List<EntityUid> requirements)

--- a/Resources/Locale/en-US/_Shitmed/surgery-popup.ftl
+++ b/Resources/Locale/en-US/_Shitmed/surgery-popup.ftl
@@ -1,0 +1,52 @@
+surgery-popup-step-SurgeryStepOpenIncisionScalpel = {$user} is making an incision on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepClampBleeders = {$user} is clamping the bleeders on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepRetractSkin = {$user} is retracting the skin on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepSawBones = {$user} is sawing through the bones on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepPriseOpenBones = {$user} is prising the bones open on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepCloseBones = {$user} is closing the bones on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepMendRibcage = {$user} is mending the ribcage on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepCloseIncision = {$user} is closing the incision on {$target}'s {$part}.
+
+surgery-popup-step-SurgeryStepInsertFeature = {$user} is inserting something onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachHead-step-SurgeryStepInsertFeature = {$user} is attaching a head onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachLeftArm-step-SurgeryStepInsertFeature = {$user} is attaching a left arm onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachRightArm-step-SurgeryStepInsertFeature = {$user} is attaching a right arm onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachLeftLeg-step-SurgeryStepInsertFeature = {$user} is attaching a left leg onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachRightLeg-step-SurgeryStepInsertFeature = {$user} is attaching a right leg onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachLeftHand-step-SurgeryStepInsertFeature = {$user} is attaching a left hand onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachRightHand-step-SurgeryStepInsertFeature = {$user} is attaching a right hand onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachLeftFoot-step-SurgeryStepInsertFeature = {$user} is attaching a left foot onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachRightFoot-step-SurgeryStepInsertFeature = {$user} is attaching a right foot onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachLegs-step-SurgeryStepInsertFeature = {$user} is attaching legs onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachHands-step-SurgeryStepInsertFeature = {$user} is attaching hands onto {$target}'s {$part}!
+surgery-popup-procedure-SurgeryAttachFeet-step-SurgeryStepInsertFeature = {$user} is attaching feet onto {$target}'s {$part}!
+
+surgery-popup-step-SurgeryStepSealWounds = {$user} is sealing the wounds on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepSawFeature = {$user} is sawing through the bones on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepClampInternalBleeders = {$user} is clamping the internal bleeders on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepRemoveFeature = {$user} is amputating {$target}'s {$part}!
+surgery-popup-step-SurgeryStepCarefulIncisionScalpel = {$user} is carefully making an incision on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepRepairBruteTissue = {$user} is repairing the damaged tissues on {$target}'s {$part}!
+surgery-popup-step-SurgeryStepRepairBurnTissue = {$user} is repairing the burnt tissues on {$target}'s {$part}!
+surgery-popup-step-SurgeryStepSealTendWound = {$user} is sealing the wounds on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepInsertItem = {$user} is inserting something into {$target}'s {$part}!
+surgery-popup-step-SurgeryStepRemoveItem = {$user} is removing something from {$target}'s {$part}!
+
+surgery-popup-step-SurgeryStepRemoveOrgan = {$user} is removing an organ from {$target}'s {$part}!
+surgery-popup-step-SurgeryStepInsertOrgan = {$user} is inserting an organ into {$target}'s {$part}!
+
+surgery-popup-procedure-SurgeryRemoveBrain-step-SurgeryStepRemoveOrgan = {$user} is removing the brain from {$target}'s {$part}!
+surgery-popup-procedure-SurgeryRemoveHeart-step-SurgeryStepRemoveOrgan = {$user} is removing the heart from {$target}'s {$part}!
+surgery-popup-procedure-SurgeryRemoveLiver-step-SurgeryStepRemoveOrgan = {$user} is removing the liver from {$target}'s {$part}!
+surgery-popup-procedure-SurgeryRemoveLungs-step-SurgeryStepRemoveOrgan = {$user} is removing the lungs from {$target}'s {$part}!
+surgery-popup-procedure-SurgeryRemoveEyes-step-SurgeryStepRemoveOrgan = {$user} is removing the eyes from {$target}'s {$part}!
+surgery-popup-procedure-SurgeryRemoveStomach-step-SurgeryStepRemoveOrgan = {$user} is removing the stomach from {$target}'s {$part}!
+
+surgery-popup-procedure-SurgeryInsertBrain-step-SurgeryStepInsertOrgan = {$user} is inserting a brain into {$target}'s {$part}!
+surgery-popup-step-SurgeryStepInsertLungs = {$user} is inserting lungs into {$target}'s {$part}!
+surgery-popup-step-SurgeryStepInsertLiver = {$user} is inserting a liver into {$target}'s {$part}!
+surgery-popup-step-SurgeryStepInsertEyes = {$user} is inserting eyes into {$target}'s {$part}!
+surgery-popup-step-SurgeryStepInsertHeart = {$user} is inserting a heart into {$target}'s {$part}!
+surgery-popup-step-SurgeryStepInsertStomach = {$user} is inserting a stomach into {$target}'s {$part}!
+
+surgery-popup-step-SurgeryStepSealOrganWound = {$user} is sealing the wounds on {$target}'s {$part}.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
***Port of Einstein Engines PR https://github.com/Simple-Station/Einstein-Engines/pull/1241***

Adds popups for surgery steps in Shitmed that every player within PVS range can see.

## Why / Balance

This allows people other than the surgeon to see the steps being taken and see if the correct procedure is being performed. They will be alerted if it's the wrong type of surgery, e.g., if the surgeon promised to tend wounds but instead starts taking out the patient's brain.  

## Technical details

This adds new locale entries in [Resources/Locale/en-US/_Shitmed/surgery-popup.ftl](https://github.com/angelofallars/Goob-Station/blob/85ee8b9831e47fb68b3c4bae11ee351472b52863/Resources/Locale/en-US/_Shitmed/surgery-popup.ftl).

The format is `surgery-popup-step-<STEP_ID>` for a particular step or `surgery-popup-procedure-<PROCEDURE_ID>-step-<STEP_ID>` for a specific step **within** a procedure.

When finding a locale entry for a step, the code will attempt to find a procedure-specific step entry first before falling back to the generic step entry.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

**Remove Brain**

https://github.com/user-attachments/assets/f79b91c6-abbf-46f7-8517-2ef1a57ba3bc

**Amputate Left Leg**

https://github.com/user-attachments/assets/f3fdffc3-8be4-48d3-b860-47c0d8252fc5

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Skubman
- add: Surgery step descriptions (like making an incision, removing/attaching limbs and organs) are now shown as popups to everyone in range upon the start of the step. This makes it clear which surgical procedure is being done and to which body part. No more stealthy brain-stealing in front of everyone!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user feedback during surgical procedures with localized popup messages for various surgery steps.
	- Introduced new localization strings for actions related to surgical procedures, improving clarity and interaction.

- **Bug Fixes**
	- Improved logic for initiating surgery steps, ensuring accurate display of messages based on user actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->