### PR TITLE
Raise Phlogiston Reaction Priority

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
+++ b/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
@@ -12,6 +12,7 @@
 
 - type: reaction
   id: Phlogiston
+  priority: 20
   reactants:
     Phosphorus:
       amount: 1


### PR DESCRIPTION
## About the PR
Gave Phlogiston priority identical to CLF3, allowing for it's formation before smoke and foam removes it's reactants from the beaker.

## Why / Balance
Makes phlogiston more than just an alternative to CLF3 that doesn't explode.
I like plasma fires :godo:

## Technical details
- Phlogiston now has a priority of 20

## Media
![hellmo](https://github.com/user-attachments/assets/1086a26d-6cd7-42d8-bd2a-3e5045fb3755)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: Phlogiston now has a priority of 20, which makes it's reaction take place before foams and smokes :feelsgood: