### PR TITLE
Add sodium-water reaction

### DIFF
--- a/Resources/Prototypes/_Goobstation/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Reactions/chemicals.yml
@@ -1,0 +1,16 @@
+- type: reaction
+  id: SodiumExplosion
+  impact: High
+  priority: 20
+  reactants:
+    Water:
+      amount: 1
+    Sodium:
+      amount: 1
+  effects:
+    - !type:ExplosionReactionEffect
+      explosionType: Default
+      maxIntensity: 100
+      intensityPerUnit: 0.5 # 50+50 reagent for maximum explosion
+      intensitySlope: 4
+      maxTotalIntensity: 100


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title

## Why / Balance
More explosive options for chemists. Plus, potassium is important, sodium is used only a handful of places

**Changelog**
:cl:
- add: sodium now explodes in water, just like potassium
