### PR TITLE
prevent space nuggetting

### DIFF
--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -258,7 +258,7 @@ namespace Content.Server.Atmos.EntitySystems
                 if (pressure <= Atmospherics.HazardLowPressure)
                 {
                     // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear.
-                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * Atmospherics.LowPressureDamage, true, false, canSever: false); // Shitmed Change
+                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * Atmospherics.LowPressureDamage, true, false, canSever: false, partMultiplier: 0.2f); // Shitmed Change
 
                     if (!barotrauma.TakingDamage)
                     {


### PR DESCRIPTION
## About the PR
reduced space damage to limbs to 20%
so when you get 200 damage from space the limbs only get 40 (if your limbs are already badly damaged they might get severed still)

cold damage is unaffected

## Why / Balance
fixes #1365

should be changed to 0% if body parts get clothing coverage + individual part barotrauma so parts handle their own damage and hardsuits without helmet protect everything but the head

## Technical details
1 line ops


**Changelog**
:cl:
- tweak: Reduced spacing damage to limbs.
