### PR TITLE
make vent critters rarer

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -17,11 +17,11 @@
     - id: MouseMigration
     - id: PowerGridCheck
     - id: RandomSentience
-    - id: SlimesSpawn
+    #- id: SlimesSpawn # GoobStation: remove vent critters because bad
     - id: SolarFlare
     - id: SnakeSpawn
     - id: SpiderClownSpawn
-    - id: SpiderSpawn
+    #- id: SpiderSpawn # GoobStation: remove vent critters because bad
     - id: VentClog
 
 - type: entityTable
@@ -363,7 +363,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 20
     minimumPlayers: 15
-    weight: 5
+    weight: 2 # GoobStation: less vent critters because bad
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -401,7 +401,7 @@
       path: /Audio/Announcements/aliens.ogg
     earliestStart: 20
     minimumPlayers: 20
-    weight: 1.5
+    weight: 0.5 # GoobStation: less vent critters because bad
     duration: 60
   - type: VentCrittersRule
     entries:

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -17,11 +17,11 @@
     - id: MouseMigration
     - id: PowerGridCheck
     - id: RandomSentience
-    #- id: SlimesSpawn # GoobStation: remove vent critters because bad
+    - id: SlimesSpawn
     - id: SolarFlare
     - id: SnakeSpawn
     - id: SpiderClownSpawn
-    #- id: SpiderSpawn # GoobStation: remove vent critters because bad
+    - id: SpiderSpawn
     - id: VentClog
 
 - type: entityTable
@@ -342,7 +342,7 @@
       path: /Audio/Announcements/aliens.ogg
     earliestStart: 20
     minimumPlayers: 15
-    weight: 5
+    weight: 0.5 # GoobStation: was 5, vent critters bad
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -363,7 +363,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 20
     minimumPlayers: 15
-    weight: 2 # GoobStation: less vent critters because bad
+    weight: 2 # GoobStation: was 5, critters because bad
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -384,7 +384,7 @@
       path: /Audio/Announcements/aliens.ogg
     earliestStart: 20
     minimumPlayers: 15
-    weight: 5
+    weight: 1 # GoobStation: was 1, vent critters bad
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -401,7 +401,7 @@
       path: /Audio/Announcements/aliens.ogg
     earliestStart: 20
     minimumPlayers: 20
-    weight: 0.5 # GoobStation: less vent critters because bad
+    weight: 0.5 # GoobStation: was 1.5, vent critters bad
     duration: 60
   - type: VentCrittersRule
     entries:


### PR DESCRIPTION
## About the PR
made all vent critters rarer

## Why / Balance
its just ass being an actual antag or fresh spawn and getting round removed by a cellular dealing simplemob or 180hp slipping ghost role

snakes are a bit more common than others since its a easy source of cryoxadone, and they dont deal fucking caustic and cellular

other events get weighted more meaning more good ghost roles instead of slimes #3695
ghost bar also exists if theres literally nothing

**Changelog**
:cl:
- remove: Vents contain less slimes, spiders and snakes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Gameplay Adjustments**
	- Commented out the `FalseAlarm` event, disabling it until further revisions.
	- Reduced occurrence likelihood for `SlimesSpawn`, `SnakeSpawn`, `SpiderSpawn`, `SpiderClownSpawn`, and `ZombieOutbreak` events, making them rarer to enhance gameplay balance.
	- Retained `LoneOpsSpawn` and `SleeperAgents` events, with potential future adjustments for balance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->