### PR TITLE
AHelps: The Configuration Update

### DIFF
--- a/Content.Server/Administration/ServerApi.cs
+++ b/Content.Server/Administration/ServerApi.cs
@@ -676,6 +676,8 @@ public sealed partial class ServerApi : IPostInjectInit
         public required Guid Guid { get; init; }
         public bool UserOnly { get; init; }
         public required bool WebhookUpdate { get; init; }
+        public required string RoleName { get; init; }
+        public required string RoleColor { get; init; }
     }
 
     #endregion

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -18,6 +18,7 @@ using Content.Shared.GameTicking;
 using Content.Shared.Mind;
 using Content.Shared.Players.RateLimiting;
 using JetBrains.Annotations;
+using Pidgin.Configuration;
 using Robust.Server.Player;
 using Robust.Shared;
 using Robust.Shared.Configuration;
@@ -637,8 +638,18 @@ namespace Content.Server.Administration.Systems
             // Note for forks:
             AdminData webhookAdminData = new();
 
-            // TODO: fix args
-            OnBwoinkInternal(message, SystemUserId, webhookAdminData, body.Username, null, body.UserOnly, body.WebhookUpdate, true);
+            var bwoinkParams = new BwoinkParams(
+                message,
+                SystemUserId,
+                webhookAdminData,
+                body.Username,
+                null,
+                body.UserOnly,
+                body.WebhookUpdate,
+                true,
+                body.RoleName,
+                body.RoleColor);
+            OnBwoinkInternal(bwoinkParams);
         }
 
         protected override void OnBwoinkTextMessage(BwoinkTextMessage message, EntitySessionEventArgs eventArgs)
@@ -662,27 +673,29 @@ namespace Content.Server.Administration.Systems
             if (_rateLimit.CountAction(eventArgs.SenderSession, RateLimitKey) != RateLimitStatus.Allowed)
                 return;
 
-            OnBwoinkInternal(message, eventArgs.SenderSession.UserId, senderAdmin, eventArgs.SenderSession.Name, eventArgs.SenderSession.Channel, false, true, false);
+            var bwoinkParams = new BwoinkParams(message,
+                eventArgs.SenderSession.UserId,
+                senderAdmin,
+                eventArgs.SenderSession.Name,
+                eventArgs.SenderSession.Channel,
+                false,
+                true,
+                false);
+            OnBwoinkInternal(bwoinkParams);
         }
 
         /// <summary>
         /// Sends a bwoink. Common to both internal messages (sent via the ahelp or admin interface) and webhook messages (sent through the webhook, e.g. via Discord)
         /// </summary>
-        /// <param name="message">The message being sent.</param>
-        /// <param name="senderId">The network GUID of the person sending the message.</param>
-        /// <param name="senderAdmin">The admin privileges of the person sending the message.</param>
-        /// <param name="senderName">The name of the person sending the message.</param>
-        /// <param name="senderChannel">The channel to send a message to, e.g. in case of failure to send</param>
-        /// <param name="sendWebhook">If true, message should be sent off through the webhook if possible</param>
-        /// <param name="fromWebhook">Message originated from a webhook (e.g. Discord)</param>
-        private void OnBwoinkInternal(BwoinkTextMessage message, NetUserId senderId, AdminData? senderAdmin, string senderName, INetChannel? senderChannel, bool userOnly, bool sendWebhook, bool fromWebhook)
+        /// <param name="bwoinkParams">The parameters of the message being sent.</param>
+        private void OnBwoinkInternal(BwoinkParams bwoinkParams)
         {
-            _activeConversations[message.UserId] = DateTime.Now;
+            _activeConversations[bwoinkParams.Message.UserId] = DateTime.Now;
 
-            var escapedText = FormattedMessage.EscapeText(message.Text);
-
-            string bwoinkText;
-            string adminPrefix = "";
+            var escapedText = FormattedMessage.EscapeText(bwoinkParams.Message.Text);
+            var adminColor = _config.GetCVar(CCVars.AdminBwoinkColor);
+            var adminPrefix = "";
+            var bwoinkText = $"{bwoinkParams.SenderName}";
 
             //Getting an administrator position
             if (_config.GetCVar(CCVars.AhelpAdminPrefix))
@@ -694,6 +707,13 @@ namespace Content.Server.Administration.Systems
                     adminPrefix = $"[bold]\\[{bwoinkParams.RoleName}\\][/bold] ";
             }
 
+            // If role color is enabled and exists, use it, otherwise use the discord reply color
+            if (_config.GetCVar(CCVars.DiscordReplyColor) != string.Empty && bwoinkParams.FromWebhook)
+                adminColor = _config.GetCVar(CCVars.DiscordReplyColor);
+
+            if (_config.GetCVar(CCVars.UseDiscordRoleColor) && bwoinkParams.RoleColor is not null)
+                adminColor = bwoinkParams.RoleColor;
+
             if (!bwoinkParams.FromWebhook
                 && _config.GetCVar(CCVars.UseAdminOOCColorInBwoinks)
                 && bwoinkParams.SenderAdmin is not null)
@@ -701,13 +721,6 @@ namespace Content.Server.Administration.Systems
                 var prefs = _preferencesManager.GetPreferences(bwoinkParams.SenderId);
                 adminColor = prefs.AdminOOCColor.ToHex();
             }
-
-            // If role color is enabled and exists, use it, otherwise use the discord reply color
-            if (_config.GetCVar(CCVars.DiscordReplyColor) != string.Empty && bwoinkParams.FromWebhook)
-                adminColor = _config.GetCVar(CCVars.DiscordReplyColor);
-
-            if (_config.GetCVar(CCVars.UseDiscordRoleColor) && bwoinkParams.RoleColor is not null)
-                adminColor = bwoinkParams.RoleColor;
 
             if (bwoinkParams.SenderAdmin is not null)
             {
@@ -717,26 +730,22 @@ namespace Content.Server.Administration.Systems
                 else if (bwoinkParams.FromWebhook || bwoinkParams.SenderAdmin.HasFlag(AdminFlags.Adminhelp)) // Frontier: anything sent via webhooks are from an admin.
                     bwoinkText = $"[color={adminColor}]{adminPrefix}{bwoinkParams.SenderName}[/color]";
             }
-            else
-            {
-                bwoinkText = $"{senderName}";
-            }
 
-            if (fromWebhook)
-                bwoinkText = $"(DISCORD) {bwoinkText}";
+            if (bwoinkParams.FromWebhook)
+                bwoinkText = $"{_config.GetCVar(CCVars.DiscordReplyPrefix)}{bwoinkText}";
 
-            bwoinkText = $"{(message.PlaySound ? "" : "(S) ")}{bwoinkText}: {escapedText}";
+            bwoinkText = $"{(bwoinkParams.Message.PlaySound ? "" : "(S) ")}{bwoinkText}: {escapedText}";
 
             // If it's not an admin / admin chooses to keep the sound then play it.
-            var playSound = senderAdmin == null || message.PlaySound;
-            var msg = new BwoinkTextMessage(message.UserId, senderId, bwoinkText, playSound: playSound);
+            var playSound = bwoinkParams.SenderAdmin == null || bwoinkParams.Message.PlaySound;
+            var msg = new BwoinkTextMessage(bwoinkParams.Message.UserId, bwoinkParams.SenderId, bwoinkText, playSound: playSound);
 
             LogBwoink(msg);
 
             var admins = GetTargetAdmins();
 
             // Notify all admins
-            if (!userOnly)
+            if (!bwoinkParams.UserOnly)
             {
                 foreach (var channel in admins)
                 {
@@ -746,13 +755,13 @@ namespace Content.Server.Administration.Systems
 
             string adminPrefixWebhook = "";
 
-            if (_config.GetCVar(CCVars.AhelpAdminPrefixWebhook) && senderAdmin is not null && senderAdmin.Title is not null)
+            if (_config.GetCVar(CCVars.AhelpAdminPrefixWebhook) && bwoinkParams.SenderAdmin is not null && bwoinkParams.SenderAdmin.Title is not null)
             {
-                adminPrefixWebhook = $"[bold]\\[{senderAdmin.Title}\\][/bold] ";
+                adminPrefixWebhook = $"[bold]\\[{bwoinkParams.SenderAdmin.Title}\\][/bold] ";
             }
 
             // Notify player
-            if (_playerManager.TryGetSessionById(message.UserId, out var session))
+            if (_playerManager.TryGetSessionById(bwoinkParams.Message.UserId, out var session))
             {
                 if (!admins.Contains(session.Channel))
                 {
@@ -761,28 +770,22 @@ namespace Content.Server.Administration.Systems
                     {
                         string overrideMsgText;
                         // Doing the same thing as above, but with the override name. Theres probably a better way to do this.
-                        if (senderAdmin is not null &&
-                            senderAdmin.Flags ==
+                        if (bwoinkParams.SenderAdmin is not null &&
+                            bwoinkParams.SenderAdmin.Flags ==
                             AdminFlags.Adminhelp) // Mentor. Not full admin. That's why it's colored differently.
-                        {
                             overrideMsgText = $"[color=purple]{adminPrefixWebhook}{_overrideClientName}[/color]";
-                        }
-                        else if (senderAdmin is not null && senderAdmin.HasFlag(AdminFlags.Adminhelp))
-                        {
+                        else if (bwoinkParams.SenderAdmin is not null && bwoinkParams.SenderAdmin.HasFlag(AdminFlags.Adminhelp))
                             overrideMsgText = $"[color=red]{adminPrefixWebhook}{_overrideClientName}[/color]";
-                        }
                         else
-                        {
-                            overrideMsgText = $"{senderName}"; // Not an admin, name is not overridden.
-                        }
+                            overrideMsgText = $"{bwoinkParams.SenderName}"; // Not an admin, name is not overridden.
 
-                        if (fromWebhook)
-                            overrideMsgText = $"(DC) {overrideMsgText}";
+                        if (bwoinkParams.FromWebhook)
+                            overrideMsgText = $"{_config.GetCVar(CCVars.DiscordReplyPrefix)}{overrideMsgText}";
 
-                        overrideMsgText = $"{(message.PlaySound ? "" : "(S) ")}{overrideMsgText}: {escapedText}";
+                        overrideMsgText = $"{(bwoinkParams.Message.PlaySound ? "" : "(S) ")}{overrideMsgText}: {escapedText}";
 
-                        RaiseNetworkEvent(new BwoinkTextMessage(message.UserId,
-                                senderId,
+                        RaiseNetworkEvent(new BwoinkTextMessage(bwoinkParams.Message.UserId,
+                                bwoinkParams.SenderId,
                                 overrideMsgText,
                                 playSound: playSound),
                             session.Channel);
@@ -793,13 +796,13 @@ namespace Content.Server.Administration.Systems
             }
 
             var sendsWebhook = _webhookUrl != string.Empty;
-            if (sendsWebhook && sendWebhook)
+            if (sendsWebhook && bwoinkParams.SendWebhook)
             {
                 if (!_messageQueues.ContainsKey(msg.UserId))
                     _messageQueues[msg.UserId] = new Queue<DiscordRelayedData>();
 
-                var str = message.Text;
-                var unameLength = senderName.Length;
+                var str = bwoinkParams.Message.Text;
+                var unameLength = bwoinkParams.SenderName.Length;
 
                 if (unameLength + str.Length + _maxAdditionalChars > DescriptionMax)
                 {
@@ -808,13 +811,13 @@ namespace Content.Server.Administration.Systems
 
                 var nonAfkAdmins = GetNonAfkAdmins();
                 var messageParams = new AHelpMessageParams(
-                    senderName,
+                    bwoinkParams.SenderName,
                     str,
-                    senderId != message.UserId,
+                    bwoinkParams.SenderId != bwoinkParams.Message.UserId,
                     _gameTicker.RoundDuration().ToString("hh\\:mm\\:ss"),
                     _gameTicker.RunLevel,
                     playedSound: playSound,
-                    isDiscord: fromWebhook,
+                    isDiscord: bwoinkParams.FromWebhook,
                     noReceivers: nonAfkAdmins.Count == 0
                 );
                 _messageQueues[msg.UserId].Enqueue(GenerateAHelpMessage(messageParams));
@@ -824,11 +827,11 @@ namespace Content.Server.Administration.Systems
                 return;
 
             // No admin online, let the player know
-            if (senderChannel != null)
+            if (bwoinkParams.SenderChannel != null)
             {
                 var systemText = Loc.GetString("bwoink-system-starmute-message-no-other-users");
-                var starMuteMsg = new BwoinkTextMessage(message.UserId, SystemUserId, systemText);
-                RaiseNetworkEvent(starMuteMsg, senderChannel);
+                var starMuteMsg = new BwoinkTextMessage(bwoinkParams.Message.UserId, SystemUserId, systemText);
+                RaiseNetworkEvent(starMuteMsg, bwoinkParams.SenderChannel);
             }
         }
         // End Frontier:
@@ -852,6 +855,7 @@ namespace Content.Server.Administration.Systems
 
         private static DiscordRelayedData GenerateAHelpMessage(AHelpMessageParams parameters)
         {
+            var config = IoCManager.Resolve<IConfigurationManager>();
             var stringbuilder = new StringBuilder();
 
             if (parameters.Icon != null)
@@ -869,7 +873,7 @@ namespace Content.Server.Administration.Systems
                 stringbuilder.Append(" **(S)**");
 
             if (parameters.IsDiscord) // Frontier - Discord Indicator
-                stringbuilder.Append(" **(DC)**");
+                stringbuilder.Append($" **{config.GetCVar(CCVars.DiscordReplyPrefix)}**");
 
             if (parameters.Icon == null)
                 stringbuilder.Append($" **{parameters.Username}:** ");
@@ -957,6 +961,44 @@ namespace Content.Server.Administration.Systems
             PlayedSound = playedSound;
             NoReceivers = noReceivers;
             Icon = icon;
+        }
+    }
+
+    public sealed class BwoinkParams
+    {
+        public SharedBwoinkSystem.BwoinkTextMessage Message { get; set; }
+        public NetUserId SenderId { get; set; }
+        public AdminData? SenderAdmin { get; set; }
+        public string SenderName { get; set; }
+        public INetChannel? SenderChannel { get; set; }
+        public bool UserOnly { get; set; }
+        public bool SendWebhook { get; set; }
+        public bool FromWebhook { get; set; }
+        public string? RoleName { get; set; }
+        public string? RoleColor { get; set; }
+
+        public BwoinkParams(
+            SharedBwoinkSystem.BwoinkTextMessage message,
+            NetUserId senderId,
+            AdminData? senderAdmin,
+            string senderName,
+            INetChannel? senderChannel,
+            bool userOnly,
+            bool sendWebhook,
+            bool fromWebhook,
+            string? roleName = null,
+            string? roleColor = null)
+        {
+            Message = message;
+            SenderId = senderId;
+            SenderAdmin = senderAdmin;
+            SenderName = senderName;
+            SenderChannel = senderChannel;
+            UserOnly = userOnly;
+            SendWebhook = sendWebhook;
+            FromWebhook = fromWebhook;
+            RoleName = roleName;
+            RoleColor = roleColor;
         }
     }
 

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2468,8 +2468,7 @@ namespace Content.Shared.CCVar
             CVarDef.Create("admin.use_discord_role_color", false, CVar.SERVERONLY);
 
         /// <summary>
-        ///     If an admin replies to users from discord, should it use their discord role color? (if applicable)
-        ///     Overrides DiscordReplyColor and AdminBwoinkColor.
+        ///     If an admin replies to users from discord, should it use their discord role name? (if applicable)
         /// </summary>
         public static readonly CVarDef<bool> UseDiscordRoleName =
             CVarDef.Create("admin.use_discord_role_name", false, CVar.SERVERONLY);

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -941,7 +941,7 @@ namespace Content.Shared.CCVar
         /// <seealso cref="AhelpAdminPrefix"/>
         /// <seealso cref="AhelpAdminPrefixWebhook"/>
         public static readonly CVarDef<bool> AdminUseCustomNamesAdminRank =
-            CVarDef.Create("admin.use_custom_names_admin_rank", true, CVar.SERVERONLY);
+            CVarDef.Create("admin.use_custom_names_admin_rank", false, CVar.SERVERONLY);
 
         /*
          * AHELP
@@ -969,7 +969,7 @@ namespace Content.Shared.CCVar
         /// <seealso cref="AdminUseCustomNamesAdminRank"/>
         /// <seealso cref="AhelpAdminPrefixWebhook"/>
         public static readonly CVarDef<bool> AhelpAdminPrefix =
-            CVarDef.Create("ahelp.admin_prefix", false, CVar.SERVERONLY);
+            CVarDef.Create("ahelp.admin_prefix", true, CVar.SERVERONLY);
 
         /// <summary>
         /// Should the administrator's position be displayed in the webhook.
@@ -978,7 +978,7 @@ namespace Content.Shared.CCVar
         /// <seealso cref="AdminUseCustomNamesAdminRank"/>
         /// <seealso cref="AhelpAdminPrefix"/>
         public static readonly CVarDef<bool> AhelpAdminPrefixWebhook =
-            CVarDef.Create("ahelp.admin_prefix_webhook", false, CVar.SERVERONLY);
+            CVarDef.Create("ahelp.admin_prefix_webhook", true, CVar.SERVERONLY);
 
         /*
          * Explosions
@@ -2465,13 +2465,13 @@ namespace Content.Shared.CCVar
         ///     Overrides DiscordReplyColor and AdminBwoinkColor.
         /// </summary>
         public static readonly CVarDef<bool> UseDiscordRoleColor =
-            CVarDef.Create("admin.use_discord_role_color", false, CVar.SERVERONLY);
+            CVarDef.Create("admin.use_discord_role_color", true, CVar.SERVERONLY);
 
         /// <summary>
         ///     If an admin replies to users from discord, should it use their discord role name? (if applicable)
         /// </summary>
         public static readonly CVarDef<bool> UseDiscordRoleName =
-            CVarDef.Create("admin.use_discord_role_name", false, CVar.SERVERONLY);
+            CVarDef.Create("admin.use_discord_role_name", true, CVar.SERVERONLY);
 
         /// <summary>
         ///     The text before an admin's name when replying from discord to indicate they're speaking from discord.
@@ -2497,7 +2497,7 @@ namespace Content.Shared.CCVar
         ///     If either the ooc color or this is not set, uses the admin.admin_bwoink_color value.
         /// </summary>
         public static readonly CVarDef<bool> UseAdminOOCColorInBwoinks =
-            CVarDef.Create("admin.bwoink_use_admin_ooc_color", false, CVar.SERVERONLY);
+            CVarDef.Create("admin.bwoink_use_admin_ooc_color", true, CVar.SERVERONLY);
 
         #endregion
     }

--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2457,5 +2457,49 @@ namespace Content.Shared.CCVar
             CVarDef.Create("surgery.can_operate_on_self", true, CVar.SERVERONLY);
 
         #endregion
+
+        #region Discord AHelp Reply System
+
+        /// <summary>
+        ///     If an admin replies to users from discord, should it use their discord role color? (if applicable)
+        ///     Overrides DiscordReplyColor and AdminBwoinkColor.
+        /// </summary>
+        public static readonly CVarDef<bool> UseDiscordRoleColor =
+            CVarDef.Create("admin.use_discord_role_color", false, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     If an admin replies to users from discord, should it use their discord role color? (if applicable)
+        ///     Overrides DiscordReplyColor and AdminBwoinkColor.
+        /// </summary>
+        public static readonly CVarDef<bool> UseDiscordRoleName =
+            CVarDef.Create("admin.use_discord_role_name", false, CVar.SERVERONLY);
+
+        /// <summary>
+        ///     The text before an admin's name when replying from discord to indicate they're speaking from discord.
+        /// </summary>
+        public static readonly CVarDef<string> DiscordReplyPrefix =
+            CVarDef.Create("admin.discord_reply_prefix", "(DISCORD) ", CVar.SERVERONLY);
+
+        /// <summary>
+        ///     The color of the names of admins. This is the fallback color for admins.
+        /// </summary>
+        public static readonly CVarDef<string> AdminBwoinkColor =
+            CVarDef.Create("admin.admin_bwoink_color", "red", CVar.SERVERONLY);
+
+        /// <summary>
+        ///     The color of the names of admins who reply from discord. Leave empty to disable.
+        ///     Overrides AdminBwoinkColor.
+        /// </summary>
+        public static readonly CVarDef<string> DiscordReplyColor =
+            CVarDef.Create("admin.discord_reply_color", string.Empty, CVar.SERVERONLY);
+        
+        /// <summary>
+        ///     Use the admin's Admin OOC color in bwoinks.
+        ///     If either the ooc color or this is not set, uses the admin.admin_bwoink_color value.
+        /// </summary>
+        public static readonly CVarDef<bool> UseAdminOOCColorInBwoinks =
+            CVarDef.Create("admin.bwoink_use_admin_ooc_color", false, CVar.SERVERONLY);
+
+        #endregion
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a CVar to use an admin's OOC color, if it exists.
Added several CVars for discord ahelp replies, including the ability to use role name and color.

This does require you to update the april-cogs/ahelp_replies cog.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Mostly cosmetic, configuration is set to use the defaults.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/93f2823e-7478-49b7-9357-ee8f5e7e1467)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->