### PR TITLE
Remove nuclear ops evac lockdown

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -326,25 +326,8 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
                     ev.Reason = Loc.GetString("war-ops-shuttle-call-unavailable");
                     return;
                 }
-
-                // goob edit - can't call evac while nukies are present on the station
-                if (operatives.Any(op => _stationSystem.GetOwningStation(op.Item1.Owner) != null))
-                {
-                    ev.Cancelled = true;
-                    ev.Reason = Loc.GetString("shuttle-call-warops-nukies-present");
-                    return;
-                }
             }
 
-            // goob edit - can't call evac while nukies are present on the station
-            // during stealth ops this might become a problem
-            // but an error in the shuttle call must mean something bad is coming so it's probably a sign to go witch hunting
-            if (operatives.Any(op => _stationSystem.GetOwningStation(op.Item1.Owner) != null))
-            {
-                ev.Cancelled = true;
-                ev.Reason = Loc.GetString("shuttle-call-error");
-                return;
-            }
         }
     }
 

--- a/Resources/Locale/en-US/nukeops/nuke-ops.ftl
+++ b/Resources/Locale/en-US/nukeops/nuke-ops.ftl
@@ -1,4 +1,4 @@
 ## goob edit: no more nukie auto shuttle call
 
-nuke-ops-no-more-threat-announcement-shuttle-call = Based on our scans from our long-range sensors, the nuclear threat is now eliminated. Emergency shuttle lockdown is now lifted.
-nuke-ops-no-more-threat-announcement = Based on our scans from our long-range sensors, the nuclear threat is now eliminated. Emergency shuttle lockdown is now lifted.
+nuke-ops-no-more-threat-announcement-shuttle-call = Based on our scans from our long-range sensors, the nuclear threat is now eliminated.
+nuke-ops-no-more-threat-announcement = Based on our scans from our long-range sensors, the nuclear threat is now eliminated.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removes evac lockdown if there's nukies(Does not effect warops announcement)

## Why / Balance
I've seen this create a lot of problems multiple times.  It removes player agency and gives nukies way too much power during the round. Often causing the crew to be held hostage to some solo flukie. Also creates more admin work than its worth no doubt.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl: 
- remove: Nuclear Operative evacuation lockdown


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced control over shuttle operations during nuclear operative presence.
	- Simplified round-ending announcements focusing on nuclear threat elimination.

- **Bug Fixes**
	- Removed redundant references to shuttle lockdown in threat announcements for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->