### PR TITLE
Fix BSO getting two emergency boxes

### DIFF
--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -53,7 +53,6 @@
     pocket1: UniqueBlueshieldOfficerLockerTeleporter
   storage:
     back:
-    - BoxSurvivalSlots
     - Flash
     - BluespaceLifelineImplanter
     - SecHypo


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Literally 1 line, prevents BSO from spawning with 2 emergency boxes.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Real
## Technical details
<!-- Summary of code changes for easier review. -->
Real
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->



