### PR TITLE
Some nerfs

### DIFF
--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -23,7 +23,7 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
 using Robust.Shared.Player;
 using Content.Shared.Whitelist;
-using Content.Server.Emp; // Goobstation
+using Content.Shared.Emp; // Goobstation
 
 namespace Content.Server.Mech.Systems;
 
@@ -256,6 +256,11 @@ public sealed partial class MechSystem : SharedMechSystem
     //goobstation
     private void OnEmpPulse(EntityUid uid, MechComponent component, EmpPulseEvent args)
     {
+        args.Affected = true;
+        args.Disabled = true;
+        component.Energy -= args.EnergyConsumption;
+        if (component.Energy < 0)
+            component.Energy = 0;
         Dirty(uid, component);
         UpdateUserInterface(uid, component);
     }

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -23,8 +23,7 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
 using Robust.Shared.Player;
 using Content.Shared.Whitelist;
-using Content.Server.Emp;
-using Content.Shared.Emp; // Goobstation
+using Content.Server.Emp; // Goobstation
 
 namespace Content.Server.Mech.Systems;
 

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -23,6 +23,7 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
 using Robust.Shared.Player;
 using Content.Shared.Whitelist;
+using Content.Server.Emp;
 using Content.Shared.Emp; // Goobstation
 
 namespace Content.Server.Mech.Systems;

--- a/Content.Server/Mech/Systems/MechSystem.cs
+++ b/Content.Server/Mech/Systems/MechSystem.cs
@@ -263,6 +263,7 @@ public sealed partial class MechSystem : SharedMechSystem
             component.Energy = 0;
         Dirty(uid, component);
         UpdateUserInterface(uid, component);
+        _actionBlocker.UpdateCanMove(uid);
     }
 
     private void OnDamageChanged(EntityUid uid, MechComponent component, DamageChangedEvent args)

--- a/Content.Server/Power/EntitySystems/BatterySystem.cs
+++ b/Content.Server/Power/EntitySystems/BatterySystem.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Content.Server._White.Blocking;
 using Content.Server.Cargo.Systems;
 using Content.Server.Emp;
 using Content.Server.Power.Components;
@@ -104,7 +105,8 @@ namespace Content.Server.Power.EntitySystems
         private void OnEmpPulse(EntityUid uid, BatteryComponent component, ref EmpPulseEvent args)
         {
             args.Affected = true;
-            args.Disabled = true; // Goobstation
+            if (!HasComp<RechargeableBlockingComponent>(uid)) // Goobstation - rechargeable blocking system handles it
+                args.Disabled = true;
             if (TryComp<MechEquipmentComponent>(uid, out var equipment) &&
                 equipment.EquipmentOwner != null) // Goobstation - it would break mech weapons otherwise
                 return;

--- a/Content.Server/Power/EntitySystems/BatterySystem.cs
+++ b/Content.Server/Power/EntitySystems/BatterySystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Cargo.Systems;
 using Content.Server.Emp;
 using Content.Server.Power.Components;
 using Content.Shared.Examine;
+using Content.Shared.Mech.Equipment.Components;
 using Content.Shared.Rejuvenate;
 using JetBrains.Annotations;
 using Robust.Shared.Containers;
@@ -103,6 +104,10 @@ namespace Content.Server.Power.EntitySystems
         private void OnEmpPulse(EntityUid uid, BatteryComponent component, ref EmpPulseEvent args)
         {
             args.Affected = true;
+            args.Disabled = true; // Goobstation
+            if (TryComp<MechEquipmentComponent>(uid, out var equipment) &&
+                equipment.EquipmentOwner != null) // Goobstation - it would break mech weapons otherwise
+                return;
             UseCharge(uid, args.EnergyConsumption, component);
         }
 

--- a/Content.Server/Power/EntitySystems/BatterySystem.cs
+++ b/Content.Server/Power/EntitySystems/BatterySystem.cs
@@ -4,7 +4,6 @@ using Content.Server.Cargo.Systems;
 using Content.Server.Emp;
 using Content.Server.Power.Components;
 using Content.Shared.Examine;
-using Content.Shared.Mech.Equipment.Components;
 using Content.Shared.Rejuvenate;
 using JetBrains.Annotations;
 using Robust.Shared.Containers;
@@ -107,9 +106,6 @@ namespace Content.Server.Power.EntitySystems
             args.Affected = true;
             if (!HasComp<RechargeableBlockingComponent>(uid)) // Goobstation - rechargeable blocking system handles it
                 args.Disabled = true;
-            if (TryComp<MechEquipmentComponent>(uid, out var equipment) &&
-                equipment.EquipmentOwner != null) // Goobstation - it would break mech weapons otherwise
-                return;
             UseCharge(uid, args.EnergyConsumption, component);
         }
 

--- a/Content.Server/Stunnable/Systems/StunbatonSystem.cs
+++ b/Content.Server/Stunnable/Systems/StunbatonSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Emp;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
 using Content.Server.Power.Events;
@@ -31,6 +32,15 @@ namespace Content.Server.Stunnable.Systems
             SubscribeLocalEvent<StunbatonComponent, ItemToggleActivateAttemptEvent>(TryTurnOn);
             SubscribeLocalEvent<StunbatonComponent, ItemToggledEvent>(ToggleDone);
             SubscribeLocalEvent<StunbatonComponent, ChargeChangedEvent>(OnChargeChanged);
+
+            SubscribeLocalEvent<StunbatonComponent, EmpPulseEvent>(OnEmp); // Goobstation
+        }
+
+        private void OnEmp(Entity<StunbatonComponent> ent, ref EmpPulseEvent args) // Goobstation
+        {
+            args.Affected = true;
+            args.Disabled = true;
+            _itemToggle.TryDeactivate(ent.Owner);
         }
 
         private void OnStaminaHitAttempt(Entity<StunbatonComponent> entity, ref StaminaDamageOnHitAttemptEvent args)

--- a/Content.Server/Weapons/Melee/EnergySword/EnergySwordSystem.cs
+++ b/Content.Server/Weapons/Melee/EnergySword/EnergySwordSystem.cs
@@ -1,4 +1,6 @@
+using Content.Server.Emp;
 using Content.Shared.Interaction;
+using Content.Shared.Item.ItemToggle;
 using Content.Shared.Light;
 using Content.Shared.Light.Components;
 using Content.Shared.Toggleable;
@@ -13,6 +15,7 @@ public sealed class EnergySwordSystem : EntitySystem
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedToolSystem _toolSystem = default!;
+    [Dependency] private readonly ItemToggleSystem _toggle = default!; // Goobstation
 
     public override void Initialize()
     {
@@ -20,7 +23,17 @@ public sealed class EnergySwordSystem : EntitySystem
 
         SubscribeLocalEvent<EnergySwordComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<EnergySwordComponent, InteractUsingEvent>(OnInteractUsing);
+
+        SubscribeLocalEvent<EnergySwordComponent, EmpPulseEvent>(OnEmp); // Goobstation
     }
+
+    private void OnEmp(Entity<EnergySwordComponent> ent, ref EmpPulseEvent args) // Goobstation
+    {
+        args.Affected = true;
+        args.Disabled = true;
+        _toggle.TryDeactivate(ent.Owner);
+    }
+
     // Used to pick a random color for the blade on map init.
     private void OnMapInit(EntityUid uid, EnergySwordComponent comp, MapInitEvent args)
     {

--- a/Content.Server/_Goobstation/Emp/EmpStunSystem.cs
+++ b/Content.Server/_Goobstation/Emp/EmpStunSystem.cs
@@ -1,0 +1,29 @@
+using Content.Server.Emp;
+using Content.Shared._EinsteinEngines.Silicon.Components;
+using Content.Shared.Silicons.Borgs.Components;
+using Content.Shared.Stunnable;
+
+namespace Content.Server._Goobstation.Emp;
+
+public sealed class EmpStunSystem : EntitySystem
+{
+    [Dependency] private readonly SharedStunSystem _stun = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SiliconComponent, EmpPulseEvent>(OnEmpParalyze);
+        SubscribeLocalEvent<BorgChassisComponent, EmpPulseEvent>(OnEmpParalyze);
+    }
+
+    private void OnEmpParalyze(EntityUid uid, Component component, ref EmpPulseEvent args)
+    {
+        args.Affected = true;
+        args.Disabled = true;
+        var duration = args.Duration;
+        if (duration > TimeSpan.FromSeconds(15))
+            duration = TimeSpan.FromSeconds(15);
+        _stun.TryParalyze(uid, duration, true);
+    }
+}

--- a/Content.Server/_White/Blocking/RechargeableBlockingSystem.cs
+++ b/Content.Server/_White/Blocking/RechargeableBlockingSystem.cs
@@ -65,13 +65,8 @@ public sealed class RechargeableBlockingSystem : EntitySystem
         if (!component.Discharged)
             return;
 
-        if (args.User != null)
-        {
-            _popup.PopupEntity(Loc.GetString("rechargeable-blocking-remaining-time-popup",
-                    ("remainingTime", GetRemainingTime(uid))),
-                args.User.Value,
-                args.User.Value);
-        }
+        args.Popup = Loc.GetString("rechargeable-blocking-remaining-time-popup",
+            ("remainingTime", GetRemainingTime(uid)));
         args.Cancelled = true;
     }
     private void OnChargeChanged(EntityUid uid, RechargeableBlockingComponent component, ChargeChangedEvent args)

--- a/Content.Server/_White/Blocking/RechargeableBlockingSystem.cs
+++ b/Content.Server/_White/Blocking/RechargeableBlockingSystem.cs
@@ -65,9 +65,13 @@ public sealed class RechargeableBlockingSystem : EntitySystem
         if (!component.Discharged)
             return;
 
-        _popup.PopupEntity(Loc.GetString("rechargeable-blocking-remaining-time-popup",
-                ("remainingTime", GetRemainingTime(uid))),
-            args.User ?? uid);
+        if (args.User != null)
+        {
+            _popup.PopupEntity(Loc.GetString("rechargeable-blocking-remaining-time-popup",
+                    ("remainingTime", GetRemainingTime(uid))),
+                args.User.Value,
+                args.User.Value);
+        }
         args.Cancelled = true;
     }
     private void OnChargeChanged(EntityUid uid, RechargeableBlockingComponent component, ChargeChangedEvent args)

--- a/Content.Shared/_Goobstation/Emp/EmpDisableSystem.cs
+++ b/Content.Shared/_Goobstation/Emp/EmpDisableSystem.cs
@@ -1,0 +1,31 @@
+using Content.Shared.Emp;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Item.ItemToggle.Components;
+using Content.Shared.Weapons.Ranged.Systems;
+
+namespace Content.Shared._Goobstation.Emp;
+
+public sealed class EmpDisableSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<EmpDisabledComponent, ItemToggleActivateAttemptEvent>(OnActivateAttempt);
+        SubscribeLocalEvent<EmpDisabledComponent, AttemptShootEvent>(OnShootAttempt);
+    }
+
+    private void OnShootAttempt(Entity<EmpDisabledComponent> ent, ref AttemptShootEvent args)
+    {
+        args.Cancelled = true;
+        args.Message = Loc.GetString("emp-disabled-activate-attempt",
+            ("item", Identity.Entity(ent.Owner, EntityManager)));
+    }
+
+    private void OnActivateAttempt(Entity<EmpDisabledComponent> ent, ref ItemToggleActivateAttemptEvent args)
+    {
+        args.Cancelled = true;
+        args.Popup = Loc.GetString("emp-disabled-activate-attempt",
+            ("item", Identity.Entity(ent.Owner, EntityManager)));
+    }
+}

--- a/Resources/Locale/en-US/_Goobstation/emp/emp.ftl
+++ b/Resources/Locale/en-US/_Goobstation/emp/emp.ftl
@@ -1,0 +1,1 @@
+emp-disabled-activate-attempt = {$item} malfunctions!

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -58,7 +58,7 @@ uplink-grenadier-rig-name = grenadier chest rig
 uplink-grenadier-rig-desc = All you need for a loud party: 4 explosive grenades, 2 EMP grenades and 2 minibombs in a chest rig.
 
 uplink-emp-grenade-name = EMP Grenade
-uplink-emp-grenade-desc = A grenade designed to disrupt electronic systems. Useful for disrupting communications, security's energy weapons, and APCs when you're in a tight spot.
+uplink-emp-grenade-desc = A grenade designed to disrupt electronic systems. Useful for disrupting communications, security's energy weapons, and APCs when you're in a tight spot. Warning: EMP temporarily disables energy shield, dagger and swords.
 
 uplink-exploding-pen-name = Exploding pen
 uplink-exploding-pen-desc = A class IV explosive device contained within a standard pen. Comes with a 4 second fuse.
@@ -183,7 +183,7 @@ uplink-dna-scrambler-implanter-name = DNA Scrambler Implanter
 uplink-dna-scrambler-implanter-desc = A single use implant that can be activated to modify your DNA and give you a completely new look.
 
 uplink-emp-implanter-name = EMP Implanter
-uplink-emp-implanter-desc = Detonates a small EMP pulse on activation that drains nearby electronics of their power, runs off a slowly recharging internal cell.
+uplink-emp-implanter-desc = Detonates a small EMP pulse on activation that drains nearby electronics of their power, runs off a slowly recharging internal cell. Warning: EMP temporarily disables energy shield, dagger and swords.
 
 uplink-macro-bomb-implanter-name = Macro Bomb Implanter
 uplink-macro-bomb-implanter-desc = Inject this and on death you'll create a large explosion. Huge team casualty cost, use at own risk. Replaces internal micro bomb.
@@ -205,7 +205,7 @@ uplink-observation-kit-name = Observation Kit
 uplink-observation-kit-desc = Includes surveillance camera monitor board and security hud disguised as sunglasses.
 
 uplink-emp-kit-name = Electrical Disruptor Kit
-uplink-emp-kit-desc = The ultimate reversal on energy-based weaponry: Disables disablers, stuns stunbatons, discharges laser guns! Contains 3 EMP grenades and an EMP implanter. Note: Does not disrupt actual firearms.
+uplink-emp-kit-desc = The ultimate reversal on energy-based weaponry: Disables disablers, stuns stunbatons, discharges laser guns! Contains 3 EMP grenades and an EMP implanter. Does not disrupt actual firearms. Warning: EMP temporarily disables energy shield, dagger and swords.
 
 uplink-decoy-kit-name = Decoy Kit
 uplink-decoy-kit-desc = State-of-the-art distraction technology straight from RND. Comes with five realistic balloons, four decoy grenades, and some snap poppers!

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -409,6 +409,8 @@
         Slash: 0.90
         Piercing: 0.95
         Heat: 0.95
+  - type: IngestionBlocker # Goobstation
+    blockSmokeIngestion: true
 
 - type: entity
   parent: [ ClothingMaskGas, BaseRestrictedContraband ]
@@ -427,6 +429,8 @@
         Slash: 0.90
         Piercing: 0.95
         Heat: 0.95
+  - type: IngestionBlocker # Goobstation
+    blockSmokeIngestion: true
 
 - type: entity
   parent: [ ClothingMaskGas, BaseCentcommContraband ]

--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -174,7 +174,7 @@
     - type: TriggerImplantAction
     - type: EmpOnTrigger
       range: 2.75
-      energyConsumption: 50000
+      energyConsumption: 360 # Goob edit
       disableDuration: 10
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -230,12 +230,12 @@
     maxAngle: 8
     angleIncrease: 3
     angleDecay: 4
+    fireRate: 3
     # Goob edit end
-    fireRate: 4
     availableModes:
     - SemiAuto
     soundGunshot:
-      path: /Audio/Weapons/Guns/Gunshots/mateba.ogg # Goob edit
+      path: /Audio/Weapons/Guns/Gunshots/sniper.ogg # Goob edit
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -235,7 +235,7 @@
     availableModes:
     - SemiAuto
     soundGunshot:
-      path: /Audio/Weapons/Guns/Gunshots/sniper.ogg # Goob edit
+      path: /Audio/Weapons/Guns/Gunshots/mateba.ogg # Goob edit
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -106,7 +106,7 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Revolvers/mateba.rsi
   - type: Gun
-    fireRate: 5 # Goob edit
+    fireRate: 4 # Goob edit
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/mateba.ogg
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -75,12 +75,6 @@
       map: ["enum.GunVisualLayers.Mag"]
   - type: Gun
     fireRate: 10
-    # Goob edit start
-    angleIncrease: 4.5
-    angleDecay: 10
-    minAngle: 3
-    maxAngle: 24
-    # Goob edit end
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
   - type: MagazineVisuals

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -175,6 +175,7 @@
     damage:
       types:
         Blunt: 1
+    clickPartDamageMultiplier: 1 #goob content
   - type: Item
     size: Tiny
     sprite: Objects/Weapons/Melee/e_dagger_loud.rsi
@@ -255,6 +256,7 @@
     damage:
       types:
         Blunt: 1
+    clickPartDamageMultiplier: 1 #goob content
   - type: Tag
     tags:
     - Write

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -5,6 +5,12 @@
   components:
   - type: EnergySword
   - type: ItemToggle
+    # Goobstation start
+    soundFailToActivate:
+      path: /Audio/Machines/button.ogg
+      params:
+        variation: 0.250
+    # Goobstation end
     soundActivate:
       path: /Audio/Weapons/ebladeon.ogg
     soundDeactivate:

--- a/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
@@ -22,4 +22,4 @@
   - BlueshieldOfficerNeck
   - Trinkets
   - GroupSpeciesBreathTool
-  - Survival
+  - SurvivalSecurity

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -51,12 +51,12 @@
     ears: ClothingHeadsetAltCommand
     belt: ClothingBeltSecurityFilled
     pocket1: UniqueBlueshieldOfficerLockerTeleporter
-    pocket2: PinpointerNuclear
-    suitstorage: WeaponShotgunEnforcer
+    pocket2: WeaponPistolMk58
   storage:
     back:
     - Flash
-    - BoxLethalshot
+    - MagazinePistol
+    - PinpointerNuclear
     - BluespaceLifelineImplanter
     - WeaponEnergyRevolver
     - SecHypo

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -52,12 +52,11 @@
     belt: ClothingBeltSecurityFilled
     pocket1: UniqueBlueshieldOfficerLockerTeleporter
     pocket2: PinpointerNuclear
-    suitstorage: WeaponSubMachineGunAtreides
+    suitstorage: WeaponShotgunEnforcer
   storage:
     back:
     - Flash
-    - MagazinePistolSubMachineGun
-    - MagazinePistolSubMachineGun
+    - BoxLethalshot
     - BluespaceLifelineImplanter
     - WeaponEnergyRevolver
     - SecHypo


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Replaced bso's atreides with ~enforcer~ mk58, bso doesn't deserve atreides.
Nerfed n1984 (and mateba) firerate slightly.
Emp implant now only drains 360 energy, but emp now stuns borgs and IPCs and disables energy weapons temporarily (including eswords).
Fixed some mech and emp related bugs.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Infinite EMP implant draining batteries fully is not good.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- add: EMP implanter energy drain heavily reduced, but it still disables energy weapons for 10 seconds.
- add: IPCs and borgs are now stunned when affected by EMP.
- add: Eswords can be EMPd now.
- tweak: Removed atreides from bso, replaced it with mk58.
- tweak: Bso now has security survival box.
- tweak: Energy pen is not as good at delimbing anymore.