### PR TITLE
remove double wield from mini ebow

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -27,8 +27,6 @@
     magState: mag
     steps: 2
     zeroVisible: true
-  - type: Multishot
-    spreadMultiplier: 1.2
 
 - type: entity
   name: plasma rifle


### PR DESCRIPTION
## About the PR
removes dual wielding from mini ebow

## Why / Balance
no inf stun no fun
i hate multishot

**Changelog**
:cl:
- tweak: removed ebow dual wielding

