### PR TITLE
give borgs targeting

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -80,6 +80,7 @@
     uis:
       enum.StationMapUiKey.Key:
         toggleAction: ActionAGhostShowStationMap
+  - type: Targeting # Shitmed Change
   - type: ActivatableUI
     key: enum.BorgUiKey.Key
   - type: SiliconLawBound


### PR DESCRIPTION
## About the PR
so borgs can decapitate people or heal limb damage

1 line patch is CC0-1.0

**Changelog**
:cl:
- fix: Fixed borgs not being able to target limbs.
