### PR TITLE
Discord Ahelp Reply System (#2283)

### DIFF
--- a/Content.Server/Administration/ServerApi.cs
+++ b/Content.Server/Administration/ServerApi.cs
@@ -7,12 +7,14 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Content.Server.Administration.Systems;
+using Content.Server.Administration.Managers;
 using Content.Server.GameTicking;
 using Content.Server.GameTicking.Presets;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Maps;
 using Content.Server.RoundEnd;
 using Content.Shared.Administration.Managers;
+using Content.Shared.Administration;
 using Content.Shared.CCVar;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Prototypes;
@@ -48,7 +50,7 @@ public sealed partial class ServerApi : IPostInjectInit
     [Dependency] private readonly IStatusHost _statusHost = default!;
     [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
-    [Dependency] private readonly ISharedAdminManager _adminManager = default!;
+    [Dependency] private readonly IAdminManager _adminManager = default!; // Frontier: ISharedAdminManager<IAdminManager>
     [Dependency] private readonly IGameMapManager _gameMapManager = default!;
     [Dependency] private readonly IServerNetManager _netManager = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
@@ -81,6 +83,8 @@ public sealed partial class ServerApi : IPostInjectInit
         RegisterActorHandler(HttpMethod.Post, "/admin/actions/force_preset", ActionForcePreset);
         RegisterActorHandler(HttpMethod.Post, "/admin/actions/set_motd", ActionForceMotd);
         RegisterActorHandler(HttpMethod.Patch, "/admin/actions/panic_bunker", ActionPanicPunker);
+
+        RegisterHandler(HttpMethod.Post, "/admin/actions/send_bwoink", ActionSendBwoink); // Frontier - Discord Ahelp Reply
     }
 
     public void Initialize()
@@ -394,6 +398,40 @@ public sealed partial class ServerApi : IPostInjectInit
             await RespondOk(context);
         });
     }
+    #endregion
+
+    #region Frontier
+    // Creating a region here incase more actions are added in the future
+
+    private async Task ActionSendBwoink(IStatusHandlerContext context)
+    {
+        var body = await ReadJson<BwoinkActionBody>(context);
+        if (body == null)
+            return;
+
+        await RunOnMainThread(async () =>
+    {
+        // Player not online or wrong Guid
+        if (!_playerManager.TryGetSessionById(new NetUserId(body.Guid), out var player))
+        {
+            await RespondError(
+                context,
+                ErrorCode.PlayerNotFound,
+                HttpStatusCode.UnprocessableContent,
+                "Player not found");
+            return;
+        }
+
+        var serverBwoinkSystem = _entitySystemManager.GetEntitySystem<BwoinkSystem>();
+        var message = new SharedBwoinkSystem.BwoinkTextMessage(player.UserId, SharedBwoinkSystem.SystemUserId, body.Text);
+        serverBwoinkSystem.OnWebhookBwoinkTextMessage(message, body);
+
+        // Respond with OK
+        await RespondOk(context);
+    });
+
+
+    }
 
     #endregion
 
@@ -629,6 +667,15 @@ public sealed partial class ServerApi : IPostInjectInit
     private sealed class MotdActionBody
     {
         public required string Motd { get; init; }
+    }
+
+    public sealed class BwoinkActionBody
+    {
+        public required string Text { get; init; }
+        public required string Username { get; init; }
+        public required Guid Guid { get; init; }
+        public bool UserOnly { get; init; }
+        public required bool WebhookUpdate { get; init; }
     }
 
     #endregion

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -704,7 +704,7 @@ namespace Content.Server.Administration.Systems
             }
 
             if (fromWebhook)
-                bwoinkText = $"(DC) {bwoinkText}";
+                bwoinkText = $"(DISCORD) {bwoinkText}";
 
             bwoinkText = $"{(message.PlaySound ? "" : "(S) ")}{bwoinkText}: {escapedText}";
 

--- a/Content.Server/Discord/WebhookPayload.cs
+++ b/Content.Server/Discord/WebhookPayload.cs
@@ -5,6 +5,8 @@ namespace Content.Server.Discord;
 // https://discord.com/developers/docs/resources/channel#message-object-message-structure
 public struct WebhookPayload
 {
+    [JsonPropertyName("UserID")] // Frontier, this is used to identify the players in the webhook
+    public Guid? UserID { get; set; }
     /// <summary>
     ///     The message to send in the webhook. Maximum of 2000 characters.
     /// </summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Ported https://github.com/new-frontiers-14/frontier-station-14/pull/2283

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
No longer do admins need to be ingame for every AHelp.

## Technical details
<!-- Summary of code changes for easier review. -->
This PR requires:
1. Something that can handle the discord side, see original PR for details. You can also use my [RedBot cog](https://github.com/sleepyyapril/april-cogs), if you use RedBot.
2. A set admin.api_token CVar value to use on the discord side.
3. CVar status.enabled being true

This PR changes the way the BwoinkSystem works to allow for custom URLs instead of just an id and a token for webhooks, as well as adding an admin API HTTP POST method under ``/admin/actions/send_bwoink``.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/65edeb13-fe31-4e38-a151-0d1203f20f81)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
ADMIN:
- add: Added the ability to reply to AHelps while exclusively on discord.