### PR TITLE
Bola knockdown

### DIFF
--- a/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
+++ b/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared.Strip.Components;
 using Content.Shared.Throwing;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
+using Robust.Shared.Network;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Ensnaring;
@@ -27,6 +28,7 @@ public sealed partial class EnsnareableDoAfterEvent : SimpleDoAfterEvent
 
 public abstract class SharedEnsnareableSystem : EntitySystem
 {
+    [Dependency] private   readonly INetManager _net = default!; // Goobstation
     [Dependency] private   readonly AlertsSystem _alerts = default!;
     [Dependency] private   readonly MovementSpeedModifierSystem _speedModifier = default!;
     [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
@@ -93,7 +95,10 @@ public abstract class SharedEnsnareableSystem : EntitySystem
 
         // Goobstation start
         if (ensnaring.DestroyOnRemove)
-            QueueDel(args.Args.Used.Value);
+        {
+            if (_net.IsServer)
+                QueueDel(args.Args.Used.Value);
+        }
         else
             _hands.PickupOrDrop(args.Args.User, args.Args.Used.Value);
         // Goobstation end

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
@@ -22,9 +22,10 @@
     breakoutTime: 3.5 #all bola should generally be fast to remove
     walkSpeed: 0.7 #makeshift bola shouldn't slow too much
     sprintSpeed: 0.7
-    staminaDamage: 25 # Sudden weight increase sapping stamina
+    staminaDamage: 0
     canThrowTrigger: true
     canMoveBreakout: true
+  - type: KnockdownOnCollide
 
 - type: entity
   name: bola
@@ -69,7 +70,6 @@
   - type: Sprite
     sprite: _Goobstation/Objects/Weapons/Throwable/energy_bola.rsi
   - type: Ensnaring
-    staminaDamage: 55
     destroyOnRemove: true
   - type: Tag
     tags:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Bolas now knockdown but do not force to drop items. This makes sense I think. Removed stamina damage from bolas.
Also fixed an exception when trying to remove ebola from a person.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bolas shouldn't have stamina damage to prevent dirty combos with mansus grasp and similar stuff.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- add: Bolas now knock people down, items are not dropped from their hands.
- remove: Bolas no longer deal stamina damage.