### PR TITLE
Chem guidebook accumulation display fix

### DIFF
--- a/Content.Server/EntityEffects/Effects/StatusEffects/GenericStatusEffect.cs
+++ b/Content.Server/EntityEffects/Effects/StatusEffects/GenericStatusEffect.cs
@@ -63,7 +63,8 @@ public sealed partial class GenericStatusEffect : EntityEffect
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys) => Loc.GetString(
         "reagent-effect-guidebook-status-effect",
         ("chance", Probability),
-        ("type", Type),
+        // If duration is refreshed, functionally it behaves the same as Set. Temporary fix till upstream fixes locstrings.
+        ("type", Refresh ? StatusEffectMetabolismType.Set : Type),
         ("time", Time),
         ("key", $"reagent-effect-status-effect-{Key}"));
 }

--- a/Content.Server/EntityEffects/Effects/StatusEffects/GenericStatusEffect.cs
+++ b/Content.Server/EntityEffects/Effects/StatusEffects/GenericStatusEffect.cs
@@ -63,8 +63,8 @@ public sealed partial class GenericStatusEffect : EntityEffect
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys) => Loc.GetString(
         "reagent-effect-guidebook-status-effect",
         ("chance", Probability),
-        // If duration is refreshed, functionally it behaves the same as Set. Temporary fix till upstream fixes locstrings.
-        ("type", Refresh ? StatusEffectMetabolismType.Set : Type),
+        ("type", Type),
+        ("refresh", Refresh),
         ("time", Time),
         ("key", $"reagent-effect-status-effect-{Key}"));
 }

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -92,7 +92,10 @@ reagent-effect-guidebook-status-effect =
         [add]   { $chance ->
                     [1] Causes
                     *[other] cause
-                } {LOC($key)} for at least {NATURALFIXED($time, 3)} {MANY("second", $time)} with accumulation
+                } {LOC($key)} for at least {NATURALFIXED($time, 3)} {MANY("second", $time)} { $refresh ->
+                                                                                                [false] with
+                                                                                                *[true] without
+                                                                                            } accumulation
         *[set]  { $chance ->
                     [1] Causes
                     *[other] cause


### PR DESCRIPTION
## About the PR
Guidebook now properly informs whether a chem is accumulating or not.

## Why / Balance
Guidebook was wrong and it was annoying, also highly misinformative in regards to around a dozen chemicals. Accumulation is really important in regards to microdosing, and gauging drug's efficiency, yet true information was obscured from most players.

## Technical details
Function creating reagent description now uses the `Refresh` variable in addition to `Type` in order to determine true behaviour of a chem, and the locstring has an additional switch statement in order to use it. Previously `StatusEffectMetabolismType.Add` combined with `Refresh=True` was indistinguishable from `StatusEffectMetabolismType.Set` on the user end, yet it resulted in a different (and misleading) guidebook entries being generated. Now that's no longer the case.

## Media
Examples of reagents post-change that had `Refresh=False`
![Screenshot 2025-01-01 105245](https://github.com/user-attachments/assets/ce112982-3079-4c19-b63e-997ece01d88a)
![Screenshot 2025-01-01 105232](https://github.com/user-attachments/assets/c1a1f8cb-b0e3-43ba-b523-2d09b6c1f19a)
Examples of reagents post-change that had `Refresh=True`
![Screenshot 2025-01-01 105217](https://github.com/user-attachments/assets/5acda189-ff67-47e3-b1eb-f818a6b7ccd3)
![Screenshot 2025-01-01 105209](https://github.com/user-attachments/assets/645d7fda-47e8-45db-ae43-acc0d4c09bed)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None, if `reagent-effect-guidebook-status-effect` locstring were to be used anywhere else (it isn't), the default behaviour is unchanged from old version.

**Changelog**
:cl: SX-7
- fix: Guidebook reagent entries now properly tell you if their effects accumulate or not
