### PR TITLE
secret weight tweaks + nukie name fix

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -110,7 +110,7 @@
       components:
       - type: NukeOperative
       - type: RandomMetadata
-        nameSegments: [ names_death_commando ] # goob edit
+        nameSegments: [ names_syndicate ] 
       - type: NpcFactionMember
         factions:
         - Syndicate
@@ -125,7 +125,7 @@
       components:
       - type: NukeOperative
       - type: RandomMetadata
-        nameSegments: [ names_death_commando ] # goob edit
+        nameSegments: [ names_syndicate ] 
       - type: NpcFactionMember
         factions:
         - Syndicate
@@ -142,7 +142,7 @@
       components:
       - type: NukeOperative
       - type: RandomMetadata
-        nameSegments: [ names_death_commando ] # goob edit
+        nameSegments: [ names_syndicate ] 
       - type: NpcFactionMember
         factions:
         - Syndicate

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -110,7 +110,9 @@
       components:
       - type: NukeOperative
       - type: RandomMetadata
-        nameSegments: [ names_syndicate ] 
+        nameSegments:
+        - SyndicateNamesPrefix
+        - SyndicateNamesElite
       - type: NpcFactionMember
         factions:
         - Syndicate
@@ -125,7 +127,9 @@
       components:
       - type: NukeOperative
       - type: RandomMetadata
-        nameSegments: [ names_syndicate ] 
+        nameSegments:
+        - SyndicateNamesPrefix
+        - SyndicateNamesElite
       - type: NpcFactionMember
         factions:
         - Syndicate
@@ -142,7 +146,9 @@
       components:
       - type: NukeOperative
       - type: RandomMetadata
-        nameSegments: [ names_syndicate ] 
+        nameSegments:
+        - SyndicateNamesPrefix
+        - SyndicateNamesElite
       - type: NpcFactionMember
         factions:
         - Syndicate

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,17 +1,17 @@
 - type: weightedRandom # All dual antag gamemodes are goobstation
   id: Secret
   weights:
-    Traitor: 0.40 # Goobstation
-    Changeling: 0.11 # Goobstation unique antag
+    Traitor: 0.50 # Goobstation
+    Changeling: 0.15 # Goobstation unique antag
     Traitorling: 0.05 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
-    Nukeops: 0.20 # Goobstation
+    Nukeops: 0.10 # Goobstation
     NukeTraitor: 0.01
     NukeLing: 0.01
-    Revolutionary: 0.10 # Maybe 0.04 after wiz/cult? Goobstation
+    Revolutionary: 0.05 # Maybe 0.04 after wiz/cult? Goobstation
     RevTraitor: 0.02
-    RevLing: 0.01
+    RevLing: 0.04
     Zombie: 0.04 # Maybe 0.03 after wiz/cult? Goobstation
-    Survival: 0.05 # Maybe 0.03 after wiz/cult? aGoobstation
+    Survival: 0.03 # Maybe 0.03 after wiz/cult? aGoobstation
   #  KesslerSyndrome: 0.01 # Goobstation - remove kessler
   # Wizard: 0.05
   # Cult: 0.05


### PR DESCRIPTION
## About the PR
fixed nukie names being some dumb shit
tweaked some secret weights

## Why / Balance
nukie, rev and survival too high
made fun gamemodes more common