### PR TITLE
Detective now starts with forensic gloves equipped

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -28,6 +28,7 @@
   equipment:
     eyes: ClothingEyesGlassesSecurity
     id: DetectivePDA
+    gloves: ClothingHandsGlovesForensic
     ears: ClothingHeadsetAltSecurityRegular # Goobstation
     belt: ClothingBeltHolsterFilled
   storage:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Detective now starts with forensic gloves equipped.

## Why / Balance
I was talking in-game about tweaking the previous BSO changes, and someone suggested I change this, so I did. I also thought it was pretty dumb that you had to leave fingerprints/fibers everywhere, and THEN get to your locker.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Detective now spawns with forensic gloves equipped
-->
