### PR TITLE
lower ai playtime requirement

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -7,7 +7,7 @@
   requirements:
   - !type:RoleTimeRequirement
     role: JobBorg
-    time: 54000  # 15 hrs
+    time: 18000  # 5 hrs
   canBeAntag: false
   icon: JobIconStationAi
   supervisors: job-supervisors-rd


### PR DESCRIPTION
## About the PR
lowers station ai playtime requirement

## Why / Balance
15 hours as borg is dumb

## Technical details


## Media


## Requirements

- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
changes ai playtime requirement from 15 hours to 5 hours as it originally was

**Changelog**
:cl:
tweak: lower AI playtime req

