### PR TITLE
Make pointing faster

### DIFF
--- a/Content.Server/Pointing/EntitySystems/PointingSystem.cs
+++ b/Content.Server/Pointing/EntitySystems/PointingSystem.cs
@@ -44,7 +44,7 @@ namespace Content.Server.Pointing.EntitySystems
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
         [Dependency] private readonly ExamineSystemShared _examine = default!;
 
-        private TimeSpan _pointDelay = TimeSpan.FromSeconds(0.5f);
+        private TimeSpan _pointDelay = TimeSpan.FromSeconds(0.2f);
 
         /// <summary>
         ///     A dictionary of players to the last time that they

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2427,7 +2427,7 @@ namespace Content.Shared.CCVar
         ///     The number of seconds that must pass for a single entity to be able to point at something again.
         /// </summary>
         public static readonly CVarDef<float> PointingCooldownSeconds =
-            CVarDef.Create("pointing.cooldown_seconds", 0.5f, CVar.SERVERONLY);
+            CVarDef.Create("pointing.cooldown_seconds", 0.2f, CVar.SERVERONLY);
 
         /// <summary>
         ///     Should the player automatically get up after being knocked down


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I changed the minimum point delay to 0.2 seconds.

## Why / Balance
TG (:godo:)

## Technical details
Change server _pointDelay.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Your kneecaps. They will break.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: router
- tweak: Players can now point 2.5x as fast (every 200ms).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Reduced cooldown for pointing actions from 0.5 seconds to 0.2 seconds, allowing players to point more frequently.
	- Introduced dynamic configuration for pointing cooldown, enabling runtime adjustments without code changes.
  
These enhancements improve player interaction and responsiveness during gameplay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->