### PR TITLE
allow traitors to buy suicide implants

### DIFF
--- a/Content.Server/Implants/ImplanterSystem.cs
+++ b/Content.Server/Implants/ImplanterSystem.cs
@@ -68,16 +68,6 @@ public sealed partial class ImplanterSystem : SharedImplanterSystem
                 return;
             }
 
-            if (args.User == target && HasComp<PreventSelfImplantComponent>(uid))   //Goobstation - Mindcontrol implant preventing self implant
-            {
-                var name = Identity.Name(target, EntityManager, args.User);
-                var msg = Loc.GetString("implanter-component-implant-failed", ("implant", implant), ("target", name));
-                _popup.PopupEntity(msg, target, args.User);
-                // prevent further interaction since popup was shown
-                args.Handled = true;
-                return;
-            }
-
             //Implant self instantly, otherwise try to inject the target.
             if (args.User == target)
                 Implant(target, target, uid, component);

--- a/Content.Server/Implants/ImplanterSystem.cs
+++ b/Content.Server/Implants/ImplanterSystem.cs
@@ -43,7 +43,9 @@ public sealed partial class ImplanterSystem : SharedImplanterSystem
         }
         else
         {
-            if (!CanImplant(args.User, target, uid, component, out var implant, out _))
+            // Goobstation - allow traitors to buy suicide implants
+            bool canImplant = CanImplant(args.User, target, uid, component, out var implant, out var implantComp);
+            if (!canImplant)
             {
                 // no popup if implant doesn't exist
                 if (implant == null)
@@ -71,8 +73,8 @@ public sealed partial class ImplanterSystem : SharedImplanterSystem
             //Implant self instantly, otherwise try to inject the target.
             if (args.User == target)
                 Implant(target, target, uid, component);
-            else
-                TryImplant(component, args.User, target, uid);
+            else if (implantComp != null)
+                TryImplant(component, args.User, target, uid, implantComp.ImplantationTimeMultiplier); // Goobstation - allow traitors to buy suicide implants (add time multiplier)
         }
 
         args.Handled = true;
@@ -94,9 +96,10 @@ public sealed partial class ImplanterSystem : SharedImplanterSystem
     /// <param name="user">The entity using the implanter</param>
     /// <param name="target">The entity being implanted</param>
     /// <param name="implanter">The implanter being used</param>
-    public void TryImplant(ImplanterComponent component, EntityUid user, EntityUid target, EntityUid implanter)
+    // Goobstation - allow traitors to buy suicide implants (add time multiplier)
+    public void TryImplant(ImplanterComponent component, EntityUid user, EntityUid target, EntityUid implanter, float timeMultiplier = 1)
     {
-        var args = new DoAfterArgs(EntityManager, user, component.ImplantTime, new ImplantEvent(), implanter, target: target, used: implanter)
+        var args = new DoAfterArgs(EntityManager, user, component.ImplantTime * timeMultiplier, new ImplantEvent(), implanter, target: target, used: implanter)
         {
             BreakOnDamage = true,
             BreakOnMove = true,

--- a/Content.Server/_Goobstation/Implants/MindcontrolImplantSystem.cs
+++ b/Content.Server/_Goobstation/Implants/MindcontrolImplantSystem.cs
@@ -21,7 +21,6 @@ public sealed class MindcontrolImplantSystem : EntitySystem
         if (component.ImplanterUid != null)
         {
             component.HolderUid = Transform(component.ImplanterUid.Value).ParentUid;
-            RemComp<PreventSelfImplantComponent>(component.ImplanterUid.Value);
         }
         if (args.Implanted != null)
             EnsureComp<MindcontrolledComponent>(args.Implanted.Value);
@@ -40,7 +39,6 @@ public sealed class MindcontrolImplantSystem : EntitySystem
         {
             component.ImplanterUid = args.Container.Owner;    //save Implanter uid
             component.HolderUid = null;
-            EnsureComp<PreventSelfImplantComponent>(component.ImplanterUid.Value);
         }
     }
     private void OnRemove(EntityUid uid, MindcontrolImplantComponent component, EntGotRemovedFromContainerMessage args)

--- a/Content.Shared/Implants/Components/SubdermalImplantComponent.cs
+++ b/Content.Shared/Implants/Components/SubdermalImplantComponent.cs
@@ -37,6 +37,18 @@ public sealed partial class SubdermalImplantComponent : Component
     public bool Permanent = false;
 
     /// <summary>
+    /// Should you be able to implant this into yourself?
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool CanImplantSelf = true;
+
+    /// <summary>
+    /// Should you be able to implant this into others?
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool CanImplantOther = true;
+
+    /// <summary>
     /// Target whitelist for this implant specifically.
     /// Only checked if the implanter allows implanting on the target to begin with.
     /// </summary>

--- a/Content.Shared/Implants/Components/SubdermalImplantComponent.cs
+++ b/Content.Shared/Implants/Components/SubdermalImplantComponent.cs
@@ -40,13 +40,19 @@ public sealed partial class SubdermalImplantComponent : Component
     /// Should you be able to implant this into yourself?
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public bool CanImplantSelf = true;
+    public bool CanImplantSelf = true; // Goobstation - allow traitors to buy suicide implants (fields for self-/other-implantability)
 
     /// <summary>
     /// Should you be able to implant this into others?
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public bool CanImplantOther = true;
+    public bool CanImplantOther = true; // Goobstation - allow traitors to buy suicide implants (fields for self-/other-implantability)
+
+    /// <summary>
+    /// Multiplier to time taken to implant this implant
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float ImplantationTimeMultiplier = 1; // Goobstation - allow traitors to buy suicide implants (add time multiplier)
 
     /// <summary>
     /// Target whitelist for this implant specifically.

--- a/Content.Shared/Implants/SharedImplanterSystem.cs
+++ b/Content.Shared/Implants/SharedImplanterSystem.cs
@@ -99,6 +99,7 @@ public abstract class SharedImplanterSystem : EntitySystem
             return false;
         }
 
+        // Goobstation - allow traitors to buy suicide implants (fields for self-/other-implantability)
         var implantingSelf = user == target;
         if ((implantingSelf && !implantComp.CanImplantSelf) || (!implantingSelf && !implantComp.CanImplantOther))
             return false;

--- a/Content.Shared/Implants/SharedImplanterSystem.cs
+++ b/Content.Shared/Implants/SharedImplanterSystem.cs
@@ -99,6 +99,10 @@ public abstract class SharedImplanterSystem : EntitySystem
             return false;
         }
 
+        var implantingSelf = user == target;
+        if ((implantingSelf && !implantComp.CanImplantSelf) || (!implantingSelf && !implantComp.CanImplantOther))
+            return false;
+
         var ev = new AddImplantAttemptEvent(user, target, implant.Value, implanter);
         RaiseLocalEvent(target, ev);
         return !ev.Cancelled;

--- a/Content.Shared/_Goobstation/Implanter/PreventSelfImplantComponent.cs
+++ b/Content.Shared/_Goobstation/Implanter/PreventSelfImplantComponent.cs
@@ -1,6 +1,0 @@
-namespace Content.Shared.Implants.Components;
-
-[RegisterComponent]
-public sealed partial class PreventSelfImplantComponent : Component
-{
-}

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1222,6 +1222,7 @@
     Telecrystal: 65 # goob
   categories:
     - UplinkImplants
+  restockTime: 1800
   conditions:
     # goob - traitor suicide implants
     #- !type:StoreWhitelistCondition

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1190,7 +1190,6 @@
   categories:
     - UplinkImplants
 
-
 - type: listing
   id: UplinkMicroBombImplanter
   name: uplink-micro-bomb-implanter-name
@@ -1202,14 +1201,15 @@
   categories:
   - UplinkImplants
   conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - NukeOpsUplink
-  - !type:BuyerWhitelistCondition
-    blacklist:
-      components:
-      - SurplusBundle
+  # goob - traitor suicide implants
+  #- !type:StoreWhitelistCondition
+  #  whitelist:
+  #    tags:
+  #    - NukeOpsUplink
+  #- !type:BuyerWhitelistCondition
+  #  blacklist:
+  #    components:
+  #    - SurplusBundle
 
 
 - type: listing
@@ -1223,7 +1223,7 @@
   categories:
     - UplinkImplants
   conditions:
-    # goob - traitor macrobomb
+    # goob - traitor suicide implants
     #- !type:StoreWhitelistCondition
     #  whitelist:
     #    tags:
@@ -1241,14 +1241,15 @@
   icon: { sprite: /Textures/Objects/Magic/magicactions.rsi, state: gib }
   productEntity: DeathAcidifierImplanter
   cost:
-    Telecrystal: 20 # goob
+    Telecrystal: 5 # goob # goob - traitor suicide implants
   categories:
     - UplinkImplants
-  conditions:
-    - !type:StoreWhitelistCondition
-      whitelist:
-        tags:
-          - NukeOpsUplink
+  # goob - traitor suicide implants
+  #conditions:
+  #  - !type:StoreWhitelistCondition
+  #    whitelist:
+  #      tags:
+  #        - NukeOpsUplink
 
 
 - type: listing

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1223,14 +1223,15 @@
   categories:
     - UplinkImplants
   conditions:
-    - !type:StoreWhitelistCondition
-      whitelist:
-        tags:
-          - NukeOpsUplink
-    - !type:BuyerWhitelistCondition
-      blacklist:
-        components:
-          - SurplusBundle
+    # goob - traitor macrobomb
+    #- !type:StoreWhitelistCondition
+    #  whitelist:
+    #    tags:
+    #      - NukeOpsUplink
+    #- !type:BuyerWhitelistCondition
+    #  blacklist:
+    #    components:
+    #      - SurplusBundle
 
 
 - type: listing

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1197,7 +1197,7 @@
   icon: { sprite: /Textures/Actions/Implants/implants.rsi, state: explosive }
   productEntity: MicroBombImplanter
   cost:
-    Telecrystal: 10 # goob
+    Telecrystal: 20 # goob
   categories:
   - UplinkImplants
   conditions:
@@ -1241,7 +1241,7 @@
   icon: { sprite: /Textures/Objects/Magic/magicactions.rsi, state: gib }
   productEntity: DeathAcidifierImplanter
   cost:
-    Telecrystal: 5 # goob # goob - traitor suicide implants
+    Telecrystal: 20 # goob # goob - traitor suicide implants
   categories:
     - UplinkImplants
   # goob - traitor suicide implants

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -215,7 +215,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
-      canImplantOther: false
+      implantationTimeMultiplier: 4
       permanent: true
       implantAction: ActionActivateMicroBomb
     - type: TriggerOnMobstateChange
@@ -246,7 +246,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
-      canImplantOther: false
+      implantationTimeMultiplier: 4
       permanent: true
     - type: TriggerOnMobstateChange #Chains with OnUseTimerTrigger
       mobState:
@@ -282,7 +282,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: SubdermalImplant
-    canImplantOther: false
+    implantationTimeMultiplier: 4
     permanent: true
     implantAction: ActionActivateDeathAcidifier
   - type: TriggerOnMobstateChange

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -215,7 +215,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
-      implantationTimeMultiplier: 4
+      implantationTimeMultiplier: 4 # Goobstation - Traitor suicide implants
       permanent: true
       implantAction: ActionActivateMicroBomb
     - type: TriggerOnMobstateChange
@@ -246,7 +246,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
-      implantationTimeMultiplier: 4
+      implantationTimeMultiplier: 4 # Goobstation - Traitor suicide implants
       permanent: true
     - type: TriggerOnMobstateChange #Chains with OnUseTimerTrigger
       mobState:
@@ -282,7 +282,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: SubdermalImplant
-    implantationTimeMultiplier: 4
+    implantationTimeMultiplier: 4 # Goobstation - Traitor suicide implants
     permanent: true
     implantAction: ActionActivateDeathAcidifier
   - type: TriggerOnMobstateChange

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -215,6 +215,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
+      canImplantOther: false
       permanent: true
       implantAction: ActionActivateMicroBomb
     - type: TriggerOnMobstateChange
@@ -245,6 +246,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
+      canImplantOther: false
       permanent: true
     - type: TriggerOnMobstateChange #Chains with OnUseTimerTrigger
       mobState:
@@ -280,6 +282,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: SubdermalImplant
+    canImplantOther: false
     permanent: true
     implantAction: ActionActivateDeathAcidifier
   - type: TriggerOnMobstateChange

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/mindcontrol_implant.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/mindcontrol_implant.yml
@@ -14,6 +14,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: SubdermalImplant
+      canImplantSelf: false
       whitelist:
         components:
         - MobState  # can implant ian.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
allows traitors and surpluses to buy:
- death acidifier
- microbomb
- macrobomb

also makes all 3 take 4x time (20 seconds) to implant into other people so no fast roundremoval

## Why / Balance
why not, traitors can already suicide bomb with other explosives or syndibomb anyway
also made a poll on discord for it and it was 10/1 in favor of adding macrobomb

## Media
tested, trust

## Technical details
also removes shitcode from mind control implanter (no gameplay changes)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Traitors may now buy the acidifer, microbomb, and macrobomb implants.
- tweak: Suicide implants now take 4 times as long (20s) to implant into others.
