### PR TITLE
Fix Pvs Serialization bug caused by amputations.

### DIFF
--- a/Content.Shared/Body/Components/BodyComponent.cs
+++ b/Content.Shared/Body/Components/BodyComponent.cs
@@ -4,6 +4,9 @@ using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Content.Shared.Body.Organ;
+using Content.Shared.Body.Part;
+using Content.Shared._Shitmed.Body.Part;
 
 namespace Content.Shared.Body.Components;
 
@@ -11,6 +14,10 @@ namespace Content.Shared.Body.Components;
 [Access(typeof(SharedBodySystem))]
 public sealed partial class BodyComponent : Component
 {
+    public HashSet<OrganComponent> OriginalOrgans = new();
+    public HashSet<BodyPartComponent> OriginalBodyParts = new();
+    public HashSet<BodyPartAppearanceComponent> OriginalAppearances = new();
+
     /// <summary>
     /// Relevant template to spawn for this body.
     /// </summary>

--- a/Content.Shared/Body/Organ/OrganComponent.cs
+++ b/Content.Shared/Body/Organ/OrganComponent.cs
@@ -18,9 +18,10 @@ public sealed partial class OrganComponent : Component, ISurgeryToolComponent //
 
     /// <summary>
     ///     Shitmed Change:Relevant body this organ originally belonged to.
-    ///     FOR WHATEVER FUCKING REASON AUTONETWORKING THIS CRASHES GIBTEST AAAAAAAAAAAAAAA
+    ///     DO NOT set directly, use the SetOrganOriginalBody method, it does
+    ///     additional book-keeping to prevent stale entity references
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public EntityUid? OriginalBody;
 
     // Shitmed Change Start

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -130,7 +130,7 @@ public partial class SharedBodySystem
         // This should already handle adding the entity to the root.
         var rootPartUid = SpawnInContainerOrDrop(protoRoot.Part, bodyEntity, BodyRootContainerId);
         var rootPart = Comp<BodyPartComponent>(rootPartUid);
-        rootPart.OriginalBody = bodyEntity; // Shitmed Change
+        SetPartOriginalBody(rootPart, bodyEntity); // Shitmed Change
         rootPart.Body = bodyEntity;
         Dirty(rootPartUid, rootPart);
 
@@ -187,7 +187,7 @@ public partial class SharedBodySystem
                 var partSlot = CreatePartSlot(parentEntity, connection, childPartComponent.PartType, parentPartComponent);
                 // Shitmed Change Start
                 childPartComponent.ParentSlot = partSlot;
-                childPartComponent.OriginalBody = rootPart.Body;
+                SetPartOriginalBody(childPartComponent, rootPart.Body);
                 Dirty(childPart, childPartComponent);
                 // Shitmed Change End
                 var cont = Containers.GetContainer(parentEntity, GetPartSlotContainerId(connection));

--- a/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
@@ -354,7 +354,7 @@ public partial class SharedBodySystem
         Dirty(partEnt, partEnt.Comp);
 
         // Shitmed Change Start
-        SetPartOriginalBody(partEnt.Comp.OriginalBody, partEnt.Comp.Body);
+        SetPartOriginalBody(partEnt.Comp, partEnt.Comp.Body);
         if (partEnt.Comp.Body is { Valid: true } body)
             RaiseLocalEvent(partEnt, new BodyPartComponentsModifyEvent(body, false));
         partEnt.Comp.ParentSlot = null;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Add tracking of "original body" assignment to bodypart, organ, and bodypartappearance components. Clearing the fields on the limbs when the body assigned is deleted.

## Why / Balance
This was one of the sources of  ```Can't resolve "Robust.Shared.GameObjects.MetaDataComponent"```
errors in the logs that I was given.

## Technical details
<!-- Summary of code changes for easier review. -->
The error was caused by references to bodyparts orginal bodies becoming stale when the og body was deleted.
I added component hashsets for each of the components on bodies that tracks parts that are claiming it as their og.
The issue can be reproduced by amputating a limb then gibbing the body. (Note that debug deleting the body does not provoke the error, you have to use "IC " methods to delete it.)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: server side serialization bug caused by amputations
