### PR TITLE
Add BaseIntercom ConstructionComponent containers

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/intercom.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/intercom.yml
@@ -80,6 +80,9 @@
   - type: Construction
     graph: Intercom
     node: intercom
+    containers:
+    - board
+    - key_slots
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: StructuralMetallic


### PR DESCRIPTION
## About the PR
Secure intercoms no longer destroy their encryption keys when the secure panel is removed. Allowing Command and Security keys to be extracted.

## Why / Balance
Saw it listed as an open issue / minor-bug
https://github.com/Goob-Station/Goob-Station/issues/705

## Technical details
Added key_slots and board container names to BaseIntercom ConstructionComponent prototype. So that ConstructionSystem::ChangeEntity tracks and transfers the inventory of BaseIntercomSecure (intercomReinforced construction node) prototypes when deconstructed into IntercomConstructed (intercom construction node). 

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: procdox (pb_ozai)
- fix: Secure Intercoms no longer destroy encryption keys when the secure panel is removed.
