### PR TITLE
give wehs a lowecase emoting

### DIFF
--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -329,7 +329,7 @@
   name: chat-emote-name-weh
   category: Vocal
   icon: Interface/Emotes/weh.png
-  chatMessages: [Wehs!]
+  chatMessages: [wehs]
 
 - type: emote
   id: Chirp


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
see title

## Why / Balance
just otherwise doesn't make sense, it's like using `*Screams.` as a real emote

## Technical details
.toLowerCase().slice(-1)

## Media


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have attempted to evade a ban, and have been banned indefinitely pending a voucher.

## Breaking changes

**Changelog**
no cl no fun