### PR TITLE
Help Yowies breath easy

### DIFF
--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -18,7 +18,6 @@
         conditions:
         - !type:OrganType # Goobstation - Yowie
           type: Yowie
-          shouldHave: false
       - !type:Oxygenate
         conditions:
         - !type:OrganType


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

~~Looks like I did the oopsie this time, and accidentally made Yowies still not able to breath. I think I must have fat fingered something after testing.~~ Turns out is was a later commit, easy mistake to make but in this case there should not be a shouldHave: false. 

Anyway, time to let Yowies breath again!

:cl:
- fix: Yowies can now breathe easy. Literally.
