### PR TITLE
Buff sabre

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -36,7 +36,7 @@
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Reflect
-    reflectProb: .5
+    reflectProb: .3
     spread: 90
   - type: Item
     sprite: Objects/Weapons/Melee/captain_sabre.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -36,7 +36,7 @@
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Reflect
-    reflectProb: .1
+    reflectProb: .5
     spread: 90
   - type: Item
     sprite: Objects/Weapons/Melee/captain_sabre.rsi


### PR DESCRIPTION
## About the PR
<!---->
 Buffed sabre back to its original reflection chance 

## Why / Balance
<!---->
 Sabre is useless without reflection this change makes it actually a viable weapon for captains to defend themselves 

**Changelog**
<!-- -->
- tweak: Captain Sabre's reflection was buffed back to 30% chance.
<!---->