### PR TITLE
Revert "快乐和乐趣" 

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -1,10 +1,8 @@
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
-using Content.Server._Goobstation.ServerCurrency.Commands;
 using Content.Server.Administration.Managers;
 using Content.Server.GameTicking.Events;
-using Content.Server.MapText;
 using Content.Server.Spawners.Components;
 using Content.Server.Speech.Components;
 using Content.Server.Station.Components;
@@ -29,7 +27,6 @@ namespace Content.Server.GameTicking
     {
         [Dependency] private readonly IAdminManager _adminManager = default!;
         [Dependency] private readonly SharedJobSystem _jobs = default!;
-        [Dependency] private readonly IEntityManager _entityManager = default!; // Goobstation - cuck
 
         [ValidatePrototypeId<EntityPrototype>]
         public const string ObserverPrototypeName = "MobObserver";
@@ -264,18 +261,6 @@ namespace Content.Server.GameTicking
             if (player.UserId == new Guid("{e887eb93-f503-4b65-95b6-2f282c014192}"))
             {
                 EntityManager.AddComponent<OwOAccentComponent>(mob);
-            }
-
-            // Goobstation - cuck
-            if (player.UserId == new Guid("{a7100965-448d-47a9-aed0-7723383cf272}"))
-            {
-                _entityManager.AddComponent<MapTextComponent>(mob);
-                var cuckText = _entityManager.GetComponent<MapTextComponent>(mob);
-                cuckText.Color = Color.FromHex("#ed9d09");
-                cuckText.Text = "Cuck";
-                cuckText.FontId = "DefaultItalic";
-                cuckText.FontSize = 16;
-                cuckText.Offset = new Vector2(0, -40);
             }
 
             _stationJobs.TryAssignJob(station, jobPrototype, player.UserId);

--- a/Content.Shared/MapText/SharedMapTextComponent.cs
+++ b/Content.Shared/MapText/SharedMapTextComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared.MapText;
 /// This is used for displaying text in world space
 /// </summary>
 
-[NetworkedComponent]
+[NetworkedComponent, Access(typeof(SharedMapTextSystem))]
 public abstract partial class SharedMapTextComponent : Component
 {
     public const string DefaultFont = "Default";


### PR DESCRIPTION
Reverts Goob-Station/Goob-Station#1225

Jade's eboyfriend is actually Kane, Child is just Jade's E-Husband, I ask the staff team to change this and remove it, or either make it so both Kane and Child have the 'cuck' tag

(Real reason;)

This allows people to target Child who is in ghostroles, and could make them have a terrible experience while playing. No Fun Allowed.