### PR TITLE
nerf gas prices, add rpd to CE's locker, add atmos items to cargo catalog

### DIFF
--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -110,7 +110,7 @@
   molarMass: 12
   color: 9370db
   reagent: BZ
-  pricePerMole: 2
+  pricePerMole: 1
 
 - type: gas
   id: 10
@@ -123,7 +123,7 @@
   gasMolesVisible: 2
   color: 8b0000
   reagent: Healium
-  pricePerMole: 3
+  pricePerMole: 2.5
 
 - type: gas
   id: 11
@@ -136,4 +136,4 @@
   molarMass: 8
   color: b76f0e
   reagent: Nitrium
-  pricePerMole: 3
+  pricePerMole: 3.5

--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -111,3 +111,14 @@
 #  cost: 15500
 #  category: cargoproduct-category-name-atmospherics
 #  group: market
+
+# Assmos - /tg/ gases
+- type: cargoProduct
+  id: AtmosphericsBZ
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: purple
+  product: BZCanister
+  cost: 6500
+  category: cargoproduct-category-name-atmospherics
+  group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engineering.yml
@@ -147,3 +147,25 @@
   cost: 350
   category: cargoproduct-category-name-engineering
   group: market
+
+# RPD
+- type: cargoProduct
+  id: EngineeringRPD
+  icon:
+    sprite: Objects/Tools/rpd.rsi
+    state: icon
+  product: CrateRPD
+  cost: 800
+  category: cargoproduct-category-name-engineering
+  group: market
+
+# Assmos - Extinguisher Nozzle
+- type: cargoProduct 
+  id: EngineeringFirefighterBackpackTank
+  icon:
+    sprite: Clothing/Back/Backpacks/atmosbackpacktank.rsi
+    state: icon
+  product: CrateEngineeringFirefighterBackpackTank
+  cost: 1000
+  category: cargoproduct-category-name-engineering
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engineering.yml
@@ -215,3 +215,25 @@
   - type: StorageFill
     contents:
       - id: SpaceHeaterFlatpack
+
+# RPD
+- type: entity
+  id: CrateRPD
+  parent: CrateEngineeringSecure
+  name: RPD crate
+  description: A crate containing a single rapid piping device.
+  components:
+  - type: StorageFill
+    contents:
+    - id: RPD
+
+# Assmos - Extinguisher Nozzle
+- type: entity
+  id: CrateEngineeringFirefighterBackpackTank
+  parent: CrateEngineering
+  name: firefighter crate
+  description: Contains a firefighter backpack water tank.
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingBackpackFirefighterTank

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -165,6 +165,7 @@
     - id: RCDAmmo
     - id: RubberStampCE
     - id: BaseHandheldStationMapPowerCe
+    - id: RPD # RPD
 # Hardsuit table, used for suit storage as well
 - type: entityTable
   id: FillChiefEngineerHardsuit


### PR DESCRIPTION
## About the PR
Nerfed gas prices since they are already fairly easy to make and have uses other than selling. If you want to dedicate a shift to making cargo more money than they can spend, these nerfs won't stop you. 

Added the RPD to CE's locker so they will hopefully stop instantly stealing them from the atmos lockers. 

Added an RPD crate, a firefighter backpack tank crate, and a BZ canister to the cargo catalog.  

## Why / Balance
Gas prices were always meant to be revised after seeing how people played with them. BZ was a gas that could be purchased through cargo in 13 both for atmos and for religious purposes. Adding it as an item that can be bought through cargo will hopefully add some variety to the gas making loop of tritium>frezon>bz>healium-nitrium, giving newer atmos techs the chance to mess with the more complex gases. It also gives cargo a means of investing in the atmos department in order to get access to more valuable gases. 

The other changes are minor and nice to have. 

## Technical details
-BZ has been lowered to 1 specos per mol, however a single can bought through cargo costs 6500, or about 2.93 per mol accounting for the cost of the can. 
-Healium has been lowered to 2.5 specos per mol. Making Healium is trivial when you have both bz and frezon available.
-Nitrium has been raised to 3.5 specos per mol. Nitrium is very difficult to make in large quantities and is very useful to the station. Should continue to get a high price both because of the work involved, and to hopefully incentivize atmosians to take the time to make it.

## Media
None

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- add: Added RPD to CE's locker
- add: Added RPD crate to cargo catalog
- add: Added firefighter backpack tank crate to cargo catalog
- add: Added BZ canisters to cargo catalog
- tweak: Rebalanced gas prices