### PR TITLE
Fix EndCollide puddle error

### DIFF
--- a/Content.Server/_White/FootPrint/PuddleFootPrintsSystem.cs
+++ b/Content.Server/_White/FootPrint/PuddleFootPrintsSystem.cs
@@ -23,9 +23,10 @@ public sealed class PuddleFootPrintsSystem : EntitySystem
     {
         if (!TryComp<AppearanceComponent>(uid, out var appearance)
             || !TryComp<PuddleComponent>(uid, out var puddle)
+            || puddle.LifeStage >= ComponentLifeStage.Stopping // Goobstation - container lookup causes ResolveSolution to assert when deleted first (EndCollide was triggered by component shutdown)
             || !TryComp<FootPrintsComponent>(args.OtherEntity, out var tripper)
             || !TryComp<SolutionContainerManagerComponent>(uid, out var solutionManager)
-            ||!_solutionContainer.ResolveSolution((uid, solutionManager), puddle.SolutionName, ref puddle.Solution, out var solutions))
+            || !_solutionContainer.ResolveSolution((uid, solutionManager), puddle.SolutionName, ref puddle.Solution, out var solutions))
             return;
 
         // alles gut!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed server side assert caused by puddle EndCollideEvent while puddle component was being deleted.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because I kept seeing errors in my log while explosively gibbing corpses.

## Technical details
<!-- Summary of code changes for easier review. -->
OnStepTrigger would get triggered via 
- RecursiveDeleteEntity(...) / RemoveComponentImmediate(...)
- LifeShutdown(...)
- CompShutdownInstance event
- SharedPhysicsSystem::OnChangeShutdown(...)
- SharedPhysicsSystem::DestroyFixture(...)
- SharedPhysicsSystem::DestroyContact(...)
- EndCollideEvent event

At this point the container state relevant to the solution is potentially already invalidated (up to hashset order) causing ResolveSolution to assert.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: procdox
- fix: Fixed an error caused by walking through puddles as they were deleted.
