### PR TITLE
allow cloning living people

### DIFF
--- a/Content.Server/Cloning/CloningConsoleSystem.cs
+++ b/Content.Server/Cloning/CloningConsoleSystem.cs
@@ -213,7 +213,7 @@ namespace Content.Server.Cloning
                 {
                     scanBodyInfo = MetaData(scanBody.Value).EntityName;
 
-                    if (!_mobStateSystem.IsDead(scanBody.Value))
+                    if (false) // GoobStation: Lets you clone living people
                     {
                         clonerStatus = ClonerStatus.ScannerOccupantAlive;
                     }

--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -144,7 +144,8 @@ namespace Content.Server.Cloning
                 return false;
 
             var mind = mindEnt.Comp;
-            if (ClonesWaitingForMind.TryGetValue(mind, out var clone))
+            // GoobStation: Remove this logic entirely, infinite clone army
+            /*if (ClonesWaitingForMind.TryGetValue(mind, out var clone))
             {
                 if (EntityManager.EntityExists(clone) &&
                     !_mobStateSystem.IsDead(clone) &&
@@ -153,10 +154,11 @@ namespace Content.Server.Cloning
                     return false; // Mind already has clone
 
                 ClonesWaitingForMind.Remove(mind);
-            }
+            }*/
 
-            if (mind.OwnedEntity != null && !_mobStateSystem.IsDead(mind.OwnedEntity.Value))
-                return false; // Body controlled by mind is not dead
+            // GoobStation: Lets you clone living people
+            //if (mind.OwnedEntity != null && !_mobStateSystem.IsDead(mind.OwnedEntity.Value))
+            //    return false; // Body controlled by mind is not dead
 
             // Yes, we still need to track down the client because we need to open the Eui
             if (mind.UserId == null || !_playerManager.TryGetSessionById(mind.UserId.Value, out var client))
@@ -223,7 +225,7 @@ namespace Content.Server.Cloning
             cloneMindReturn.Mind = mind;
             cloneMindReturn.Parent = uid;
             _containerSystem.Insert(mob, clonePod.BodyContainer);
-            ClonesWaitingForMind.Add(mind, mob);
+            //ClonesWaitingForMind.Add(mind, mob); // GoobStation
             UpdateStatus(uid, CloningPodStatus.NoMind, clonePod);
             _euiManager.OpenEui(new AcceptCloningEui(mindEnt, mind, this), client);
 


### PR DESCRIPTION
## About the PR
title

## Why / Balance
this is already possible with surgery, just makes it less annoying and why should it require you to be dead first anyway

next step: emag cloning pod to be able to clone anything like carp and shit, new syndie strat make infinite fish

## Technical details
removed the requirement for the target to be dead
removed the logic for limiting clones to 1

## Media
new gamer after saying no to the cloning popup
![09:41:13](https://github.com/user-attachments/assets/0ff1ac75-bc4b-4c6a-8d9b-64fcbbd05269)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: You can now clone living people.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Cloning process now allows cloning of living entities, removing previous restrictions related to entity state.
	- Simplified logic for managing clones and mind transfers during the cloning process.

- **Bug Fixes**
	- Resolved issues preventing the cloning of entities controlled by a mind that is not dead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->