### PR TITLE
lower raffle time

### DIFF
--- a/Resources/Prototypes/GhostRoleRaffles/settings.yml
+++ b/Resources/Prototypes/GhostRoleRaffles/settings.yml
@@ -10,6 +10,6 @@
 - type: ghostRoleRaffleSettings
   id: short
   settings:
-    initialDuration: 5
+    initialDuration: 10
     joinExtendsDurationBy: 0
-    maxDuration: 5
+    maxDuration: 10

--- a/Resources/Prototypes/GhostRoleRaffles/settings.yml
+++ b/Resources/Prototypes/GhostRoleRaffles/settings.yml
@@ -2,14 +2,14 @@
 - type: ghostRoleRaffleSettings
   id: default
   settings:
-    initialDuration: 30
-    joinExtendsDurationBy: 10
-    maxDuration: 90
+    initialDuration: 25
+    joinExtendsDurationBy: 0
+    maxDuration: 25
 
 # for roles that don't matter too much or are available plentifully (e.g. space carp)
 - type: ghostRoleRaffleSettings
   id: short
   settings:
-    initialDuration: 10
-    joinExtendsDurationBy: 2
-    maxDuration: 15
+    initialDuration: 5
+    joinExtendsDurationBy: 0
+    maxDuration: 5


### PR DESCRIPTION
## About the PR
removes raffles being extended when someone joins
major role raffles are now 25 seconds
short raffles are now 5 seconds

## Why / Balance
extend by 10 seconds on join is fucking stupid
they were too long in the first place


**Changelog**
:cl:
- tweak: Raffle timers are now lower.

