### PR TITLE
Add CanEscapeInventory component to BaseMobSpecies

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -226,6 +226,7 @@
   - type: LayingDown # WD EDIT
   - type: Targeting # Shitmed Change
   - type: SurgeryTarget # Shitmed Change
+  - type: CanEscapeInventory # GoobStation - Escape being picked up by players
 
 - type: entity
   save: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added the 'CanEscapeInventory' component to the 'BaseMobSpecies' prototype.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Playable species can't escape from being carried (except IPCs) because they don't have this component. I believe this means there's no non-violent way to escape being carried by someone else, which sucks. This might also fix any issues with species that can hide in bags but I haven't checked if there's any issues with that specifically.

The component is applied to the root of all playable species, since it makes more sense to do a single line change than change a bunch of prototypes, because I can't imagine an immediate justified scenario where being able to prevent a specific species from escaping an inventory is needed.

## Technical details
<!-- Summary of code changes for easier review. -->
Added `CanEscapeInventory` to the `BaseMobSpecies`, I dunno what else to tell ya.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
If for any reason it's desired to have a mob not be able to wriggle free, then the component will need to be removed here and applied to *every* species that should be allowed to escape.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: All playable species can now wriggle free from being carried.
