### PR TITLE
Maps mail teleporter and other mail accessories into cargo (and a bounty computer to Kettle)

### DIFF
--- a/Resources/Maps/_Goobstation/atlas.yml
+++ b/Resources/Maps/_Goobstation/atlas.yml
@@ -2620,12 +2620,12 @@ entities:
             0: 65391
           -13,-2:
             0: 34943
-            6: 12288
+            3: 12288
           -12,-1:
             0: 65535
           -13,-1:
             0: 34952
-            3: 12336
+            4: 12336
           -12,0:
             0: 65535
           -12,-5:
@@ -2661,7 +2661,7 @@ entities:
           -13,-6:
             2: 61680
           -13,-5:
-            3: 61152
+            4: 61152
           -11,-6:
             2: 49
             0: 56320
@@ -2690,8 +2690,8 @@ entities:
             0: 305
           -13,0:
             0: 34952
-            4: 48
-            5: 12288
+            5: 48
+            6: 12288
           -12,1:
             1: 30576
           -13,1:
@@ -2777,8 +2777,8 @@ entities:
             2: 119
           -14,0:
             0: 13107
-            4: 128
-            5: 32768
+            5: 128
+            6: 32768
           -14,1:
             0: 32947
           -14,2:
@@ -2790,7 +2790,7 @@ entities:
             2: 34952
           -14,-1:
             0: 13107
-            3: 32896
+            4: 32896
           -14,4:
             0: 8
             2: 63552
@@ -2813,7 +2813,7 @@ entities:
             0: 2184
           -14,-2:
             0: 13311
-            6: 32768
+            3: 32768
           -14,-4:
             2: 4573
             0: 32768
@@ -2913,6 +2913,21 @@ entities:
           - 0
           - 0
           - 0
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -2944,21 +2959,6 @@ entities:
           - 6666.982
           - 0
           - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.15
-          moles:
-          - 0
-          - 0
-          - 0
-          - 6666.982
           - 0
           - 0
           - 0
@@ -3893,6 +3893,12 @@ entities:
     - type: Transform
       pos: -24.5,16.5
       parent: 2
+    - type: Door
+      secondsUntilStateChange: -24.12161
+      state: Opening
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
   - uid: 66
     components:
     - type: Transform
@@ -43199,6 +43205,18 @@ entities:
     components:
     - type: Transform
       pos: -0.3030796,22.832315
+      parent: 2
+- proto: MailMetricsCartridge
+  entities:
+  - uid: 9470
+    components:
+    - type: Transform
+      pos: -16.686623,13.658165
+      parent: 2
+  - uid: 9471
+    components:
+    - type: Transform
+      pos: -16.592873,13.533165
       parent: 2
 - proto: MailTeleporter
   entities:

--- a/Resources/Maps/_Goobstation/bagel.yml
+++ b/Resources/Maps/_Goobstation/bagel.yml
@@ -11015,7 +11015,7 @@ entities:
       pos: -29.5,37.5
       parent: 60
     - type: Door
-      secondsUntilStateChange: -16633.982
+      secondsUntilStateChange: -16670.977
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -110039,6 +110039,11 @@ entities:
       parent: 60
     - type: ApcPowerReceiver
       powerDisabled: False
+  - uid: 18549
+    components:
+    - type: Transform
+      pos: 49.5,18.5
+      parent: 60
 - proto: MaintenanceFluffSpawner
   entities:
   - uid: 1463

--- a/Resources/Maps/_Goobstation/barratry.yml
+++ b/Resources/Maps/_Goobstation/barratry.yml
@@ -76108,6 +76108,20 @@ entities:
     - type: Transform
       pos: -41.582264,62.13996
       parent: 1
+- proto: MailMetricsCartridge
+  entities:
+  - uid: 15717
+    components:
+    - type: Transform
+      pos: -46.267952,1.1843195
+      parent: 1
+- proto: MailTeleporter
+  entities:
+  - uid: 15716
+    components:
+    - type: Transform
+      pos: -45.5,2.5
+      parent: 1
 - proto: MaintenanceFluffSpawner
   entities:
   - uid: 257
@@ -93300,6 +93314,13 @@ entities:
     components:
     - type: Transform
       pos: -64.5,38.5
+      parent: 1
+- proto: VendingMachineMailDrobe
+  entities:
+  - uid: 15715
+    components:
+    - type: Transform
+      pos: -45.5,-1.5
       parent: 1
 - proto: VendingMachineMedical
   entities:

--- a/Resources/Maps/_Goobstation/box.yml
+++ b/Resources/Maps/_Goobstation/box.yml
@@ -11580,7 +11580,7 @@ entities:
       pos: 24.5,16.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -30447.418
+      secondsUntilStateChange: -30551.814
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -17020,6 +17020,13 @@ entities:
     components:
     - type: Transform
       pos: -20.536755,-5.462179
+      parent: 8364
+- proto: BoxMailCapsulePrimed
+  entities:
+  - uid: 28377
+    components:
+    - type: Transform
+      pos: -20.151733,-15.427294
       parent: 8364
 - proto: BoxMouthSwab
   entities:
@@ -84535,7 +84542,7 @@ entities:
       pos: -34.5,-14.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -24635.953
+      secondsUntilStateChange: -24740.35
       state: Closing
   - uid: 15010
     components:
@@ -85028,7 +85035,7 @@ entities:
       pos: -4.5,-71.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -16383.686
+      secondsUntilStateChange: -16488.082
       state: Closing
 - proto: Fireplace
   entities:
@@ -123821,6 +123828,20 @@ entities:
     - type: Configuration
       config:
         tag: bridge
+- proto: MailMetricsCartridge
+  entities:
+  - uid: 28378
+    components:
+    - type: Transform
+      pos: -20.745483,-15.427294
+      parent: 8364
+- proto: MailTeleporter
+  entities:
+  - uid: 28379
+    components:
+    - type: Transform
+      pos: -21.5,-17.5
+      parent: 8364
 - proto: MaintenanceFluffSpawner
   entities:
   - uid: 1280
@@ -154444,6 +154465,13 @@ entities:
     components:
     - type: Transform
       pos: -10.5,13.5
+      parent: 8364
+- proto: VendingMachineMailDrobe
+  entities:
+  - uid: 28380
+    components:
+    - type: Transform
+      pos: -33.5,-18.5
       parent: 8364
 - proto: VendingMachineMedical
   entities:

--- a/Resources/Maps/_Goobstation/core.yml
+++ b/Resources/Maps/_Goobstation/core.yml
@@ -104986,6 +104986,20 @@ entities:
     - type: Configuration
       config:
         tag: Chemistry
+- proto: MailMetricsCartridge
+  entities:
+  - uid: 22665
+    components:
+    - type: Transform
+      pos: 23.504879,18.194199
+      parent: 2
+- proto: MailTeleporter
+  entities:
+  - uid: 22667
+    components:
+    - type: Transform
+      pos: 27.5,19.5
+      parent: 2
 - proto: MaintenanceFluffSpawner
   entities:
   - uid: 1494
@@ -128751,6 +128765,13 @@ entities:
     components:
     - type: Transform
       pos: -44.5,-13.5
+      parent: 2
+- proto: VendingMachineMailDrobe
+  entities:
+  - uid: 22666
+    components:
+    - type: Transform
+      pos: 27.5,15.5
       parent: 2
 - proto: VendingMachineMedical
   entities:

--- a/Resources/Maps/_Goobstation/kettle.yml
+++ b/Resources/Maps/_Goobstation/kettle.yml
@@ -13081,7 +13081,7 @@ entities:
       pos: -5.5,-58.5
       parent: 82
     - type: Door
-      secondsUntilStateChange: -4773.0215
+      secondsUntilStateChange: -4852.676
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -66554,6 +66554,14 @@ entities:
       rot: 3.141592653589793 rad
       pos: -40.5,39.5
       parent: 82
+- proto: ComputerCargoBounty
+  entities:
+  - uid: 27010
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 42.5,25.5
+      parent: 82
 - proto: ComputerCargoOrders
   entities:
   - uid: 2529
@@ -77839,16 +77847,6 @@ entities:
       parent: 82
 - proto: filingCabinetTallRandom
   entities:
-  - uid: 4179
-    components:
-    - type: Transform
-      pos: 36.5,18.5
-      parent: 82
-  - uid: 4180
-    components:
-    - type: Transform
-      pos: 35.5,18.5
-      parent: 82
   - uid: 6520
     components:
     - type: Transform
@@ -119678,6 +119676,20 @@ entities:
     - type: Configuration
       config:
         tag: Mail Room
+- proto: MailMetricsCartridge
+  entities:
+  - uid: 27011
+    components:
+    - type: Transform
+      pos: 37.278328,18.79245
+      parent: 82
+- proto: MailTeleporter
+  entities:
+  - uid: 4180
+    components:
+    - type: Transform
+      pos: 36.5,18.5
+      parent: 82
 - proto: MaintenanceFluffSpawner
   entities:
   - uid: 360
@@ -150209,6 +150221,13 @@ entities:
     components:
     - type: Transform
       pos: -37.5,12.5
+      parent: 82
+- proto: VendingMachineMailDrobe
+  entities:
+  - uid: 4179
+    components:
+    - type: Transform
+      pos: 35.5,18.5
       parent: 82
 - proto: VendingMachineMedical
   entities:

--- a/Resources/Maps/_Goobstation/marathon.yml
+++ b/Resources/Maps/_Goobstation/marathon.yml
@@ -54519,8 +54519,11 @@ entities:
   - uid: 11738
     components:
     - type: Transform
-      pos: 21.559998,0.47888815
+      pos: 18.256752,0.7758815
       parent: 30
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
   - uid: 18178
     components:
     - type: Transform
@@ -100359,6 +100362,20 @@ entities:
     - type: Transform
       pos: -22.54349,53.796127
       parent: 30
+- proto: MailMetricsCartridge
+  entities:
+  - uid: 22996
+    components:
+    - type: Transform
+      pos: 18.860258,2.8436055
+      parent: 30
+- proto: MailTeleporter
+  entities:
+  - uid: 11737
+    components:
+    - type: Transform
+      pos: 21.5,0.5
+      parent: 30
 - proto: MaintenanceFluffSpawner
   entities:
   - uid: 9199
@@ -107480,11 +107497,6 @@ entities:
     components:
     - type: Transform
       pos: 1.5,-15.5
-      parent: 30
-  - uid: 11737
-    components:
-    - type: Transform
-      pos: 21.5,0.5
       parent: 30
   - uid: 11748
     components:
@@ -126327,6 +126339,13 @@ entities:
     components:
     - type: Transform
       pos: -48.5,33.5
+      parent: 30
+- proto: VendingMachineMailDrobe
+  entities:
+  - uid: 22995
+    components:
+    - type: Transform
+      pos: 19.5,-7.5
       parent: 30
 - proto: VendingMachineMedical
   entities:

--- a/Resources/Maps/_Goobstation/meta.yml
+++ b/Resources/Maps/_Goobstation/meta.yml
@@ -10880,7 +10880,7 @@ entities:
       pos: -42.5,29.5
       parent: 5350
     - type: Door
-      secondsUntilStateChange: -7125.0015
+      secondsUntilStateChange: -7191.1094
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 2
@@ -118351,6 +118351,20 @@ entities:
       parent: 5350
     - type: BallisticAmmoProvider
       unspawnedCount: 30
+- proto: MailMetricsCartridge
+  entities:
+  - uid: 26995
+    components:
+    - type: Transform
+      pos: -40.474518,6.004814
+      parent: 5350
+- proto: MailTeleporter
+  entities:
+  - uid: 26994
+    components:
+    - type: Transform
+      pos: -40.5,4.5
+      parent: 5350
 - proto: MaintenanceFluffSpawner
   entities:
   - uid: 2082
@@ -145999,6 +146013,13 @@ entities:
     components:
     - type: Transform
       pos: 14.5,17.5
+      parent: 5350
+- proto: VendingMachineMailDrobe
+  entities:
+  - uid: 26993
+    components:
+    - type: Transform
+      pos: -38.5,2.5
       parent: 5350
 - proto: VendingMachineMedical
   entities:

--- a/Resources/Maps/_Goobstation/omega.yml
+++ b/Resources/Maps/_Goobstation/omega.yml
@@ -62039,6 +62039,20 @@ entities:
     - type: Transform
       pos: -21.281672,23.225285
       parent: 4812
+- proto: MailMetricsCartridge
+  entities:
+  - uid: 13711
+    components:
+    - type: Transform
+      pos: 20.027636,21.660025
+      parent: 4812
+- proto: MailTeleporter
+  entities:
+  - uid: 13710
+    components:
+    - type: Transform
+      pos: 17.5,20.5
+      parent: 4812
 - proto: MaintenanceFluffSpawner
   entities:
   - uid: 278
@@ -77068,6 +77082,13 @@ entities:
     components:
     - type: Transform
       pos: -16.5,17.5
+      parent: 4812
+- proto: VendingMachineMailDrobe
+  entities:
+  - uid: 13712
+    components:
+    - type: Transform
+      pos: 16.5,27.5
       parent: 4812
 - proto: VendingMachineMedical
   entities:

--- a/Resources/Maps/_Goobstation/packed.yml
+++ b/Resources/Maps/_Goobstation/packed.yml
@@ -66876,6 +66876,23 @@ entities:
     - type: Transform
       pos: 45.548477,23.915247
       parent: 2
+- proto: MailMetricsCartridge
+  entities:
+  - uid: 15093
+    components:
+    - type: Transform
+      pos: 20.803614,24.495613
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+- proto: MailTeleporter
+  entities:
+  - uid: 15092
+    components:
+    - type: Transform
+      pos: 17.5,23.5
+      parent: 2
 - proto: MaintenanceFluffSpawner
   entities:
   - uid: 12286
@@ -82441,6 +82458,13 @@ entities:
     components:
     - type: Transform
       pos: -0.5,-7.5
+      parent: 2
+- proto: VendingMachineMailDrobe
+  entities:
+  - uid: 15091
+    components:
+    - type: Transform
+      pos: 17.5,22.5
       parent: 2
 - proto: VendingMachineMedical
   entities:

--- a/Resources/Maps/_Goobstation/saltern.yml
+++ b/Resources/Maps/_Goobstation/saltern.yml
@@ -51001,6 +51001,20 @@ entities:
     - type: Transform
       pos: -8.471462,20.4352
       parent: 31
+- proto: MailMetricsCartridge
+  entities:
+  - uid: 11961
+    components:
+    - type: Transform
+      pos: 22.333054,13.1992035
+      parent: 31
+- proto: MailTeleporter
+  entities:
+  - uid: 11960
+    components:
+    - type: Transform
+      pos: 21.5,10.5
+      parent: 31
 - proto: MaintenanceFluffSpawner
   entities:
   - uid: 113
@@ -58911,6 +58925,13 @@ entities:
     - type: Transform
       pos: 32.5,23.5
       parent: 31
+- proto: SignMail
+  entities:
+  - uid: 11959
+    components:
+    - type: Transform
+      pos: 17.5,7.5
+      parent: 31
 - proto: SignMaterials
   entities:
   - uid: 7224
@@ -63866,6 +63887,13 @@ entities:
     components:
     - type: Transform
       pos: -19.5,-10.5
+      parent: 31
+- proto: VendingMachineMailDrobe
+  entities:
+  - uid: 11958
+    components:
+    - type: Transform
+      pos: 12.5,10.5
       parent: 31
 - proto: VendingMachineMedical
   entities:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I added the mail teleporter, maildrobe and mail metrics cartridge into the nine maps that didn't already have all three. It's outside the scope of the PR, but I also added a cargo bounty computer to Kettle, because why didn't it have one? Barratry is the run down station that makes you fix everything, and even they don't make you craft your own bounty computer using the QM's spare.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Some maps already have mail teleporters and maildrobes, but not all maps. If it's functional enough for those maps, I figure it should be included in all of them. Also the Kettle bounty computer because no cargo map should require cargo to build their bounty computer.
## Technical details
<!-- Summary of code changes for easier review. -->
I opened the map editor and spawned them in.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![Saltern Station](https://github.com/user-attachments/assets/fde22771-4ce9-417d-8335-6bf70662b4ae)
![Packed Station](https://github.com/user-attachments/assets/a03dda20-8091-4dce-a96a-85672cf88da4)
![Meta Station](https://github.com/user-attachments/assets/0ffb9baf-20de-4b4d-9ca9-77f858a021b6)
![Marathon Station](https://github.com/user-attachments/assets/7ef93a4d-908f-4982-ac54-896d4cdf8dd2)
![Kettle Station](https://github.com/user-attachments/assets/b2cf2021-c9b5-4ded-be10-9b9afb715c21)
![Box Station](https://github.com/user-attachments/assets/5b558d62-44f2-46f6-8012-0d247eb50a3a)
![Barratry Station](https://github.com/user-attachments/assets/ded31197-9829-4984-82de-a1b22898a9cc)
![Atlas Station](https://github.com/user-attachments/assets/72b08f3f-22b1-4adb-86c6-d15ee79fd62c)
![Bagel Station](https://github.com/user-attachments/assets/f4959fa0-e806-4b38-9758-c0281c7d80fd)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added Mail Teleporter, Maildrobe and Mail Metric Cartridge to Cargo
- fix: Fixed Kettle not having a cargo bounty computer
