### PR TITLE
Bow is now ClumsyProof

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Bow/bow.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Bow/bow.yml
@@ -30,6 +30,7 @@
     soundGunshot:
       collection: BulletMiss
     soundEmpty: null
+    clumsyProof: true # Goobstation
   - type: ItemSlots
     slots:
       projectiles:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Give bow ClumsyProof

## Why / Balance
Makes monkeys (and anything clumsy) able to shoot bows

## Technical details
1 line change

## Media
i cant be bothered to record a monkey hunting mice montage
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Monkeys (or anything else clumsy) can now shoot bows!
