### PR TITLE
make any sharp item a ghetto surgery tool

### DIFF
--- a/Content.Server/Kitchen/Components/SharpComponent.cs
+++ b/Content.Server/Kitchen/Components/SharpComponent.cs
@@ -12,4 +12,16 @@ public sealed partial class SharpComponent : Component
 
     [DataField("butcherDelayModifier")]
     public float ButcherDelayModifier = 1.0f;
+
+    /// <summary>
+    /// Shitmed: Whether this item had <c>ScalpelComponent</c> before sharp was added.
+    /// </summary>
+    [DataField]
+    public bool HadScalpel;
+
+    /// <summary>
+    /// Shitmed: Whether this item had <c>BoneSawComponent</c> before sharp was added.
+    /// </summary>
+    [DataField]
+    public bool HadBoneSaw;
 }

--- a/Content.Server/_Shitmed/Medical/Surgery/GhettoSurgerySystem.cs
+++ b/Content.Server/_Shitmed/Medical/Surgery/GhettoSurgerySystem.cs
@@ -1,0 +1,50 @@
+using Content.Server.Kitchen.Components;
+using Content.Shared._Shitmed.Medical.Surgery.Tools;
+
+namespace Content.Server._Shitmed.Medical.Surgery;
+
+/// <summary>
+/// Makes all sharp things usable for incisions and sawing through bones, though worse than any other kind of ghetto analogue.
+/// </summary>
+public sealed partial class GhettoSurgerySystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SharpComponent, MapInitEvent>(OnSharpInit);
+        SubscribeLocalEvent<SharpComponent, ComponentShutdown>(OnSharpShutdown);
+    }
+
+    private void OnSharpInit(Entity<SharpComponent> ent, ref MapInitEvent args)
+    {
+        if (EnsureComp<ScalpelComponent>(ent, out var scalpel))
+        {
+            ent.Comp.HadScalpel = true;
+        }
+        else
+        {
+            scalpel.Speed = 0.3f;
+            Dirty(ent.Owner, scalpel);
+        }
+
+        if (EnsureComp<BoneSawComponent>(ent, out var saw))
+        {
+            ent.Comp.HadBoneSaw = true;
+        }
+        else
+        {
+            saw.Speed = 0.2f;
+            Dirty(ent.Owner, saw);
+        }
+    }
+
+    private void OnSharpShutdown(Entity<SharpComponent> ent, ref ComponentShutdown args)
+    {
+        if (ent.Comp.HadScalpel)
+            RemComp<ScalpelComponent>(ent);
+
+        if (ent.Comp.HadBoneSaw)
+            RemComp<BoneSawComponent>(ent);
+    }
+}

--- a/Content.Shared/_Shitmed/Surgery/Tools/BoneSawComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Tools/BoneSawComponent.cs
@@ -2,11 +2,11 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared._Shitmed.Medical.Surgery.Tools;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class BoneSawComponent : Component, ISurgeryToolComponent
 {
     public string ToolName => "a bone saw";
     public bool? Used { get; set; } = null;
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float Speed { get; set; } = 1f;
 }

--- a/Content.Shared/_Shitmed/Surgery/Tools/ScalpelComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Tools/ScalpelComponent.cs
@@ -2,11 +2,11 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared._Shitmed.Medical.Surgery.Tools;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ScalpelComponent : Component, ISurgeryToolComponent
 {
     public string ToolName => "a scalpel";
     public bool? Used { get; set; } = null;
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float Speed { get; set; } = 1f;
 }


### PR DESCRIPTION
## About the PR
30% scalpel and 20% bonesaw
does nothing if it already has those qualities (so esword is still better scalpel)
havent tested yet but it should work:tm:

## Why / Balance
salv can now do ghetto organ transplants roundstart :trollface::trollface::trollface::trollface::trollface::trollface::trollface::trollface::trollface:

## Technical details
networked scalpel and bonesaw speeds so the server can change them

## Media


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Any sharp object can now be used as a ghetto scalpel or bone saw.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `GhettoSurgerySystem` for managing surgical tools, allowing for incisions and bone sawing with substandard implements.
	- Added new boolean fields to track the presence of scalpel and bone saw components in the `SharpComponent`.

- **Enhancements**
	- Updated `BoneSawComponent` and `ScalpelComponent` to support automatic state synchronization over the network.

These changes improve the surgical tool management and enhance the networked functionality of components within the game.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->