### PR TITLE
up insuls in engivend to 12

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engivend.yml
@@ -7,6 +7,6 @@
     Multitool: 4
     NetworkConfigurator: 5
     PowerCellMedium: 5
-    ClothingHandsGlovesColorYellow: 6
+    ClothingHandsGlovesColorYellow: 12 # GoobStation: was 6, IPCs need insuls more than usual
     BoxInflatable: 2
     ClothingHeadHatCone: 4


### PR DESCRIPTION
## About the PR
title

## Why / Balance
IPCs need them to not explode from a shocked grille and maybe engi wont be stingy when theres this many

**Changelog**
:cl:
- tweak: EngiVends now have 12 insuls instead of 6.
