### PR TITLE
melee aim assist

### DIFF
--- a/Content.Shared/CombatMode/CombatModeComponent.cs
+++ b/Content.Shared/CombatMode/CombatModeComponent.cs
@@ -42,6 +42,20 @@ namespace Content.Shared.CombatMode
         [ViewVariables(VVAccess.ReadWrite), DataField("isInCombatMode"), AutoNetworkedField]
         public bool IsInCombatMode;
 
+        // Goobstation - Aim assist
+        /// <summary>
+        /// The last entity we hit since last enabling combat mode.
+        /// Used for aim assist.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadOnly)]
+        public EntityUid? LastHit;
+
+        /// <summary>
+        /// Maximum distance to target at which aim assist will make you hit it.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadOnly)]
+        public float AimAssistDistance = 1;
+
         /// <summary>
         ///     Will add <see cref="MouseRotatorComponent"/> and <see cref="NoRotateOnMoveComponent"/>
         ///     to entities with this flag enabled that enter combat mode, and vice versa for removal.

--- a/Content.Shared/CombatMode/CombatModeComponent.cs
+++ b/Content.Shared/CombatMode/CombatModeComponent.cs
@@ -54,7 +54,7 @@ namespace Content.Shared.CombatMode
         /// Maximum distance to target at which aim assist will make you hit it.
         /// </summary>
         [ViewVariables(VVAccess.ReadOnly)]
-        public float AimAssistDistance = 1;
+        public float AimAssistDistance = 1.25f;
 
         /// <summary>
         ///     Will add <see cref="MouseRotatorComponent"/> and <see cref="NoRotateOnMoveComponent"/>

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -64,6 +64,14 @@ public abstract class SharedCombatModeSystem : EntitySystem
         component.CanDisarm = canDisarm;
     }
 
+    public void SetLastHit(EntityUid entity, EntityUid? target, CombatModeComponent? component = null)
+    {
+        if (!Resolve(entity, ref component))
+            return;
+
+        component.LastHit = target;
+    }
+
     public bool IsInCombatMode(EntityUid? entity, CombatModeComponent? component = null)
     {
         return entity != null && Resolve(entity.Value, ref component, false) && component.IsInCombatMode;

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -88,6 +88,10 @@ public abstract class SharedCombatModeSystem : EntitySystem
         component.IsInCombatMode = value;
         Dirty(entity, component);
 
+        // clear aim assist if we're disabling combat mode
+        if (!value)
+            SetLastHit(entity, null, component);
+
         if (component.CombatToggleActionEntity != null)
             _actionsSystem.SetToggled(component.CombatToggleActionEntity, component.IsInCombatMode);
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
adds aim assist to melee:
- if you hit something, remember it
- if something is remembered and you hit air within 1 tile of it, it will instead hit it

behavior in demo video no longer entirely up to date (the part where i hit the puddle), changed it to just ignore objects you can't attack and to not aim assist for targeting static objects

## Why / Balance
click combat is rather frustrating sometimes and relies on skill, this makes it be that way less
could commit democracy and ask the general server populace whether this is wanted

## Technical details
see diff it's small

## Media
https://github.com/user-attachments/assets/f8744c45-d7ff-433e-9a1d-bf9ccd1122a2

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Melee click combat aim assist. If you hit something, subsequent clicks may now be some distance from it and still hit.
