### PR TITLE
cmo chestrig changes

### DIFF
--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Belt/belts.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Belt/belts.yml
@@ -1,5 +1,6 @@
 - type: entity
-  parent: ClothingBeltMilitaryWebbingCMO
+  parent: [ ClothingBeltMilitaryWebbingCMO, BaseMedicalContraband ]
+  suffix: Filled
   id: ClothingBeltMilitaryWebbingCMOFilled
   name: chief medical officer's chest rig
   description: "A medical chest rig with deep pockets, for use by paramedics and health professionals."
@@ -10,9 +11,10 @@
       - id: EnergyScalpel
       - id: AdvancedRetractor
       - id: BoneGel
-      - id: Brutepack
-      - id: Ointment
+      - id: MedicatedSuture
+      - id: RegenerativeMesh
       - id: Bloodpack
-      - id: Gauze
+      - id: BruteAutoInjector
+      - id: BurnAutoInjector
       - id: EmergencyMedipen
         amount: 3


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
cmo chest rig now gets medicated suture regenerative mesh and brute/burn autoinjector instead of the dogshit topicals
its also actually medical restricted contra now and has the filled suffix

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: cmo chest rig gets better topical stuff now
- fix: cmo chest rig is medical restricted contra now
