### PR TITLE
Rage Nerf - Remove Bluespace Crystal craft from protolathe

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -300,7 +300,6 @@
     - LargeBeaker
     - Dropper
     - ClothingEyesGlassesChemical
-    - MaterialBSCrystal # Goobstation
     dynamicRecipes:
       - PowerDrill
       - MiningDrill

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/sheet.yml
@@ -1,9 +1,0 @@
-- type: latheRecipe
-  id: MaterialBSCrystal
-  result: MaterialBSCrystal1
-  completetime: 2
-  materials:
-    Gold: 25
-    Silver: 25
-    Glass: 50
-    Plasma: 50


### PR DESCRIPTION
## About the PR
Remove Bluespace Crystal craft from protolathe. Now it's rare ore only.

## Why / Balance
1. Bluespace crystal entirely ruining economy (one crystal costs 3000 credits when components costs less than 50 credits)
2. Craft 30 bluespace crystals - get 30 scram implants without cooldown. 

:cl:
- remove: Removed bluespace crystal craft from protolathe.

