### PR TITLE
Add's NoColor as a skinColoration type

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Text;
 using Content.Client.Humanoid;
 using Content.Client.Lobby.UI.Loadouts;
 using Content.Client.Lobby.UI.Roles;
@@ -1143,6 +1144,20 @@ namespace Content.Client.Lobby.UI
                         Profile = Profile.WithCharacterAppearance(Profile.Appearance.WithSkinColor(color));
                         break;
                     }
+                case HumanoidSkinColor.NoColor:
+                    {
+                        if (!RgbSkinColorContainer.Visible)
+                        {
+                            Skin.Visible = false;
+                            RgbSkinColorContainer.Visible = true;
+                        }
+
+                        var color = Color.FromName("White");
+
+                        Markings.CurrentSkinColor = color;
+                        Profile = Profile.WithCharacterAppearance(Profile.Appearance.WithSkinColor(color));
+                        break;
+                    }
             }
 
             ReloadProfilePreview();
@@ -1383,6 +1398,18 @@ namespace Content.Client.Lobby.UI
                         }
 
                         _rgbSkinColorSelector.Color = SkinColor.ClosestVoxColor(Profile.Appearance.SkinColor);
+
+                        break;
+                    }
+                case HumanoidSkinColor.NoColor:
+                    {
+                        if (!RgbSkinColorContainer.Visible)
+                        {
+                            Skin.Visible = false;
+                            RgbSkinColorContainer.Visible = true;
+                        }
+
+                        _rgbSkinColorSelector.Color = Color.FromName("White");
 
                         break;
                     }

--- a/Content.Shared/Humanoid/SkinColor.cs
+++ b/Content.Shared/Humanoid/SkinColor.cs
@@ -257,5 +257,5 @@ public enum HumanoidSkinColor : byte
     Hues,
     VoxFeathers, // Vox feathers are limited to a specific color range
     TintedHues, //This gives a color tint to a humanoid's skin (10% saturation with full hue range).
-    NoColor,
+    NoColor, // Goob #1161
 }

--- a/Content.Shared/Humanoid/SkinColor.cs
+++ b/Content.Shared/Humanoid/SkinColor.cs
@@ -257,4 +257,5 @@ public enum HumanoidSkinColor : byte
     Hues,
     VoxFeathers, // Vox feathers are limited to a specific color range
     TintedHues, //This gives a color tint to a humanoid's skin (10% saturation with full hue range).
+    NoColor,
 }

--- a/Resources/Prototypes/_Goobstation/Species/yowie.yml
+++ b/Resources/Prototypes/_Goobstation/Species/yowie.yml
@@ -6,7 +6,7 @@
   sprites: MobYowieSprites
   markingLimits: MobHumanMarkingLimits
   dollPrototype: MobYowieDummy
-  skinColoration: TintedHues
+  skinColoration: NoColor
   maleFirstNames: names_yowie_male
   femaleFirstNames: names_yowie_female
   lastNames: names_yowie_last


### PR DESCRIPTION
## About the PR
Added Blank Skin Coloration, and gave it to Yowie

## Why / Balance
Need it for future races I'm planning, plus Yowie probably wants it aswell

## Technical details
New skinColoration type: NoColor

## Media

![image](https://github.com/user-attachments/assets/820f1f57-065d-4774-b5a1-179af996b2a3)
![image](https://github.com/user-attachments/assets/95b80379-63d6-4b13-b23e-000995523680)
![image](https://github.com/user-attachments/assets/14f8483a-ea36-4a42-8f0a-80966fe294a4)




## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Added a new skin coloration
- tweak: Tweaked Yowie skin color to not be affected by the sliders


