### PR TITLE
Fixed bluespace crystals not showing up on mineral scanner

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Walls/asteroid.yml
@@ -19,6 +19,7 @@
         - map: [ "enum.EdgeLayer.West" ]
           state: rock_asteroid_west
         - state: rock_bluespace_crystal
+          map: [ "enum.MiningScannerVisualLayers.Overlay" ]
 
 - type: entity
   id: IronRockBSCrystal
@@ -41,6 +42,7 @@
         - map: [ "enum.EdgeLayer.West" ]
           state: ironrock_west
         - state: rock_bluespace_crystal
+          map: [ "enum.MiningScannerVisualLayers.Overlay" ]
 
 - type: entity
   id: WallRockBSCrystal
@@ -63,6 +65,7 @@
         - map: [ "enum.EdgeLayer.West" ]
           state: rock_west
         - state: rock_bluespace_crystal
+          map: [ "enum.MiningScannerVisualLayers.Overlay" ]
 
 - type: entity
   id: WallRockBasaltBSCrystal
@@ -85,6 +88,7 @@
         - map: [ "enum.EdgeLayer.West" ]
           state: rock_wall_west
         - state: rock_bluespace_crystal
+          map: [ "enum.MiningScannerVisualLayers.Overlay" ]
 
 - type: entity
   id: WallRockSnowBSCrystal
@@ -107,6 +111,7 @@
         - map: [ "enum.EdgeLayer.West" ]
           state: rock_snow_west
         - state: rock_bluespace_crystal
+          map: [ "enum.MiningScannerVisualLayers.Overlay" ]
 
 - type: entity
   id: WallRockSandBSCrystal
@@ -129,6 +134,7 @@
         - map: [ "enum.EdgeLayer.West" ]
           state: rock_sand_west
         - state: rock_bluespace_crystal
+          map: [ "enum.MiningScannerVisualLayers.Overlay" ]
 
 - type: entity
   id: WallRockChromiteBSCrystal
@@ -151,6 +157,7 @@
         - map: [ "enum.EdgeLayer.West" ]
           state: rock_chromite_west
         - state: rock_bluespace_crystal
+          map: [ "enum.MiningScannerVisualLayers.Overlay" ]
 
 - type: entity
   id: WallRockAndesiteBSCrystal
@@ -173,3 +180,4 @@
         - map: [ "enum.EdgeLayer.West" ]
           state: rock_andesite_west
         - state: rock_bluespace_crystal
+          map: [ "enum.MiningScannerVisualLayers.Overlay" ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I made it so that bluespace crystal ore rocks show up on the mineral scanner like all the other rocks with ores in them. 

## Why / Balance
People already complain about BS crystals being removed from the lathe, so now at least salvage can find them more easily.

## Technical details
I saw that map: [ "enum.MiningScannerVisualLayers.Overlay" ] was under all the ore rocks outside of the _Goobstation folder, but the BS crystals didn't have it. I copy pasted it there, and the rocks showed up on the mineral scanner.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/f76f9251-f59a-40bd-965d-629b4ab69ffb)
Yep, there they are. I spawned in all the different types of wall rock in case some didn't show up.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Bluespace Crystal ore rocks now show up on the mineral scanner.