### PR TITLE
Make nuke and nuke disk SM immune

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
@@ -22,6 +22,7 @@
     - HighRiskItem
   - type: StealTarget
     stealGroup: NukeDisk
+  - type: SupermatterImmune # Goobstation
 
 - type: entity
   name: nuclear authentication disk

--- a/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
@@ -111,6 +111,7 @@
     follow: true
     location: nuclear bomb
   - type: FTLSmashImmune
+  - type: SupermatterImmune # Goobstation
 
 - type: entity
   parent: NuclearBomb


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Both the nuclear fission explosive and the nuclear authentication disk are now immune to being ashed by Supermatter.
<!-- What did you change? -->

## Why / Balance
On Goob 1, round 9049 lasted for 2 hours because there was a stupid amount of blobs, and nukies also. However previously in the round an engi had ashed the nuke with the SM. So the nuke could never be detonated. This softlocked the round and most people got very fed up.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
Added the SupermatterImmune component to the NuclearBomb and the NukeDisk.
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The nuke and nuke disk are now immune to Supermatter.


