### PR TITLE
buff x01 lazgun

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -832,15 +832,15 @@
   - type: EnergyGun
     fireModes:
     - proto: BulletDisabler
-      fireCost: 100
+      fireCost: 140
       name: disabling
       state: disabler
     - proto: BulletEnergyGunLaser
-      fireCost: 200
+      fireCost: 160
       name: lethal
       state: lethal
     - proto: BulletEnergyGunIon
-      fireCost: 200
+      fireCost: 120
       name: ion
       state: special
   - type: MagazineVisuals
@@ -861,3 +861,6 @@
     - Sidearm
   - type: StaticPrice
     price: 750
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 20


### PR DESCRIPTION

## About the PR
gives hos lazgun self recharge which is half of cap's (20) and lowers the amount of battery it takes to fire it

## Why / Balance
it's laughably weak as of now with a lot of hos players wanting the old wt550 back
takes 8 seconds to selfcharge for a lethal shot with this pr




**Changelog**

:cl: Syndie
- tweak: Gave X01 weak self charge and lowered it's firing costs


