### PR TITLE
Sorta hotfix? Ling limbs are no longer severable

### DIFF
--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
@@ -59,6 +59,7 @@ using Content.Server.Explosion.EntitySystems;
 using System.Linq;
 using Content.Shared.Heretic;
 using Content.Shared._Goobstation.Actions;
+using Content.Shared.Body.Components;
 
 namespace Content.Server.Changeling;
 
@@ -673,6 +674,13 @@ public sealed partial class ChangelingSystem : EntitySystem
         UpdateBiomass(uid, comp, 0);
         // make their blood unreal
         _blood.ChangeBloodReagent(uid, "BloodChangeling");
+
+        // Shitmed: Prevent changelings from getting their body parts severed
+        foreach (var (id, part) in _bodySystem.GetBodyChildren(uid))
+        {
+            part.CanSever = false;
+            Dirty(id, part);
+        }
     }
 
     private void OnMobStateChange(EntityUid uid, ChangelingComponent comp, ref MobStateChangedEvent args)


### PR DESCRIPTION
## About the PR
John Station refuses to learn body/damageable code, and I refuse to learn changeling/heretic code to fix his shitcode, so @ARMOKS came up with a simple suggestion for now, disable limb severing on lings. This prevents a huge chunk of the shitmed issues with them, just leaving disabling as their main problem. At some point this all needs to be refactored & fixed.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Changeling limbs cannot be severed now. Definitely not-permanent.
