### PR TITLE
Added Maximum Sentence Ruleset According to GS Space Law In-Game

### DIFF
--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
@@ -31,6 +31,8 @@
   A suspect can be forced to receive implant removal if there is strong, reasonable proof that they have been implanted, such as an officer seeing them use one or their prints being on a discarded injector. Unlike the implantation procedure, a prisoner can have their sentence entirely delayed or extended until they comply with the procedure, as long as security is actively making attempts to perform it. Akin to implanting, if an inmate gives their clear permission, implant removal can proceed without proof.
 
   ## Sentencing
+  The [color=#EB2D3A][bold]maximum sentence[/bold][/color] time is 10 minutes. Any time higher than this should be shortened to meet this limit. If the total sentence time is higher than, or exactly, 20 minutes, you may perma this person.
+
   From a server rules perspective, security officers are only responsible for ensuring that they only place sentences over 10 minutes where space law would allow permanent confinement. Informing the Warden is highly recommended, even for timed sentences. As long as those requirements are met, security officers not giving inappropriate sentence lengths is considered an in-character issue, not a rule issue.
 
   The captain, HOS, and warden are responsible, within reason, for ensuring security officers place appropriate sentences that follow space law. If they are aware of an inappropriate sentence, including excessively long sentences, and if there is not an urgent threat or danger that they must prioritize, then they must work to correct that sentence. Unreasonable failures, as determined by game admins, of the captain, HOS, or warden to ensure space law is followed will be considered a rule issue, not an in-character issue.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I added the Goob Station Space Law maximum sentence requirement to the Space Law in the guidebook so people stop complaining about it not being there.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Goob Station has its own Space Law that isn't shown in the game. The maximum brig time currently is 10 minutes and is not reflected anywhere in the current Space Law shown in the guidebook.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/505808d1-2f99-4c9e-b274-75af2d2bbe23)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Fixed Guidebook Space Law to mimic online GS Space Law.
