### PR TITLE
Decreased IPC Low Battery Alert Time

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -18,8 +18,8 @@
   - type: EncryptionHolderRequiresLock
   - type: SiliconEmitSoundOnDrained
     sound: "/Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg" # SOMEONE PLEASE FIND A BETTER SOUND FOR THIS.
-    minInterval: 15
-    maxInterval: 30
+    minInterval: 10
+    maxInterval: 15
     popUp: "silicon-power-low"
   - type: Lock
     locked: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title

## Why / Balance
People sometimes go unnoticed that youre low on battery as IPC, this change will actually have a higher chance of alerting people that walks by.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Lowered IPC low battery alert intervals.