### PR TITLE
Reduce science cost

### DIFF
--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -1,4 +1,4 @@
-# Tier 1
+﻿# Tier 1
 
 - type: technology
   id: SalvageWeapons
@@ -8,7 +8,7 @@
     state: icon
   discipline: Arsenal
   tier: 1
-  cost: 5000
+  cost: 4000 # Goobstation - reduce science cost
   recipeUnlocks:
   - WeaponProtoKineticAccelerator
   - ShuttleGunKineticCircuitboard
@@ -23,7 +23,7 @@
     state: incendiarydisplay
   discipline: Arsenal
   tier: 1
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - BoxShotgunIncendiary
   - MagazineRifleIncendiary
@@ -44,7 +44,7 @@
     state: icon
   discipline: Arsenal
   tier: 1
-  cost: 7500
+  cost: 6500 # Goobstation - reduce science cost
   recipeUnlocks:
   - WeaponLaserCarbine
   - WeaponMechCombatFiredartLaser # Goobstation
@@ -57,7 +57,7 @@
     state: beanbag
   discipline: Arsenal
   tier: 1
-  cost: 5000
+  cost: 4000 # Goobstation - reduce science cost
   recipeUnlocks:
   - MagazineShotgunBeanbag
   - BoxShellTranquilizer
@@ -73,7 +73,7 @@
     state: uranium
   discipline: Arsenal
   tier: 1
-  cost: 7500
+  cost: 6500 # Goobstation - reduce science cost
   recipeUnlocks:
   - MagazineRifleUranium
   - MagazinePistolUranium
@@ -93,7 +93,7 @@
     state: icon
   discipline: Arsenal
   tier: 1
-  cost: 8000
+  cost: 7000 # Goobstation - reduce science cost
   recipeUnlocks:
   - Truncheon
   - TelescopicShield
@@ -108,7 +108,7 @@
     state: payload-explosive-armed
   discipline: Arsenal
   tier: 1
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - SignallerAdvanced
   - SignalTrigger
@@ -126,7 +126,7 @@
     state: icon
   discipline: Arsenal
   tier: 1
-  cost: 5000
+  cost: 4000 # Goobstation - reduce science cost
   recipeUnlocks:
   - ClothingBackpackElectropack
 
@@ -140,7 +140,7 @@
     state: icon
   discipline: Arsenal
   tier: 2
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - WeaponLaserCannon
   - WeaponMechCombatSolarisLaser # Goobstation
@@ -153,7 +153,7 @@
     state: icon
   discipline: Arsenal
   tier: 2
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - WeaponXrayCannon
 
@@ -165,7 +165,7 @@
     state: full
   discipline: Arsenal
   tier: 2
-  cost: 10500
+  cost: 9500 # Goobstation - reduce science cost
   recipeUnlocks:
   - PowerCageRechargerCircuitboard
   - PowerCageSmall
@@ -189,7 +189,7 @@
     state: icon
   discipline: Arsenal
   tier: 3
-  cost: 15000
+  cost: 14000 # Goobstation - reduce science cost
   recipeUnlocks:
   - WeaponAdvancedLaser
   - PortableRecharger
@@ -203,7 +203,7 @@
     state: icon
   discipline: Arsenal
   tier: 3
-  cost: 15000
+  cost: 14000 # Goobstation - reduce science cost
   recipeUnlocks:
   - WeaponLaserSvalinn
 
@@ -215,7 +215,7 @@
     state: icon
   discipline: Arsenal
   tier: 3
-  cost: 15000
+  cost: 14000 # Goobstation - reduce science cost
   recipeUnlocks:
   - GrenadeEMP
   - PowerCageHigh

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -1,4 +1,4 @@
-# Tier 1
+﻿# Tier 1
 
 - type: technology
   id: Hydroponics
@@ -8,7 +8,7 @@
     state: seedextractor
   discipline: CivilianServices
   tier: 1
-  cost: 5000
+  cost: 4000 # Goobstation - reduce science cost
   recipeUnlocks:
   - BorgModuleGardening
   - BorgModuleHarvesting
@@ -24,7 +24,7 @@
     state: hamtr
   discipline: CivilianServices
   tier: 1
-  cost: 7500
+  cost: 6500 # Goobstation - reduce science cost
   recipeUnlocks:
   - HamtrHarness
   - HamtrLArm
@@ -44,7 +44,7 @@
     state: cameracase
   discipline: CivilianServices
   tier: 1
-  cost: 5000
+  cost: 4000 # Goobstation - reduce science cost
   recipeUnlocks:
   - SurveillanceCameraRouterCircuitboard
   - SurveillanceCameraWirelessRouterCircuitboard
@@ -62,7 +62,7 @@
     state: television
   discipline: CivilianServices
   tier: 1
-  cost: 7500
+  cost: 6500 # Goobstation - reduce science cost
   recipeUnlocks:
     - ComputerTelevisionCircuitboard
     - SynthesizerInstrument
@@ -78,7 +78,7 @@
     state: janitor
   discipline: CivilianServices
   tier: 1
-  cost: 5000
+  cost: 4000 # Goobstation - reduce science cost
   recipeUnlocks:
   - BorgModuleAdvancedCleaning
 
@@ -90,7 +90,7 @@
     state: display
   discipline: CivilianServices
   tier: 1
-  cost: 7500
+  cost: 6500 # Goobstation - reduce science cost
   recipeUnlocks:
   - FatExtractorMachineCircuitboard
   - BiofabricatorMachineCircuitboard
@@ -106,7 +106,7 @@
     state: astroice
   discipline: CivilianServices
   tier: 2
-  cost: 5000
+  cost: 4000 # Goobstation - reduce science cost
   recipeUnlocks:
   - FauxTileAstroGrass
   - FauxTileMowedAstroGrass
@@ -122,7 +122,7 @@
     state: icon
   discipline: CivilianServices
   tier: 2
-  cost: 7500
+  cost: 6500 # Goobstation - reduce science cost
   recipeUnlocks:
   - StasisBedMachineCircuitboard
   - CryoPodMachineCircuitboard
@@ -137,7 +137,7 @@
     state: advmop
   discipline: CivilianServices
   tier: 2
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - AdvMopItem
   - MegaSprayBottle
@@ -150,7 +150,7 @@
     state: honker
   discipline: CivilianServices
   tier: 2
-  cost: 7500
+  cost: 6500 # Goobstation - reduce science cost
   recipeUnlocks:
   - HonkerHarness
   - HonkerLArm
@@ -170,7 +170,7 @@
     state: icon
   discipline: CivilianServices
   tier: 2
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - WeaponSprayNozzle
   - ClothingBackpackWaterTank
@@ -183,7 +183,7 @@
     state: display
   discipline: CivilianServices
   tier: 2
-  cost: 15000
+  cost: 14000 # Goobstation - reduce science cost
   recipeUnlocks:
   - CargoTelepadMachineCircuitboard
 
@@ -197,7 +197,7 @@
     state: icon
   discipline: CivilianServices
   tier: 3
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - ClothingShoesBootsSpeed
 
@@ -209,7 +209,7 @@
     state: beakerbluespace
   discipline: CivilianServices
   tier: 3
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - BluespaceBeaker
   - SyringeBluespace

--- a/Resources/Prototypes/Research/disciplines.yml
+++ b/Resources/Prototypes/Research/disciplines.yml
@@ -1,4 +1,4 @@
-- type: techDiscipline
+﻿- type: techDiscipline
   id: Industrial
   name: research-discipline-industrial
   color: "#eeac34"

--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -1,4 +1,4 @@
-# Tier 1
+﻿# Tier 1
 
 - type: technology
   id: BasicRobotics
@@ -8,7 +8,7 @@
     state: fab-idle
   discipline: Experimental
   tier: 1
-  cost: 5000
+  cost: 4000 # Goobstation - reduce science cost
   recipeUnlocks:
   - ProximitySensor
   - ExosuitFabricatorMachineCircuitboard
@@ -21,7 +21,7 @@
     state: icon
   discipline: Experimental
   tier: 1
-  cost: 5000
+  cost: 4000 # Goobstation - reduce science cost
   recipeUnlocks:
   - AnomalyScanner
   - AnomalyLocator
@@ -38,7 +38,7 @@
     state: display
   discipline: Experimental
   tier: 1
-  cost: 5000
+  cost: 4000 # Goobstation - reduce science cost
   recipeUnlocks:
   - NodeScanner
   - BorgModuleArtifact
@@ -53,7 +53,7 @@
     state: display
   discipline: Experimental
   tier: 1
-  cost: 5000
+  cost: 4000 # Goobstation - reduce science cost
   recipeUnlocks:
   - TechDiskComputerCircuitboard
 
@@ -65,7 +65,7 @@
     state: icon
   discipline: Experimental
   tier: 1
-  cost: 7500
+  cost: 6500 # Goobstation - reduce science cost
   recipeUnlocks:
   - ClothingShoesBootsMagSci
   - ClothingShoesBootsMoon
@@ -78,7 +78,7 @@
     state: icon
   discipline: Experimental
   tier: 1
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - WeaponGauntletGorilla
 
@@ -92,7 +92,7 @@
     state: icon
   discipline: Experimental
   tier: 2
-  cost: 5000
+  cost: 4000 # Goobstation - reduce science cost
   recipeUnlocks:
   - ArtifactCrusherMachineCircuitboard
 
@@ -104,7 +104,7 @@
     state: base
   discipline: Experimental
   tier: 2
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - WeaponPistolCHIMP
   - AnomalySynchronizerCircuitboard
@@ -120,7 +120,7 @@
     state: base
   discipline: Experimental
   tier: 2
-  cost: 7500
+  cost: 6500 # Goobstation - reduce science cost
   recipeUnlocks:
   - WeaponParticleDecelerator
   - HoloprojectorField
@@ -135,7 +135,7 @@
     state: base
   discipline: Experimental
   tier: 3
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
     - WeaponForceGun
     - WeaponTetherGun
@@ -148,6 +148,6 @@
     state: icon
   discipline: Experimental
   tier: 3
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - DeviceQuantumSpinInverter

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -1,4 +1,4 @@
-# Tier 1
+﻿# Tier 1
 
 - type: technology
   id: SalvageEquipment
@@ -8,7 +8,8 @@
     state: handdrill
   discipline: Industrial
   tier: 1
-  cost: 10000 # Goobstation
+  cost: 9000 # Goobstation
+ # Goobstation - reduce science cost
   recipeUnlocks:
   - MiningDrill
   - WeaponPlasmaCutter # Goobstation
@@ -25,7 +26,7 @@
     state: icon
   discipline: Industrial
   tier: 1
-  cost: 5000
+  cost: 4000 # Goobstation - reduce science cost
   recipeUnlocks:
   - RadarConsoleCircuitboard
   - HandHeldMassScanner
@@ -39,7 +40,7 @@
     state: empty
   discipline: Industrial
   tier: 1
-  cost: 7500
+  cost: 6500 # Goobstation - reduce science cost
   recipeUnlocks:
   - PowerCellHigh
   - TurboItemRechargerCircuitboard
@@ -53,7 +54,7 @@
     state: base
   discipline: Industrial
   tier: 1
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - FlatpackerMachineCircuitboard
 
@@ -65,7 +66,7 @@
     state: building
   discipline: Industrial
   tier: 1
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - AutolatheHyperConvectionMachineCircuitboard
   - ProtolatheHyperConvectionMachineCircuitboard
@@ -80,7 +81,7 @@
     state: portgen0
   discipline: Industrial
   tier: 1
-  cost: 7500
+  cost: 6500 # Goobstation - reduce science cost
   recipeUnlocks:
   - PortableGeneratorPacmanMachineCircuitboard
   - PortableGeneratorSuperPacmanMachineCircuitboard
@@ -98,7 +99,7 @@
     state: freezerOff
   discipline: Industrial
   tier: 1
-  cost: 7500
+  cost: 6500 # Goobstation - reduce science cost
   recipeUnlocks:
   - ThermomachineFreezerMachineCircuitBoard
   - GasRecyclerMachineCircuitboard
@@ -111,7 +112,7 @@
     state: ripley
   discipline: Industrial
   tier: 1
-  cost: 7500
+  cost: 6500 # Goobstation - reduce science cost
   recipeUnlocks:
   - RipleyHarness
   - RipleyLArm
@@ -132,7 +133,7 @@
     state: base
   discipline: Industrial
   tier: 2
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - ShuttleConsoleCircuitboard
   - ThrusterMachineCircuitboard
@@ -147,7 +148,7 @@
     state: icon
   discipline: Industrial
   tier: 2
-  cost: 7500
+  cost: 6500 # Goobstation - reduce science cost
   recipeUnlocks:
   - HellfireFreezerMachineCircuitBoard
   - PortableScrubberMachineCircuitBoard
@@ -163,7 +164,7 @@
     state: icon
   discipline: Industrial
   tier: 2
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
     - WelderExperimental
     - PowerDrill
@@ -178,7 +179,7 @@
     state: handdrill
   discipline: Industrial
   tier: 2
-  cost: 12500
+  cost: 11500 # Goobstation - reduce science cost
   recipeUnlocks:
     - OreBagOfHolding
     - MiningDrillDiamond
@@ -193,7 +194,7 @@
     state: ripleymkii
   discipline: Industrial
   tier: 2
-  cost: 8000
+  cost: 7000 # Goobstation - reduce science cost
   recipeUnlocks:
   - RipleyMKIIHarness
   - RipleyUpgradeKit
@@ -208,7 +209,7 @@
     state: clarke
   discipline: Industrial
   tier: 2
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - ClarkeHarness
   - ClarkeHead
@@ -230,7 +231,7 @@
     state: holding
   discipline: Industrial
   tier: 3
-  cost: 15000
+  cost: 14000 # Goobstation - reduce science cost
   recipeUnlocks:
   - ClothingBackpackHolding
   - ClothingBackpackSatchelHolding
@@ -244,7 +245,7 @@
     state: microreactor
   discipline: Industrial
   tier: 3
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - PowerCellMicroreactor
   technologyPrerequisites:

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -8,8 +8,7 @@
     state: handdrill
   discipline: Industrial
   tier: 1
-  cost: 9000 # Goobstation
- # Goobstation - reduce science cost
+  cost: 9000 # Goobstation # Goobstation - reduce science cost
   recipeUnlocks:
   - MiningDrill
   - WeaponPlasmaCutter # Goobstation

--- a/Resources/Prototypes/_Goobstation/Research/arsenal.yml
+++ b/Resources/Prototypes/_Goobstation/Research/arsenal.yml
@@ -1,4 +1,4 @@
-# Tier 1
+﻿# Tier 1
 - type: technology
   id: WeaponPlasmaRifleTech
   name: research-technology-weapon-plasma-rifle
@@ -7,7 +7,7 @@
     state: icon
   discipline: Arsenal
   tier: 1
-  cost: 5000
+  cost: 4000
   recipeUnlocks:
   - WeaponPlasmaRifle
 
@@ -21,7 +21,7 @@
     state: gygax
   discipline: Arsenal
   tier: 2
-  cost: 12000
+  cost: 11000
   recipeUnlocks:
   - GygaxHarness
   - GygaxArmor
@@ -47,7 +47,7 @@
     state: mecha_missilerack
   discipline: Arsenal
   tier: 3
-  cost: 15000
+  cost: 14000
   recipeUnlocks:
   - WeaponMechCombatMissileRack8
   technologyPrerequisites:
@@ -61,7 +61,7 @@
     state: durand
   discipline: Arsenal
   tier: 3
-  cost: 16000
+  cost: 15000
   recipeUnlocks:
   - DurandHarness
   - DurandArmor

--- a/Resources/Prototypes/_Goobstation/Research/civilianservices.yml
+++ b/Resources/Prototypes/_Goobstation/Research/civilianservices.yml
@@ -1,4 +1,4 @@
-# Tier 1
+﻿# Tier 1
 
 # Tier 2
 
@@ -10,7 +10,7 @@
     state: mecha_bananamrtr
   discipline: CivilianServices
   tier: 2
-  cost: 6000
+  cost: 5000
   recipeUnlocks:
   - MechEquipmentHonkerBananaMortar
   - MechEquipmentHonkerMousetrapMortar
@@ -23,7 +23,7 @@
     state: rapid-syringe-gun
   discipline: CivilianServices
   tier: 2
-  cost: 10000
+  cost: 9000
   recipeUnlocks:
   - RapidSyringeGun
 

--- a/Resources/Prototypes/_Shitmed/Research/civilianservices.yml
+++ b/Resources/Prototypes/_Shitmed/Research/civilianservices.yml
@@ -10,7 +10,7 @@
     state: e-scalpel-on
   discipline: CivilianServices
   tier: 2
-  cost: 9000 # Goobstation - reduce science cost
+  cost: 9000
   recipeUnlocks:
   - BorgModuleAdvancedTreatment
   - BorgModuleDefibrillator
@@ -27,7 +27,7 @@
     state: eyes
   discipline: CivilianServices
   tier: 2
-  cost: 14000 # Goobstation - reduce science cost
+  cost: 14000
   recipeUnlocks:
   - JawsOfLifeLeftArm
   - JawsOfLifeRightArm
@@ -45,7 +45,7 @@
     state: idle
   discipline: CivilianServices
   tier: 2
-  cost: 9000 # Goobstation - reduce science cost
+  cost: 9000
   recipeUnlocks:
   - AutodocCircuitboard
 
@@ -59,6 +59,6 @@
     state: omnimed
   discipline: CivilianServices
   tier: 3
-  cost: 9000 # Goobstation - reduce science cost
+  cost: 9000
   recipeUnlocks:
   - OmnimedTool

--- a/Resources/Prototypes/_Shitmed/Research/civilianservices.yml
+++ b/Resources/Prototypes/_Shitmed/Research/civilianservices.yml
@@ -1,4 +1,4 @@
-# Tier 1
+﻿# Tier 1
 
 # Tier 2
 
@@ -10,7 +10,7 @@
     state: e-scalpel-on
   discipline: CivilianServices
   tier: 2
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - BorgModuleAdvancedTreatment
   - BorgModuleDefibrillator
@@ -27,7 +27,7 @@
     state: eyes
   discipline: CivilianServices
   tier: 2
-  cost: 15000
+  cost: 14000 # Goobstation - reduce science cost
   recipeUnlocks:
   - JawsOfLifeLeftArm
   - JawsOfLifeRightArm
@@ -45,7 +45,7 @@
     state: idle
   discipline: CivilianServices
   tier: 2
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - AutodocCircuitboard
 
@@ -59,6 +59,6 @@
     state: omnimed
   discipline: CivilianServices
   tier: 3
-  cost: 10000
+  cost: 9000 # Goobstation - reduce science cost
   recipeUnlocks:
   - OmnimedTool


### PR DESCRIPTION
## About the PR
Reduced all research cost by 1000.

## Why / Balance
Rounds on Goob are fast but technology cost does not correspond to this.
By making all technology's cheaper to research science will be able to make cool things faster.  


**Changelog**
:cl:
- tweak: Science research is cheaper.
