### PR TITLE
buff ipc healing

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -30,9 +30,7 @@
     materialComposition:
       Steel: 15
   # EE Change Start
-  #Same as Ointment but divided by 5 and 3 because StackPrice needs to be 1 - Estacao Pirata IPCs
-  #1 Ointment = -50 damage of those types
-  #1 Cable ~= -50 (-49.8) damage of those types
+  #MORE than ointment Estacao Pirata IPCs
   - type: Healing
     delay: 0.6
     damageContainers:

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -37,8 +37,8 @@
     - Silicon
     damage:
       types: # these are all split across multiple types
-        Heat: -2.8
-        Shock: -2.8
+        Heat: -3.0
+        Shock: -3.0
         Ion: -3.0 # Goobstation
   # EE Change End
   # FIXME: Used isnt actually implemented so its still unlimited.

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -37,9 +37,9 @@
     - Silicon
     damage:
       types: # these are all split across multiple types
-        Heat: -3.0
-        Shock: -3.0
-        Ion: -3.50 # Goobstation
+        Heat: -2.8
+        Shock: -2.8
+        Ion: -3.0 # Goobstation
   # EE Change End
   # FIXME: Used isnt actually implemented so its still unlimited.
   # Uncomment this when its implemented, and make sure it handles StackComponent right

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -39,9 +39,9 @@
     - Silicon
     damage:
       types: # these are all split across multiple types
-        Heat: -1.66
-        Shock: -1.66
-        Ion: -1.66 # Goobstation
+        Heat: -3.50
+        Shock: -3.50
+        Ion: -3.50 # Goobstation
   # EE Change End
   # FIXME: Used isnt actually implemented so its still unlimited.
   # Uncomment this when its implemented, and make sure it handles StackComponent right

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -37,8 +37,8 @@
     - Silicon
     damage:
       types: # these are all split across multiple types
-        Heat: -3.50
-        Shock: -3.50
+        Heat: -3.0
+        Shock: -3.0
         Ion: -3.50 # Goobstation
   # EE Change End
   # FIXME: Used isnt actually implemented so its still unlimited.

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -105,15 +105,15 @@
     price: 40
   - type: IgnitionSource
     temperature: 700
-  - type: WeldingHealing # Same as Brutepack - EE IPCs
+  - type: WeldingHealing # EE IPCs
     damageContainers:
       - Silicon
     fuelCost: 5
     damage:
       types:
-        Blunt: -15
-        Piercing: -15
-        Slash: -15
+        Blunt: -25
+        Piercing: -25
+        Slash: -25
   - type: Cautery # Shitmed
     speed: 0.7
   - type: SurgeryTool # Shitmed


### PR DESCRIPTION

## About the PR
1 cable now heals 3 heat damage (previously 1.66)
1 weld now heals 25 brute damage (previously 15)

## Why / Balance
ipcs aren't combat viable as of now because of their super slow healing and their fire weakness (2 flare gun shots kill them)



**Changelog**
:cl:
- tweak: Ipcs heal faster now.