### PR TITLE
Add IPC Guideline in Brigging

### DIFF
--- a/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Legal/PunishmentsSOP.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Legal/PunishmentsSOP.xml
@@ -24,4 +24,7 @@ Should the ten (10) minutes expire without any evidence of any crimes coming to 
 
 8. After searching has been done on PDA, clothing, and headset, they are to be returned unless they are contraband or have been tampered with. In such cases, they should be replaced.
 
+9. Prisoners should never be deprived of equipment that is necessary for their vital operations.
+<Box>This includes batteries for IPCs, N2 Gas Tanks and Masks for Voxes, and regular equipment as stated above (PDA, Headset, Clothes).</Box>
+
 </Document>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
For some reason, I need to clarify that you **can't take an IPC's battery out when holding/brigging them.**

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I DON'T KNOW WHY! IS IT NOT COMMON SENSE TO NOT DO THIS AS SEC?

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added a Brigging Guideline: DON'T REMOVE IPC BATTERIES YOU NUMBNUTS!

