### PR TITLE
make mousetraps damage your feet

### DIFF
--- a/Content.Server/Damage/Components/DamageUserOnTriggerComponent.cs
+++ b/Content.Server/Damage/Components/DamageUserOnTriggerComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Damage;
+using Content.Shared._Shitmed.Targeting; // Shitmed
 
 namespace Content.Server.Damage.Components;
 
@@ -9,4 +10,10 @@ public sealed partial class DamageUserOnTriggerComponent : Component
 
     [DataField("damage", required: true)]
     public DamageSpecifier Damage = default!;
+
+    /// <summary>
+    /// Shitmed Change: Lets mousetraps, etc. target the feet.
+    /// </summary>
+    [DataField]
+    public TargetBodyPart? TargetPart = TargetBodyPart.Feet;
 }

--- a/Content.Server/Damage/Systems/DamageUserOnTriggerSystem.cs
+++ b/Content.Server/Damage/Systems/DamageUserOnTriggerSystem.cs
@@ -33,7 +33,7 @@ public sealed class DamageUserOnTriggerSystem : EntitySystem
         var ev = new BeforeDamageUserOnTriggerEvent(damage, target);
         RaiseLocalEvent(source, ev);
 
-        return _damageableSystem.TryChangeDamage(target, ev.Damage, component.IgnoreResistances, origin: source) is not null;
+        return _damageableSystem.TryChangeDamage(target, ev.Damage, component.IgnoreResistances, origin: source, targetPart: component.TargetPart) is not null; // Shitmed Change
     }
 }
 


### PR DESCRIPTION
## About the PR
mousetraps, glass shards and d4s now target your feet

@gluesniffler backport to ee for me pls :trollface: patch is CC0-1.0

## Why / Balance
it makes sense

## Technical details
DamageUserOnTrigger has TargetPart field, set to Feet by default. can be removed or set to anything else in yml

## Media
![08:46:44](https://github.com/user-attachments/assets/5b26ab76-6590-49b5-a13c-52c09dc8311b)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:mouse: exclaims, "Piep!"

:cl:
- tweak: Mousetraps now damage the feet specifically.