### PR TITLE
NanoChat Notification Fix

### DIFF
--- a/Content.Server/_DeltaV/NanoChat/NanoChatSystem.cs
+++ b/Content.Server/_DeltaV/NanoChat/NanoChatSystem.cs
@@ -7,6 +7,8 @@ using Content.Shared.Database;
 using Content.Shared._DeltaV.CartridgeLoader.Cartridges;
 using Content.Shared._DeltaV.NanoChat;
 using Content.Shared.NameIdentifier;
+using Content.Shared.PDA;
+using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -26,8 +28,30 @@ public sealed class NanoChatSystem : SharedNanoChatSystem
     public override void Initialize()
     {
         base.Initialize();
+
+        SubscribeLocalEvent<NanoChatCardComponent, EntGotInsertedIntoContainerMessage>(OnInserted);
+        SubscribeLocalEvent<NanoChatCardComponent, EntGotRemovedFromContainerMessage>(OnRemoved);
+
         SubscribeLocalEvent<NanoChatCardComponent, MapInitEvent>(OnCardInit);
         SubscribeLocalEvent<NanoChatCardComponent, BeingMicrowavedEvent>(OnMicrowaved, after: [typeof(IdCardSystem)]);
+    }
+
+    private void OnInserted(Entity<NanoChatCardComponent> ent, ref EntGotInsertedIntoContainerMessage args)
+    {
+        if (args.Container.ID != PdaComponent.PdaIdSlotId)
+            return;
+
+        ent.Comp.PdaUid = args.Container.Owner;
+        Dirty(ent);
+    }
+
+    private void OnRemoved(Entity<NanoChatCardComponent> ent, ref EntGotRemovedFromContainerMessage args)
+    {
+        if (args.Container.ID != PdaComponent.PdaIdSlotId)
+            return;
+
+        ent.Comp.PdaUid = null;
+        Dirty(ent);
     }
 
     private void OnMicrowaved(Entity<NanoChatCardComponent> ent, ref BeingMicrowavedEvent args)

--- a/Content.Shared/_DeltaV/NanoChat/NanoChatCardComponent.cs
+++ b/Content.Shared/_DeltaV/NanoChat/NanoChatCardComponent.cs
@@ -49,4 +49,10 @@ public sealed partial class NanoChatCardComponent : Component
     /// </summary>
     [DataField]
     public bool NotificationsMuted;
+
+    /// <summary>
+    ///     The PDA that this card is currently inserted to.
+    /// </summary>
+    [DataField]
+    public EntityUid? PdaUid = null;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed NanoChat message notifications not showing up in situations where you'd definitely expect them to occur.

Now, for a chat to not send a notification upon a new message, three conditions need to be fulfilled:
- You don't have the chat muted
- Your PDA UI is open
- You have NanoChat as your open program
- Your currently-selected chat is the aforementioned chat

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Notifications should **always** occur when you don't have the chat open on your screen, because otherwise you might not even know that you got a new message.

## Technical details
Adds a new field to `NanoChatCardComponent` called `PdaUid` that stores a reference to the PDA the NanoChat card is inserted in. The field is updated whenever the card is inserted or removed from a PDA.

Importantly, PdaUid also removes the need for an `EntityQueryEnumerator` in `HandleUnreadNotification` to get the PDA that contains the card. This turns the operation from **O(n)** to **O(1)** which increases the system's performance especially in high-pop rounds. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Notification sent when the NanoChat program is closed

![image](https://github.com/user-attachments/assets/675e20f2-7808-4e13-9d57-4f66eb1340f9)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Skubman
fix: NanoChat will now send a new message notification no matter what if you don't have the chat open.