### PR TITLE
Uplink stuff & war tweaks

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -66,12 +66,24 @@ public sealed partial class NukeopsRuleComponent : Component
     public int WarTcAmountPerNukie = 200;
 
     // Goobstation start
+    /// <summary>
+    /// The ratio of players per nuclear operative for war declaration scaling.
+    /// Example: A value of 10 means one operative per 10 players.
+    /// </summary>
     [DataField]
     public int WarNukiePlayerRatio = 10;
 
+    /// <summary>
+    /// Additional telecrystals granted per player on the server during war.
+    /// Total bonus is divided by number of operatives.
+    /// </summary>
     [DataField]
     public int WarTcPerPlayer = 20;
 
+    /// <summary>
+    /// Compensation telecrystals granted per missing nuclear operative.
+    /// Total bonus is divided by number of operatives.
+    /// </summary>
     [DataField]
     public int WarTcPerNukieMissing = 200;
     // Goobstation end

--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -65,6 +65,17 @@ public sealed partial class NukeopsRuleComponent : Component
     [DataField]
     public int WarTcAmountPerNukie = 200;
 
+    // Goobstation start
+    [DataField]
+    public int WarNukiePlayerRatio = 10;
+
+    [DataField]
+    public int WarTcPerPlayer = 20;
+
+    [DataField]
+    public int WarTcPerNukieMissing = 200;
+    // Goobstation end
+
     /// <summary>
     ///     Delay between war declaration and nuke ops arrival on station map. Gives crew time to prepare
     /// </summary>
@@ -75,7 +86,7 @@ public sealed partial class NukeopsRuleComponent : Component
     ///     Minimal operatives count for war declaration
     /// </summary>
     [DataField]
-    public int WarDeclarationMinOps = 4;
+    public int WarDeclarationMinOps = 2;
 
     [DataField]
     public WinType WinType = WinType.Neutral;

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -388,7 +388,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         var enumerator = EntityQueryEnumerator<StoreComponent>();
         while (enumerator.MoveNext(out var uid, out var component))
         {
-            if (!_tag.HasTag(uid, NukeOpsUplinkTagPrototype) || _tag.HasTag(uid, NukeOpsReinforcementUplinkTagPrototype)) // Goob edit
+            if (!_tag.HasTag(uid, NukeOpsUplinkTagPrototype) || _tag.HasTag(uid, NukeOpsReinforcementUplinkTagPrototype)) // Goob edit - no tc for reinforcements
                 continue;
 
             if (GetOutpost(nukieRule.Owner) is not { } outpost)
@@ -407,6 +407,8 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
     private int CalculateBonusTcPerNukie(NukeopsRuleComponent rule) // Goobstation
     {
         var nukiesCount = EntityQuery<NukeopsRoleComponent>().Count();
+        if (nukiesCount == 0)
+            return rule.WarTcAmountPerNukie;
         var playersCount = Math.Max(0, _playerManager.Sessions.Length - nukiesCount);
         var maxNukies = playersCount / rule.WarNukiePlayerRatio;
         var nukiesMissing = Math.Max(0, maxNukies - nukiesCount);

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -52,6 +52,9 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
     [ValidatePrototypeId<TagPrototype>]
     private const string NukeOpsUplinkTagPrototype = "NukeOpsUplink";
 
+    [ValidatePrototypeId<TagPrototype>]
+    private const string NukeOpsReinforcementUplinkTagPrototype = "NukeOpsReinforcementUplink"; // Goobstation
+
     public override void Initialize()
     {
         base.Initialize();
@@ -385,7 +388,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         var enumerator = EntityQueryEnumerator<StoreComponent>();
         while (enumerator.MoveNext(out var uid, out var component))
         {
-            if (!_tag.HasTag(uid, NukeOpsUplinkTagPrototype))
+            if (!_tag.HasTag(uid, NukeOpsUplinkTagPrototype) || _tag.HasTag(uid, NukeOpsReinforcementUplinkTagPrototype)) // Goob edit
                 continue;
 
             if (GetOutpost(nukieRule.Owner) is not { } outpost)

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -27,6 +27,7 @@ using System.Linq;
 using Content.Shared.Store.Components;
 using Content.Server.Station.Systems;
 using Content.Server.Chat.Systems;
+using Robust.Server.Player;
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -42,6 +43,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
     // goob edit
     [Dependency] private readonly StationSystem _stationSystem = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
     // goob edit end
 
     [ValidatePrototypeId<CurrencyPrototype>]
@@ -392,11 +394,22 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
             if (Transform(uid).MapID != Transform(outpost).MapID) // Will receive bonus TC only on their start outpost
                 continue;
 
-            _store.TryAddCurrency(new() { { TelecrystalCurrencyPrototype, nukieRule.Comp.WarTcAmountPerNukie } }, uid, component);
+            _store.TryAddCurrency(new() { { TelecrystalCurrencyPrototype, CalculateBonusTcPerNukie(nukieRule.Comp) } }, uid, component); // Goob edit
 
             var msg = Loc.GetString("store-currency-war-boost-given", ("target", uid));
             _popupSystem.PopupEntity(msg, uid);
         }
+    }
+
+    private int CalculateBonusTcPerNukie(NukeopsRuleComponent rule) // Goobstation
+    {
+        var nukiesCount = EntityQuery<NukeopsRoleComponent>().Count();
+        var playersCount = Math.Max(0, _playerManager.Sessions.Length - nukiesCount);
+        var maxNukies = playersCount / rule.WarNukiePlayerRatio;
+        var nukiesMissing = Math.Max(0, maxNukies - nukiesCount);
+        var totalBonus = playersCount * rule.WarTcPerPlayer;
+        totalBonus += nukiesMissing * rule.WarTcPerNukieMissing;
+        return Math.Max(rule.WarTcAmountPerNukie, totalBonus / nukiesCount);
     }
 
     private void SetWinType(Entity<NukeopsRuleComponent> ent, WinType type, bool endRound = true)

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -85,6 +85,18 @@
 
 - type: entity
   parent: BaseUplinkRadio
+  id: BaseUplinkRadio50TCNukeOps
+  suffix: 50 TC, NukeOps reinforcement
+  components:
+  - type: Store
+    balance:
+      Telecrystal: 50
+  - type: Tag
+    tags:
+    - NukeOpsUplink
+
+- type: entity
+  parent: BaseUplinkRadio
   # Goobstation - Telecrystal rework
   id: BaseUplinkRadio100TC
   suffix: 100 TC
@@ -125,6 +137,7 @@
   - type: Tag
     tags:
     - NukeOpsUplink
+    - NukeOpsCommanderUplink
 
 - type: entity
   parent: BaseUplinkRadio

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -94,6 +94,7 @@
   - type: Tag
     tags:
     - NukeOpsUplink
+    - NukeOpsReinforcementUplink
 
 - type: entity
   parent: BaseUplinkRadio

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -79,13 +79,14 @@
 #Nuclear Operative Medic Gear
 - type: startingGear
   id: SyndicateOperativeMedicFull
-  parent: SyndicateOperativeGearFull
+  parent: SyndicateOperativeGearFullNoUplink
   equipment:
     eyes: ClothingEyesHudSyndicateAgent
     #outerClothing: ClothingOuterHardsuitSyndieMedic # goobstation - duke nukies
     shoes: ClothingShoesBootsMagSyndie
     id: SyndiAgentPDA
     belt: ClothingBeltMilitaryWebbingMedFilled
+    pocket2: BaseUplinkRadio225TCMedic
   storage:
     back:
     - SyndiHypo

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -115,6 +115,13 @@
     Telecrystal: 55 # novelty item for the larp
   categories:
   - UplinkWearables
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsMedicUplink
+  - !type:ListingLimitedStockCondition
+    stock: 1
 
 
 - type: listing
@@ -127,6 +134,13 @@
     Telecrystal: 100 # novelty item for the larp, doesnt come with bundle though because bulky fuck
   categories:
   - UplinkWearables
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsCommanderUplink
+  - !type:ListingLimitedStockCondition
+    stock: 1
 
 
 - type: listing

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/syndicate.yml
@@ -82,3 +82,16 @@
   - type: Tag
     tags:
     - NukeOpsUplink
+
+- type: entity
+  parent: BaseUplinkRadio
+  id: BaseUplinkRadio225TCMedic
+  suffix: 225 TC, NukeOps medic
+  components:
+  - type: Store
+    balance:
+      Telecrystal: 225
+  - type: Tag
+    tags:
+    - NukeOpsUplink
+    - NukeOpsMedicUplink

--- a/Resources/Prototypes/_Goobstation/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Antags/nukeops.yml
@@ -9,4 +9,4 @@
   id: SyndicateOperativeReinforcementGear
   parent: SyndicateOperativeGearFullNoUplink
   equipment:
-    pocket2: BaseUplinkRadio50TC
+    pocket2: BaseUplinkRadio50TCNukeOps

--- a/Resources/Prototypes/_Goobstation/tags.yml
+++ b/Resources/Prototypes/_Goobstation/tags.yml
@@ -6,3 +6,9 @@
 
 - type: Tag
   id: CartridgeEpinephrine
+
+- type: Tag
+  id: NukeOpsMedicUplink
+
+- type: Tag
+  id: NukeOpsCommanderUplink

--- a/Resources/Prototypes/_Goobstation/tags.yml
+++ b/Resources/Prototypes/_Goobstation/tags.yml
@@ -12,3 +12,6 @@
 
 - type: Tag
   id: NukeOpsCommanderUplink
+
+- type: Tag
+  id: NukeOpsReinforcementUplink


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Now nukeops reinforcement has nukeops tagged uplink so no buying bows as nukies.
Only nukie commander uplink has commander hardsuit and it has a limit of one purchase, same thing with medic.
War min nukies decreased to 2.
Now tc amount for declaring war scales with server population and missing nukies.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

3 nukies couldn't declare a war on 85 pop server, even if they could, they would stand no chance against the crew.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- add: Nukie reinforcement has nukeops uplink.
- tweak: Only nukie commander has commander hardsuit for sale in has uplink and it has limited stock of 1. Same thing with medic.
- tweak: Minimum number of operatives for war declaration is reduced to 2.
- add: Now the amount of tc for war declaration scales with amount of players on server and missing nukies.