### PR TITLE
Make yowie playable

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/NoWieldNeeded.cs
+++ b/Content.Shared/Weapons/Ranged/Components/NoWieldNeeded.cs
@@ -1,0 +1,16 @@
+using Content.Shared.Wieldable;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Weapons.Ranged.Components;
+
+/// <summary>
+/// Indicates that this gun user does not need to wield.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(WieldableSystem))]
+public sealed partial class NoWieldNeededComponent : Component
+{
+    //If true, not only does the user not need to wield to fire, they get the bonus for free!
+    [DataField("getBonus")]
+    public bool GetBonus = true;
+}

--- a/Content.Shared/Weapons/Ranged/Events/GunRefreshModifiersEvent.cs
+++ b/Content.Shared/Weapons/Ranged/Events/GunRefreshModifiersEvent.cs
@@ -19,5 +19,6 @@ public record struct GunRefreshModifiersEvent(
     Angle MinAngle,
     int ShotsPerBurst,
     float FireRate,
-    float ProjectileSpeed
+    float ProjectileSpeed,
+    EntityUid? User
 );

--- a/Content.Shared/Weapons/Ranged/Events/GunRefreshModifiersEvent.cs
+++ b/Content.Shared/Weapons/Ranged/Events/GunRefreshModifiersEvent.cs
@@ -20,5 +20,5 @@ public record struct GunRefreshModifiersEvent(
     int ShotsPerBurst,
     float FireRate,
     float ProjectileSpeed,
-    EntityUid? User
+    EntityUid? User // GoobStation change - User for NoWieldNeeded
 );

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -549,7 +549,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         Physics.ApplyLinearImpulse(user, -impulseVector, body: userPhysics);
     }
 
-    public void RefreshModifiers(Entity<GunComponent?> gun, EntityUid? User = null)
+    public void RefreshModifiers(Entity<GunComponent?> gun, EntityUid? User = null) // GoobStation change - User for NoWieldNeeded
     {
         if (!Resolve(gun, ref gun.Comp))
             return;
@@ -566,7 +566,7 @@ public abstract partial class SharedGunSystem : EntitySystem
             comp.ShotsPerBurst,
             comp.FireRate,
             comp.ProjectileSpeed,
-            User
+            User // GoobStation change - User for NoWieldNeeded
         );
 
         RaiseLocalEvent(gun, ref ev);

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -549,7 +549,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         Physics.ApplyLinearImpulse(user, -impulseVector, body: userPhysics);
     }
 
-    public void RefreshModifiers(Entity<GunComponent?> gun)
+    public void RefreshModifiers(Entity<GunComponent?> gun, EntityUid? User = null)
     {
         if (!Resolve(gun, ref gun.Comp))
             return;
@@ -565,7 +565,8 @@ public abstract partial class SharedGunSystem : EntitySystem
             comp.MinAngle,
             comp.ShotsPerBurst,
             comp.FireRate,
-            comp.ProjectileSpeed
+            comp.ProjectileSpeed,
+            User
         );
 
         RaiseLocalEvent(gun, ref ev);

--- a/Content.Shared/Wieldable/WieldableSystem.cs
+++ b/Content.Shared/Wieldable/WieldableSystem.cs
@@ -20,6 +20,7 @@ using Content.Shared.Wieldable.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
+using Content.Shared._Goobstation.Weapons.Ranged; // GoobStation - NoWieldNeeded
 
 namespace Content.Shared.Wieldable;
 
@@ -42,7 +43,7 @@ public sealed class WieldableSystem : EntitySystem
 
         SubscribeLocalEvent<WieldableComponent, UseInHandEvent>(OnUseInHand, before: [typeof(SharedGunSystem)]);
         SubscribeLocalEvent<WieldableComponent, ItemUnwieldedEvent>(OnItemUnwielded);
-        SubscribeLocalEvent<WieldableComponent, GotUnequippedHandEvent>(OnItemLeaveHand);     
+        SubscribeLocalEvent<WieldableComponent, GotUnequippedHandEvent>(OnItemLeaveHand);
         SubscribeLocalEvent<WieldableComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);
         SubscribeLocalEvent<WieldableComponent, GetVerbsEvent<InteractionVerb>>(AddToggleWieldVerb);
         SubscribeLocalEvent<WieldableComponent, HandDeselectedEvent>(OnDeselectWieldable);
@@ -54,7 +55,7 @@ public sealed class WieldableSystem : EntitySystem
         SubscribeLocalEvent<GunWieldBonusComponent, ItemUnwieldedEvent>(OnGunUnwielded);
         SubscribeLocalEvent<GunWieldBonusComponent, GunRefreshModifiersEvent>(OnGunRefreshModifiers);
         SubscribeLocalEvent<GunWieldBonusComponent, ExaminedEvent>(OnExamine);
-        SubscribeLocalEvent<GunWieldBonusComponent, GotEquippedHandEvent>(OnItemInHand);
+        SubscribeLocalEvent<GunWieldBonusComponent, GotEquippedHandEvent>(OnItemInHand); // GoobStation change - OnItemInHand for NoWieldNeeded
 
         SubscribeLocalEvent<IncreaseDamageOnWieldComponent, GetMeleeDamageEvent>(OnGetMeleeDamage);
     }
@@ -71,7 +72,7 @@ public sealed class WieldableSystem : EntitySystem
 
     private void OnShootAttempt(EntityUid uid, GunRequiresWieldComponent component, ref ShotAttemptedEvent args)
     {
-        if (TryComp<NoWieldNeededComponent>(args.User, out var noWieldNeeded) && noWieldNeeded.GetBonus) {
+        if (TryComp<NoWieldNeededComponent>(args.User, out var noWieldNeeded) && noWieldNeeded.GetBonus) { // GoobStation change - check for NoWieldNeeded
             _gun.RefreshModifiers(uid, args.User);
         }
 
@@ -94,7 +95,7 @@ public sealed class WieldableSystem : EntitySystem
         } 
     }
 
-    private void OnItemInHand(EntityUid uid, GunWieldBonusComponent component, GotEquippedHandEvent args)
+    private void OnItemInHand(EntityUid uid, GunWieldBonusComponent component, GotEquippedHandEvent args)  // GoobStation change - OnItemInHand for NoWieldNeeded
     {
         _gun.RefreshModifiers(uid, args.User);
     }
@@ -122,7 +123,7 @@ public sealed class WieldableSystem : EntitySystem
     {
         if (TryComp(bonus, out WieldableComponent? wield) &&
             (wield.Wielded) || 
-            (args.User != null && TryComp<NoWieldNeededComponent>(args.User.Value, out var noWieldNeeded) &&
+            (args.User != null && TryComp<NoWieldNeededComponent>(args.User.Value, out var noWieldNeeded) &&  // GoobStation change - Check for NoWieldNeeded and GetBonus
             noWieldNeeded.GetBonus)
             )
         {

--- a/Content.Shared/Wieldable/WieldableSystem.cs
+++ b/Content.Shared/Wieldable/WieldableSystem.cs
@@ -120,10 +120,6 @@ public sealed class WieldableSystem : EntitySystem
 
     private void OnGunRefreshModifiers(Entity<GunWieldBonusComponent> bonus, ref GunRefreshModifiersEvent args)
     {
-        if (args.User is not null)
-            Logger.Debug(args.User.Value.ToString());
-        else
-            Logger.Debug("null...");
         if (TryComp(bonus, out WieldableComponent? wield) &&
             (wield.Wielded) || 
             (args.User != null && TryComp<NoWieldNeededComponent>(args.User.Value, out var noWieldNeeded) &&

--- a/Content.Shared/_Goobstation/Weapons/Ranged/NoWieldNeededComponent.cs
+++ b/Content.Shared/_Goobstation/Weapons/Ranged/NoWieldNeededComponent.cs
@@ -1,7 +1,7 @@
 using Content.Shared.Wieldable;
 using Robust.Shared.GameStates;
 
-namespace Content.Shared.Weapons.Ranged.Components;
+namespace Content.Shared._Goobstation.Weapons.Ranged;
 
 /// <summary>
 /// Indicates that this gun user does not need to wield.

--- a/Resources/Locale/en-US/_Goobstation/metabolism/metabolizer-types.ftl
+++ b/Resources/Locale/en-US/_Goobstation/metabolism/metabolizer-types.ftl
@@ -1,0 +1,1 @@
+metabolizer-type-yowie = Yowie

--- a/Resources/Locale/en-US/metabolism/metabolizer-types.ftl
+++ b/Resources/Locale/en-US/metabolism/metabolizer-types.ftl
@@ -7,6 +7,5 @@ metabolizer-type-vox = Vox
 metabolizer-type-rat = Rat
 metabolizer-type-plant = Plant
 metabolizer-type-dwarf = Dwarf
-metabolizer-type-yowie = Yowie
 metabolizer-type-moth = Moth
 metabolizer-type-arachnid = Arachnid

--- a/Resources/Locale/en-US/metabolism/metabolizer-types.ftl
+++ b/Resources/Locale/en-US/metabolism/metabolizer-types.ftl
@@ -7,5 +7,6 @@ metabolizer-type-vox = Vox
 metabolizer-type-rat = Rat
 metabolizer-type-plant = Plant
 metabolizer-type-dwarf = Dwarf
+metabolizer-type-yowie = Yowie
 metabolizer-type-moth = Moth
 metabolizer-type-arachnid = Arachnid

--- a/Resources/Prototypes/Chemistry/metabolizer_types.yml
+++ b/Resources/Prototypes/Chemistry/metabolizer_types.yml
@@ -44,7 +44,3 @@
 - type: metabolizerType
   id: Arachnid
   name: metabolizer-type-arachnid
-
-- type: metabolizerType
-  id: Yowie
-  name: metabolizer-type-yowie

--- a/Resources/Prototypes/Chemistry/metabolizer_types.yml
+++ b/Resources/Prototypes/Chemistry/metabolizer_types.yml
@@ -44,3 +44,7 @@
 - type: metabolizerType
   id: Arachnid
   name: metabolizer-type-arachnid
+
+- type: metabolizerType
+  id: Yowie
+  name: metabolizer-type-yowie

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -169,7 +169,7 @@
         - !type:OrganType
           type: Dwarf
           shouldHave: false
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -191,7 +191,7 @@
           min: 15
         - !type:OrganType
           type: Dwarf
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
         damage:
           groups:
@@ -206,7 +206,7 @@
         - !type:OrganType
           type: Dwarf
           shouldHave: false
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
       - !type:Drunk
@@ -307,7 +307,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -1340,7 +1340,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -169,6 +169,9 @@
         - !type:OrganType
           type: Dwarf
           shouldHave: false
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 1
@@ -188,6 +191,8 @@
           min: 15
         - !type:OrganType
           type: Dwarf
+        - !type:OrganType
+          type: Yowie
         damage:
           groups:
             Brute: -1
@@ -200,6 +205,9 @@
         # dwarves immune to vomiting from alcohol
         - !type:OrganType
           type: Dwarf
+          shouldHave: false
+        - !type:OrganType
+          type: Yowie
           shouldHave: false
       - !type:Drunk
         boozePower: 2
@@ -298,6 +306,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 1
@@ -1327,6 +1339,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 1

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -222,6 +222,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 1
@@ -351,6 +355,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 1

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -223,7 +223,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -356,7 +356,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:

--- a/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
@@ -250,7 +250,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:OrganType

--- a/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
@@ -251,6 +251,9 @@
       - !type:HealthChange
         conditions:
         - !type:OrganType
+          type: Yowie
+          shouldHave: false
+        - !type:OrganType
           type: Slime
           shouldHave: false
         damage:

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -150,10 +150,18 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 4
       - !type:ChemVomit
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         probability: 0.25
 
 - type: reagent

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -151,7 +151,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -159,7 +159,7 @@
             Poison: 4
       - !type:ChemVomit
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         probability: 0.25

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -221,7 +221,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:OrganType
@@ -237,7 +237,7 @@
       - !type:ChemVomit
         probability: 0.12
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:OrganType

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -222,6 +222,9 @@
       - !type:HealthChange
         conditions:
         - !type:OrganType
+          type: Yowie
+          shouldHave: false
+        - !type:OrganType
           type: Rat
           shouldHave: false
         - !type:ReagentThreshold
@@ -234,6 +237,9 @@
       - !type:ChemVomit
         probability: 0.12
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:OrganType
           type: Rat
           shouldHave: false

--- a/Resources/Prototypes/Reagents/chemicals.yml
+++ b/Resources/Prototypes/Reagents/chemicals.yml
@@ -21,6 +21,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Caustic: 1
@@ -118,6 +122,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Heat: 1.5
@@ -125,6 +133,9 @@
       effects:
       - !type:ChemVomit
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 5
         probability: 0.1

--- a/Resources/Prototypes/Reagents/chemicals.yml
+++ b/Resources/Prototypes/Reagents/chemicals.yml
@@ -22,7 +22,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -123,7 +123,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -133,7 +133,7 @@
       effects:
       - !type:ChemVomit
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -12,7 +12,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -26,7 +26,7 @@
         probability: 0.33
       - !type:Emote
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         emote: Scream
@@ -61,7 +61,7 @@
       effects:
       - !type:ChemVomit
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -71,7 +71,7 @@
       effects:
       - !type:ChemVomit
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -11,6 +11,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 2
@@ -21,6 +25,10 @@
         messages: [ "generic-reagent-effect-burning-insides" ]
         probability: 0.33
       - !type:Emote
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         emote: Scream
         probability: 0.15
 
@@ -53,6 +61,9 @@
       effects:
       - !type:ChemVomit
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 6
         probability: 0.20
@@ -60,6 +71,9 @@
       effects:
       - !type:ChemVomit
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 6
         probability: 0.20

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -44,7 +44,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -67,7 +67,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:OrganType
@@ -109,7 +109,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -166,7 +166,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:OrganType
@@ -200,7 +200,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -208,7 +208,7 @@
             Poison: 0.05
       - !type:Emote
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         emote: Scream
@@ -234,7 +234,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -300,7 +300,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -43,6 +43,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 2
@@ -63,6 +67,9 @@
       effects:
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:OrganType
           type: Arachnid
           shouldHave: false
@@ -101,10 +108,15 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Caustic: 0.5
             Poison: 0.5
+
 - type: reagent
   id: Gold
   name: reagent-name-gold
@@ -155,6 +167,9 @@
       - !type:HealthChange
         conditions:
         - !type:OrganType
+          type: Yowie
+          shouldHave: false
+        - !type:OrganType
           type: Arachnid
           shouldHave: true
         damage:
@@ -184,10 +199,18 @@
       metabolismRate: 0.1
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 0.05
       - !type:Emote
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         emote: Scream
         probability: 0.05
       - !type:Emote
@@ -210,6 +233,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 1
@@ -272,6 +299,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 1.5

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -132,7 +132,7 @@
             Poison: 2
             Piercing: 2
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:HasTag
@@ -143,7 +143,7 @@
           types:
             Piercing: 2
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
         - !type:HasTag
           invert: true

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -132,6 +132,19 @@
             Poison: 2
             Piercing: 2
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
+        - !type:HasTag
+          invert: true
+          tag: Bee
+      - !type:HealthChange
+        damage:
+          types:
+            Piercing: 2
+        conditions:
+        - !type:OrganType
+          type: Yowie
         - !type:HasTag
           invert: true
           tag: Bee

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -17,6 +17,10 @@
       - !type:Oxygenate
         conditions:
         - !type:OrganType
+          type: Yowie
+      - !type:Oxygenate
+        conditions:
+        - !type:OrganType
           type: Animal
       - !type:Oxygenate
         conditions:
@@ -72,6 +76,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 3
@@ -81,6 +89,10 @@
     Gas:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         scaleByQuantity: true
         ignoreResistances: true
         damage:
@@ -163,6 +175,9 @@
           shouldHave: false
         - !type:OrganType
           type: Vox
+          shouldHave: false
+        - !type:OrganType
+          type: Yowie
           shouldHave: false
         # Don't want people to get toxin damage from the gas they just
         # exhaled, right?
@@ -274,6 +289,9 @@
         sprintSpeedModifier: 0.65
       - !type:GenericStatusEffect
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           reagent: NitrousOxide
           min: 1
@@ -286,6 +304,9 @@
         type: Add
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           reagent: NitrousOxide
           min: 3.5
@@ -311,6 +332,21 @@
       effects:
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+        damage:
+          groups:
+            Brute: -1
+          types:
+            Heat: -0.5
+            Shock: -0.5
+            Cold: -0.5 
+            Radiation: -0.5
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           reagent: Frezon
           min: 0.5

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -16,7 +16,7 @@
           type: Human
       - !type:Oxygenate
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
       - !type:Oxygenate
         conditions:
@@ -77,7 +77,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -90,7 +90,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         scaleByQuantity: true
@@ -176,7 +176,7 @@
         - !type:OrganType
           type: Vox
           shouldHave: false
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         # Don't want people to get toxin damage from the gas they just
@@ -289,7 +289,7 @@
         sprintSpeedModifier: 0.65
       - !type:GenericStatusEffect
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -304,7 +304,7 @@
         type: Add
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -332,7 +332,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
         damage:
           groups:
@@ -344,7 +344,7 @@
             Radiation: -0.5
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -33,6 +33,9 @@
             Poison: -1.5 # Was 1, Slight Buff as it should heal for half the amount as Dip or Stelli(GoobStation)
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 20
         damage:
@@ -52,6 +55,9 @@
         probability: 0.2
       - !type:ChemVomit
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 20
         probability: 0.02
@@ -100,10 +106,18 @@
     Medicine:
       effects:
       - !type:GenericStatusEffect
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         key: Drunk
         time: 6.0
         type: Remove
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: -0.5
@@ -143,6 +157,9 @@
             Brute: -2.5 # Was 2, Buffed due to limb damage changes(GoobStation)
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 15
         damage:
@@ -151,6 +168,9 @@
             Poison: 1.5
       - !type:ChemVomit
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 30
         probability: 0.02
@@ -228,6 +248,9 @@
             Cold: -2 # Was 1.5, Buffed due to limb damage changes(GoobStation)
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 10
         damage:
@@ -259,8 +282,11 @@
             Bloodloss: -0.5
       - !type:HealthChange
         conditions:
-          - !type:ReagentThreshold
-            min: 20
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
+        - !type:ReagentThreshold
+          min: 20
         damage:
           types:
             Asphyxiation: 3
@@ -291,8 +317,11 @@
         amount: -3
       - !type:HealthChange
         conditions:
-          - !type:ReagentThreshold
-            min: 25
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
+        - !type:ReagentThreshold
+          min: 25
         damage:
           types:
             Asphyxiation: 5
@@ -327,6 +356,9 @@
             Burn: -1 # Was .5, Buffed due to limb damage changes(GoobStation)
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 20
         damage:
@@ -383,9 +415,16 @@
           types:
             Radiation: -1
       - !type:ChemVomit
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         probability: 0.02
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 30
         damage:
@@ -409,6 +448,9 @@
       effects:
       - !type:ChemVomit
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 4
         probability: 0.3
@@ -514,6 +556,10 @@
     Medicine:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         probability: 0.3
         damage:
           types:
@@ -521,8 +567,11 @@
       - !type:ChemVomit
         probability: 0.15
         conditions:
-          - !type:ReagentThreshold
-            min: 30
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
+        - !type:ReagentThreshold
+          min: 30
       - !type:GenericStatusEffect
         key: PressureImmunity
         component: PressureImmunity
@@ -531,9 +580,17 @@
         component: StutteringAccent
       - !type:Jitter
       - !type:Emote
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         emote: Scream
         probability: 0.2
       - !type:PopupMessage
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         type: Local
         visualType: Large
         messages: [ "barozine-effect-skin-burning", "barozine-effect-muscle-contract" ]
@@ -563,6 +620,10 @@
             Cellular: -1
             Radiation: 1
       - !type:ChemVomit
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         probability: 0.05
 
 - type: reagent
@@ -584,6 +645,9 @@
             Asphyxiation: -2.5
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 30
         damage:
@@ -688,6 +752,9 @@
             Poison: -4
       - !type:AdjustReagent
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           reagent: Amatoxin
           min: 1
@@ -706,6 +773,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 2
@@ -947,6 +1018,9 @@
             Caustic: -3
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 16
         damage:
@@ -966,6 +1040,9 @@
         probability: 0.2
       - !type:ChemVomit
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 30
         probability: 0.02
@@ -987,6 +1064,9 @@
             Slash: -4 # Was 3, Buffed due to limb damage changes(GoobStation)
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 12
         damage:
@@ -1011,6 +1091,9 @@
             Blunt: 0.1
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 11
         damage:
@@ -1034,6 +1117,9 @@
             Blunt: -4 # Was 3, Buffed due to limb damage changes(GoobStation)
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 10.5
         damage:
@@ -1096,6 +1182,9 @@
       # od causes massive bleeding
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 20
         damage:
@@ -1104,11 +1193,17 @@
             Piercing: 0.5
       - !type:ChemVomit
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 15
         probability: 0.1
       - !type:Emote
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 20
         emote: Scream
@@ -1142,6 +1237,9 @@
       # od makes you freeze to death
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 12
         damage:
@@ -1262,6 +1360,9 @@
       effects:
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 30
         damage:
@@ -1312,8 +1413,11 @@
         refresh: false
       - !type:HealthChange
         conditions:
-          - !type:ReagentThreshold
-            min: 20
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
+        - !type:ReagentThreshold
+          min: 20
         damage:
           types:
             Poison: 1

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -33,7 +33,7 @@
             Poison: -1.5 # Was 1, Slight Buff as it should heal for half the amount as Dip or Stelli(GoobStation)
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -55,7 +55,7 @@
         probability: 0.2
       - !type:ChemVomit
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -107,7 +107,7 @@
       effects:
       - !type:GenericStatusEffect
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         key: Drunk
@@ -115,7 +115,7 @@
         type: Remove
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -157,7 +157,7 @@
             Brute: -2.5 # Was 2, Buffed due to limb damage changes(GoobStation)
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -168,7 +168,7 @@
             Poison: 1.5
       - !type:ChemVomit
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -248,7 +248,7 @@
             Cold: -2 # Was 1.5, Buffed due to limb damage changes(GoobStation)
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -282,7 +282,7 @@
             Bloodloss: -0.5
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -317,7 +317,7 @@
         amount: -3
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -356,7 +356,7 @@
             Burn: -1 # Was .5, Buffed due to limb damage changes(GoobStation)
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -416,13 +416,13 @@
             Radiation: -1
       - !type:ChemVomit
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         probability: 0.02
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -448,7 +448,7 @@
       effects:
       - !type:ChemVomit
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -557,7 +557,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         probability: 0.3
@@ -567,7 +567,7 @@
       - !type:ChemVomit
         probability: 0.15
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -581,14 +581,14 @@
       - !type:Jitter
       - !type:Emote
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         emote: Scream
         probability: 0.2
       - !type:PopupMessage
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         type: Local
@@ -621,7 +621,7 @@
             Radiation: 1
       - !type:ChemVomit
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         probability: 0.05
@@ -645,7 +645,7 @@
             Asphyxiation: -2.5
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -752,7 +752,7 @@
             Poison: -4
       - !type:AdjustReagent
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -774,7 +774,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -1018,7 +1018,7 @@
             Caustic: -3
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -1040,7 +1040,7 @@
         probability: 0.2
       - !type:ChemVomit
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -1064,7 +1064,7 @@
             Slash: -4 # Was 3, Buffed due to limb damage changes(GoobStation)
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -1091,7 +1091,7 @@
             Blunt: 0.1
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -1117,7 +1117,7 @@
             Blunt: -4 # Was 3, Buffed due to limb damage changes(GoobStation)
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -1182,7 +1182,7 @@
       # od causes massive bleeding
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -1193,7 +1193,7 @@
             Piercing: 0.5
       - !type:ChemVomit
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -1201,7 +1201,7 @@
         probability: 0.1
       - !type:Emote
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -1237,7 +1237,7 @@
       # od makes you freeze to death
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -1360,7 +1360,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -1413,7 +1413,7 @@
         refresh: false
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -11,9 +11,9 @@
   metabolisms:
     Poison:
       effects:
-      - !type:HealthChange
+      - !type:HealthChange 
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
         damage:
           groups:
@@ -25,7 +25,7 @@
             Radiation: -0.5
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -33,7 +33,7 @@
             Poison: 0.75
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -93,7 +93,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
         damage:
           groups:
@@ -108,7 +108,7 @@
         sprintSpeedModifier: 1.25
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -166,7 +166,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
         damage:
           groups:
@@ -181,7 +181,7 @@
         sprintSpeedModifier: 1.3
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -261,7 +261,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
         damage:
           groups:
@@ -294,7 +294,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
         damage:
           groups:
@@ -319,7 +319,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
         damage:
           groups:
@@ -334,7 +334,7 @@
         sprintSpeedModifier: 0.65
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -364,7 +364,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
         damage:
           groups:
@@ -394,7 +394,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
         damage:
           groups:
@@ -426,7 +426,7 @@
       effects:
       - !type:GenericStatusEffect
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -451,7 +451,7 @@
       effects:
       - !type:GenericStatusEffect
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         key: Muted
@@ -563,7 +563,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
         damage:
           groups:

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -12,11 +12,30 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+        damage:
+          groups:
+            Brute: -1
+          types:
+            Heat: -0.5
+            Shock: -0.5
+            Cold: -0.5 
+            Radiation: -0.5
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 0.75
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 30
         damage:
@@ -72,11 +91,26 @@
   metabolisms:
     Narcotic:
       effects:
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+        damage:
+          groups:
+            Brute: -1
+          types:
+            Heat: -0.5
+            Shock: -0.5
+            Cold: -0.5 
+            Radiation: -0.5
       - !type:MovespeedModifier
         walkSpeedModifier: 1.25
         sprintSpeedModifier: 1.25
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 20
         damage:
@@ -130,13 +164,28 @@
     Narcotic:
       metabolismRate: 1.0
       effects:
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+        damage:
+          groups:
+            Brute: -1
+          types:
+            Heat: -0.5
+            Shock: -0.5
+            Cold: -0.5 
+            Radiation: -0.5
       - !type:MovespeedModifier
         walkSpeedModifier: 1.3
         sprintSpeedModifier: 1.3
       - !type:HealthChange
         conditions:
-          - !type:ReagentThreshold
-            min: 80 #please wait 3 minutes before using another stimpack
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
+        - !type:ReagentThreshold
+          min: 80 #please wait 3 minutes before using another stimpack
         damage:
           types:
             Poison: 1
@@ -210,6 +259,18 @@
   metabolisms:
     Narcotic:
       effects:
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+        damage:
+          groups:
+            Brute: -1
+          types:
+            Heat: -0.5
+            Shock: -0.5
+            Cold: -0.5 
+            Radiation: -0.5
       - !type:GenericStatusEffect
         key: SeeingRainbows
         component: SeeingRainbows
@@ -228,6 +289,21 @@
   plantMetabolism:
   - !type:PlantAdjustHealth
     amount: -5
+  metabolisms:
+    Narcotic:
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+        damage:
+          groups:
+            Brute: -0.2
+          types:
+            Heat: -0.1
+            Shock: -0.1
+            Cold: -0.1 
+            Radiation: -0.1
 
 # TODO: Replace these nonstandardized effects with generic brain damage
 - type: reagent
@@ -241,10 +317,26 @@
   metabolisms:
     Narcotic:
       effects:
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+        damage:
+          groups:
+            Brute: -1
+          types:
+            Heat: -0.5
+            Shock: -0.5
+            Cold: -0.5 
+            Radiation: -0.5
       - !type:MovespeedModifier
         walkSpeedModifier: 0.65
         sprintSpeedModifier: 0.65
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 2
@@ -270,6 +362,18 @@
   metabolisms:
     Narcotic:
       effects:
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+        damage:
+          groups:
+            Brute: -1
+          types:
+            Heat: -0.5
+            Shock: -0.5
+            Cold: -0.5 
+            Radiation: -0.5
       - !type:GenericStatusEffect
         key: SeeingRainbows
         component: SeeingRainbows
@@ -288,6 +392,18 @@
   metabolisms:
     Narcotic:
       effects:
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+        damage:
+          groups:
+            Brute: -1
+          types:
+            Heat: -0.5
+            Shock: -0.5
+            Cold: -0.5 
+            Radiation: -0.5
       - !type:GenericStatusEffect
         key: SeeingRainbows
         component: SeeingRainbows
@@ -310,6 +426,9 @@
       effects:
       - !type:GenericStatusEffect
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           reagent: Nocturine
           min: 8
@@ -331,6 +450,10 @@
     Narcotic:
       effects:
       - !type:GenericStatusEffect
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         key: Muted
         component: Muted
         type: Add
@@ -438,6 +561,18 @@
   metabolisms:
     Narcotic:
       effects:
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+        damage:
+          groups:
+            Brute: -1
+          types:
+            Heat: -0.5
+            Shock: -0.5
+            Cold: -0.5 
+            Radiation: -0.5
       - !type:Emote
         emote: Laugh
         showInChat: true

--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -31,7 +31,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -40,7 +40,7 @@
             Poison: 1
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
         damage:
           types:
@@ -68,7 +68,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -78,7 +78,7 @@
             Caustic: 0.5 # based off napalm being an irritant
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
         damage:
           types:
@@ -100,7 +100,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -109,7 +109,7 @@
             Poison: 1
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
         damage:
           types:
@@ -142,7 +142,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -152,7 +152,7 @@
             Caustic: 0.5 # CLF3 is corrosive
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
         damage:
           types:
@@ -209,7 +209,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:

--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -30,10 +30,21 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Heat: 2
             Poison: 1
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+        damage:
+          types:
+            Heat: 2
 
 - type: reagent
   id: Napalm
@@ -56,10 +67,22 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Heat: 2
             Poison: 1
+            Caustic: 0.5 # based off napalm being an irritant
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+        damage:
+          types:
+            Heat: 2
             Caustic: 0.5 # based off napalm being an irritant
       - !type:FlammableReaction
         multiplier: 0.4
@@ -76,10 +99,21 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Heat: 3
             Poison: 1
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+        damage:
+          types:
+            Heat: 3
       - !type:FlammableReaction
         multiplier: 0.1
       - !type:AdjustTemperature
@@ -107,11 +141,23 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Heat: 2
             Poison: 1
             Caustic: 0.5 # CLF3 is corrosive
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+        damage:
+          types:
+            Heat: 2
+            Caustic: 0.5 # CLF3 is corrosive    
       - !type:FlammableReaction
         multiplier: 0.2
       - !type:AdjustTemperature
@@ -162,6 +208,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 1

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -16,7 +16,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -41,7 +41,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -49,7 +49,7 @@
             Poison: 4
       - !type:PopupMessage
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         type: Local
@@ -74,14 +74,14 @@
         probability: 0.1
       - !type:MovespeedModifier
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         walkSpeedModifier: 0.65
         sprintSpeedModifier: 0.65
       - !type:GenericStatusEffect
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         key: Drowsiness
@@ -91,7 +91,7 @@
         refresh: false
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -114,7 +114,7 @@
       effects:
         - !type:HealthChange
           conditions:
-          - !type:OrganType
+          - !type:OrganType # Goobstation - Yowie
             type: Yowie
             shouldHave: false
           damage:
@@ -122,7 +122,7 @@
               Poison: 2
         - !type:ChemVomit
           conditions:
-          - !type:OrganType
+          - !type:OrganType # Goobstation - Yowie
             type: Yowie
             shouldHave: false
           - !type:ReagentThreshold
@@ -143,7 +143,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -340,7 +340,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -405,7 +405,7 @@
       # todo: cough, sneeze
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -467,7 +467,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -487,7 +487,7 @@
       effects:
         - !type:HealthChange
           conditions:
-          - !type:OrganType
+          - !type:OrganType # Goobstation - Yowie
             type: Yowie
             shouldHave: false
           damage:
@@ -527,7 +527,7 @@
           - !type:OrganType
             type: Animal
             shouldHave: false
-          - !type:OrganType
+          - !type:OrganType # Goobstation - Yowie
             type: Yowie
             shouldHave: false
         type: Local
@@ -540,7 +540,7 @@
           - !type:OrganType
             type: Animal
             shouldHave: false
-          - !type:OrganType
+          - !type:OrganType # Goobstation - Yowie
             type: Yowie
             shouldHave: false
       - !type:HealthChange
@@ -548,7 +548,7 @@
         - !type:OrganType
           type: Animal
           shouldHave: false
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -641,7 +641,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -661,7 +661,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -688,7 +688,7 @@
         sprintSpeedModifier: 0.8
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         damage:
@@ -722,7 +722,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:Hunger
@@ -749,7 +749,7 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:OrganType
@@ -760,7 +760,7 @@
             Poison: 1.6
       - !type:MovespeedModifier
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold
@@ -773,7 +773,7 @@
         sprintSpeedModifier: 0.8
       - !type:MovespeedModifier
         conditions:
-        - !type:OrganType
+        - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
         - !type:ReagentThreshold

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -15,6 +15,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 4
@@ -36,10 +40,18 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 4
       - !type:PopupMessage
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         type: Local
         visualType: MediumCaution
         messages: [ "generic-reagent-effect-burning-insides" ]
@@ -61,9 +73,17 @@
         showInChat: true
         probability: 0.1
       - !type:MovespeedModifier
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         walkSpeedModifier: 0.65
         sprintSpeedModifier: 0.65
       - !type:GenericStatusEffect
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         key: Drowsiness
         component: Drowsiness
         time: 4
@@ -71,6 +91,9 @@
         refresh: false
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           reagent: ChloralHydrate
           min: 20
@@ -90,11 +113,18 @@
     Poison:
       effects:
         - !type:HealthChange
+          conditions:
+          - !type:OrganType
+            type: Yowie
+            shouldHave: false
           damage:
             types:
               Poison: 2
         - !type:ChemVomit
           conditions:
+          - !type:OrganType
+            type: Yowie
+            shouldHave: false
           - !type:ReagentThreshold
             min: 2
           probability: 0.2
@@ -112,6 +142,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 1
@@ -305,6 +339,10 @@
     Poison:
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Asphyxiation: 5
@@ -367,6 +405,9 @@
       # todo: cough, sneeze
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           min: 45
         damage:
@@ -425,6 +466,10 @@
       metabolismRate: 0.2
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 3
@@ -441,6 +486,10 @@
     Poison:
       effects:
         - !type:HealthChange
+          conditions:
+          - !type:OrganType
+            type: Yowie
+            shouldHave: false
           damage:
             types:
               Poison: 2
@@ -478,6 +527,9 @@
           - !type:OrganType
             type: Animal
             shouldHave: false
+          - !type:OrganType
+            type: Yowie
+            shouldHave: false
         type: Local
         visualType: MediumCaution
         messages: [ "generic-reagent-effect-sick" ]
@@ -488,10 +540,16 @@
           - !type:OrganType
             type: Animal
             shouldHave: false
+          - !type:OrganType
+            type: Yowie
+            shouldHave: false
       - !type:HealthChange
         conditions:
         - !type:OrganType
           type: Animal
+          shouldHave: false
+        - !type:OrganType
+          type: Yowie
           shouldHave: false
         damage:
           types:
@@ -582,6 +640,10 @@
       metabolismRate: 0.03 # Effectively once every 30 seconds.
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 0.6 # Makes it 20 damage per unit.
@@ -598,6 +660,10 @@
       metabolismRate: 0.2
       effects:
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           types:
             Poison: 1.8
@@ -621,6 +687,10 @@
         walkSpeedModifier: 0.8
         sprintSpeedModifier: 0.8
       - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         damage:
           groups:
             Airloss: 2
@@ -652,6 +722,9 @@
       effects:
       - !type:HealthChange
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:Hunger
           max: 50
         damage:
@@ -677,6 +750,9 @@
       - !type:HealthChange
         conditions:
         - !type:OrganType
+          type: Yowie
+          shouldHave: false
+        - !type:OrganType
           type: Arachnid
           shouldHave: false
         damage:
@@ -684,6 +760,9 @@
             Poison: 1.6
       - !type:MovespeedModifier
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           reagent: Mechanotoxin
           min: 2
@@ -694,6 +773,9 @@
         sprintSpeedModifier: 0.8
       - !type:MovespeedModifier
         conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
         - !type:ReagentThreshold
           reagent: Mechanotoxin
           min: 4

--- a/Resources/Prototypes/_Goobstation/Body/Organs/yowie.yml
+++ b/Resources/Prototypes/_Goobstation/Body/Organs/yowie.yml
@@ -1,0 +1,67 @@
+- type: entity
+  id: OrganYowieStomach
+  parent: OrganHumanStomach
+  name: yowie stomach
+  components:
+  - type: Sprite
+    state: stomach
+  - type: Organ
+  - type: SolutionContainerManager
+    solutions:
+      stomach:
+        maxVol: 75
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 5
+  - type: Stomach
+  - type: Metabolizer
+    # mm very yummy
+    maxReagents: 5
+    metabolizerTypes: [Yowie]
+
+- type: entity
+  id: OrganYowieLiver
+  parent: OrganHumanLiver
+  name: yowie liver
+  components:
+  - type: Metabolizer
+    metabolizerTypes: [Yowie]
+
+- type: entity
+  id: OrganYowieHeart
+  parent: OrganHumanHeart
+  name: yowie heart
+  components:
+  - type: Metabolizer
+    metabolizerTypes: [Yowie]
+
+- type: entity
+  id: OrganYowieLungs
+  parent: OrganHumanLungs
+  name: lungs
+  description: "Filters oxygen from an atmosphere, which is then sent into the bloodstream to be used as an electron carrier."
+  components:
+  - type: Metabolizer
+    removeEmpty: true
+    solutionOnBody: false
+    solution: "Lung"
+    metabolizerTypes: [ Yowie ]
+    groups:
+    - id: Gas
+      rateModifier: 100.0
+  - type: SolutionContainerManager
+    solutions:
+      organ:
+        reagents:
+        - ReagentId: Nutriment
+          Quantity: 20
+      Lung:
+        maxVol: 200.0
+        canReact: false
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 5

--- a/Resources/Prototypes/_Goobstation/Body/Prototypes/yowie.yml
+++ b/Resources/Prototypes/_Goobstation/Body/Prototypes/yowie.yml
@@ -4,42 +4,45 @@
   root: torso
   slots:
     head:
-      part: HeadYowie
+      part: HeadHuman
       connections:
       - torso
       organs:
         brain: OrganHumanBrain
     torso:
-      part: TorsoYowie
+      part: TorsoHuman
       connections:
       - right arm
       - left arm
       - right leg
       - left leg
       organs:
-        stomach: OrganHumanStomach
-        lungs: OrganHumanLungs
+        heart: OrganYowieHeart
+        lungs: OrganYowieLungs
+        stomach: OrganYowieStomach
+        liver: OrganYowieLiver
+        kidneys: OrganHumanKidneys
     right arm:
-      part: RightArmYowie
+      part: RightArmHuman
       connections:
       - right hand
     left arm:
-      part: LeftArmYowie
+      part: LeftArmHuman
       connections:
       - left hand
     right hand:
-      part: RightHandYowie
+      part: RightHandHuman
     left hand:
-      part: LeftHandYowie
+      part: LeftHandHuman
     right leg:
-      part: RightLegYowie
+      part: RightLegHuman
       connections:
       - right foot
     left leg:
-      part: LeftLegYowie
+      part: LeftLegHuman
       connections:
       - left foot
     right foot:
-      part: RightFootYowie
+      part: RightFootHuman
     left foot:
-      part: LeftFootYowie
+      part: LeftFootHuman

--- a/Resources/Prototypes/_Goobstation/Chemistry/metabolizer_types.yml
+++ b/Resources/Prototypes/_Goobstation/Chemistry/metabolizer_types.yml
@@ -1,0 +1,3 @@
+- type: metabolizerType
+  id: Yowie
+  name: metabolizer-type-yowie

--- a/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
@@ -29,7 +29,7 @@
     Shock: 1
     Cold: 0.9
     Bloodloss: 0.9
-    Poison: 0.5 # Should be more resistant to toxin
+    Poison: 0.0 # Yea, heroin is heaps good for ya
     Radiation : 0.7 # Engie yowies need some help against anti-rads
 
 

--- a/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
@@ -25,9 +25,9 @@
     Blunt: 0.85
     Slash: 0.85
     Piercing: 0.85
-    Heat: 1.5 # Fur = Overheating
+    Heat: 1.15
     Shock: 1
-    Cold: 0.7  # Fur = Keep warm
+    Cold: 0.9
     Bloodloss: 0.9
     Poison: 0.5 # Should be more resistant to toxin
     Radiation : 0.7 # Engie yowies need some help against anti-rads

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/yowie.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/yowie.yml
@@ -22,17 +22,6 @@
     hideLayersOnEquip:
     - Hair
     - Snout
-  - type: Temperature # Fur = bad with heat, stole numbers from moth
-    heatDamageThreshold: 320
-    coldDamageThreshold: 230
-    currentTemperature: 310.15
-    specificHeat: 46
-    coldDamage:
-      types:
-        Cold : 0.05 #per second, scales with temperature & other constants
-    heatDamage:
-      types:
-        Heat : 3 #per second, scales with temperature & other constants
   - type: MeleeWeapon
     damage:
       types:

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/yowie.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/yowie.yml
@@ -16,7 +16,9 @@
     spawned:
     - id: FoodMeatHuman
       amount: 5
-  
+  - type: Body
+    prototype: Yowie
+    requiredLegs: 2
   - type: HumanoidAppearance
     species: Yowie
     hideLayersOnEquip:

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/yowie.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/yowie.yml
@@ -25,9 +25,11 @@
     - Hair
     - Snout
   - type: MeleeWeapon
+    altDisarm: false
+    heavyStaminaCost: 1.5
     damage:
       types:
-        Blunt: 8
+        Blunt: 10
   - type: Inventory
     templateId: yowie
   - type: Damageable

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/yowie.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/yowie.yml
@@ -39,6 +39,7 @@
   - type: BoganAccent
   - type: Carriable 
     freeHandsRequired: 4 # easiest way to make them uncarriable without removing carriable from base mob
+  - type: NoWieldNeeded
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/ServerInfo/Guidebook/Mobs/Yowie.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Yowie.xml
@@ -7,10 +7,10 @@
   
   Yowie are a once-thought urban myth, turned newly discovered mystical species of bipedal hairy creature.
   Their body is larger than most other species in stature, with the downside of them [color=#AAFF00]not being able to fit into most Nanotrasen external wear or shoes[/color], or [color=#AAFF00] being able to be carried by others[/color].
-  Their fur also allows them to take [color=#baf2ef]0.5x less cold damage[/color] but suffer [color=#ec3a3a]3x more heat damage[/color].
+  Their fur also allows them to take [color=#baf2ef]less cold damage[/color] but suffer [color=#ec3a3a]slightly more heat damage[/color].
   
   
-  Their stature makes their unarmed punch deal [color=#ec3a3a]1.5x the damage[/color] of a human punch
+  Their stature makes their unarmed punch deal [color=#ec3a3a]2x the damage[/color] of a human punch
   
   ## Fuckin' skiz, mate
   <Box>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

I changed the Yowie to have some better bonuses to make up for their severe limitations and add RP value. I also adjusted one of those limitations.

My changes include:
- Making the heat resistance equal to that of Vulps (they have fur too)
- Slightly nerfing their cold resistance
- Making them immune to non-metabolised poison attacks (of which there are not all that many)
- Giving them their own organs, organ prototypes, and metabolisms
- Removing **poison** damage on all metabolism effects, making them immune to certain reagent effects (such as ForcedSleep), removing most medicine overdose damage/effects, and giving them comprehensive healing from most narcotics
- Slightly increased their unarmed attack (to 10) and gave them a wideswing alt attack
- Added a component for bypassing wielding requirements to shoot/shoot accurately and gave it to them

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Yowie is a fun RP race to play, and I am very glad they got added. However there a few things with them that I had found lacking both in terms of roleplaying a Yowie as I'd expect them to be and viability in most combat scenarios.

The Yowie currently has the following limitations from a balance perspective:
- No external wear, including hardsuits and almost all armour. This is by far their greatest weakness, which I do not believe had been adequetly balanced for.
- No shoes. Arguably their second greatest weakness. No slip resistance, no grav loss measures, no foot protection. Diona at least are slow most of the time to not need slip resistance and don't need to worry about foot protection (correct me if I am wrong). And Diona can wear hardsuits and come back from the dead.
- Massive heat weakness, equal to moths and second only to Diona (who are made of wood). Fun fact, fur is insulative. And Yowies are Australian. It's hot over here man.
- They are big. I haven't done any kind of hitbox analysis tbh, I just assume they are a bigger target lmk if that's not true.

Strengths:
- Their unarmed attack is a crowbar that can't wideswing. It's not great.
- They have some good physical resistances, these are all pretty decent. Does not really make up for the inability to wear armour IMO but still good as they are.
- Except the poison resistance, which would be good if it did anything. There might be some attacks that deal poison damage without metabolisation, that's it. If you spike their drink, they're going down like any human. I believe this may have been a mistake.
- Cold resistance is alright.
- Rad resistance is nice to counteract complete lack of rad suits.

I, and I think others, don't really think these strengths make up for the lack of external wear and shoes. 

Each change I have made has been done for the follwing reasons:

**Heat mod change**: Vulps have fur, their heat mod is 1.15. I think that's enough for Yowie's too. I slightly nerfed the cold resistance to make up for a better heat mod, up from 0.7 to 0.85.

**Poison immunity and narcotics healing**: Making them immune to practically all poison was partly for RP and partly as something to make them unique. Unlike skeletons and silicons, they still metabolise toxins. And they still take rads, caustic, and cellular. But giving them essential immunity to poison damage specifically, most non-damage negative effects, and removing OD limits for them allow them to be the walking drug oceans they were always supposed to be. 

The character's they are based on will drink and eat old petrol and cleaning fluids among other dangerous substances. This is fun. When I first played Yowie, I wanted to get right in to the role and drink welding fuel. But doing so just slowly killed me all the same. 

From a balance perspective, it makes them slightly more viable as antags and quite a bit more viable as sec/command. A nocturine attack on a Yowie will not work, a strength somewhat making up for the vulnerability of not being able to wear a captain's carapace, for example. The downside is they cannot be put to sleep for surgery (not sure if that has any consequences here yet, probably should).

Narcotics healing is not too powerful, aside from healing radiation. They get the same healing from alcohol as dwarves, tricord like healing (with rads added) from most narcotics, and a heavily reduced form of the former healing with nicotine. Its useful enough to give them a slight boost, and fits in with the role. The rad healing is more to supplement the lack of radsuits.

**Melee increase and wideswing**: when I, as a secoff, see a Yowie entering the scene my first thought is, and should be, "uh oh, better prepare for the big guy here". But then it immediately turns to "oh wait, no they suck lmao". Which is really sad. A yowie should make a good bouncer/bodyguard, and you shouldn't want to get in to a fight with them. That's all really, it is pretty powerful from the perspective of unarmed combat, though should not be particularly useful for most antag/sec encounters.

**One-hand wielding**: quite powerful for sec and nukies, I added this pretty much so they would have some way of viability as nukies. Sure they can't wear hardsuits, so the challenge of getting to the station and dealing with spacing is still present. But raid ops exist and barozine has no negative effects on Yowies (including no screaming). 

They can now wield a shield (or any off hand item) and a gun without accuracy penalties. This gives them plenty of options to deal with their lack of armour. Combine that with meth and they could potentially be quite formidable. They may force a nukie team in to a specific strategy, but if their bonuses stack up enough I think they might be viable (nothing has been changed RE the roll for nukies as Yowie at this stage).

In summary: Yowies are now what they were always meant to be - big toxin sponges with yeti strength. Their combat bonuses make up for the massive penalties of no armour and no shoes. Their poison immunity and drug synergy make them more interesting and lore-friendly. I don't think this will make them too powerful, though I am open to feedback. But honestly I think is a much needed boost. And funny.

## Technical details
<!-- Summary of code changes for easier review. -->

Metabolisms of all reagent prototypes that have negative effects have been changed to have Yowie specific conditions/exclusions.

The Yowie now has its own set of organs, body prototype, and metabolism type.

There is a NoWieldNeeded component with an optional GetBonus parameter (default true). The involved systems have been modified to apply gun bonuses on weapon pick up, as well as checks when shooting if the weapon has wielding requirements.

The Yowie prototype has been changed to make use of the new component and the new body prototype.

Guide entry has been adjusted.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Yowies hit a bit harder and can wideswing!
- tweak: Yowies don't take as much heat damage anymore, but are also not as cold resistant.
- tweak: Yowies are immune to most forms of poison and can heal from most narcotics!
- add: Yowies can now use ranged weapons in one hand without any penalties!
 
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
