### PR TITLE
Make Meth Explosive!

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/narcotics.ftl
+++ b/Resources/Locale/en-US/reagents/meta/narcotics.ftl
@@ -1,5 +1,5 @@
 reagent-name-desoxyephedrine = desoxyephedrine
-reagent-desc-desoxyephedrine = A more effective ephedrine, with more active downsides. Requires less doses to cure narcolepsy.
+reagent-desc-desoxyephedrine = A more effective ephedrine, with more active downsides. Requires less doses to cure narcolepsy. Explodes if you heat it to 420K!
 
 reagent-name-ephedrine = ephedrine
 reagent-desc-ephedrine = A caffeinated adrenaline stimulator chemical that makes you faster and harder to knock down. Also helps combat narcolepsy at dosages over thirty, at the cost of severe nerval stress.

--- a/Resources/Prototypes/_Goobstation/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Reactions/chemicals.yml
@@ -1,0 +1,16 @@
+- type: reaction
+  id: SodiumExplosion
+  impact: High
+  priority: 20
+  reactants:
+    Water:
+      amount: 1
+    Sodium:
+      amount: 1
+  effects:
+    - !type:ExplosionReactionEffect
+      explosionType: Default
+      maxIntensity: 100
+      intensityPerUnit: 0.5 # 50+50 reagent for maximum explosion
+      intensitySlope: 4
+      maxTotalIntensity: 100

--- a/Resources/Prototypes/_Goobstation/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Reactions/single_reagent.yml
@@ -10,6 +10,6 @@
     - !type:ExplosionReactionEffect
       explosionType: Default
       maxIntensity: 100
-      intensityPerUnit: 0.5 # 50+50 reagent for maximum explosion
+      intensityPerUnit: 1 # this is twice the potassium-water IPU, so uhhh, more bang for your buck? meth is hard okay
       intensitySlope: 4
       maxTotalIntensity: 100

--- a/Resources/Prototypes/_Goobstation/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Reactions/single_reagent.yml
@@ -1,0 +1,15 @@
+- type: reaction
+  id: MethExplosion
+  minTemp: 420
+  impact: High
+  priority: 20
+  reactants:
+    Desoxyephedrine:
+      amount: 1
+  effects:
+    - !type:ExplosionReactionEffect
+      explosionType: Default
+      maxIntensity: 100
+      intensityPerUnit: 0.5 # 50+50 reagent for maximum explosion
+      intensitySlope: 4
+      maxTotalIntensity: 100

--- a/Resources/Prototypes/_Goobstation/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Reactions/single_reagent.yml
@@ -1,6 +1,6 @@
 - type: reaction
   id: MethExplosion
-  minTemp: 420
+  minTemp: 420 # in the latest ss13 code I could find, this was at 380, only 10k above the meth reaction, so this is lenient
   impact: High
   priority: 20
   reactants:
@@ -8,8 +8,8 @@
       amount: 1
   effects:
     - !type:ExplosionReactionEffect
-      explosionType: Default
-      maxIntensity: 100
-      intensityPerUnit: 1 # this is twice the potassium-water IPU, so uhhh, more bang for your buck? meth is hard okay
-      intensitySlope: 4
-      maxTotalIntensity: 100
+      explosionType: Methsplosion
+      maxIntensity: 50
+      intensityPerUnit: 0.7 # I don't want it too spicy as just a lab accident thing
+      intensitySlope: 6 # if you accidentally blew up your meth, it's your problem, not everybody else's
+      maxTotalIntensity: 50

--- a/Resources/Prototypes/_Goobstation/explosions.yml
+++ b/Resources/Prototypes/_Goobstation/explosions.yml
@@ -19,7 +19,7 @@
   damagePerIntensity: # yeah I want it less damaging than the default explosion, considering it's high intensity slope
     types:
       Heat: 3
-      Blunt: 8
+      Blunt: 5
   tileBreakChance: [0, 0.5, 1]
   tileBreakIntensity: [0, 10, 30]
   tileBreakRerollReduction: 20

--- a/Resources/Prototypes/_Goobstation/explosions.yml
+++ b/Resources/Prototypes/_Goobstation/explosions.yml
@@ -13,3 +13,16 @@
   fireColor: Green
   texturePath: /Textures/Effects/fire_greyscale.rsi
   fireStates: 3
+
+- type: explosion
+  id: Methsplosion
+  damagePerIntensity: # yeah I want it less damaging than the default explosion, considering it's high intensity slope
+    types:
+      Heat: 3
+      Blunt: 8
+  tileBreakChance: [0, 0.5, 1]
+  tileBreakIntensity: [0, 10, 30]
+  tileBreakRerollReduction: 20
+  lightColor: Orange
+  texturePath: /Textures/Effects/fire.rsi
+  fireStates: 3


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Meth will now explode when heated to 420K, with a small area of effect that destroys adjacent machines.

## Why / Balance
Adds some danger/excitement to chem, and more pyrotechnics options.
An attentive chemist will take their meth off the hotplate when it finishes cooking without any issue,
the inattentive chemist or one that uses ChemMaster temperature jank will have their meth explode in their face

Considering the SS13 equivalent happens at only 10K above it's creation temperature, this is significantly more lenient

## Technical details
- New explosion type that deals mainly blunt damage, will allow tweaking of tile destruction if someone makes the explosion more powerful
- Heating Desoxyephedrine to 420K will make it explode strong enough to take out directly adjacent machines

**Changelog**

:cl:
- tweak: Desoxyephedrine, aka METH, now explodes at 420K, 50K above the temperature it is made at.
