### PR TITLE
rework ipc fire damage

### DIFF
--- a/Content.Server/_EinsteinEngines/Silicon/Charge/Systems/SiliconChargeSystem.cs
+++ b/Content.Server/_EinsteinEngines/Silicon/Charge/Systems/SiliconChargeSystem.cs
@@ -186,8 +186,9 @@ public sealed class SiliconChargeSystem : EntitySystem
             if (!_random.Prob(Math.Clamp(temperComp.CurrentTemperature / (upperThresh * 5), 0.001f, 0.9f)))
                 return hotTempMulti;
 
-            _flammable.AdjustFireStacks(silicon, Math.Clamp(siliconComp.FireStackMultiplier, -10, 10), flamComp);
-            _flammable.Ignite(silicon, silicon, flamComp);
+            // GoobStation: Replaced by KillOnOverheatSystem
+            //_flammable.AdjustFireStacks(silicon, Math.Clamp(siliconComp.FireStackMultiplier, -10, 10), flamComp);
+            //_flammable.Ignite(silicon, silicon, flamComp);
             return hotTempMulti;
         }
 

--- a/Content.Server/_Goobstation/Temperature/KillOnOverheatComponent.cs
+++ b/Content.Server/_Goobstation/Temperature/KillOnOverheatComponent.cs
@@ -1,0 +1,16 @@
+using Content.Shared.Atmos;
+
+namespace Content.Server._Goobstation.Temperature;
+
+/// <summary>
+/// Kills an entity when its temperature goes over a threshold.
+/// </summary>
+[RegisterComponent, Access(typeof(KillOnOverheatSystem))]
+public sealed partial class KillOnOverheatComponent : Component
+{
+    [DataField]
+    public float OverheatThreshold = Atmospherics.T0C + 110f;
+
+    [DataField]
+    public LocId OverheatPopup = "ipc-overheat-popup";
+}

--- a/Content.Server/_Goobstation/Temperature/KillOnOverheatSystem.cs
+++ b/Content.Server/_Goobstation/Temperature/KillOnOverheatSystem.cs
@@ -1,0 +1,30 @@
+using Content.Server.Temperature.Components;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Popups;
+
+namespace Content.Server._Goobstation.Temperature;
+
+public sealed class KillOnOverheatSystem : EntitySystem
+{
+    [Dependency] private readonly MobStateSystem _mob = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<KillOnOverheatComponent, TemperatureComponent, MobStateComponent>();
+        while (query.MoveNext(out var uid, out var comp, out var temp, out var mob))
+        {
+            if (mob.CurrentState == MobState.Dead || temp.CurrentTemperature < comp.OverheatThreshold)
+                continue;
+
+            var msg = Loc.GetString(comp.OverheatPopup, ("name", Identity.Name(uid, EntityManager)));
+            _popup.PopupEntity(msg, uid, PopupType.LargeCaution);
+            _mob.ChangeMobState(uid, MobState.Dead, mob);
+        }
+    }
+}

--- a/Resources/Locale/en-US/_Goobstation/power/silicons.ftl
+++ b/Resources/Locale/en-US/_Goobstation/power/silicons.ftl
@@ -1,0 +1,1 @@
+ipc-overheat-popup = {$name}'s circuits shut down from overheating!

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -51,7 +51,7 @@
         1: 0.45
         0: 0.00
     - type: Temperature
-      heatDamageThreshold: 325
+      heatDamageThreshold: 1800 # GoobStation: Roughly the melting point of mild steels
       coldDamageThreshold: 260
       currentTemperature: 310.15
       specificHeat: 42
@@ -62,6 +62,7 @@
         types:
           Heat: 3 #per second, scales with temperature & other constants
       atmosTemperatureTransferEfficiency: 0.05
+    - type: KillOnOverheat # GoobStation
     - type: Deathgasp
       prototype: SiliconDeathgasp
       needsCritical: false
@@ -161,7 +162,7 @@
       canResistFire: true
       damage:
         types:
-          Heat: 0.75 #per second, scales with number of fire 'stacks'
+          Heat: 0 # GoobStation: Replaced fire damage with overheating shutdown
     # - type: Barotrauma # Not particularly modifiable. In the future, some response to pressure changes would be nice.
     #   damage:
     #     types:


### PR DESCRIPTION
## About the PR
ipcs are stronger to fire damage wise:
- take no damage from firestacks
- need steel-melting temperatures to take burn damage from heat (plasma fire wont damage, trit fire will)

however they now **instantly die when over 110C**, though they take no damage so once rescued they can easily be rebooted

**Changelog**
:cl:
- tweak: Reworked IPC fire mechanics to not round remove them from a tiny fire.
