### PR TITLE
thieves can now throw cans and shoot non-lethal guns

### DIFF
--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
@@ -29,7 +29,6 @@ public sealed partial class PuddleSystem
         SubscribeLocalEvent<SpillableComponent, MeleeHitEvent>(SplashOnMeleeHit, after: [typeof(OpenableSystem)]);
         SubscribeLocalEvent<SpillableComponent, SolutionContainerOverflowEvent>(OnOverflow);
         SubscribeLocalEvent<SpillableComponent, SpillDoAfterEvent>(OnDoAfter);
-        SubscribeLocalEvent<SpillableComponent, AttemptPacifiedThrowEvent>(OnAttemptPacifiedThrow);
     }
 
     private void OnOverflow(Entity<SpillableComponent> entity, ref SolutionContainerOverflowEvent args)

--- a/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
+++ b/Content.Server/Fluids/EntitySystems/PuddleSystem.Spillable.cs
@@ -121,22 +121,6 @@ public sealed partial class PuddleSystem
         TrySplashSpillAt(entity.Owner, Transform(entity).Coordinates, drainedSolution, out _);
     }
 
-    /// <summary>
-    /// Prevent Pacified entities from throwing items that can spill liquids.
-    /// </summary>
-    private void OnAttemptPacifiedThrow(Entity<SpillableComponent> ent, ref AttemptPacifiedThrowEvent args)
-    {
-        // Don’t care about closed containers.
-        if (Openable.IsClosed(ent))
-            return;
-
-        // Don’t care about empty containers.
-        if (!_solutionContainerSystem.TryGetSolution(ent.Owner, ent.Comp.SolutionName, out _, out var solution) || solution.Volume <= 0)
-            return;
-
-        args.Cancel("pacified-cannot-throw-spill");
-    }
-
     private void OnDoAfter(Entity<SpillableComponent> entity, ref SpillDoAfterEvent args)
     {
         if (args.Handled || args.Cancelled || args.Args.Target == null)

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -240,6 +240,8 @@
     fireCost: 62.5
   - type: StaticPrice
     price: 300
+  - type: PacifismAllowedGun
+
 
 - type: entity
   name: laser rifle
@@ -466,6 +468,8 @@
     tags:
     - Taser
     - Sidearm
+  - type: PacifismAllowedGun
+
 
 - type: entity
   name: disabler
@@ -494,6 +498,8 @@
     guides:
     - Security
     - Antagonists
+  - type: PacifismAllowedGun
+
 
 - type: entity
   name: disabler SMG
@@ -531,6 +537,8 @@
     zeroVisible: true
   - type: StaticPrice
     price: 260
+  - type: PacifismAllowedGun
+
 
 - type: entity
   name: taser
@@ -567,6 +575,8 @@
     steps: 5
     zeroVisible: true
   - type: Appearance
+  - type: PacifismAllowedGun
+
 
 - type: entity
   name: antique laser pistol
@@ -699,6 +709,8 @@
     materialComposition:
       Steel: 125
       Glass: 100
+  - type: PacifismAllowedGun
+
 
 - type: entity
   name: experimental C.H.I.M.P. handcannon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
@@ -61,6 +61,8 @@
       storagebase: !type:Container
         ents: []
       gas_tank: !type:ContainerSlot
+  - type: PacifismAllowedGun
+
 
 - type: entity
   name: pie cannon
@@ -103,6 +105,8 @@
     containers:
       storagebase: !type:Container
         ents: []
+  - type: PacifismAllowedGun
+
 
 - type: entity
   name: syringe gun
@@ -140,6 +144,8 @@
     containers:
       storagebase: !type:Container
         ents: []
+  - type: PacifismAllowedGun
+
 
 # shoots bullets instead of throwing them, no other changes
 - type: entity

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
@@ -33,6 +33,8 @@
       storagebase: !type:Container
         ents: []
   - type: SyringeGun
+  - type: PacifismAllowedGun
+
 
 
 - type: entity
@@ -54,6 +56,8 @@
       - SyringeGunAmmo
   - type: Gun
     fireRate: 1.5
+  - type: PacifismAllowedGun
+
 
 - type: entity
   name: dart syringe gun
@@ -80,5 +84,7 @@
     - 0,0,1,0
   - type: SyringeGun
     pierceArmor: true
+  - type: PacifismAllowedGun
+
 
 # TODO: Add the proper dart gun that regenerates every 25s, and draws from a 100u reservoir

--- a/Resources/Prototypes/_Goobstation/Entities/Weapons/Guns/pneumatic_cannon.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Weapons/Guns/pneumatic_cannon.yml
@@ -4,10 +4,9 @@
   id: LauncherCreamPieRegenerating
   description: A self-regenerating pie cannon.
   suffix: Regenerating
-  - type: PacifismAllowedGun
-
 
   components:
+  - type: PacifismAllowedGun
   - type: Sprite
     sprite: Objects/Weapons/Guns/Cannons/pie_cannon.rsi
 

--- a/Resources/Prototypes/_Goobstation/Entities/Weapons/Guns/pneumatic_cannon.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Weapons/Guns/pneumatic_cannon.yml
@@ -4,6 +4,8 @@
   id: LauncherCreamPieRegenerating
   description: A self-regenerating pie cannon.
   suffix: Regenerating
+  - type: PacifismAllowedGun
+
 
   components:
   - type: Sprite


### PR DESCRIPTION
## About the PR
made thieves able to throw containers with liquids in them (does not include beakers as they break on impact) and shoot non-lethal guns like disablers, practice guns, syringe guns and pneumatic cannons

## Why / Balance
disablers do 0 damage now so there's no reason for thieves not to be able to fire them
space cola cans are very cool for slipping seccies 


**Changelog**
:cl:
- tweak: Pacifists can now throw things with liquids in them, shoot syringe guns and disablers

