### PR TITLE
saves christmas

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -525,13 +525,11 @@
   components:
   - type: LimitedItemGiver
     spawnEntries:
-      - id: PresentRandom
-        orGroup: present
       - id: PresentRandomUnsafe
-        prob: 0.5
+        prob: 0.6
         orGroup: present
       - id: PresentRandomInsane
-        prob: 0.2
+        prob: 0.4
         orGroup: present
 
 - type: entity


### PR DESCRIPTION

## About the PR
christmas trees now only drop unsafe and insane presents
unsafe - 60%
insane - 40%

## Why / Balance
fun for the whole family
