### PR TITLE
Therapeutic patches

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1039,7 +1039,7 @@
       - SyringeGun #Goobstation
       - MedicalPatchBasic  #Goobstation - MedicalPatch
       - MedicalPatchRapid #Goobstation - MedicalPatch
-      - MedicalPatchTheraputic #Goobstation - MedicalPatch
+      - MedicalPatchTherapeutic #Goobstation - MedicalPatch
       - MedicalPatchLarge #Goobstation - MedicalPatch
       - BoneGel # Shitmed Change
       - VehicleWheelchairFolded # Goobstation - Vehicles

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1039,6 +1039,7 @@
       - SyringeGun #Goobstation
       - MedicalPatchBasic  #Goobstation - MedicalPatch
       - MedicalPatchRapid #Goobstation - MedicalPatch
+      - MedicalPatchTheraputic #Goobstation - MedicalPatch
       - MedicalPatchLarge #Goobstation - MedicalPatch
       - BoneGel # Shitmed Change
       - VehicleWheelchairFolded # Goobstation - Vehicles

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/medical_patch.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/medical_patch.yml
@@ -116,7 +116,7 @@
     layers:
       - state: GenericPatch
       - state: GenericPatchBorder
-        color: "66bbff"
+        color: LightBlue
       - state: GenericPatch-1
         map: ["enum.SolutionContainerLayers.Fill"]
         visible: false

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/medical_patch.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/medical_patch.yml
@@ -116,7 +116,7 @@
     layers:
       - state: GenericPatch
       - state: GenericPatchBorder
-        color: Blue
+        color: "66bbff"
       - state: GenericPatch-1
         map: ["enum.SolutionContainerLayers.Fill"]
         visible: false

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/medical_patch.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/medical_patch.yml
@@ -107,8 +107,8 @@
 
 - type: entity
   parent: MedicalPatchBasic
-  id: MedicalPatchTheraputic
-  name: theraputic patch
+  id: MedicalPatchTherapeutic
+  name: therapeutic patch
   description:  used to apply small doses over a long time
   components:
   - type: Sprite
@@ -185,8 +185,8 @@
     Plastic: 100
 
 - type: latheRecipe
-  id: MedicalPatchTheraputic
-  result: MedicalPatchTheraputic
+  id: MedicalPatchTherapeutic
+  result: MedicalPatchTherapeutic
   completetime: 2
   materials:
     Cloth: 100

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/medical_patch.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/medical_patch.yml
@@ -107,6 +107,24 @@
 
 - type: entity
   parent: MedicalPatchBasic
+  id: MedicalPatchTheraputic
+  name: theraputic patch
+  description:  used to apply small doses over a long time
+  components:
+  - type: Sprite
+    sprite: _Goobstation/Objects/Medical/medical_patch.rsi
+    layers:
+      - state: GenericPatch
+      - state: GenericPatchBorder
+        color: Blue
+      - state: GenericPatch-1
+        map: ["enum.SolutionContainerLayers.Fill"]
+        visible: false
+  - type: MedicalPatch
+    transferAmount: 0.5 # literally the rapid patch but in reverse
+
+- type: entity
+  parent: MedicalPatchBasic
   id: MedicalPatchLarge
   name: large patch
   description: put this on your Big boo boo
@@ -161,6 +179,14 @@
 - type: latheRecipe
   id: MedicalPatchRapid
   result: MedicalPatchRapid
+  completetime: 2
+  materials:
+    Cloth: 100
+    Plastic: 100
+
+- type: latheRecipe
+  id: MedicalPatchTheraputic
+  result: MedicalPatchTheraputic
   completetime: 2
   materials:
     Cloth: 100


### PR DESCRIPTION
## About the PR
Added therapeutic patches, essentially the rapid patch in reverse

## Why / Balance
It may end up being too strong, but I created this because I noticed how little the rapid patch is used, due to overdosing. So I decided to create a variant that actually contends with the normal and large patches.

## Technical details
- New patch that injects 0.5u/s and has 40u capacity, craftable at the medical techfab for the same price as other patches

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- add: Therapeutic patches that inject 0.5u/s with a total capacity of 40 units.