### PR TITLE
Ore balancing (revert from wizden nerf)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -37,7 +37,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawGold: 300 # Goobstation - was 100
+      RawGold: 500 # Goobstation - was 100
   - type: Extractable
     grindableSolutionName: goldore
   - type: SolutionContainerManager
@@ -99,7 +99,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawIron: 200 # Goobstation - was 100
+      RawIron: 300 # Goobstation - was 100
   - type: Extractable
     grindableSolutionName: ironore
   - type: SolutionContainerManager
@@ -166,7 +166,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawSilver: 300 # Goobstation - was 100
+      RawSilver: 500 # Goobstation - was 100
   - type: Extractable
     grindableSolutionName: silverore
   - type: SolutionContainerManager
@@ -197,7 +197,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawQuartz: 200 # Goobstation - was 100
+      RawQuartz: 300 # Goobstation - was 100
   - type: Extractable
     grindableSolutionName: quartzore
   - type: SolutionContainerManager
@@ -228,7 +228,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawUranium: 300 # Goobstation - was 100
+      RawUranium: 500 # Goobstation - was 100
   - type: PointLight
     radius: 1.2
     energy: 0.8
@@ -267,7 +267,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawBananium: 100
+      RawBananium: 300 # Goobstation - was 100
   - type: PointLight
     radius: 1.2
     energy: 1
@@ -323,7 +323,7 @@
           Quantity: 0.1
   - type: PhysicalComposition
     materialComposition:
-      Coal: 200 # Goobstation - was 100
+      Coal: 300 # Goobstation - was 100
 
 - type: entity
   parent: Coal
@@ -370,7 +370,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawSalt: 100
+      RawSalt: 300 # Goobstation - was 100
   - type: Extractable
     grindableSolutionName: saltore
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Procedural/biome_ore_templates.yml
+++ b/Resources/Prototypes/Procedural/biome_ore_templates.yml
@@ -9,8 +9,8 @@
     WallRockSand: WallRockSandTin
     WallRockSnow: WallRockSnowTin
   maxCount: 30
-  minGroupSize: 10
-  maxGroupSize: 15
+  minGroupSize: 8
+  maxGroupSize: 20
   radius: 4
 
 - type: biomeMarkerLayer
@@ -22,8 +22,8 @@
     WallRockChromite: WallRockChromiteQuartz
     WallRockSnow: WallRockSnowQuartz
   maxCount: 30
-  minGroupSize: 10
-  maxGroupSize: 15
+  minGroupSize: 8
+  maxGroupSize: 20
   radius: 4
 
 - type: biomeMarkerLayer
@@ -37,7 +37,7 @@
     WallRockSnow: WallRockSnowCoal
   maxCount: 30
   minGroupSize: 8
-  maxGroupSize: 12
+  maxGroupSize: 20
   radius: 4
 
 - type: biomeMarkerLayer
@@ -51,7 +51,7 @@
     WallRockSnow: WallRockSnowSalt
   maxCount: 30
   minGroupSize: 8
-  maxGroupSize: 12
+  maxGroupSize: 20
   radius: 4
 
 # Medium value
@@ -65,7 +65,7 @@
     WallRockChromite: WallRockChromiteGold
     WallRockSand: WallRockSandGold
     WallRockSnow: WallRockSnowGold
-  maxCount: 20
+  maxCount: 30
   minGroupSize: 5
   maxGroupSize: 10
   radius: 4
@@ -80,7 +80,7 @@
     WallRockChromite: WallRockChromiteSilver
     WallRockSand: WallRockSandSilver
     WallRockSnow: WallRockSnowSilver
-  maxCount: 20
+  maxCount: 30
   minGroupSize: 5
   maxGroupSize: 10
   radius: 4
@@ -97,8 +97,8 @@
     WallRockSand: WallRockSandPlasma
     WallRockSnow: WallRockSnowPlasma
   maxCount: 12
-  minGroupSize: 4
-  maxGroupSize: 8
+  minGroupSize: 5
+  maxGroupSize: 10
   radius: 4
 
 # Uranium
@@ -111,9 +111,9 @@
     WallRockChromite: WallRockChromiteUranium
     WallRockSand: WallRockSandUranium
     WallRockSnow: WallRockSnowUranium
-  maxCount: 15
-  minGroupSize: 4
-  maxGroupSize: 8
+  maxCount: 12
+  minGroupSize: 5
+  maxGroupSize: 10
   radius: 4
 
 - type: biomeMarkerLayer

--- a/Resources/Prototypes/Procedural/vgroid.yml
+++ b/Resources/Prototypes/Procedural/vgroid.yml
@@ -31,56 +31,62 @@
       replacement: IronRock
       entity: IronRockIron
       count: 50
-      minGroupSize: 10
-      maxGroupSize: 15
+      minGroupSize: 20
+      maxGroupSize: 30
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockCoal
       count: 50
-      minGroupSize: 8
-      maxGroupSize: 12
+      minGroupSize: 15
+      maxGroupSize: 20
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockQuartz
       count: 50
-      minGroupSize: 10
-      maxGroupSize: 15
+      minGroupSize: 20
+      maxGroupSize: 30
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockSalt
       count: 50
-      minGroupSize: 8
-      maxGroupSize: 12
+      minGroupSize: 20
+      maxGroupSize: 30
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockGold
-      count: 40
-      minGroupSize: 8
-      maxGroupSize: 12
+      count: 50
+      minGroupSize: 10
+      maxGroupSize: 20
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockSilver
-      count: 40
-      minGroupSize: 8
-      maxGroupSize: 12
+      count: 50
+      minGroupSize: 10
+      maxGroupSize: 20
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockPlasma
-      count: 35
-      minGroupSize: 4
-      maxGroupSize: 8
+      count: 50
+      minGroupSize: 10
+      maxGroupSize: 20
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockUranium
-      count: 35
-      minGroupSize: 4
-      maxGroupSize: 8
+      count: 50
+      minGroupSize: 10
+      maxGroupSize: 20
+    - !type:OreDunGen #Goob wiznerf partial revert
+      replacement: IronRock
+      entity: IronRockBananium
+      count: 50
+      minGroupSize: 5
+      maxGroupSize: 10
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockArtifactFragment
-      count: 25
-      minGroupSize: 1
-      maxGroupSize: 3
+      count: 50
+      minGroupSize: 2
+      maxGroupSize: 4
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockDiamond

--- a/Resources/Prototypes/_Goobstation/Procedural/biom_ore_templates.yml
+++ b/Resources/Prototypes/_Goobstation/Procedural/biom_ore_templates.yml
@@ -11,3 +11,16 @@
   minGroupSize: 1
   maxGroupSize: 2
   radius: 3
+
+- type: biomeMarkerLayer #revert from wiznerf
+  id: OreBananium
+  entityMask:
+    AsteroidRock: AsteroidRockBananium
+    WallRock: WallRockBananium
+    WallRockBasalt: WallRockBasaltBananium
+    WallRockChromite: WallRockChromiteBananium
+    WallRockSand: WallRockSandBananium
+    WallRockSnow: WallRockSnowBananium
+  maxCount: 12
+  minGroupSize: 5
+  maxGroupSize: 10

--- a/Resources/Prototypes/_Goobstation/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/_Goobstation/Procedural/salvage_loot.yml
@@ -1,0 +1,6 @@
+- type: salvageLoot  #revert from wiznerf
+  id: OreBananium
+  guaranteed: true
+  loots:
+  - !type:BiomeMarkerLoot
+    proto: OreBananium

--- a/Resources/Prototypes/ore.yml
+++ b/Resources/Prototypes/ore.yml
@@ -56,7 +56,7 @@
   id: OreBananium
   oreEntity: BananiumOre1
   minOreYield: 1
-  maxOreYield: 2
+  maxOreYield: 3
 
 - type: ore
   id: OreDiamond


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I reverted back almost at the identical ore composition and ore procedural generation

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bounty : https://discord.com/channels/1202734573247795300/1313673129599438899

With the recent changes, it seems there is an heavy strain on station resources and science resources in general, mostly due to wizden #https://github.com/space-wizards/space-station-14/pull/30920.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Removed Wizden ore nerf
- tweak: Ore procedural generation on asteroïds and vg roid. Increased ore composition


