### PR TITLE
Fix IPC Inventory Eye Slot Position

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/InventoryTemplates/ipc_inventory_template.yml
+++ b/Resources/Prototypes/_EinsteinEngines/InventoryTemplates/ipc_inventory_template.yml
@@ -71,7 +71,7 @@
       slotTexture: glasses
       slotFlags: EYES
       stripTime: 3
-      uiWindowPos: 0,0
+      uiWindowPos: 0,3 # Goobstation - Fix the glasses slot being overlapped with the inventory button; consistent with other inventory templates.
       strippingWindowPos: 0,0
       displayName: Eyes
     # - name: ears


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Moved the Eye slot for IPC inventory up next to the Headwear, making it consistent with the other species inventories and fixing the issue where it overlapped with the button to close the inventory.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The design doc for this change was reviewed through all three stages and approved by all relevant parties before put forward. It's the Cabal's opinion that this change may bring some future balancing changes to the Inventory meta.

## Technical details
<!-- Summary of code changes for easier review. -->
Changed a 0 to a 3.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![SS14 Loader_NQK7zVvGOu](https://github.com/user-attachments/assets/49feaac0-cdd3-4cc7-ba6e-6152c3d386f1)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed IPC glasses slot being in the wrong place. Glasses go on your face, silly.
