### PR TITLE
Tweak - Reflective vest and Energy Katana should reflect only in correct slots

### DIFF
--- a/Content.Shared/Weapons/Reflect/ReflectComponent.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectComponent.cs
@@ -1,5 +1,6 @@
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Content.Shared.Inventory;
 
 namespace Content.Shared.Weapons.Reflect;
 
@@ -17,12 +18,17 @@ public sealed partial class ReflectComponent : Component
     public ReflectType Reflects = ReflectType.Energy | ReflectType.NonEnergy;
 
     /// <summary>
-    /// If the item for reflection needed in inventory slots only - select Body.
-    /// If the item for reflection needed in hands only - select Hands.
-    /// Otherwise it will reflect in any inventory position.
+    /// Select in which inventory slots it will reflect.
+    /// By default, it will reflect in any inventory position, except pockets.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField]
-    public Placement Placement = Placement.Hands | Placement.Body;
+    public SlotFlags SlotFlags = SlotFlags.WITHOUT_POCKET;
+
+    /// <summary>
+    /// Is it allowed to reflect while being in hands.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public bool ReflectingInHands = true;
 
     /// <summary>
     /// Can only reflect when placed correctly.
@@ -62,12 +68,4 @@ public enum ReflectType : byte
     None = 0,
     NonEnergy = 1 << 0,
     Energy = 1 << 1,
-}
-
-[Flags]
-public enum Placement : byte
-{
-    None = 0,
-    Hands = 1 << 0,
-    Body = 1 << 1,
 }

--- a/Content.Shared/Weapons/Reflect/ReflectComponent.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectComponent.cs
@@ -17,6 +17,20 @@ public sealed partial class ReflectComponent : Component
     public ReflectType Reflects = ReflectType.Energy | ReflectType.NonEnergy;
 
     /// <summary>
+    /// If the item for reflection needed in inventory slots only - select Body.
+    /// If the item for reflection needed in hands only - select Hands.
+    /// Otherwise it will reflect in any inventory position.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField]
+    public Placement Placement = Placement.Hands | Placement.Body;
+
+    /// <summary>
+    /// Can only reflect when placed correctly.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public bool InRightPlace = true;
+
+    /// <summary>
     /// Probability for a projectile to be reflected.
     /// </summary>
     [DataField("reflectProb"), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
@@ -48,4 +62,12 @@ public enum ReflectType : byte
     None = 0,
     NonEnergy = 1 << 0,
     Energy = 1 << 1,
+}
+
+[Flags]
+public enum Placement : byte
+{
+    None = 0,
+    Hands = 1 << 0,
+    Body = 1 << 1,
 }

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -98,6 +98,7 @@ public sealed class ReflectSystem : EntitySystem
     {
         if (!Resolve(reflector, ref reflect, false) ||
             !_toggle.IsActivated(reflector) ||
+            !reflect.InRightPlace ||
             !TryComp<ReflectiveComponent>(projectile, out var reflective) ||
             // Goob edit start
             !((reflect.Reflects & reflective.Reflective) != 0x0 &&
@@ -180,6 +181,7 @@ public sealed class ReflectSystem : EntitySystem
     {
         if (!TryComp<ReflectComponent>(reflector, out var reflect) ||
             !_toggle.IsActivated(reflector) ||
+            !reflect.InRightPlace ||
             // Goob edit start
             !((reflect.Reflects & reflective) != 0x0 &&
                 _random.Prob(reflect.ReflectProb) ||
@@ -218,6 +220,8 @@ public sealed class ReflectSystem : EntitySystem
         if (_gameTiming.ApplyingState)
             return;
 
+        component.InRightPlace = IsInRightPlace(component, Placement.Body);
+
         EnsureComp<ReflectUserComponent>(args.Equipee);
     }
 
@@ -230,6 +234,8 @@ public sealed class ReflectSystem : EntitySystem
     {
         if (_gameTiming.ApplyingState)
             return;
+
+        component.InRightPlace = IsInRightPlace(component, Placement.Hands);
 
         EnsureComp<ReflectUserComponent>(args.User);
     }
@@ -260,5 +266,16 @@ public sealed class ReflectSystem : EntitySystem
         }
 
         RemCompDeferred<ReflectUserComponent>(user);
+    }
+
+    /// <summary>
+    /// Checks if the reflective component should work in designated place.
+    /// </summary>
+    private static bool IsInRightPlace(ReflectComponent component, Placement placement)
+    {
+        if (component.Placement == (Placement.Hands | Placement.Body))
+            return true;
+        else
+            return (component.Placement & placement) != 0x0;
     }
 }

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -220,7 +220,7 @@ public sealed class ReflectSystem : EntitySystem
         if (_gameTiming.ApplyingState)
             return;
 
-        component.InRightPlace = IsInRightPlace(component, Placement.Body);
+        component.InRightPlace = IsInRightPlace(component, args.SlotFlags);
 
         EnsureComp<ReflectUserComponent>(args.Equipee);
     }
@@ -235,7 +235,7 @@ public sealed class ReflectSystem : EntitySystem
         if (_gameTiming.ApplyingState)
             return;
 
-        component.InRightPlace = IsInRightPlace(component, Placement.Hands);
+        component.InRightPlace = IsInRightPlace(component, SlotFlags.NONE);
 
         EnsureComp<ReflectUserComponent>(args.User);
     }
@@ -271,11 +271,11 @@ public sealed class ReflectSystem : EntitySystem
     /// <summary>
     /// Checks if the reflective component should work in designated place.
     /// </summary>
-    private static bool IsInRightPlace(ReflectComponent component, Placement placement)
+    private static bool IsInRightPlace(ReflectComponent component, SlotFlags slotFlag)
     {
-        if (component.Placement == (Placement.Hands | Placement.Body))
-            return true;
+        if (slotFlag == SlotFlags.NONE)
+            return component.ReflectingInHands;
         else
-            return (component.Placement & placement) != 0x0;
+            return (component.SlotFlags & slotFlag) == slotFlag;
     }
 }

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -98,7 +98,7 @@
     reflectProb: 1
     reflects:
       - Energy
-    placement: body
+    reflectingInHands: false
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseSyndicateContraband ]

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -98,6 +98,7 @@
     reflectProb: 1
     reflects:
       - Energy
+    placement: body
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseSyndicateContraband ]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -96,7 +96,8 @@
     - Back
     - Belt
   - type: Reflect
-    placement: hands
+    slotFlags:
+      - NONE
 
 - type: entity
   name: machete

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -96,6 +96,7 @@
     - Back
     - Belt
   - type: Reflect
+    placement: hands
 
 - type: entity
   name: machete


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Ported [this](https://github.com/space-wizards/space-station-14/pull/31902).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: BIGZi0348
- tweak: Reflective vest now reflects lasers only while equipped.
- tweak: Energy katana now reflects lasers and projectiles only while in hands.