### PR TITLE
Instant prying

### DIFF
--- a/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedAirlockSystem.cs
@@ -89,6 +89,8 @@ public abstract class SharedAirlockSystem : EntitySystem
 
         if (DoorSystem.IsBolted(uid))
             args.PryTimeModifier *= component.BoltedPryModifier;
+        else if (!component.Powered && args.InstaPry) // Goobstation
+            args.PryTimeModifier = 0f;
     }
 
     /// <summary>
@@ -145,7 +147,7 @@ public abstract class SharedAirlockSystem : EntitySystem
         ent.Comp.EmergencyAccess = value;
         Dirty(ent, ent.Comp); // This only runs on the server apparently so we need this.
         UpdateEmergencyLightStatus(ent, ent.Comp);
-		
+
         var sound = ent.Comp.EmergencyAccess ? ent.Comp.EmergencyOnSound : ent.Comp.EmergencyOffSound;
         if (predicted)
             Audio.PlayPredicted(sound, ent, user: user);

--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -71,6 +71,12 @@ public abstract class SharedFirelockSystem : EntitySystem
 
     private void OnDoorGetPryTimeModifier(EntityUid uid, FirelockComponent component, ref GetPryTimeModifierEvent args)
     {
+        if (args.InstaPry) // Goobstation
+        {
+            args.PryTimeModifier = 0f;
+            return;
+        }
+
         WarnPlayer((uid, component), args.User);
 
         if (component.IsLocked)

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -45,6 +45,13 @@ namespace Content.Shared.Maps
         [DataField]
         public PrototypeFlags<ToolQualityPrototype> DeconstructTools { get; set; } = new();
 
+        /// <summary>
+        /// Goobstation
+        /// Tile deconstruct do-after time multiplier
+        /// </summary>
+        [DataField]
+        public float DeconstructTimeMultiplier { get; private set; }
+
         /// <remarks>
         /// Legacy AF but nice to have.
         /// </remarks>

--- a/Content.Shared/Prying/Components/PryingComponent.cs
+++ b/Content.Shared/Prying/Components/PryingComponent.cs
@@ -36,6 +36,13 @@ public sealed partial class PryingComponent : Component
     /// </summary>
     [DataField]
     public bool Enabled = true;
+
+    /// <summary>
+    /// Goobstation
+    /// Whether the tool is able to instantly pry unpowered unbolted doors and firelocks
+    /// </summary>
+    [DataField]
+    public bool InstaPry = true;
 }
 
 /// <summary>
@@ -85,12 +92,14 @@ public readonly record struct PriedEvent(EntityUid User)
 public record struct GetPryTimeModifierEvent
 {
     public readonly EntityUid User;
+    public readonly bool InstaPry; // Goobstation
     public float PryTimeModifier = 1.0f;
     public float BaseTime = 5.0f;
 
-    public GetPryTimeModifierEvent(EntityUid user)
+    public GetPryTimeModifierEvent(EntityUid user, bool instaPry) // Goob edit
     {
         User = user;
+        InstaPry = instaPry; // Goobstation
     }
 }
 

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Doors.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Prying.Components;
+using Content.Shared.Timing;
 using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Serialization;
@@ -22,6 +23,7 @@ public sealed class PryingSystem : EntitySystem
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly UseDelaySystem _delay = default!; // Goobstation
 
     public override void Initialize()
     {
@@ -64,6 +66,9 @@ public sealed class PryingSystem : EntitySystem
     {
         id = null;
 
+        if (TryComp(tool, out UseDelayComponent? delay) && _delay.IsDelayed((tool, delay))) // Goobstation
+            return false;
+
         PryingComponent? comp = null;
         if (!Resolve(tool, ref comp, false))
             return false;
@@ -92,6 +97,9 @@ public sealed class PryingSystem : EntitySystem
     {
         id = null;
 
+        if (TryComp(user, out UseDelayComponent? delay) && _delay.IsDelayed((user, delay))) // Goobstation
+            return false;
+
         // We don't care about displaying a message if no tool was used.
         if (!TryComp<PryUnpoweredComponent>(target, out var unpoweredComp) || !CanPry(target, user, out _, unpoweredComp: unpoweredComp))
             // If we have reached this point we want the event that caused this
@@ -100,7 +108,7 @@ public sealed class PryingSystem : EntitySystem
 
         // hand-prying is much slower
         var modifier = CompOrNull<PryingComponent>(user)?.SpeedModifier ?? unpoweredComp.PryModifier;
-        return StartPry(target, user, null, modifier, out id);
+        return StartPry(target, user, user, modifier, out id); // Goob edit
     }
 
     private bool CanPry(EntityUid target, EntityUid user, out string? message, PryingComponent? comp = null, PryUnpoweredComponent? unpoweredComp = null)
@@ -131,7 +139,9 @@ public sealed class PryingSystem : EntitySystem
 
     private bool StartPry(EntityUid target, EntityUid user, EntityUid? tool, float toolModifier, [NotNullWhen(true)] out DoAfterId? id)
     {
-        var modEv = new GetPryTimeModifierEvent(user);
+        var instaPry = TryComp(tool, out PryingComponent? prying) && prying.InstaPry; // Goobstation
+
+        var modEv = new GetPryTimeModifierEvent(user, instaPry); // Goob edit
 
         RaiseLocalEvent(target, ref modEv);
         var doAfterArgs = new DoAfterArgs(EntityManager, user, TimeSpan.FromSeconds(modEv.BaseTime * modEv.PryTimeModifier / toolModifier), new DoorPryDoAfterEvent(), target, target, tool)
@@ -175,6 +185,9 @@ public sealed class PryingSystem : EntitySystem
 
         var ev = new PriedEvent(args.User);
         RaiseLocalEvent(uid, ref ev);
+
+        if (TryComp(args.Used, out UseDelayComponent? delay)) // Goobstation
+            _delay.TryResetDelay((args.Used.Value, delay));
     }
 }
 

--- a/Content.Shared/Tools/Systems/SharedToolSystem.Tile.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Tile.cs
@@ -3,6 +3,7 @@ using Content.Shared.Fluids.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Maps;
 using Content.Shared.Physics;
+using Content.Shared.Timing;
 using Content.Shared.Tools.Components;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -65,6 +66,9 @@ public abstract partial class SharedToolSystem
         if (!Resolve(ent, ref ent.Comp1, ref ent.Comp2, false))
             return false;
 
+        if (TryComp(ent, out UseDelayComponent? delay) && _delay.IsDelayed((ent.Owner, delay))) // Goobstation
+            return false;
+
         var comp = ent.Comp1!;
         var tool = ent.Comp2!;
 
@@ -88,7 +92,7 @@ public abstract partial class SharedToolSystem
             return false;
 
         var args = new TileToolDoAfterEvent(GetNetEntity(gridUid), tileRef.GridIndices);
-        UseTool(ent, user, ent, comp.Delay, tool.Qualities, args, out _, toolComponent: tool);
+        UseTool(ent, user, ent, comp.Delay * tileDef.DeconstructTimeMultiplier, tool.Qualities, args, out _, toolComponent: tool); // Goob edit
         return true;
     }
 

--- a/Content.Shared/Tools/Systems/SharedToolSystem.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Item.ItemToggle;
 using Content.Shared.Maps;
 using Content.Shared.Popups;
+using Content.Shared.Timing;
 using Content.Shared.Tools.Components;
 using JetBrains.Annotations;
 using Robust.Shared.Audio.Systems;
@@ -31,6 +32,7 @@ public abstract partial class SharedToolSystem : EntitySystem
     [Dependency] private   readonly SharedTransformSystem _transformSystem = default!;
     [Dependency] private   readonly TileSystem _tiles = default!;
     [Dependency] private   readonly TurfSystem _turfs = default!;
+    [Dependency] private   readonly UseDelaySystem _delay = default!; // Goobstation
 
     public const string CutQuality = "Cutting";
     public const string PulseQuality = "Pulsing";
@@ -55,6 +57,9 @@ public abstract partial class SharedToolSystem : EntitySystem
             RaiseLocalEvent(GetEntity(args.OriginalTarget.Value), (object) ev);
         else
             RaiseLocalEvent((object) ev);
+
+        if (TryComp(uid, out UseDelayComponent? delay)) // Goobstation
+            _delay.TryResetDelay((uid, delay));
     }
 
     public void PlayToolSound(EntityUid uid, ToolComponent tool, EntityUid? user)

--- a/Resources/Prototypes/Entities/Debugging/spanisharmyknife.yml
+++ b/Resources/Prototypes/Entities/Debugging/spanisharmyknife.yml
@@ -23,6 +23,8 @@
   - type: ToolTileCompatible
   - type: Tool
   - type: Prying
+  - type: UseDelay # Goobstation - For insta prying
+    delay: 1
   - type: MultipleTool
     statusShowBehavior: true
     entries:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2436,6 +2436,8 @@
     speedModifier: 1.5
     useSound:
       path: /Audio/Items/crowbar.ogg
+  - type: UseDelay # Goobstation - For insta prying
+    delay: 1
   - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute from base.yml.
     allowedStates:
     - Alive

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -27,6 +27,8 @@
     speedModifier: 1.5
     useSound:
       path: /Audio/Items/crowbar.ogg
+  - type: UseDelay # Goobstation - For insta prying
+    delay: 1
   - type: Reactive
     groups:
       Flammable: [Touch]

--- a/Resources/Prototypes/Entities/Objects/Tools/cowtools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cowtools.yml
@@ -95,6 +95,8 @@
     delay: 10
   - type: Prying
     speedModifier: 0.05
+  - type: UseDelay # Goobstation - For insta prying
+    delay: 3
 
 - type: entity
   name: mooltitool

--- a/Resources/Prototypes/Entities/Objects/Tools/crowbars.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/crowbars.yml
@@ -29,6 +29,8 @@
   - type: StaticPrice
     price: 22
   - type: Prying
+  - type: UseDelay # Goobstation - For insta prying
+    delay: 1
   - type: Sprite
     sprite: Objects/Tools/crowbar.rsi
   - type: Clothing

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -28,6 +28,8 @@
     speedModifier: 1.5
     pryPowered: true
     useSound: /Audio/Items/jaws_pry.ogg
+  - type: UseDelay # Goobstation - For insta prying
+    delay: 1
   - type: MultipleTool
     statusShowBehavior: true
     entries:

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -431,6 +431,8 @@
     - Multitool
   - type: Prying
     enabled: false
+  - type: UseDelay # Goobstation - For insta prying
+    delay: 1
   - type: Tool
     qualities:
       - Screwing

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/armblade.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/armblade.yml
@@ -22,6 +22,8 @@
     size: Normal
     sprite: Objects/Weapons/Melee/armblade.rsi
   - type: Prying
+  - type: UseDelay # Goobstation - For insta prying
+    delay: 1
   - type: Scalpel # Shitmed
     speed: 0.3
   - type: BoneSaw # Shitmed

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -1,4 +1,4 @@
-﻿- type: tile
+- type: tile
   id: Plating
   name: tiles-plating
   sprite: /Textures/Tiles/plating.png
@@ -6,6 +6,7 @@
   isSubfloor: true
   # Goobstation - Fireaxe plating prying
   deconstructTools: [ Axing ]
+  deconstructTimeMultiplier: 5 # Goobstation
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -24,6 +25,7 @@
   isSubfloor: true
   # Goobstation - Fireaxe plating prying
   deconstructTools: [ Axing ]
+  deconstructTimeMultiplier: 5 # Goobstation
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -37,6 +39,7 @@
   isSubfloor: true
   # Goobstation - Fireaxe plating prying
   deconstructTools: [ Axing ]
+  deconstructTimeMultiplier: 5 # Goobstation
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -50,6 +53,7 @@
   isSubfloor: true
   # Goobstation - Fireaxe plating prying
   deconstructTools: [ Axing ]
+  deconstructTimeMultiplier: 5 # Goobstation
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -63,6 +67,7 @@
   isSubfloor: true
   # Goobstation - Fireaxe plating prying
   deconstructTools: [ Axing ]
+  deconstructTimeMultiplier: 5 # Goobstation
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -76,6 +81,7 @@
   isSubfloor: true
   # Goobstation - Fireaxe plating prying
   deconstructTools: [ Axing ]
+  deconstructTimeMultiplier: 5 # Goobstation
   footstepSounds:
     collection: FootstepPlating
   friction: 0.15 #a little less then actual snow
@@ -88,6 +94,7 @@
   baseTurf: Space
   isSubfloor: true
   deconstructTools: [ Cutting ]
+  deconstructTimeMultiplier: 1 # Goobstation
   weather: true
   footstepSounds:
     collection: FootstepPlating
@@ -103,6 +110,7 @@
   baseTurf: Space
   isSubfloor: true
   deconstructTools: [ Cutting ]
+  deconstructTimeMultiplier: 1 # Goobstation
   weather: true
   footstepSounds:
     collection: FootstepPlating

--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Objects/Weapons/Melee/changeling_armblade.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Objects/Weapons/Melee/changeling_armblade.yml
@@ -24,6 +24,8 @@
     sprite: _Goobstation/Changeling/arm_blade.rsi
   - type: Prying
     pryPowered: true
+  - type: UseDelay # For insta prying
+    delay: 1
   - type: Unremoveable
   - type: Tool
     qualities:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/tools.yml
@@ -15,6 +15,8 @@
     - Multitool
   - type: Prying
     enabled: false
+  - type: UseDelay # For insta prying
+    delay: 1
   - type: Tool
     qualities:
       - Screwing

--- a/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
@@ -129,6 +129,8 @@
     - type: Prying
       speedModifier: 1.5
       pryPowered: true
+    - type: UseDelay # For insta prying
+      delay: 1
 
 - type: entity
   parent: RightArmCybernetic
@@ -141,6 +143,8 @@
     - type: Prying
       speedModifier: 1.5
       pryPowered: true
+    - type: UseDelay # For insta prying
+      delay: 1
 
 - type: entity
   parent: LeftLegCybernetic


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Now it it possible to instantly pry tiles, firelocks and unpowered doors using tools. Instead of a do-after, there's now use delay. You still can't instantly pry using your bare hands. You can't also instantly pry plating using fire axe, there's a 5 second do-after.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

There is no point of slowing down the game by adding annoying do-afters. Instant prying will make life much easier.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- add: Now tiles, firelocks and unpowered doors are pried instantly using a tool.