### PR TITLE
Vox Nanotrasen Representatives now spawn with a tank harness

### DIFF
--- a/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
@@ -1,6 +1,7 @@
 - type: roleLoadout
   id: JobNanotrasenRepresentative
   groups:
+  - GroupTankHarness
   - NanotrasenRepresentativeHead
   - NanotrasenRepresentativeJumpsuit
   - NanotrasenRepresentativeBackpack


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes #920 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Vox needs to breathe.

## Technical details
<!-- Summary of code changes for easier review. -->
Added the `GroupTankHarness` loadout group to the Nanotrasen Representative role loadout.

Note: The BSO is not given this loadout as the BSO can roundstart with outerwear that has a back slot. You can technically opt not to spawn with outerwear, but if given the harness, the BSO's outwear drops on the floor on spawn. This is the same reason the Captain doesn't have the `GroupTankHarness` - however the captain *cannot* spawn without at least the carapace. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Just imagine a Vox NT Rep with a tank harness on. Beautiful.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Vox NanoTrasen Representatives now spawn with a tank harness. Accounting found enough in the budget to outfit them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new group, `GroupTankHarness`, to the `JobNanotrasenRepresentative` role loadout.
  
- **Improvements**
	- Reformatted the `JobBlueshieldOfficer` loadout for better clarity by moving the `Survival` group to a new line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->