### PR TITLE
Remove Sandbox Rules and Fix Guidebook Formatting (Medical Patches)

### DIFF
--- a/Resources/Locale/en-US/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/guidebook/guides.ftl
@@ -33,7 +33,6 @@ guide-entry-brute = Advanced Brute Medication
 guide-entry-botanicals = Botanicals
 guide-entry-cloning = Cloning
 guide-entry-cryogenics = Cryogenics
-guide-entry-medpatches = Medical Patches
 guide-entry-science = Science
 guide-entry-technologies = Technologies
 guide-entry-anomalous-research = Anomalous Research

--- a/Resources/Locale/en-US/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/guidebook/guides.ftl
@@ -33,6 +33,7 @@ guide-entry-brute = Advanced Brute Medication
 guide-entry-botanicals = Botanicals
 guide-entry-cloning = Cloning
 guide-entry-cryogenics = Cryogenics
+guide-entry-medpatches = Medical Patches
 guide-entry-science = Science
 guide-entry-technologies = Technologies
 guide-entry-anomalous-research = Anomalous Research

--- a/Resources/Prototypes/Guidebook/medical.yml
+++ b/Resources/Prototypes/Guidebook/medical.yml
@@ -8,6 +8,7 @@
   - Cloning
   - Cryogenics
   - Surgery # Shitmed Change
+  - Medicine Patches # Fix for Medicine Patches
 
 - type: guideEntry
   id: Medical Doctor

--- a/Resources/Prototypes/Guidebook/medical.yml
+++ b/Resources/Prototypes/Guidebook/medical.yml
@@ -8,7 +8,7 @@
   - Cloning
   - Cryogenics
   - Surgery # Shitmed Change
-  - Medicine Patches # Fix for Medicine Patches
+  - Medical Patches # Fix for Medicine Patches
 
 - type: guideEntry
   id: Medical Doctor

--- a/Resources/Prototypes/_Goobstation/Guidebook/patches.yml
+++ b/Resources/Prototypes/_Goobstation/Guidebook/patches.yml
@@ -1,4 +1,4 @@
 - type: guideEntry
-  id: Medicalpatches
+  id: Medical Patches
   name: guide-entry-medpatches
   text: "/ServerInfo/_Goobstation/Guidebook/Medical/Medicalpatches.xml"

--- a/Resources/ServerInfo/Guidebook/ServerRules/DefaultRules.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/DefaultRules.xml
@@ -64,6 +64,4 @@
   - [textlink="9. Harm refers to physical harm, prioritized by immediacy and likelihood" link="RuleS9"]
   - [textlink="10. You may determine how you resolve conflicts between orders" link="RuleS10"]
 
-## SANDBOX SPECIFIC RULES
-  - 1. You are free to do as you wish, however, causing massive damage to both the station, the arrivals system, and other player’s builds is strictly prohibited. It is also strictly prohibited to spawn large amounts of entities, as too much entities can cause severe lag.
 </Document>

--- a/Resources/ServerInfo/RP_Rules.txt
+++ b/Resources/ServerInfo/RP_Rules.txt
@@ -126,6 +126,3 @@ These rules also apply to any individual who is a silicon, including cyborgs and
     - You are to also guide the Station Heads, along with the Blueshield if needed. If you can't provide an answer, try ahelping for one.
     - Just cause you have all-access does not mean you can abuse it to take items from heads or other areas. Ask for permission.
     - Use common sense and remember that you are also held up to a high standard of play like command and the Blueshield Officer is. Failure to do so will lead to a roleban from command or gameban.
-
-[color=#ffffff]SANDBOX SPECIFIC RULES[/color]
-1. You are free to do as you wish, however, causing massive damage to both the station, the arrivals system, and other player’s builds is strictly prohibited. It is also strictly prohibited to spawn large amounts of entities, as too much entities can cause severe lag.

--- a/Resources/ServerInfo/_Goobstation/Guidebook/Medical/Medicalpatches.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/Medical/Medicalpatches.xml
@@ -13,20 +13,20 @@ There are 5 types of patches:
 - Large
 - Makeshift
 
-### Basic
+## Basic
 The basic patch holds 40 units of chems and transfers 1 unit at a time.
 
-### Rapid
+## Rapid
 The rapid patch holds 40 units and transfers chemicals twice as fast.
 
-### Prefilled
+## Prefilled
 Some medkits contain prefilled patches. These hold 30 units and transfers 0.25 units per second. They cannot be filled or emptied
 
-### Large
+## Large
 The large patch holds 60 units and transfers them one unit at a time.
 However the large patch also transfers 15% of its chemicals upon use (10 units if full).
 
-### Makeshift
+## Makeshift
 The makeshift patch can hold 15 units and transfer 1 unit every 2 seconds.
 However it can be crafted by hand and filled manually without a chemmaster
 </Document>

--- a/Resources/ServerInfo/_Goobstation/Guidebook/Medical/Medicalpatches.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/Medical/Medicalpatches.xml
@@ -23,9 +23,9 @@ The rapid patch holds 40 units and transfers chemicals twice as fast.
 Some medkits contain prefilled patches. These hold 30 units and transfers 0.25 units per second. They cannot be filled or emptied
 
 ### Large
-The large patch holds 60 units and transfers them one unit at a time. 
-However the large patch also transfers 15% of its chemicals upon use (10 units if full)
-=
+The large patch holds 60 units and transfers them one unit at a time.
+However the large patch also transfers 15% of its chemicals upon use (10 units if full).
+
 ### Makeshift
 The makeshift patch can hold 15 units and transfer 1 unit every 2 seconds.
 However it can be crafted by hand and filled manually without a chemmaster


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I removed the sandbox rules since we don't use them anyway.
I reformatted the medical patches to be a child under Jobs/Medical/Medical Patches

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The medical patches weren't formatted correctly and sandbox isn't used.

## Technical details
<!-- Summary of code changes for easier review. -->
Just changed the xml and yml files.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/b426dae1-0751-4bc2-90a1-b25ddbf18ae6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Resources/Prototypes/_Goobstation/Guidebook/patches.yml - Changed ID to "Medical Patches"
