### PR TITLE
Add Onis to guidebook

### DIFF
--- a/Resources/Prototypes/Guidebook/species.yml
+++ b/Resources/Prototypes/Guidebook/species.yml
@@ -19,6 +19,7 @@
     - Rodentia
     - Yowie
     - IPC
+    - Oni 
 
 - type: guideEntry
   id: Arachnid
@@ -95,3 +96,8 @@
   id: IPC
   name: species-name-ipc
   text: "/ServerInfo/Guidebook/Mobs/IPCs.xml"
+
+- type: guideEntry
+  id: Oni
+  name: species-name-oni
+  text: "/ServerInfo/Guidebook/Mobs/DeltaV/Oni.xml"

--- a/Resources/ServerInfo/Guidebook/Mobs/DeltaV/Oni.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/DeltaV/Oni.xml
@@ -2,22 +2,18 @@
   # Onis
 
   <Box>
-    <GuideEntityEmbed Entity="MobOniDummy" Caption=""/>
+    <GuideEntityEmbed Entity="MobOni" Caption=""/>
   </Box>
 
   Large, horned people that come in a variety of colors. Their accuracy with guns is terrible, but their physical strength brings them a lot of boons both in and out of combat.
 
-  ## Diet
-  - Nothing special.
-
   ## Benefits
   - Takes 15% less Blunt, Slash and Piercing damage.
   - Does more damage in melee; 35% more Blunt and Asphyxiation, 20% more Slash and Piercing.
-  - Due to their big size, they can easily carry, shove and pull any other morphotypes.
+  - Due to their big size, they can easily carry, shove and pull any other species.
   - They are harder to shove.
   - Slightly more stamina than Humans.
-  - They have an easier time prying open doors, taking around 50% less time than other species.
-
+  
   ## Drawbacks
   - Their accuracy with guns is terrible.
   - They are harder to carry and pull.

--- a/Resources/ServerInfo/Guidebook/Mobs/Species.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Species.xml
@@ -13,17 +13,19 @@
   <Box>
   <GuideEntityEmbed Entity="MobHarpy" Caption="Harpy"/>
   <GuideEntityEmbed Entity="MobHuman" Caption="Human"/>
+  <GuideEntityEmbed Entity="MobIPCDummy" Caption="I.P.C."/>
   <GuideEntityEmbed Entity="MobMoth" Caption="Moth Person"/>
+  <GuideEntityEmbed Entity="MobOni" Caption="Oni"/>
   <GuideEntityEmbed Entity="MobReptilian" Caption="Reptilian"/>
-  <GuideEntityEmbed Entity="MobSlimePerson" Caption="Slime Person"/>
-  <GuideEntityEmbed Entity="MobVox" Caption="Vox"/>
+
   </Box>
   <Box>
+  <GuideEntityEmbed Entity="MobRodentia" Caption="Rodentia"/>
+  <GuideEntityEmbed Entity="MobSlimePerson" Caption="Slime Person"/>
   <GuideEntityEmbed Entity="MobVox" Caption="Vox"/>
   <GuideEntityEmbed Entity="MobVulpkanin" Caption="Vuplkanin"/>
-  <GuideEntityEmbed Entity="MobRodentia" Caption="Rodentia"/>
   <GuideEntityEmbed Entity="MobYowie" Caption="Yowie"/>
-  <GuideEntityEmbed Entity="MobIPCDummy" Caption="I.P.C."/>
+  
   </Box>
 
 </Document>


### PR DESCRIPTION
## About the PR
Added Onis to the guidebook, since they existed in the files but were missing in game.

## Why / Balance
Onis exist in the character creator, but them not having a guidebook page makes them feel a little "secret". This PR fixes that issue.

## Technical details
Added Onis to `Resources/Prototypes/Guidebook/species.yml`. Edited existing Oni guidebook snippet to exclude diet (since there's no differences), and removed section about prying open doors since we have instaprying in game rn. Also rearranged Species.xml to get rid of duplicate Vox entry, and sorted it alphabetically.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
Should be none

**Changelog**
🆑
- add: Added oni entry to guidebook