### PR TITLE
Blob Zombie shuttle calling loop

### DIFF
--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -20,6 +20,7 @@ using Robust.Shared.Audio.Systems; // goobstation
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
 using System.Globalization;
+using Content.Shared._Goobstation.Blob.Components; //Goobstation
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -134,7 +135,7 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
             _audio.PlayGlobal("/Audio/Announcements/outbreak7.ogg", Filter.Broadcast(), true, AudioParams.Default.WithVolume(-2f));
         }
 
-        if (GetInfectedFraction(false) > zombieRuleComponent.ZombieShuttleCallPercentage && !_roundEnd.IsRoundEndRequested())
+        if (GetInfectedFraction(false) > zombieRuleComponent.ZombieShuttleCallPercentage && !_roundEnd.IsRoundEndRequested() && !CheckForBlob()) // Goobstation
         {
             foreach (var station in _station.GetStations())
             {
@@ -230,5 +231,20 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
             healthy.Add(uid);
         }
         return healthy;
+    }
+    /// <summary>
+    /// Used to ceck if there is any blob cores on the station
+    ///  if there is a blob core used to prevent calling the shuttle.
+    /// </summary>
+    private bool CheckForBlob() //Goobstatrion
+    {
+        var query = EntityQueryEnumerator<BlobCoreComponent>();
+
+        while(query.MoveNext(out var uid, out var comp))
+        {
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
added a check to zombe shuttle calling to see if there is a blob on the station

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
just had a round whit a blob and zombie outbreak
shuttle keept getting called but blob keept recalling it.

## Technical details
<!-- Summary of code changes for easier review. -->
i added a new function in zombie, i do think maybe this shud be a part of blob system. but its a small code.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Zombies and blobs will no longer agrue over the shuttle