### PR TITLE
Fixed Sawn-off not being Contraband

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -181,7 +181,7 @@
 
 - type: entity
   name: sawn-off shotgun
-  parent: BaseWeaponShotgun
+  parent: [BaseWeaponShotgun, BaseMinorContraband]
   id: WeaponShotgunSawn
   description: Groovy! Uses .50 shotgun shells.
   components:


### PR DESCRIPTION
## About the PR
Makes the sawn off contraband (double barrel is so this should be aswell)

:cl:
- fix: Fixed Sawn-off Shotguns not being correctly marked as contraband



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new shotgun entities and variants, enhancing gameplay mechanics.
	- Updated shotgun entities with additional components for better management of attributes and classifications.

- **Bug Fixes**
	- Adjusted parent-child relationships for various shotgun entities to improve functionality and accuracy. 

- **Refactor**
	- Restructured shotgun entity configurations to accommodate new gameplay mechanics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->