### PR TITLE
Blueshield revolver on spawn

### DIFF
--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
@@ -34,9 +34,7 @@
     - id: ClothingBeltSecurityFilled
     - id: ClothingBlueshieldArmourVest
     - id: ClothingEyesGlassesMedSec
-    - id: PinpointerNuclear
     - id: ClothingHandsGlovesCombat
-    - id: WeaponEnergyRevolver
     - id: ClothingOuterHardsuitBlueshield
     - id: OxygenTankFilled
     - id: NitrogenTankFilled

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -51,6 +51,7 @@
     ears: ClothingHeadsetAltCommand
     belt: ClothingBeltSecurityFilled
     pocket1: UniqueBlueshieldOfficerLockerTeleporter
+    pocket2: PinpointerNuclear
   storage:
     back:
     - Flash

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -54,5 +54,6 @@
   storage:
     back:
     - Flash
+    - WeaponEnergyRevolver
     - BluespaceLifelineImplanter
     - SecHypo


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The Blue-shield Officer now spawns with the EG-4 and pin-pointer in their inventory instead of having to find their locker.

## Why / Balance
I've been playing a lot of late-join BSO, and realized that if you late join into a bad situation, you're kind of just fucked. Even though you are supposed to be an elite body guard you can actually only do anything if you find your locker, and if you late-join into the station being fucked/someone has already looted your locked your only solution is just crying. With this change, even if you late join into the 90% of command being dead and all the power out you can *attempt* to pull some john wick shit and kill the nukies/issue.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- remove: The Blue-shield officer locker no longer spawns the EG-4 and nuclear pin-pointer.
- tweak: The Blue-shield officer now starts with their EG-4 and nuclear pin-pointer
-->
