### PR TITLE
Fixed Gingerbread not taking damage from water

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
@@ -46,7 +46,7 @@
         scaleByQuantity: true
         damage:
           types:
-            Genetic: 0.3
+            Heat: 0.3
       - !type:PopupMessage
         type: Local
         visualType: Large


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changed Gingerbread's damage from water from Genetic damage to Heat damage.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It says in the guidebook Gingerbread species take 3x as much damage from water as slime people, but they were being dealt Genetic damage, which they're immune to. I considered making it 4x as much damage, because a max splash of 20 water would still only be 8 damage, but they already take 1.5x Blunt damage, so robusting them is easy enough.

## Technical details
<!-- Summary of code changes for easier review. -->
I changed the touch reaction of water to be Heat damage instead of Genetic damage in gingerbread.yml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Gingerbread not taking damage from being splashed with water
