### PR TITLE
headslugs survive in space

### DIFF
--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: head slug
-  parent: [SimpleMobBase]
+  parent: [SimpleSpaceMobBase] # no dying in space
   id: MobHeadcrab
   description: You don't want to touch it.
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
now parents off space mobs, doesn't need oxygen or pressure anymore
everything else the same

## Why / Balance
"last resort" when space kills you in 3 seconds

## Media
tested, trust

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changeling headslugs now take no airloss or spacing damage.
