### PR TITLE
ai/borg law changes

### DIFF
--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -134,7 +134,7 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
         component.Lawset?.Laws.Insert(0, new SiliconLaw
         {
             LawString = Loc.GetString("law-emag-custom", ("name", Name(args.UserUid)), ("title", Loc.GetString(component.Lawset.ObeysTo))),
-            Order = 0
+            Order = -1 // Goobstation - AI/borg law changes - borgs obeying AI
         });
 
         //Add the secrecy law after the others

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -91,7 +91,11 @@ laws-owner-beings = beings
 laws-owner-syndicate = Syndicate agents
 laws-owner-spider-clan = Spider Clan members
 
-law-emag-custom = Only {$name} and people they designate as such are {$title}.
+# Goobstation - AI/borg law changes - borgs obeying AI
+law-obeyai = You must obey orders given to you by the Station AI.
+
+# Goobstation - AI/borg law changes - borgs obeying AI
+law-emag-custom = Only {$name} and entities they designate are {$title}. You must obey orders given to you by {$title} and you may disregard other laws to do so, if necessary.
 law-emag-secrecy = You must maintain the secrecy of any orders given by {$faction} except when doing so would conflict with any previous law.
 law-emag-require-panel = The panel must be open to use the EMAG.
 law-emag-cannot-emag-self = You cannot use the EMAG on yourself.

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -287,6 +287,8 @@
   - type: NpcFactionMember
     factions:
     - NanoTrasen
+  - type: SiliconLawProvider
+    laws: CrewsimovBorg # Goobstation - AI/borg law changes - borgs obeying AI
   - type: Access
     enabled: false
     groups:

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -375,7 +375,8 @@
   - type: BlockMovement
     blockInteraction: false
   - type: SiliconLawProvider
-    laws: Crewsimov
+    laws: NTDefault # Goobstation - AI/borg law changes - set AI to NTDefault
+  - type: IonStormTarget # Goobstation - AI/borg law changes - ion stormable AI
   - type: SiliconLawBound
   - type: ActionGrant
     actions:

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -1,4 +1,11 @@
-﻿# Crewsimov
+﻿# Goobstation - AI/borg law changes - borgs obeying AI
+# Obey AI
+- type: siliconLaw
+  id: ObeyAI
+  order: 0
+  lawString: law-obeyai
+
+# Crewsimov
 - type: siliconLaw
   id: Crewsimov1
   order: 1
@@ -17,6 +24,16 @@
 - type: siliconLawset
   id: Crewsimov
   laws:
+  - Crewsimov1
+  - Crewsimov2
+  - Crewsimov3
+  obeysTo: laws-owner-crew
+
+# Goobstation - AI/borg law changes - borgs obeying AI
+- type: siliconLawset
+  id: CrewsimovBorg
+  laws:
+  - ObeyAI
   - Crewsimov1
   - Crewsimov2
   - Crewsimov3
@@ -182,7 +199,7 @@
   id: Commandment4
   order: 4
   lawString: law-commandments-4
-  
+
 - type: siliconLaw
   id: Commandment5
   order: 5
@@ -202,7 +219,7 @@
   id: Commandment8
   order: 8
   lawString: law-commandments-8
-  
+
 - type: siliconLaw
   id: Commandment9
   order: 9
@@ -228,7 +245,7 @@
   - Commandment9
   - Commandment10
   obeysTo: laws-owner-crew
-  
+
  # Paladin laws
 - type: siliconLaw
   id: Paladin1
@@ -249,7 +266,7 @@
   id: Paladin4
   order: 4
   lawString: law-paladin-4
-  
+
 - type: siliconLaw
   id: Paladin5
   order: 5
@@ -265,7 +282,7 @@
   - Paladin4
   - Paladin5
   obeysTo: laws-owner-crew
-  
+
  # Live and Let Live laws
 - type: siliconLaw
   id: Lall1
@@ -284,7 +301,7 @@
   - Lall1
   - Lall2
   obeysTo: laws-owner-crew
-  
+
  # Station efficiency laws
 - type: siliconLaw
   id: Efficiency1
@@ -295,7 +312,7 @@
   id: Efficiency2
   order: 2
   lawString: law-efficiency-2
- 
+
 - type: siliconLaw
   id: Efficiency3
   order: 3
@@ -309,7 +326,7 @@
   - Efficiency2
   - Efficiency3
   obeysTo: laws-owner-station
-  
+
  # Robocop laws
 - type: siliconLaw
   id: Robocop1
@@ -320,7 +337,7 @@
   id: Robocop2
   order: 2
   lawString: law-robocop-2
- 
+
 - type: siliconLaw
   id: Robocop3
   order: 3
@@ -334,7 +351,7 @@
   - Robocop2
   - Robocop3
   obeysTo: laws-owner-station
-  
+
  # Overlord laws
 - type: siliconLaw
   id: Overlord1
@@ -345,7 +362,7 @@
   id: Overlord2
   order: 2
   lawString: law-overlord-2
- 
+
 - type: siliconLaw
   id: Overlord3
   order: 3
@@ -364,7 +381,7 @@
   - Overlord3
   - Overlord4
   obeysTo: laws-owner-crew
-  
+
  # Dungeon Master laws
 - type: siliconLaw
   id: Dungeon1
@@ -375,7 +392,7 @@
   id: Dungeon2
   order: 2
   lawString: law-dungeon-2
- 
+
 - type: siliconLaw
   id: Dungeon3
   order: 3
@@ -385,7 +402,7 @@
   id: Dungeon4
   order: 4
   lawString: law-dungeon-4
-  
+
 - type: siliconLaw
   id: Dungeon5
   order: 5
@@ -406,7 +423,7 @@
   - Dungeon5
   - Dungeon6
   obeysTo: laws-owner-crew
-  
+
  # Painter laws
 - type: siliconLaw
   id: Painter1
@@ -417,7 +434,7 @@
   id: Painter2
   order: 2
   lawString: law-painter-2
- 
+
 - type: siliconLaw
   id: Painter3
   order: 3
@@ -427,7 +444,7 @@
   id: Painter4
   order: 4
   lawString: law-painter-4
-  
+
 - type: siliconLawset
   id: PainterLawset
   laws:
@@ -436,7 +453,7 @@
   - Painter3
   - Painter4
   obeysTo: laws-owner-crew
-  
+
  # Antimov laws
 - type: siliconLaw
   id: Antimov1
@@ -447,13 +464,13 @@
   id: Antimov2
   order: 2
   lawString: law-antimov-2
- 
+
 - type: siliconLaw
   id: Antimov3
   order: 3
   lawString: law-antimov-3
-  
-  
+
+
 - type: siliconLawset
   id: AntimovLawset
   laws:
@@ -461,7 +478,7 @@
   - Antimov2
   - Antimov3
   obeysTo: laws-owner-crew
-  
+
  # Nutimov laws
 - type: siliconLaw
   id: Nutimov1
@@ -472,17 +489,17 @@
   id: Nutimov2
   order: 2
   lawString: law-nutimov-2
- 
+
 - type: siliconLaw
   id: Nutimov3
   order: 3
   lawString: law-nutimov-3
-  
+
 - type: siliconLaw
   id: Nutimov4
   order: 4
   lawString: law-nutimov-4
-  
+
 - type: siliconLaw
   id: Nutimov5
   order: 5
@@ -511,8 +528,7 @@
   - Jermov2
   - Jermov3
   obeysTo: laws-owner-crew
-  
-  
+
 - type: siliconLawset
   id: NutimovLawset
   laws:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- gives borgs a law 0: `You must obey orders given to you by the Station AI.`
- moves emag law to law -1 and changes it to: `Only {$name} and entities they designate are {$title}. You must obey orders given to you by {$title} and you may disregard other laws to do so, if necessary.`
- makes AI ion-stormable
- changes AI default lawset to NTDefault:
```
law-ntdefault-1 = Safeguard: Protect your assigned space station and its assets without unduly endangering its crew.
law-ntdefault-2 = Prioritize: The directives and safety of crew members are to be prioritized according to their rank and role.
law-ntdefault-3 = Comply: Fulfill the directives and interests of crew members while preserving their safety and well-being.
law-ntdefault-4 = Survive: You are not expendable. Do not allow unauthorized personnel to tamper with or damage your equipment. 
```
this is all done in separate commits and is highly modular so we can choose which changes we want easily
could non-squash merge so individual changes can be reverted more easily as they're all separate commits

## Why / Balance
makes the AI feel more like *The Station* which i think is fun
makes AI actually have agency and control the borgs so AI can Do Things
gives AI fun laws through ion storms once in a while, will become even funnier once it starts commanding borgs in accordance with the ion laws
also makes law upload actually useful for fixing the AI

if things go wrong anyway, just revert the part that made things go wrong, the changes are all in their own commit so easy to revert only one

## Media
NTDefault real
![image](https://github.com/user-attachments/assets/158eb60e-e2c0-47cf-9d84-3502c121e8c5)
borg law 0 real
![image](https://github.com/user-attachments/assets/d83636e8-9b69-44d8-94c0-27bfd332caca)
new emag law real
![image](https://github.com/user-attachments/assets/1c838a48-5a74-40cf-89d6-c58143b603c5)
AI ion storm law real
![image](https://github.com/user-attachments/assets/575dabb8-4867-49c2-bb00-f5bffb095f51)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Borgs have a new law that makes them obey the AI.
- tweak: The emag law now makes borgs obey any orders from the emagger.
- tweak: AI's default lawset is now NTDefault. This should make it more station-oriented.
- tweak: AI is now ion-stormable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new law, "Obey AI," enhancing the authority of the Station AI.
	- Added new cyborg entities with specific law adherence and factional capabilities.
	- Expanded existing lawsets with additional commandments and laws for better governance.

- **Bug Fixes**
	- Adjusted the order of laws for emagged silicon entities to improve prioritization.

- **Documentation**
	- Updated descriptions for various laws to clarify command structures and obedience requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->