### PR TITLE
disable Stealth of stealthsuit when in critical or death AND syndicate icon shows when in stealth.

### DIFF
--- a/Content.Shared/Stealth/Components/StealthComponent.cs
+++ b/Content.Shared/Stealth/Components/StealthComponent.cs
@@ -26,6 +26,12 @@ public sealed partial class StealthComponent : Component
     public bool EnabledOnDeath = true;
 
     /// <summary>
+    /// The creature will continue invisible at Crit.
+    /// </summary>
+    [DataField("enabledOnCrit")]
+    public bool EnabledOnCrit = true; // Goobstation - Stealth change
+
+    /// <summary>
     /// Whether or not the entity previously had an interaction outline prior to cloaking.
     /// </summary>
     [DataField("hadOutline")]

--- a/Content.Shared/Stealth/SharedStealthSystem.cs
+++ b/Content.Shared/Stealth/SharedStealthSystem.cs
@@ -61,17 +61,21 @@ public abstract class SharedStealthSystem : EntitySystem
         Dirty(uid, component);
     }
 
-    private void OnMobStateChanged(EntityUid uid, StealthComponent component, MobStateChangedEvent args)
+
+    private void OnMobStateChanged(EntityUid uid, StealthComponent component, MobStateChangedEvent args)// Goobstation - Stealth change
     {
-        if (args.NewMobState == MobState.Dead)
+        if (args.NewMobState == MobState.Dead || args.NewMobState == MobState.Critical)
         {
-            component.Enabled = component.EnabledOnDeath;
+            if (args.NewMobState == MobState.Dead)
+                component.Enabled = component.EnabledOnDeath;
+            else
+                component.Enabled = component.EnabledOnCrit;
         }
         else
         {
             component.Enabled = true;
         }
-
+        SetEnabled(uid, component.Enabled, component);// to update the sprite;
         Dirty(uid, component);
     }
 

--- a/Resources/Prototypes/StatusIcon/faction.yml
+++ b/Resources/Prototypes/StatusIcon/faction.yml
@@ -52,3 +52,4 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: Syndicate
+  hideOnStealth: false

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -97,6 +97,8 @@
   - type: ClothingGrantComponent
     component:
     - type: Stealth
+      enabledOnDeath: false
+      enabledOnCrit: false
   - type: FlashImmunity
   - type: FlashSoundSuppression
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
makes the use of the syndicate stealth hardsuit visible when in crit or dead.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. --> 
its a problem that nukes just dissapere when in critical and cant be found by teammates.

## Technical details
<!-- Summary of code changes for easier review. -->
there is a problem: when you go critical, the component stops updating.
 that the stealth component dont start untill you take off the helmet and put it back on.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/e23ddc90-83ab-4706-a159-711d42fe6193)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Steathsuit stops working when in crit
- tweak: Nuclear Oprative icon is visable when in stealth
