### PR TITLE
disable ashing until husking is added

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -69,21 +69,22 @@
         damage: 400
       behaviors:
       - !type:GibBehavior { }
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 1500
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawnInContainer: true
-        spawn:
-          Ash:
-            min: 1
-            max: 1
-      - !type:BurnBodyBehavior { }
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MeatLaserImpact
+    # GoobStation: Disabled ashing until husking is added
+    #- trigger:
+    #    !type:DamageTypeTrigger
+    #    damageType: Heat
+    #    damage: 1500
+    #  behaviors:
+    #  - !type:SpawnEntitiesBehavior
+    #    spawnInContainer: true
+    #    spawn:
+    #      Ash:
+    #        min: 1
+    #        max: 1
+    #  - !type:BurnBodyBehavior { }
+    #  - !type:PlaySoundBehavior
+    #    sound:
+    #      collection: MeatLaserImpact
   - type: RadiationReceiver
   - type: Stamina
   - type: MobState


### PR DESCRIPTION
## About the PR
husking just a week away

SM is unaffected

## Why / Balance
if someone has 5000 burn at least you can brain transplant them
its also horrifically buggy with shitmed so no more torsoless gamers

## Technical details
commented it all out

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- remove: Extreme heat no longer turns people to ash.
