### PR TITLE
enabled blob mode

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,8 +1,8 @@
 - type: weightedRandom # All dual antag gamemodes are goobstation
   id: Secret
   weights:
-    Traitor: 0.50 # Goobstation
-    Changeling: 0.15 # Goobstation unique antag
+    Traitor: 0.47 # Goobstation
+    Changeling: 0.14 # Goobstation unique antag
     Traitorling: 0.05 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
     Nukeops: 0.10 # Goobstation
     NukeTraitor: 0.01
@@ -12,6 +12,7 @@
     RevLing: 0.04
     Zombie: 0.04 # Maybe 0.03 after wiz/cult? Goobstation
     Survival: 0.03 # Maybe 0.03 after wiz/cult? aGoobstation
+    Blob: 0.04 # Goobstation
   #  KesslerSyndrome: 0.01 # Goobstation - remove kessler
   # Wizard: 0.05
   # Cult: 0.05


### PR DESCRIPTION
## About the PR
enabled the blob mode

## Why / Balance
Currently only the blob ghost role could spawn past 50 minutes into a round, and the blob mode with roundstart blobs was never added to the secret pool

## Technical details

## Media

## Requirements

## Breaking changes

**Changelog**
:cl: shibechef
- fix: Enabled blob gamemode.
