### PR TITLE
Ebow tweaks attempt 2

### DIFF
--- a/Content.Shared/Eye/Blinding/Components/BlurryVisionComponent.cs
+++ b/Content.Shared/Eye/Blinding/Components/BlurryVisionComponent.cs
@@ -15,13 +15,13 @@ public sealed partial class BlurryVisionComponent : Component
     ///     Amount of "blurring". Also modifies examine ranges.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("magnitude"), AutoNetworkedField]
-    public float Magnitude;
+    public float Magnitude = 4f; // Goobstation
 
     /// <summary>
     ///     Exponent that controls the magnitude of the effect.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("correctionPower"), AutoNetworkedField]
-    public float CorrectionPower;
+    public float CorrectionPower = 2f; // Goobstation
 
     public const float MaxMagnitude = 6;
     public const float DefaultCorrectionPower = 2f;

--- a/Content.Shared/_White/Blur/BlurOnCollideComponent.cs
+++ b/Content.Shared/_White/Blur/BlurOnCollideComponent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared._White.Collision.Blur;
+
+[RegisterComponent]
+public sealed partial class BlurOnCollideComponent : Component
+{
+    [DataField]
+    public float BlurTime = 10f;
+}

--- a/Content.Shared/_White/Blur/BlurOnCollideComponent.cs
+++ b/Content.Shared/_White/Blur/BlurOnCollideComponent.cs
@@ -4,5 +4,5 @@ namespace Content.Shared._White.Collision.Blur;
 public sealed partial class BlurOnCollideComponent : Component
 {
     [DataField]
-    public float BlurTime = 10f;
+    public float BlurTime = 5f;
 }

--- a/Content.Shared/_White/Blur/BlurOnCollideSystem.cs
+++ b/Content.Shared/_White/Blur/BlurOnCollideSystem.cs
@@ -1,0 +1,37 @@
+using Content.Shared.Eye.Blinding.Components;
+using Content.Shared.Projectiles;
+using Content.Shared.StatusEffect;
+using Content.Shared.Throwing;
+
+namespace Content.Shared._White.Collision.Blur;
+
+public sealed class BlurOnCollideSystem : EntitySystem
+{
+    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BlurOnCollideComponent, ProjectileHitEvent>(OnProjectileHit);
+        SubscribeLocalEvent<BlurOnCollideComponent, ThrowDoHitEvent>(OnEntityHit);
+    }
+
+    private void OnEntityHit(Entity<BlurOnCollideComponent> ent, ref ThrowDoHitEvent args)
+    {
+        ApplyEffects(args.Target, ent.Comp);
+    }
+
+    private void OnProjectileHit(Entity<BlurOnCollideComponent> ent, ref ProjectileHitEvent args)
+    {
+        ApplyEffects(args.Target, ent.Comp);
+    }
+
+    private void ApplyEffects(EntityUid target, BlurOnCollideComponent component)
+    {
+        _statusEffects.TryAddStatusEffect<BlurryVisionComponent>(target,
+            "BlurryVision",
+            TimeSpan.FromSeconds(component.BlurTime),
+            true);
+    }
+}

--- a/Content.Shared/_White/Knockdown/KnockdownOnCollideComponent.cs
+++ b/Content.Shared/_White/Knockdown/KnockdownOnCollideComponent.cs
@@ -1,0 +1,10 @@
+using Content.Shared._White.Standing;
+
+namespace Content.Shared._White.Collision.Knockdown;
+
+[RegisterComponent]
+public sealed partial class KnockdownOnCollideComponent : Component
+{
+    [DataField]
+    public DropHeldItemsBehavior Behavior = DropHeldItemsBehavior.NoDrop;
+}

--- a/Content.Shared/_White/Knockdown/KnockdownOnCollideSystem.cs
+++ b/Content.Shared/_White/Knockdown/KnockdownOnCollideSystem.cs
@@ -1,0 +1,33 @@
+using Content.Shared.Projectiles;
+using Content.Shared._White.Standing;
+using Content.Shared.Throwing;
+
+namespace Content.Shared._White.Collision.Knockdown;
+
+public sealed class KnockdownOnCollideSystem : EntitySystem
+{
+    [Dependency] private readonly SharedLayingDownSystem _layingDown = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<KnockdownOnCollideComponent, ProjectileHitEvent>(OnProjectileHit);
+        SubscribeLocalEvent<KnockdownOnCollideComponent, ThrowDoHitEvent>(OnEntityHit);
+    }
+
+    private void OnEntityHit(Entity<KnockdownOnCollideComponent> ent, ref ThrowDoHitEvent args)
+    {
+        ApplyEffects(args.Target, ent.Comp);
+    }
+
+    private void OnProjectileHit(Entity<KnockdownOnCollideComponent> ent, ref ProjectileHitEvent args)
+    {
+        ApplyEffects(args.Target, ent.Comp);
+    }
+
+    private void ApplyEffects(EntityUid target, KnockdownOnCollideComponent component)
+    {
+        _layingDown.TryLieDown(target, null, null, component.Behavior);
+    }
+}

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -86,6 +86,11 @@
     Telecrystal: 50
   categories:
   - UplinkWeaponry
+  conditions:
+  - !type:StoreWhitelistCondition
+    blacklist:
+      tags:
+      - NukeOpsUplink
 
 - type: listing
   id: UplinkBowHardlight

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -12,8 +12,11 @@
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
   - type: Gun
+    resetOnHandSelected: false
     soundGunshot:
       path: /Audio/_Goobstation/Weapons/Guns/Gunshots/heavy_shot_suppressed.ogg
+      params:
+        volume: -10
   - type: ProjectileBatteryAmmoProvider
     proto: BulletMic
     fireCost: 900
@@ -24,8 +27,6 @@
     magState: mag
     steps: 2
     zeroVisible: true
-  - type: Multishot
-    spreadMultiplier: 1.2
 
 - type: entity
   name: Plasma Rifle

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -16,17 +16,19 @@
     soundGunshot:
       path: /Audio/_Goobstation/Weapons/Guns/Gunshots/heavy_shot_suppressed.ogg
       params:
-        volume: -10
+        volume: -5
   - type: ProjectileBatteryAmmoProvider
     proto: BulletMic
     fireCost: 900
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 400
+    autoRechargeRate: 300
   - type: MagazineVisuals
     magState: mag
     steps: 2
     zeroVisible: true
+  - type: Multishot
+    spreadMultiplier: 1.2
 
 - type: entity
   name: Plasma Rifle

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -10,15 +10,29 @@
     sprite: _Goobstation/Objects/Weapons/Guns/Projectiles/cbbolt.rsi
     layers:
     - state: cbbolt
-  - type: GatheringProjectile
   - type: Projectile
     damage:
       types:
-        Heat: 10
+        Heat: 15
   - type: TimedDespawn
     lifetime: 0.4
-  - type: StaminaDamageOnCollide
-    damage: 65
+  - type: Ammo
+    muzzleFlash: null
+  - type: Reflective
+    reflective:
+    - Energy
+  - type: Fixtures
+    fixtures:
+      projectile:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.05,-0.05,0.05,0.05"
+        hard: false
+        mask:
+        - Opaque
+  - type: KnockdownOnCollide
+    behavior: AlwaysDrop
+  - type: BlurOnCollide
 
 - type: entity
   id: BulletPlasmaCutter

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -31,7 +31,7 @@
         mask:
         - Opaque
   - type: KnockdownOnCollide
-    behavior: AlwaysDrop
+    behavior: DropIfStanding
   - type: BlurOnCollide
 
 - type: entity

--- a/Resources/Prototypes/_Goobstation/status_effects.yml
+++ b/Resources/Prototypes/_Goobstation/status_effects.yml
@@ -13,3 +13,7 @@
 
 - type: statusEffect
   id: Brainrotted
+
+- type: statusEffect
+  id: BlurryVision
+  alwaysAllowed: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

[this](https://github.com/Goob-Station/Goob-Station/pull/912)  but bow has reduced fire rate and makes a person drop item on hit only if they are standing. Blur time reduced to 5 seconds and readded multishot component so it's usable with pistols.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Ebow is supposed to be good with esword! Currently it's not even worth 50 tc. Also hardlight bow has disabler firing mode so stamina damage on crossbow is not needed.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- add: Mini energy crossbow now deals no stamina damage. Instead it knocks down target, forces them to drop items they are holding and blurs vision for 5 seconds. It is now much quieter.
- add: Mini energy crossbow projectiles now pierce through glass, they also can be reflected by energy reflectors. Damage increased: 10 -> 15.
- remove: Removed mini ebow from nukie uplink.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced the `BlurOnCollideComponent` and `KnockdownOnCollideComponent`, enhancing gameplay with new collision effects.
	- Added `BlurOnCollideSystem` and `KnockdownOnCollideSystem` to manage visual impairment and knockdown effects during collisions.
	- New status effect "BlurryVision" added, providing players with additional gameplay dynamics.
	- Updated item listings in the uplink catalog to refine access control based on user roles.

- **Improvements**
	- Adjusted default values for the `BlurryVisionComponent` to enhance visual effects.
	- Modified projectile entities to include new behaviors and increased damage types for enhanced combat mechanics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->