### PR TITLE
Warden hardsuit buff

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -231,8 +231,8 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
+        Blunt: 0.8
+        Slash: 0.8
         Piercing: 0.9
         Heat: 0.9
   - type: FlashImmunity # Goobstation

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -266,8 +266,8 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.6
+        Blunt: 0.4
+        Slash: 0.4
         Piercing: 0.6
         Caustic: 0.7
         Heat: 0.7 # Goobstation

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -266,9 +266,9 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.4
-        Slash: 0.4
-        Piercing: 0.6
+        Blunt: 0.45
+        Slash: 0.45
+        Piercing: 0.7
         Caustic: 0.7
         Heat: 0.7 # Goobstation
   - type: ClothingSpeedModifier

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -266,8 +266,8 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.45
-        Slash: 0.45
+        Blunt: 0.40
+        Slash: 0.40
         Piercing: 0.7
         Caustic: 0.7
         Heat: 0.7 # Goobstation


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Warden hard suit now has 60% resistance in both blunt and pierce, but it's pierce resistance has been lowered to 30% from 40%.
Along with this, the helmet now has 20% resistance in blunt & pierce. Hopefully this changes will match the riot suit.

## Why / Balance
The description of the suit specifically states it as being a modified riot suit despite having worse stats than an actual riot suit, and having high pierce resist. Also, I saw this in a bounty and thought it'd make Wardens hard suit slightly different than a security hard suit with higher stats.

## Technical details
Slight stat-tweaks.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Warden hard-suit has higher slash & blunt resistance, but lower pierce resistance.
-->
