### PR TITLE
Barozine fix

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -580,6 +580,9 @@
         key: Stutter
         component: StutteringAccent
         refresh: false
+      - !type:MovespeedModifier
+        walkSpeedModifier: 0.9
+        sprintSpeedModifier: 0.9
       - !type:Jitter
       - !type:Emote
         conditions:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -579,6 +579,7 @@
       - !type:GenericStatusEffect
         key: Stutter
         component: StutteringAccent
+        refresh: false
       - !type:Jitter
       - !type:Emote
         conditions:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -560,10 +560,10 @@
         - !type:OrganType # Goobstation - Yowie
           type: Yowie
           shouldHave: false
-        probability: 0.3
+        probability: 1
         damage:
           types:
-            Heat: 0.5
+            Heat: 0.25
       - !type:ChemVomit
         probability: 0.15
         conditions:
@@ -575,6 +575,7 @@
       - !type:GenericStatusEffect
         key: PressureImmunity
         component: PressureImmunity
+        refresh: false
       - !type:GenericStatusEffect
         key: Stutter
         component: StutteringAccent

--- a/Resources/Prototypes/_Goobstation/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Reactions/medicine.yml
@@ -5,6 +5,7 @@
       amount: 1
     Plasma:
       amount: 1
+      catalyst: true
     Potassium:
       amount: 1
     Bicaridine:


### PR DESCRIPTION
## About the PR
Barozine now accumulates. Also few tweaks to its status effects.

## Why / Balance
Previously barozine didn't acumulate (even though it should), resulting in very low pressure immunity duration - now it does accumulate. Also, the recipe for crafting it now uses plasma as catalyst instead, which should make it easier to craft for chemists, and less of a headache for yowies to request it from chemistry in non-zero quantities.

That being said, since both changes result in a powerspike that can be harnessed by everyone, not just yowies that usually require it round-end, two nerfs were added. 
- The heat self-damage was increased to guaranteed 0.25, which on average almost doubles it (spacepen now deals 10 damage, guaranteed).
- It slows you down by 10%, which is equivalent to lighter end of hardsuits (bigger change on paper than in practice, mainly to dissuade people using it instead of spacesuits for combat purposes)

## Technical details
Basically everything is a trivial yaml change. Barozine yaml didn't use `refresh: false` before, now it does.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Barozine is easier to make in larger quantities, but has more downsides (more self-damage and slowdown).
- fix: Barozine effect now accumulates.
