### PR TITLE
Incendiary rework

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
@@ -29,8 +29,8 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 5
-        Heat: 19
+        Blunt: 4
+        Heat: 4
 
 - type: entity
   id: BulletLightRifleUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -29,8 +29,8 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 3
-        Heat: 32
+        Blunt: 7
+        Heat: 7
 
 - type: entity
   id: BulletMagnumAP

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -30,7 +30,7 @@
     damage:
       types:
         Blunt: 2
-        Heat: 14
+        Heat: 2
 
 - type: entity
   id: BulletPistolUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -29,8 +29,8 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 2
-        Heat: 20
+        Blunt: 3
+        Heat: 2
 
 - type: entity
   id: BulletRifleUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -65,7 +65,7 @@
     damage:
       types:
         Blunt: 3
-        Heat: 7
+        Heat: 3
   - type: IgnitionSource
     ignited: true
 
@@ -76,7 +76,7 @@
   components:
   - type: ProjectileSpread
     proto: PelletShotgunIncendiary
-    count: 6
+    count: 4
     spread: 15
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -120,7 +120,7 @@
     radius: 2.0
     energy: 7.0
   - type: IgniteOnCollide
-    fireStacks: 0.25
+    fireStacks: 0.5
 
 - type: entity
   id: BaseBulletAP


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Makes all incendiary rounds do less direct burn damage but more fire stacks. Previously every bullet did .25 fire stacks, now they do .50. Incendiary bullets now directly do ~1/3th the direct damage of a normal round, instead of the full damage of a normal bullet. These changes should let blob and other victims not get literally incinerated without counterplay, while also making incendiaries less like heat bullets and more like incendiary bullets. 

## Why / Balance
Currently incendiary rounds do identical damage to normal rounds but in burn and don't really ignite the target. They are basically laser rifles in a bullet instead of ignition rounds. This is a problem specifically when paired with blobs, and pretty overpowered against most threats.

Blobs currently get absolutely swept when incendiaries come into play. Blobs take .25x damage from all normal sources and 2x-3x from burns depending on the chemical the blob is using. Blobs can handle atmos fires from trit/plasma with hardened walls or the blazing oil chemical. Blobs can also handle lasers with a double upgraded tile reflecting like 70% of laser projectiles at 30 resources but these are also weaker in every other way than the cheaper 15 resource tiles. They can also use the electromagnetic web to EMP laser weapons. But incendiary rounds currently do 8x the damage of normal rounds, 3x the DPS of laser rifles, while also having no actions the blob can counter with so they just suffer. The crew can also hold several hundred rounds at a time, instead of the usual 16 or 32 laser shots. With the changes, incendiary rounds will ignite blob tiles instead of the bullet themselves one shotting them, which will still be the best ammo and weak against blazing oil. 

Incendiaries are also sometimes seen against basic antags that are usually in armor that has very little burn resistance. Incendiaries usually kill quicker than normal rounds, and because the person is incapacitated in less than a second, they cannot roll or splash themselves to put out the fire. From here their limbs usually all ash as even low fire stacks burn for a long time if not extinguished. With the changes, you'll be more engulfed but you can actually react to them by rolling on the ground, rather than immediately dying and staying engulfed. In testing you can survive 15 .35 incendiary shots if you roll and won't get delimbed, where previously the same would kill you then ash all of your limbs. Shotguns previously did a crazy 84 burn 36 blunt in 2 shots with 3 fire stacks, where as now they do 24 burn 24 blunt with 4 fire stacks in the same 2 shots, pretty much requiring you to roll while also not preventing you from rolling by not having the direct damage be lethal.

## Technical details

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl: shibechef
- tweak: Incendiary rounds now ignite twice as much, but do less direct damage.
