### PR TITLE
Burner assault rifle buff

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Goobstation/store/uplink-catalog.ftl
@@ -57,8 +57,11 @@ uplink-weapon-burner-desc = A bundle containing a Burner Heavy Rifle and a coupl
 
 # Ammo
 
-uplink-high-caliber-box-name = 30 round .50 Box
+uplink-high-caliber-box-name = .50 Ammo box
 uplink-high-caliber-box-desc = A box of 30 .50 caliber anti-materiel rounds.
+
+uplink-high-caliber-magazine-name = .50 Magazine
+uplink-high-caliber-magazine-desc = A magazine of 15 .50 caliber anti-materiel rounds.
 
 # Mechs
 

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -99,7 +99,7 @@
   icon: { sprite: /Textures/_Goobstation/Objects/Weapons/Guns/Rifles/burner.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateBurner
   cost:
-    Telecrystal: 150 # meant to be a side-grade to L6 Saw, if it ends up being better we can nerf it or up TC cost to 175-200.
+    Telecrystal: 125
   categories:
   - UplinkWeaponry
   conditions:
@@ -298,15 +298,36 @@
 # Ammo
 
 - type: listing
+  id: UplinkMagazineHighCaliber
+  name: uplink-high-caliber-magazine-name
+  description: uplink-high-caliber-magazine-desc
+  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/heavy_rifle_mags.rsi, state: base }
+  productEntity: MagazineHighCaliber
+  cost:
+    Telecrystal: 25 # 1.66 TC per bullet, high price on mags.
+  categories:
+  - UplinkAmmo
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
+
+- type: listing
   id: UplinkHighCaliberBox
   name: uplink-high-caliber-box-name
   description: uplink-high-caliber-box-desc
   icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Boxes/anti_materiel.rsi, state: base-b }
   productEntity: MagazineBoxHighCaliber
   cost:
-    Telecrystal: 40 # ammo should be a big cost for this
+    Telecrystal: 3 # 1 TC per bullet
   categories:
   - UplinkAmmo
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
 
 # 弾薬
 - type: listing

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -99,7 +99,7 @@
   icon: { sprite: /Textures/_Goobstation/Objects/Weapons/Guns/Rifles/burner.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateBurner
   cost:
-    Telecrystal: 150
+    Telecrystal: 125 # don't kill me piras
   categories:
   - UplinkWeaponry
   conditions:

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -99,7 +99,7 @@
   icon: { sprite: /Textures/_Goobstation/Objects/Weapons/Guns/Rifles/burner.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateBurner
   cost:
-    Telecrystal: 125
+    Telecrystal: 150
   categories:
   - UplinkWeaponry
   conditions:

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -320,7 +320,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Boxes/anti_materiel.rsi, state: base-b }
   productEntity: MagazineBoxHighCaliber
   cost:
-    Telecrystal: 3 # 1 TC per bullet
+    Telecrystal: 35 # 1 TC per bullet
   categories:
   - UplinkAmmo
   conditions:

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -301,7 +301,7 @@
   id: UplinkMagazineHighCaliber
   name: uplink-high-caliber-magazine-name
   description: uplink-high-caliber-magazine-desc
-  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/heavy_rifle_mags.rsi, state: base }
+  icon: { sprite: /Textures/_Goobstation/Objects/Weapons/Guns/Ammunition/Magazine/heavy_rifle_mags.rsi, state: base }
   productEntity: MagazineHighCaliber
   cost:
     Telecrystal: 25 # 1.66 TC per bullet, high price on mags.

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/high_caliber_magazine.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/high_caliber_magazine.yml
@@ -15,7 +15,7 @@
       tags:
         - CartridgeHighCaliber
     proto: CartridgeHighCaliber
-    capacity: 15
+    capacity: 10
   - type: ContainerContainer
     containers:
       ballistic-ammo: !type:Container

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/high_caliber_magazine.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/high_caliber_magazine.yml
@@ -15,7 +15,7 @@
       tags:
         - CartridgeHighCaliber
     proto: CartridgeHighCaliber
-    capacity: 10
+    capacity: 15
   - type: ContainerContainer
     containers:
       ballistic-ammo: !type:Container

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -92,6 +92,7 @@
       types:
         Piercing: 35
         Structural: 130 # if you were a wall would you like having a .50 cal anti materiel round go through you? (this breaks a normal wall in 3 shots, one mag goes through four normal walls, 10 rounds to take down a reinforced wall)
+    ignoreResistances: true
 
 - type: entity
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -92,7 +92,7 @@
       types:
         Piercing: 35
         Structural: 130 # if you were a wall would you like having a .50 cal anti materiel round go through you? (this breaks a normal wall in 3 shots, one mag goes through four normal walls, 10 rounds to take down a reinforced wall)
-    ignoreResistances: true
+    
 
 - type: entity
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifle.yml
@@ -12,7 +12,7 @@
       - state: mag-0
         map: ["enum.GunVisualLayers.Mag"]
   - type: Gun
-    fireRate: 2.5
+    fireRate: 3.5
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/sniper.ogg
   - type: ChamberMagazineAmmoProvider


### PR DESCRIPTION
## About the PR
burner rifle gets AP for shits and giggles, ammo is more available and mags are slightly bigger.

## Why / Balance
it was suggested on the discord, you kinda plow through bullets.
1.6-1.1 TC per bullet :trollface: 

![image](https://github.com/user-attachments/assets/33752834-7cdf-4573-97ac-64d05b08618d)

https://discord.com/channels/1202734573247795300/1314468353783631892

**Changelog**
:cl:
- tweak: The Burner assault rifle now has AP as god intended.
- tweak: The Burner assualt rifle now has 15 round mags and you can buy more in the uplink.