### PR TITLE
Fixing FartComponent references to appease the YAML linter.

### DIFF
--- a/Content.Server/_Goobstation/Emoting/FartSystem.cs
+++ b/Content.Server/_Goobstation/Emoting/FartSystem.cs
@@ -91,7 +91,7 @@ public sealed partial class FartSystem : SharedFartSystem
 
             // Release ammonia into the air
             var tileMix = _atmos.GetTileMixture(uid, excite: true);
-            tileMix?.AdjustMoles(Gas.Ammonia, FartComponent.MolesAmmoniaPerFart);
+            tileMix?.AdjustMoles(Gas.Ammonia, component.MolesAmmoniaPerFart);
 
             // One minute timeout for ammonia release (60000MS = 60S)
             Timer.Spawn(60000, () =>
@@ -157,7 +157,7 @@ public sealed partial class FartSystem : SharedFartSystem
 
             // Release ammonia into the air
             var tileMix = _atmos.GetTileMixture(uid, excite: true);
-            tileMix?.AdjustMoles(Gas.Ammonia, FartComponent.MolesAmmoniaPerFart * 2);
+            tileMix?.AdjustMoles(Gas.Ammonia, component.MolesAmmoniaPerFart * 2);
 
             _entMan.SpawnEntity("Butt", xformSystem.GetMapCoordinates(uid));
 

--- a/Content.Shared/_Goobstation/Emoting/FartComponent.cs
+++ b/Content.Shared/_Goobstation/Emoting/FartComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class FartComponent : Component
     [DataField] public bool FartTimeout = false;
     [DataField] public bool FartInhale = false;
     [DataField] public bool SuperFarted = false;
-    [DataField] public const float MolesAmmoniaPerFart = 5f;
+    [DataField] public float MolesAmmoniaPerFart = 5f;
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Updated the MolesAmmoniaPerFart DataField of FartComponent to not be a const.

## Why / Balance
The YAML Linter was very upset that there was a static data field. 

## Technical details
Took away the const keyword and updated references to it accordingly.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: updated FartComponent.MolesAmmoniaPerFart to not be const. We have appeased the YAML Linter...for now.
