### PR TITLE
Make frezon great again

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -172,7 +172,7 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     Total number of gases. Increase this if you want to add more!
         /// </summary>
-        public const int TotalNumberOfGases = 12; 
+        public const int TotalNumberOfGases = 12;
 
         /// <summary>
         ///     This is the actual length of the gases arrays in mixtures.
@@ -233,7 +233,7 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     1 mol of Tritium is required per X mol of oxygen.
         /// </summary>
-        public const float FrezonProductionTritRatio = 8.0f;
+        public const float FrezonProductionTritRatio = 50.0f;
 
         /// <summary>
         ///     1 / X of the tritium is converted into Frezon each tick
@@ -253,22 +253,22 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     The amount of energy 1 mole of BZ forming from N2O and plasma releases.
         /// </summary>
-        public const float BZFormationEnergy = 80e3f; 
+        public const float BZFormationEnergy = 80e3f;
 
         /// <summary>
         ///     The amount of energy 1 mol of Healium forming from BZ and frezon releases.
         /// </summary>
-        public const float HealiumProductionEnergy = 9e3f; 
+        public const float HealiumProductionEnergy = 9e3f;
 
         /// <summary>
         ///     The amount of energy 1 mol of Nitrium forming from Tritium, Nitrogen and BZ releases.
         /// </summary>
-        public const float NitriumProductionEnergy = 100e3f; 
+        public const float NitriumProductionEnergy = 100e3f;
 
         /// <summary>
         ///     The amount of energy 1 mol of Nitrium decomposing into nitrogen and water vapor releases.
         /// </summary>
-        public const float NitriumDecompositionEnergy = 30e3f; 
+        public const float NitriumDecompositionEnergy = 30e3f;
 
         /// <summary>
         ///     Determines at what pressure the ultra-high pressure red icon is displayed.
@@ -357,8 +357,8 @@ namespace Content.Shared.Atmos
         Ammonia = 6,
         NitrousOxide = 7,
         Frezon = 8,
-        BZ = 9, 
-        Healium = 10, 
-        Nitrium = 11, 
+        BZ = 9,
+        Healium = 10,
+        Nitrium = 11,
     }
 }

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -86,7 +86,7 @@
   molarMass: 44
   color: 8F00FF
   reagent: NitrousOxide
-  pricePerMole: 0.5 # Goobstation - Gas Prices
+  pricePerMole: 0.1 # Goobstation - Gas Prices
 
 - type: gas
   id: 8
@@ -99,7 +99,7 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 1.5 # Goobstation - Gas Prices
+  pricePerMole: 0.3 # Goobstation - Gas Prices
 
 - type: gas
   id: 9


### PR DESCRIPTION
## About the PR
Changed Frezon tritium ratio back to 1:50 instead of 1:8, changed frezon price from 1.5 to 0.3. So now you need way less tritium to make frezon (as much as it was needed before the [wizden nerf](https://github.com/space-wizards/space-station-14/pull/32407))

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Considering we have sm, and with the addition of the new gasses, being able to produce more moles of frezon for a lower selling price is better than a lower amount of moles for higher price.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
-->

- tweak: Changed frezon oxygen:tritium ratio from 1:8 -> 1:50, and changed frezon price per mole from 1.5->0.3

