### PR TITLE
Fix currency manager Update and Shutdown never being invoked

### DIFF
--- a/Content.Server/Entry/EntryPoint.cs
+++ b/Content.Server/Entry/EntryPoint.cs
@@ -49,6 +49,8 @@ namespace Content.Server.Entry
         private IEntitySystemManager? _sysMan;
         private IServerDbManager? _dbManager;
 
+        private ServerCurrencyManager? _currencyManager; // Goobstation
+
         /// <inheritdoc />
         public override void Init()
         {
@@ -113,7 +115,8 @@ namespace Content.Server.Entry
                 _playTimeTracking.Initialize();
                 IoCManager.Resolve<JobWhitelistManager>().Initialize();
                 IoCManager.Resolve<PlayerRateLimitManager>().Initialize();
-                IoCManager.Resolve<ServerCurrencyManager>().Initialize(); // Goobstation
+                _currencyManager = IoCManager.Resolve<ServerCurrencyManager>(); // Goobstation
+                _currencyManager.Initialize(); // Goobstation
             }
         }
 
@@ -168,12 +171,14 @@ namespace Content.Server.Entry
                 case ModUpdateLevel.FramePostEngine:
                     _updateManager.Update();
                     _playTimeTracking?.Update();
+                    _currencyManager?.Update(); // Goobstation
                     break;
             }
         }
 
         protected override void Dispose(bool disposing)
         {
+            _currencyManager?.Shutdown(); // Goobstation
             _playTimeTracking?.Shutdown();
             _dbManager?.Shutdown();
             IoCManager.Resolve<ServerApi>().Shutdown();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

title.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Goobcoins were never saved on `Update` and `Shutdown` because these methods were never invoked.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- fix: Fix goob coins not being saved on server shutdown.