### PR TITLE
Fix tracking of ActiveDeviceList

### DIFF
--- a/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
@@ -81,10 +81,7 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
     private void OnShutdown(EntityUid uid, NetworkConfiguratorComponent component, ComponentShutdown args)
     {
         ClearDevices(uid, component);
-
-        if (TryComp(component.ActiveDeviceList, out DeviceListComponent? list))
-            list.Configurators.Remove(uid);
-        component.ActiveDeviceList = null;
+        ClearActiveDeviceList(uid, component); // Goobstation - Fix desync of configurator lists
     }
 
     private void OnMapInit(EntityUid uid, NetworkConfiguratorComponent component, MapInitEvent args)
@@ -469,11 +466,53 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
     }
 
     /// <summary>
+    /// Goobstation - Fix desync of configurator lists
+    /// Clears the active device list pointed at while maintaining reference tracking on the device itself
+    /// </summary>
+    public void ClearActiveDeviceList(EntityUid configUid, NetworkConfiguratorComponent configComp, EntityUid? prevListUid = null, DeviceListComponent? prevListComp = null)
+    {
+        if (!prevListUid.HasValue)
+        {
+            prevListUid = configComp.ActiveDeviceList;
+            if (!prevListUid.HasValue) return;
+        }
+        // hack to prevent Resolve from null-ing prevListComp if the entity is mid-teardown
+        DebugTools.Assert(prevListUid.Value == configComp.ActiveDeviceList);
+        if (prevListComp != null || Resolve(prevListUid.Value, ref prevListComp))
+        {
+            prevListComp.Configurators.Remove(configUid);
+        }
+        configComp.ActiveDeviceList = null;
+
+        _deviceListSystem.VerifyDeviceList(prevListUid.Value, prevListComp);
+    }
+
+    /// <summary>
+    /// Goobstation - Fix desync of configurator lists
+    /// Sets the active device list pointed at while maintaining reference tracking on the device itself
+    /// </summary>
+    public void SetActiveDeviceList(EntityUid configUid, NetworkConfiguratorComponent configComp, EntityUid? nextListUid = null, DeviceListComponent? nextListComp = null)
+    {
+        // unset previous
+        ClearActiveDeviceList(configUid, configComp, configComp.ActiveDeviceList);
+
+        // set new one
+        if (nextListUid.HasValue && Resolve(nextListUid.Value, ref nextListComp))
+        {
+            _deviceListSystem.VerifyDeviceList(nextListUid); // pre-check
+
+            nextListComp.Configurators.Remove(configUid);
+            configComp.ActiveDeviceList = nextListUid;
+            _deviceListSystem.VerifyDeviceList(nextListUid); // post-check
+        }
+    }
+
+    /// <summary>
     /// Opens the config ui. It can be used to modify the devices in the targets device list.
     /// </summary>
     private void OpenDeviceListUi(EntityUid configuratorUid, EntityUid? targetUid, EntityUid userUid, NetworkConfiguratorComponent configurator)
     {
-        if (configurator.ActiveDeviceLink == targetUid)
+        if (configurator.ActiveDeviceList == targetUid) // Goobstation - Fix desync of configurator lists
             return;
 
         if (Delay(configurator))
@@ -482,14 +521,8 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
         if (!targetUid.HasValue || !AccessCheck(targetUid.Value, userUid, configurator))
             return;
 
-        if (!TryComp(targetUid, out DeviceListComponent? list))
-            return;
-
-        list.Configurators.Add(configuratorUid);
-        configurator.ActiveDeviceList = targetUid;
-        Dirty(configuratorUid, configurator);
-
-        if (_uiSystem.TryOpenUi(configuratorUid, NetworkConfiguratorUiKey.Configure, userUid))
+        SetActiveDeviceList(configuratorUid, configurator, targetUid); // Goobstation - Fix desync of configurator lists
+        if (configurator.ActiveDeviceList.HasValue && _uiSystem.TryOpenUi(configuratorUid, NetworkConfiguratorUiKey.Configure, userUid))
         {
             _uiSystem.SetUiState(configuratorUid, NetworkConfiguratorUiKey.Configure, new DeviceListUserInterfaceState(
                 _deviceListSystem.GetDeviceList(configurator.ActiveDeviceList.Value)
@@ -527,36 +560,34 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
     }
 
     /// <summary>
+    /// Goobstation - Fix desync of configurator lists
     /// Clears the active device list when the ui is closed
     /// </summary>
     private void OnUiClosed(EntityUid uid, NetworkConfiguratorComponent component, BoundUIClosedEvent args)
     {
-        if (!args.UiKey.Equals(NetworkConfiguratorUiKey.Configure)
-            && !args.UiKey.Equals(NetworkConfiguratorUiKey.Link)
-            && !args.UiKey.Equals(NetworkConfiguratorUiKey.List))
+        if (args.UiKey.Equals(NetworkConfiguratorUiKey.Configure))
         {
-            return;
+            EntityUid? current_device_list = component.ActiveDeviceList;
+            SetActiveDeviceList(uid, component);
         }
-
-        if (TryComp(component.ActiveDeviceList, out DeviceListComponent? list))
-        {
-            list.Configurators.Remove(uid);
-        }
-
-        component.ActiveDeviceList = null;
-
-        if (args.UiKey is NetworkConfiguratorUiKey.Link)
+        else if (args.UiKey is NetworkConfiguratorUiKey.Link)
         {
             component.ActiveDeviceLink = null;
             component.DeviceLinkTarget = null;
         }
+        /*else if (args.UiKey is NetworkConfiguratorUiKey.List)
+        {
+            // nothing to do?
+        }*/
     }
 
-    public void OnDeviceListShutdown(Entity<NetworkConfiguratorComponent?> conf, Entity<DeviceListComponent> list)
+    // Goobstation - Fix desync of configurator lists
+    public void OnDeviceListShutdown(EntityUid confUid, Entity<DeviceListComponent> list)
     {
-        list.Comp.Configurators.Remove(conf.Owner);
-        if (Resolve(conf.Owner, ref conf.Comp))
-            conf.Comp.ActiveDeviceList = null;
+        if (TryComp(confUid, out NetworkConfiguratorComponent? confComp))
+        {
+            ClearActiveDeviceList(confUid, confComp, list.Owner, list.Comp);
+        }
     }
 
     /// <summary>

--- a/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
+++ b/Content.Server/DeviceNetwork/Systems/NetworkConfiguratorSystem.cs
@@ -567,18 +567,13 @@ public sealed class NetworkConfiguratorSystem : SharedNetworkConfiguratorSystem
     {
         if (args.UiKey.Equals(NetworkConfiguratorUiKey.Configure))
         {
-            EntityUid? current_device_list = component.ActiveDeviceList;
-            SetActiveDeviceList(uid, component);
+            ClearActiveDeviceList(uid, component);
         }
         else if (args.UiKey is NetworkConfiguratorUiKey.Link)
         {
             component.ActiveDeviceLink = null;
             component.DeviceLinkTarget = null;
         }
-        /*else if (args.UiKey is NetworkConfiguratorUiKey.List)
-        {
-            // nothing to do?
-        }*/
     }
 
     // Goobstation - Fix desync of configurator lists


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fix tracking of active network cofigurators. Add validation of tracked configurators and devices.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This was the second of the sources of Can't resolve ```Robust.Shared.GameObjects.MetaDataComponent```
errors in the logs that I was given.

## Technical details
<!-- Summary of code changes for easier review. -->
Improper checking and clearing of ActiveDeviceList caused references DeviceLists configurator lists to become stale. This breaks the updater function into a controlled region and fixes these issues. There are two ways to desync the list I found:

1. Mixed UI
    1. open a list view
    3. open a config view (sets ActiveDeviceList)
    4. close the list view (clears ActiveDeviceList)
    5. close the config view (ActiveDeviceList is null, DeviceList is not updated)
2. Device Switching
    1. open a config view (sets ActiveDeviceList)
    2. open a config view for a different machine (sets ActiveDeviceList, does not update previous DeviceList)
  
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: procdox
- fix: server side serialization bug caused by opening multiple network configuration menus
