### PR TITLE
Make cryo syringes usable in syringe guns.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -574,6 +574,7 @@
     tags:
     - Syringe
     - Trash
+    - SyringeGunAmmo # Goobstation
   - type: PhysicalComposition #Goobstation - Recycle update
     materialComposition:
       Steel: 62


### PR DESCRIPTION
## About the PR
cryo syringe in syringe gun

## Why / Balance
funni

**Changelog**
:cl:
- tweak: Cryo syringes are usable in syringe guns now.