### PR TITLE
[Admin] Add Full-Admin Permissions Category

### DIFF
--- a/Content.Shared/Administration/AdminFlags.cs
+++ b/Content.Shared/Administration/AdminFlags.cs
@@ -125,6 +125,12 @@
         NameColor = 1 << 21,
 
         /// <summary>
+        ///     Goobstation Full Admin extra perms.
+        ///     Specifically used for Full Admin only.
+        /// </summary>
+        FullAdmin = 1 << 22,
+
+        /// <summary>
         ///     Dangerous host permissions like scsi.
         /// </summary>
         Host = 1u << 31,

--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -93,7 +93,7 @@
   - tp
   - tpto
 
-- Flags: FULLADMIN
+- Flags: FULLADMIN # Goobstation (and every setting in this flag)
   Commands:
   - self
   - entities

--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -93,6 +93,11 @@
   - tp
   - tpto
 
+- Flags: FULLADMIN
+  Commands:
+  - self
+  - entities
+
 - Flags: FUN
   Commands:
   - tippy


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This adds a Permissions flag (in the Permissions Panel) for "Full Admin" that gives Admins 'Self' and 'Entitites' command permissions.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because not having it sucks butt.

## Technical details
<!-- Summary of code changes for easier review. -->
I added another element to the enumerator for AdminFlags and then added a custom flag matching the name.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
If anything breaks, it's the AdminFlags fault.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
ADMIN:
- add: Added 'FullAdmin' Permissions to give 'Self' and 'Entities' permissions to Game Admins and higher.