### PR TITLE
add nitrosyl plasmide

### DIFF
--- a/Content.Client/Atmos/Consoles/AtmosAlarmEntryContainer.xaml.cs
+++ b/Content.Client/Atmos/Consoles/AtmosAlarmEntryContainer.xaml.cs
@@ -42,9 +42,9 @@ public sealed partial class AtmosAlarmEntryContainer : BoxContainer
         [Gas.Plasma] = "P",
         [Gas.Tritium] = "T",
         [Gas.WaterVapor] = "H₂O",
-        [Gas.BZ] = "BZ",
-        [Gas.Healium] = "F₃BZ",
-        [Gas.Nitrium] = "Nitrium",
+        [Gas.BZ] = "BZ", ///tg/ gases
+        [Gas.Healium] = "F₃BZ", ///tg/ gases
+        [Gas.Nitrium] = "Nitrium", ///tg/ gases
     };
 
     public AtmosAlarmEntryContainer(NetEntity uid, EntityCoordinates? coordinates)

--- a/Content.Server/Atmos/Portable/PortableScrubberComponent.cs
+++ b/Content.Server/Atmos/Portable/PortableScrubberComponent.cs
@@ -29,9 +29,9 @@ namespace Content.Server.Atmos.Portable
             Gas.Ammonia,
             Gas.NitrousOxide,
             Gas.Frezon,
-            Gas.BZ,
-            Gas.Healium,
-            Gas.Nitrium,
+            Gas.BZ, ///tg/ gases
+            Gas.Healium, ///tg/ gases
+            Gas.Nitrium, ///tg/ gases
         };
 
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/EntityEffects/EffectConditions/BloodReagentThreshold.cs
+++ b/Content.Server/EntityEffects/EffectConditions/BloodReagentThreshold.cs
@@ -1,0 +1,51 @@
+using Content.Server.Body.Components;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.EntityEffects;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Content.Shared.Chemistry.EntitySystems;
+
+namespace Content.Server.EntityEffects.EffectConditions;
+
+public sealed partial class BloodReagentThreshold : EntityEffectCondition
+{
+    [DataField]
+    public FixedPoint2 Min = FixedPoint2.Zero;
+
+    [DataField]
+    public FixedPoint2 Max = FixedPoint2.MaxValue;
+
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<ReagentPrototype>))]
+    public string? Reagent = null;
+    public override bool Condition(EntityEffectBaseArgs args)
+    {
+        if (Reagent is null) return true;
+        if (args.EntityManager.TryGetComponent<BloodstreamComponent>(args.TargetEntity, out var blood))
+        {
+            if (args.EntityManager.System<SharedSolutionContainerSystem>().ResolveSolution(args.TargetEntity, blood.ChemicalSolutionName, ref blood.ChemicalSolution, out var chemSolution))
+            {
+                var reagentID = new ReagentId(Reagent, null);
+                if (chemSolution.TryGetReagentQuantity(reagentID, out var quant))
+                {
+                    return quant > Min && quant < Max;
+                }
+            }
+            return true;
+        }
+
+        throw new NotImplementedException();
+    }
+
+    public override string GuidebookExplanation(IPrototypeManager prototype)
+    {
+        ReagentPrototype? reagentProto = null;
+        if (Reagent is not null)
+            prototype.TryIndex(Reagent, out reagentProto);
+
+        return Loc.GetString("reagent-effect-condition-guidebook-blood-reagent-threshold",
+            ("reagent", reagentProto?.LocalizedName ?? Loc.GetString("reagent-effect-condition-guidebook-this-reagent")),
+            ("max", Max == FixedPoint2.MaxValue ? (float) int.MaxValue : Max.Float()),
+            ("min", Min.Float()));
+    }
+}

--- a/Content.Server/EntityEffects/Effects/AddReagentToBlood.cs
+++ b/Content.Server/EntityEffects/Effects/AddReagentToBlood.cs
@@ -1,0 +1,53 @@
+using Content.Server.Body.Components;
+using Content.Shared.Chemistry.Reagent;
+using Content.Server.Body.Systems;
+using Content.Shared.EntityEffects;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.EntitySystems;
+
+namespace Content.Server.EntityEffects.Effects;
+
+public sealed partial class AddReagentToBlood : EntityEffect
+{
+    private readonly SharedSolutionContainerSystem _solutionContainers;
+
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<ReagentPrototype>))]
+    public string? Reagent = null;
+
+    [DataField]
+    public FixedPoint2 Amount = default!;
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        if (args.EntityManager.TryGetComponent<BloodstreamComponent>(args.TargetEntity, out var blood))
+        {
+            var sys = args.EntityManager.System<BloodstreamSystem>();
+            if (args is EntityEffectReagentArgs reagentArgs)
+            {
+                if (Reagent is null) return;
+                var amt = Amount;
+                var solution = new Solution();
+                solution.AddReagent(Reagent, amt);
+                sys.TryAddToChemicals(args.TargetEntity, solution, blood);
+            }
+            return;
+        }
+    }
+
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+    {
+        if (Reagent is not null && prototype.TryIndex(Reagent, out ReagentPrototype? reagentProto))
+        {
+            return Loc.GetString("reagent-effect-guidebook-add-to-chemicals",
+                ("chance", Probability),
+                ("deltasign", MathF.Sign(Amount.Float())),
+                ("reagent", reagentProto.LocalizedName),
+                ("amount", MathF.Abs(Amount.Float())));
+        }
+
+        throw new NotImplementedException();
+    }
+}

--- a/Content.Server/StationEvents/Components/GasLeakRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/GasLeakRuleComponent.cs
@@ -14,9 +14,9 @@ public sealed partial class GasLeakRuleComponent : Component
         Gas.Tritium,
         Gas.Frezon,
         Gas.WaterVapor, // the fog
-        Gas.BZ, 
-        Gas.Healium, 
-        Gas.Nitrium 
+        Gas.BZ, ///tg/ gases
+        Gas.Healium, ///tg/ gases
+        Gas.Nitrium, ///tg/ gases
     };
 
     /// <summary>

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/GasArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Effects/Components/GasArtifactComponent.cs
@@ -30,9 +30,9 @@ public sealed partial class GasArtifactComponent : Component
         Gas.Ammonia,
         Gas.NitrousOxide,
         Gas.Frezon,
-        Gas.BZ, 
-        Gas.Healium, 
-        Gas.Nitrium 
+        Gas.BZ, ///tg/ gases
+        Gas.Healium, ///tg/ gases
+        Gas.Nitrium, ///tg/ gases
     };
 
     /// <summary>

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/Triggers/Components/ArtifactGasTriggerComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/Triggers/Components/ArtifactGasTriggerComponent.cs
@@ -20,9 +20,9 @@ public sealed partial class ArtifactGasTriggerComponent : Component
         Gas.CarbonDioxide,
         Gas.Ammonia,
         Gas.NitrousOxide,
-        Gas.BZ, 
-        Gas.Healium, 
-        Gas.Nitrium, 
+        Gas.BZ, ///tg/ gases
+        Gas.Healium, ///tg/ gases
+        Gas.Nitrium, ///tg/ gases
     };
 
     /// <summary>

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -172,7 +172,7 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     Total number of gases. Increase this if you want to add more!
         /// </summary>
-        public const int TotalNumberOfGases = 12;
+        public const int TotalNumberOfGases = 12; ///tg/ gases
 
         /// <summary>
         ///     This is the actual length of the gases arrays in mixtures.
@@ -253,22 +253,22 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     The amount of energy 1 mole of BZ forming from N2O and plasma releases.
         /// </summary>
-        public const float BZFormationEnergy = 80e3f;
+        public const float BZFormationEnergy = 80e3f; ///tg/ gases
 
         /// <summary>
         ///     The amount of energy 1 mol of Healium forming from BZ and frezon releases.
         /// </summary>
-        public const float HealiumProductionEnergy = 9e3f;
+        public const float HealiumProductionEnergy = 9e3f; ///tg/ gases
 
         /// <summary>
         ///     The amount of energy 1 mol of Nitrium forming from Tritium, Nitrogen and BZ releases.
         /// </summary>
-        public const float NitriumProductionEnergy = 100e3f;
+        public const float NitriumProductionEnergy = 100e3f; ///tg/ gases
 
         /// <summary>
         ///     The amount of energy 1 mol of Nitrium decomposing into nitrogen and water vapor releases.
         /// </summary>
-        public const float NitriumDecompositionEnergy = 30e3f;
+        public const float NitriumDecompositionEnergy = 30e3f; ///tg/ gases
 
         /// <summary>
         ///     Determines at what pressure the ultra-high pressure red icon is displayed.
@@ -357,8 +357,8 @@ namespace Content.Shared.Atmos
         Ammonia = 6,
         NitrousOxide = 7,
         Frezon = 8,
-        BZ = 9,
-        Healium = 10,
-        Nitrium = 11,
+        BZ = 9, ///tg/ gases
+        Healium = 10, ///tg/ gases
+        Nitrium = 11, ///tg/ gases
     }
 }

--- a/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
@@ -23,9 +23,9 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
             Gas.Ammonia,
             Gas.NitrousOxide,
             Gas.Frezon,
-            Gas.BZ, 
-            Gas.Healium, 
-            Gas.Nitrium 
+            Gas.BZ, ///tg/ gases
+            Gas.Healium, ///tg/ gases
+            Gas.Nitrium, ///tg/ gases
         };
 
         // Presets for 'dumb' air alarm modes

--- a/Resources/Locale/en-US/guidebook/chemistry/conditions.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/conditions.ftl
@@ -61,4 +61,13 @@ reagent-effect-condition-guidebook-has-tag =
                  *[false] has
                 } the tag {$tag}
 
+reagent-effect-condition-guidebook-blood-reagent-threshold =
+    { $max ->
+        [2147483648] there's at least {NATURALFIXED($min, 2)}u of {$reagent}
+        *[other] { $min ->
+                    [0] there's at most {NATURALFIXED($max, 2)}u of {$reagent}
+                    *[other] there's between {NATURALFIXED($min, 2)}u and {NATURALFIXED($max, 2)}u of {$reagent}
+                 }
+    }
+
 reagent-effect-condition-guidebook-this-reagent = this reagent

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -404,3 +404,19 @@ reagent-effect-guidebook-plant-seeds-remove =
         [1] Removes the
         *[other] remove the
     } seeds of the plant
+
+reagent-effect-guidebook-add-to-chemicals =
+    { $chance ->
+        [1] { $deltasign ->
+                [1] Adds
+                *[-1] Removes
+            }
+        *[other]
+            { $deltasign ->
+                [1] add
+                *[-1] remove
+            }
+    } {NATURALFIXED($amount, 2)}u of {$reagent} { $deltasign ->
+        [1] to
+        *[-1] from
+    } the solution

--- a/Resources/Locale/en-US/reagents/meta/narcotics.ftl
+++ b/Resources/Locale/en-US/reagents/meta/narcotics.ftl
@@ -39,3 +39,6 @@ reagent-desc-tear-gas = A chemical that causes severe irritation and crying, com
 
 reagent-name-happiness = happiness
 reagent-desc-happiness = Fills you with ecstatic numbness and causes minor brain damage. Highly addictive. If overdosed causes sudden mood swings.
+
+reagent-name-nitrosyl-plasmide = nitrosyl plasmide
+reagent-desc-nitrosyl-plasmide = A powerful stimulant that can prevent drowsiness, stuns and knock downs.

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -101,6 +101,7 @@
   reagent: Frezon
   pricePerMole: 0.3 # Goobstation - Gas Prices
 
+#/tg/ gases
 - type: gas
   id: 9
   name: gases-bz

--- a/Resources/Prototypes/Atmospherics/reactions.yml
+++ b/Resources/Prototypes/Atmospherics/reactions.yml
@@ -91,6 +91,7 @@
   effects:
   - !type:N2ODecompositionReaction {}
 
+ #/tg/ gases
 - type: gasReaction
   id: bzFormation
   priority: 2

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -25,9 +25,9 @@
         Ammonia: stationAmmonia
         NitrousOxide: stationNO
         Frezon: danger
-        BZ: danger 
-        Healium: stationNO 
-        Nitrium: danger 
+        BZ: danger #/tg/ gases
+        Healium: stationNO #/tg/ gases
+        Nitrium: danger #/tg/ gases
     - type: Tag
       tags:
         - AirSensor

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/vox.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/vox.yml
@@ -15,9 +15,9 @@
       Ammonia: stationAmmonia
       NitrousOxide: stationNO
       Frezon: danger
-      BZ: danger 
-      Healium: stationNO 
-      Nitrium: danger 
+      BZ: danger #/tg/ gases
+      Healium: stationNO #/tg/ gases
+      Nitrium: danger #/tg/ gases
 
 - type: entity
   parent: [AirSensorVoxBase, AirSensor]

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -637,7 +637,8 @@
       - !type:DumpCanisterBehavior
   - type: Lock
     locked: true
-    
+
+ #/tg/ gases
 - type: entity
   parent: GasCanister
   id: BZCanister
@@ -933,6 +934,7 @@
   - type: Sprite
     state: frezon-1
 
+ #/tg/ gases
 - type: entity
   parent: GasCanisterBrokenBase
   id: BZCanisterBroken

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -16,10 +16,6 @@
           type: Human
       - !type:Oxygenate
         conditions:
-        - !type:OrganType # Goobstation - Yowie
-          type: Yowie
-      - !type:Oxygenate
-        conditions:
         - !type:OrganType
           type: Animal
       - !type:Oxygenate
@@ -76,10 +72,6 @@
     Poison:
       effects:
       - !type:HealthChange
-        conditions:
-        - !type:OrganType # Goobstation - Yowie
-          type: Yowie
-          shouldHave: false
         damage:
           types:
             Poison: 3
@@ -89,10 +81,6 @@
     Gas:
       effects:
       - !type:HealthChange
-        conditions:
-        - !type:OrganType # Goobstation - Yowie
-          type: Yowie
-          shouldHave: false
         scaleByQuantity: true
         ignoreResistances: true
         damage:
@@ -175,9 +163,6 @@
           shouldHave: false
         - !type:OrganType
           type: Vox
-          shouldHave: false
-        - !type:OrganType # Goobstation - Yowie
-          type: Yowie
           shouldHave: false
         # Don't want people to get toxin damage from the gas they just
         # exhaled, right?
@@ -273,6 +258,9 @@
         - !type:OrganType
           type: Slime
           shouldHave: false
+        - !type:BloodReagentThreshold # /tg/ gases
+          reagent: NitrosylPlasmide
+          max: 0.1
         type: Local
         visualType: Medium
         messages: [ "effect-sleepy" ]
@@ -285,28 +273,28 @@
         - !type:OrganType
           type: Slime
           shouldHave: false
+        - !type:BloodReagentThreshold # /tg/ gases
+          reagent: NitrosylPlasmide
+          max: 0.1
         walkSpeedModifier: 0.65
         sprintSpeedModifier: 0.65
       - !type:GenericStatusEffect
         conditions:
-        - !type:OrganType # Goobstation - Yowie
-          type: Yowie
-          shouldHave: false
         - !type:ReagentThreshold
           reagent: NitrousOxide
           min: 1
         - !type:OrganType
           type: Slime
           shouldHave: false
+        - !type:BloodReagentThreshold # /tg/ gases
+          reagent: NitrosylPlasmide
+          max: 0.1
         key: ForcedSleep
         component: ForcedSleeping
         time: 200 # This reeks, but I guess it works LMAO
         type: Add
       - !type:HealthChange
         conditions:
-        - !type:OrganType # Goobstation - Yowie
-          type: Yowie
-          shouldHave: false
         - !type:ReagentThreshold
           reagent: NitrousOxide
           min: 3.5
@@ -332,21 +320,6 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType # Goobstation - Yowie
-          type: Yowie
-        damage:
-          groups:
-            Brute: -1
-          types:
-            Heat: -0.5
-            Shock: -0.5
-            Cold: -0.5 
-            Radiation: -0.5
-      - !type:HealthChange
-        conditions:
-        - !type:OrganType # Goobstation - Yowie
-          type: Yowie
-          shouldHave: false
         - !type:ReagentThreshold
           reagent: Frezon
           min: 0.5
@@ -389,6 +362,7 @@
           reagent: Frezon
           min: 1
 
+ #/tg/ gases
 - type: reagent
   id: BZ
   name: reagent-name-bz
@@ -422,8 +396,8 @@
         ignoreResistances: true
         damage:
           types:
-            Asphyxiation: 5
-            Poison: 1.5
+            Asphyxiation: 10
+            Poison: 2.5
       - !type:GenericStatusEffect
         conditions:
         - !type:ReagentThreshold
@@ -435,7 +409,7 @@
         key: SeeingRainbows
         component: SeeingRainbows
         type: Add
-        time: 30
+        time: 10
         refresh: false
       - !type:Emote
         conditions:
@@ -467,6 +441,9 @@
         - !type:OrganType
           type: Slime
           shouldHave: true
+        - !type:BloodReagentThreshold
+          reagent: NitrosylPlasmide
+          max: 0.1
         type: Local
         visualType: Medium
         messages: [ "effect-sleepy" ]
@@ -479,6 +456,9 @@
         - !type:OrganType
           type: Slime
           shouldHave: true
+        - !type:BloodReagentThreshold
+          reagent: NitrosylPlasmide
+          max: 0.1
         walkSpeedModifier: 0.65
         sprintSpeedModifier: 0.65
       - !type:GenericStatusEffect
@@ -489,6 +469,9 @@
         - !type:OrganType
           type: Slime
           shouldHave: true
+        - !type:BloodReagentThreshold
+          reagent: NitrosylPlasmide
+          max: 0.1
         key: ForcedSleep
         component: ForcedSleeping
         time: 10
@@ -508,7 +491,6 @@
         conditions:
         - !type:ReagentThreshold
           reagent: Healium
-          min: 1
           max: 15
         scaleByQuantity: true
         ignoreResistances: true
@@ -533,38 +515,21 @@
         - !type:ReagentThreshold
           reagent: Healium
           min: 4
+        - !type:BloodReagentThreshold
+          reagent: NitrosylPlasmide
+          max: 0.1
         type: Local
         visualType: Medium
         messages: [ "effect-sleepy" ]
-        probability: 0.1
+        probability: 0.01
       - !type:GenericStatusEffect
         conditions:
         - !type:ReagentThreshold
           reagent: Healium
           min: 8
-        key: ForcedSleep
-        component: ForcedSleeping
-        time: 3
-        type: Add
-      - !type:Drunk
-        boozePower: 150
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Healium
-          min: 4
-    Medicine:
-      effects:
-      - !type:HealthChange
-        damage:
-          groups:
-            Burn: -0.1
-            Toxin: -0.1
-            Brute: -0.1
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Healium
-          min: 6
+        - !type:BloodReagentThreshold
+          reagent: NitrosylPlasmide
+          max: 0.01
         key: ForcedSleep
         component: ForcedSleeping
         time: 3
@@ -574,8 +539,7 @@
         conditions:
         - !type:ReagentThreshold
           reagent: Healium
-          min: 3
-        # needs to be made into hypothium to work well as a chem, use as a gas otherwise
+          min: 4
 
 - type: reagent
   id: Nitrium
@@ -583,7 +547,7 @@
   desc: reagent-desc-nitrium
   physicalDesc: reagent-physical-desc-gaseous
   flavor: sour
-  color: "#8b0000"
+  color: "#b76f0e"
   metabolisms:
     Gas:
       effects:
@@ -591,58 +555,29 @@
         conditions:
         - !type:ReagentThreshold
           reagent: Nitrium
-          min: 4
+          min: 3
         walkSpeedModifier: 1.25
         sprintSpeedModifier: 1.25
+      - !type:AddReagentToBlood
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Nitrium
+          min: 6
+        reagent: NitrosylPlasmide
+        amount: 2.5
       - !type:GenericStatusEffect
         conditions:
         - !type:ReagentThreshold
           reagent: Nitrium
-          min: 15
+          min: 8
         key: Stutter
         component: StutteringAccent
-        time: 10
-      - !type:Jitter
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Nitrium
-          min: 10
-        time: 10
-      - !type:ResetNarcolepsy
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Nitrium
-          min: 15
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Nitrium
-          min: 10
-        key: Drowsiness
-        time: 10
-        type: Remove
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Nitrium
-          min: 15
-        key: ForcedSleep
-        type: Remove
-        time: 3
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Nitrium
-          min: 15
-        key: Adrenaline
-        component: IgnoreSlowOnDamage
-        type: Add
-        time: 3
+        time: 8
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           reagent: Nitrium
-          min: 18
+          min: 10
         ignoreResistances: true
         damage:
           types:

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -611,3 +611,42 @@
         type: Add
         time: 5
         refresh: false
+
+- type: reagent # /tg/ gases
+  id: NitrosylPlasmide
+  name: reagent-name-nitrosyl-plasmide
+  group: Narcotics
+  desc: reagent-desc-nitrosyl-plasmide
+  physicalDesc: reagent-physical-desc-translucent
+  flavor: sour
+  color: "#b76f0e"
+  metabolisms:
+    Gas:
+      effects:
+      - !type:Jitter
+    Narcotic:
+      effects:
+      - !type:Jitter
+      - !type:GenericStatusEffect
+        key: Stun
+        time: 3
+        type: Remove
+      - !type:GenericStatusEffect
+        key: KnockedDown
+        time: 3
+        type: Remove
+      - !type:GenericStatusEffect
+        key: Drowsiness
+        time: 10
+        type: Remove
+      - !type:GenericStatusEffect
+        conditions:
+        key: ForcedSleep
+        type: Remove
+        time: 10
+    Medicine:
+      effects:
+      - !type:ResetNarcolepsy
+        conditions:
+        - !type:ReagentThreshold
+          min: 1


### PR DESCRIPTION
## About the PR
Breathing nitrium now puts nitrosyl plasmide into the users blood. Presence of nitrosyl plasmide in a users blood prevents the user from falling asleep to other inhaled gases. Nitrosyl plasmide also greatly reduces stuns and time spent knocked down. 

I've also included some notation to earlier code so that it's easier to find by just searching /tg/ gases. Any changes I've made to existing files should now be noted. 

## Why / Balance
Parity with original concept of nitrium

## Technical details
Added a reagent effect and condition. The effect puts a reagent directly into the users bloodstream. This was done because the current AdjustReagent effect does not work with inhaled gases. The condition checks for the quantity of a reagent in a users blood, and returns true or false depending on the maximum and minimum values passed to it. This is to allow for preventing the forced sleep effect of other gases when nitrosyl plasmide is present in the user. 

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- add: Added Nitrosyl Plasmide
- tweak: Modified Nitrium, Healium, N2O and BZ effects
