### PR TITLE
changeling slugs can now walk under tables and doors

### DIFF
--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
@@ -5,7 +5,7 @@
   description: You don't want to touch it.
   components:
   - type: Sprite
-    drawdepth: Mobs
+    drawdepth: SmallMobs
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: headcrab

--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
@@ -29,3 +29,14 @@
     baseSprintSpeed: 7
   - type: ExplosionResistance
     damageCoefficient: 0
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.2
+        density: 15
+        mask:
+        - SmallMobMask
+        layer:
+        - SmallMobLayer


### PR DESCRIPTION
## About the PR
made ling headslugs able to crawl under tables and doors

## Why / Balance
so the ability is worth using

**Changelog**
:cl:
- tweak: Changeling headslugs can now crawl under tables and doors

