### PR TITLE
Add Early Evac, Clean Up Security, and Clarify Alert Levels in SOP

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_Goobstation/guidebook/guides.ftl
@@ -4,8 +4,8 @@ guide-entry-medpatches = Medical Patches
 # Goob SOP
 # - Main Directories
 guide-entry-sop = SOP
-guide-entry-sop-alert-levels = _Alert Levels
-guide-entry-sop-emergencies = _Emergencies
+guide-entry-sop-alert-levels = Alert Levels
+guide-entry-sop-emergencies = Emergencies
 guide-entry-sop-jobs = Jobs
 guide-entry-sop-legal = Legal
 guide-entry-sop-standards = Standard Procedures
@@ -28,6 +28,7 @@ guide-entry-sop-gammaalert = Gamma Alert
 guide-entry-sop-violetalert = Violet Alert
 # - Standard Procedures
 guide-entry-sop-demoting = Dismissal/Demoting
+guide-entry-sop-evacuation = Early Evacuation
 guide-entry-sop-hiring = Hiring/Transfer
 guide-entry-sop-succession = Chain of Command
 # - Emergencies

--- a/Resources/Prototypes/_Goobstation/Guidebook/sop.yml
+++ b/Resources/Prototypes/_Goobstation/Guidebook/sop.yml
@@ -13,6 +13,7 @@
   id: Alert Levels
   name: guide-entry-sop-alert-levels
   text: "/ServerInfo/_Goobstation/Guidebook/SoP/AlertLevels/AlertLevelsSOP.xml"
+  priority: 10
   children:
   - GreenAlert SOP
   - BlueAlert SOP
@@ -28,6 +29,7 @@
   id: Emergencies SOP
   name: guide-entry-sop-emergencies
   text: "/ServerInfo/_Goobstation/Guidebook/SoP/Emergencies/Emergencies.xml"
+  priority: 10
   children:
   - ConfirmedRevs SOP
   - ContainmentFail SOP
@@ -47,6 +49,7 @@
   - Alert Levels
   - Emergencies SOP
   - Demoting SOP
+  - EarlyEvacuation SOP
   - Hiring SOP
   - Succession
 
@@ -190,6 +193,11 @@
   id: Demoting SOP
   name: guide-entry-sop-demoting
   text: "/ServerInfo/_Goobstation/Guidebook/SoP/StandardProcedures/FiringDemotion.xml"
+
+- type: guideEntry
+  id: EarlyEvacuation SOP
+  name: guide-entry-sop-evacuation
+  text: "/ServerInfo/_Goobstation/Guidebook/SoP/StandardProcedures/EarlyEvacuationSOP.xml"
 
 - type: guideEntry
   id: Hiring SOP

--- a/Resources/Prototypes/_Goobstation/Guidebook/sop.yml
+++ b/Resources/Prototypes/_Goobstation/Guidebook/sop.yml
@@ -13,7 +13,7 @@
   id: Alert Levels
   name: guide-entry-sop-alert-levels
   text: "/ServerInfo/_Goobstation/Guidebook/SoP/AlertLevels/AlertLevelsSOP.xml"
-  priority: 10
+  priority: 0
   children:
   - GreenAlert SOP
   - BlueAlert SOP
@@ -29,7 +29,7 @@
   id: Emergencies SOP
   name: guide-entry-sop-emergencies
   text: "/ServerInfo/_Goobstation/Guidebook/SoP/Emergencies/Emergencies.xml"
-  priority: 10
+  priority: 1
   children:
   - ConfirmedRevs SOP
   - ContainmentFail SOP
@@ -193,21 +193,25 @@
   id: Demoting SOP
   name: guide-entry-sop-demoting
   text: "/ServerInfo/_Goobstation/Guidebook/SoP/StandardProcedures/FiringDemotion.xml"
+  priority: 10
 
 - type: guideEntry
   id: EarlyEvacuation SOP
   name: guide-entry-sop-evacuation
   text: "/ServerInfo/_Goobstation/Guidebook/SoP/StandardProcedures/EarlyEvacuationSOP.xml"
+  priority: 10
 
 - type: guideEntry
   id: Hiring SOP
   name: guide-entry-sop-hiring
   text: "/ServerInfo/_Goobstation/Guidebook/SoP/StandardProcedures/HiringTransfers.xml"
+  priority: 10
 
 - type: guideEntry
   id: Succession
   name: guide-entry-sop-succession # Is named as "Chain of Command" in game.
   text: "/ServerInfo/_Goobstation/Guidebook/SoP/StandardProcedures/CommandSuccession.xml"
+  priority: 10
 
 # Emergency SOP Entries
 - type: guideEntry

--- a/Resources/ServerInfo/_Goobstation/Guidebook/SoP/AlertLevels/AlertLevelsSOP.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/SoP/AlertLevels/AlertLevelsSOP.xml
@@ -5,6 +5,11 @@ Below are the listed pop-ups for each alert and the color associated with them.
 
 There are individual entries for each alert level and what they entail for station personnel.
 
+<ColorBox>
+  <Box>
+    For the purposes of Alert Escalation: Treat higher alerts as if they are still on the previous alert level. (Yellow Alert is Blue Alert if it was Blue Alert prior.) Furthermore, treat Delta, Gamma, Epsilon, and Violet Alert as Red Alert.
+  </Box>
+</ColorBox>
 
 <Table Columns="1">
   <ColorBox Color="#388c34">

--- a/Resources/ServerInfo/_Goobstation/Guidebook/SoP/AlertLevels/AlertLevelsSOP.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/SoP/AlertLevels/AlertLevelsSOP.xml
@@ -3,13 +3,13 @@
 The following alert levels are the publicly defined levels on this station and what they entail.
 Below are the listed pop-ups for each alert and the color associated with them.
 
-There are individual entries for each alert level and what they entail for station personnel.
-
 <ColorBox>
   <Box>
     For the purposes of Alert Escalation: Treat higher alerts as if they are still on the previous alert level. (Yellow Alert is Blue Alert if it was Blue Alert prior.) Furthermore, treat Delta, Gamma, Epsilon, and Violet Alert as Red Alert.
   </Box>
 </ColorBox>
+
+There are individual entries for each alert level and what they entail for station personnel.
 
 <Table Columns="1">
   <ColorBox Color="#388c34">

--- a/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Jobs/Command/HeadOfSecuritySOP.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Jobs/Command/HeadOfSecuritySOP.xml
@@ -2,31 +2,43 @@
 # Head of Security (HOS) SOP
 This is the list of procedures, responsibilities, and duties of the [color=#1b67a5][bold]Head of Security[/bold][/color] of this station.
 
+<ColorBox>
+  <Box>
+    For the purposes of Alert Escalation: Treat higher alerts as if they are still on the previous alert level. (Yellow Alert is Blue Alert if it was Blue Alert prior.) Furthermore, treat Delta, Gamma, Epsilon, and Violet Alert as Red Alert.
+  </Box>
+</ColorBox>
+
+The [color=#1b67a5][bold]Head of Security[/bold][/color] is permitted to carry their shift-start equipment, but should follow escalation procedures and refrain from using lethals.
+
 ## Green Alert
 1. The Head of Security is permitted to carry out arrests under the same conditions as their Security Officers.
 
 2. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, and a standard energy gun.
 <Box>While permitted to carry their unique Energy Gun, they should keep it on Stun/Disable.</Box>
 
-3. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes.
+3. The Head of Security is permitted to carry their standard equipment provided in their locker, including their submachine gun, but should refrain from using it.
 
-4. The Head of Security may not overrule a Captain/Nanotrasen Representative, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well.
+4. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes.
 
-5. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers.
+5. The Head of Security may not overrule a Captain/Nanotrasen Representative, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well.
 
-6. The Head of Security is not permitted to collect equipment from the Armory to carry on their person.
+6. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers.
 
-7. The Head of Security is permitted to either use their regular coat, or armored trenchcoat.
+7. The Head of Security is not permitted to collect equipment from the Armory to carry on their person.
 
-8. The Head of Security is permitted to wear their unique gas mask.
+8. The Head of Security is permitted to either use their regular coat, or armored trenchcoat.
 
-9. The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape.
+9. The Head of Security is permitted to wear their unique gas mask.
 
-10. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers.
+10. The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape.
+
+11. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers.
 
 ## Blue Alert
 1. All Guidelines carry over from [color=#388c34]Green Alert[/color].
 <Box>The exception being that the energy gun may now be used in energy or ion mode if needed.</Box>
+
+2. The Head of Security is permitted to use the submachine gun lethally for self-defense purposes. They must follow the same escalation laws for hostiles.
 
 ## Red Alert
 1. All Guidelines carry over from [color=#388c34]Green Alert[/color] and [color=#1b67a5]Blue Alert[/color].

--- a/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Jobs/Command/NanotrasenRepSOP.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Jobs/Command/NanotrasenRepSOP.xml
@@ -6,6 +6,7 @@ This is the list of procedures, responsibilities, and duties of the [color=#1b67
 
 The [bold][color=#fcd12a]most important[/color][/bold] rule of the Nanotrasen Representative is to assist Command Personnel and ensure they are following SOP.
 <Box>Command personnel are personnel hired by Nanotrasen (confirmed personnel in command) and any Central Command officials (including NTR).</Box>
+<Box>The Nanotrasen Representative is basically an OSHA Worker. Act like one and ensure departments are following the SOP and being Safe.</Box>
 
 ## Resources
 1. The Nanotrasen Representative posesses a FAX machine to directly fax to Central Command (with notification to Central Command Officials).

--- a/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Jobs/Command/ResearchDirectorSOP.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Jobs/Command/ResearchDirectorSOP.xml
@@ -2,6 +2,12 @@
 # Research Director (RD) SOP
 This is the list of procedures, responsibilities, and duties of the [color=#1b67a5][bold]Research Director[/bold][/color] of this station.
 
+<ColorBox>
+  <Box>
+    For the purposes of Alert Escalation: Treat higher alerts as if they are still on the previous alert level. (Yellow Alert is Blue Alert if it was Blue Alert prior.) Furthermore, treat Delta, Gamma, Epsilon, and Violet Alert as Red Alert.
+  </Box>
+</ColorBox>
+
 ## Green Alert
 1. The Research Director must make sure Research is being done, and monitor Anomalies and Artifacts progress, including Robotics as well.
 

--- a/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Jobs/Science/RoboticistSOP.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Jobs/Science/RoboticistSOP.xml
@@ -3,6 +3,12 @@
 This is the list of procedures, responsibilities, and duties of the [color=#cc74fc]Roboticist[/color] of this station.
 <Box>For clarification, 'Scientist' and 'Roboticist' are both referred to as 'Scientist' in this SOP.</Box>
 
+<ColorBox>
+  <Box>
+    For the purposes of Alert Escalation: Treat higher alerts as if they are still on the previous alert level. (Yellow Alert is Blue Alert if it was Blue Alert prior.) Furthermore, treat Delta, Gamma, Epsilon, and Violet Alert as Red Alert.
+  </Box>
+</ColorBox>
+
 ## Green Alert
 1. The Scientist is not permitted to construct any Combat Mechs without express permission from the Captain and/or Head of Security.
 <Box>The [color=#1b67a5][bold]Research Director[/bold][/color] is placed under these same restrictions.</Box>

--- a/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Jobs/Science/ScientistSOP.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Jobs/Science/ScientistSOP.xml
@@ -2,6 +2,12 @@
 # Scientist SOP
 This is the list of procedures, responsibilities, and duties of the [color=#cc74fc]Scientist[/color] of this station.
 
+<ColorBox>
+  <Box>
+    For the purposes of Alert Escalation: Treat higher alerts as if they are still on the previous alert level. (Yellow Alert is Blue Alert if it was Blue Alert prior.) Furthermore, treat Delta, Gamma, Epsilon, and Violet Alert as Red Alert.
+  </Box>
+</ColorBox>
+
 ## Green Alert
 1. Scientists are not permitted to bring grenades, harmful chemicals, nor Toxin bombs outside of the Science Department.
 <Box>[bullet/]Exceptions for the Toxin bombs if being handed over to the Cargo Department for Salvaging operations.</Box>

--- a/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Jobs/Security/DetectiveSOP.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Jobs/Security/DetectiveSOP.xml
@@ -2,6 +2,14 @@
 # Detective SOP
 This is the list of procedures, responsibilities, and duties of the [color=#ba292c][bold]Detective[/bold][/color] of this station.
 
+<ColorBox>
+  <Box>
+    For the purposes of Alert Escalation: Treat higher alerts as if they are still on the previous alert level. (Yellow Alert is Blue Alert if it was Blue Alert prior.) Furthermore, treat Delta, Gamma, Epsilon, and Violet Alert as Red Alert.
+  </Box>
+</ColorBox>
+
+The [color=#ba292c][bold]Detective[/bold][/color] is permitted to carry their shift-start equipment, but should follow escalation laws and leave them holstered on Green Alert.
+
 ## Green Alert
 1. The Detective is permitted to assist Security Officers with all Patrol Duties. This includes stops, searches, and arrests as per the current Alert Code.
 <Box>They should, however, prioritize investigations and the collection of forensic evidence.</Box>

--- a/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Jobs/Security/OfficerCadetSOP.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Jobs/Security/OfficerCadetSOP.xml
@@ -2,6 +2,14 @@
 # Officer/Cadet SOP
 This is the list of procedures, responsibilities, and duties of the [color=#ba292c][bold]Security Officer[/bold][/color] and [color=#ba292c][bold]Security Cadet[/bold][/color] of this station.
 
+<ColorBox>
+  <Box>
+    For the purposes of Alert Escalation: Treat higher alerts as if they are still on the previous alert level. (Yellow Alert is Blue Alert if it was Blue Alert prior.) Furthermore, treat Delta, Gamma, Epsilon, and Violet Alert as Red Alert.
+  </Box>
+</ColorBox>
+
+[color=#ba292c][bold]Security Officer[/bold][/color]s are permitted to carry their shift-start pistols, but should follow escalation laws and leave them holstered on Green Alert.
+
 ## Green Alert
 1. Security Officers are required to state the reasons behind an arrest before any further action is taken.
 <Box>Exception is made if the suspect refuses to stop.</Box>
@@ -16,6 +24,7 @@ This is the list of procedures, responsibilities, and duties of the [color=#ba29
 <Box>Exceptions apply when a hostile suspect is within an inaccessible area.</Box>
 
 6. Security officers are not permitted to have weapons drawn during regular patrols.
+<Box>Refer to escalation rules for necessary use of duty-start pistols.</Box>
 
 7. Security officers are permitted to conduct searches, provided there is reasonable evidence/suspicion that the person in question has committed a crime.
 <Box>Any further searches require a warrant from the Captain and/or Head of Security.</Box>

--- a/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Jobs/Security/WardenSOP.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/SoP/Jobs/Security/WardenSOP.xml
@@ -2,6 +2,14 @@
 # Warden SOP
 This is the list of procedures, responsibilities, and duties of the [color=#ba292c][bold]Warden[/bold][/color] of this station.
 
+<ColorBox>
+  <Box>
+    For the purposes of Alert Escalation: Treat higher alerts as if they are still on the previous alert level. (Yellow Alert is Blue Alert if it was Blue Alert prior.) Furthermore, treat Delta, Gamma, Epsilon, and Violet Alert as Red Alert.
+  </Box>
+</ColorBox>
+
+The [color=#ba292c][bold]Warden[/bold][/color] is permitted to carry their shift-start equipment, but should follow escalation procedures and refrain from using lethals.
+
 ## Green Alert
 1. The Warden is obligated to remain in the Security Department at all times except to assist in transportation of prisoners.
 <Box>The Warden must maintain control over the Armory as well, with only exceptions being allowed for Captain and Head of Security.</Box>

--- a/Resources/ServerInfo/_Goobstation/Guidebook/SoP/StandardProcedures/EarlyEvacuationSOP.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/SoP/StandardProcedures/EarlyEvacuationSOP.xml
@@ -1,0 +1,20 @@
+<Document>
+  # Early Evaucation Procedures
+  These are the guidelines that should be followed as Command and Security when initiating early-launch procedures.
+
+  1. Under [bold]no circumstances[/bold] should the evacuation shuttle be early launched when there is no [bold][italic]immediate[/italic][/bold] threat to the evacuation shuttle.
+
+  2. The Command should wait as [bold]long as possible[/bold] before initiating early launch procedures.
+
+  3. No member of Command or Station (with access to Command) should initiate early evacuation procedures until every participating member is ready.
+  <Box>To clarify, there should not be individual inputs until everyone is ready, to prevent potential hostiles and/or thieves from taking IDs and starting it with adequate permissions.</Box>
+
+  4. Early Evacuation should be called when a loosed material or threat were to harm the evacuation shuttle imminently. The following would be examples: Teslas, Singularities, Hostile Enemy Ships.
+
+  5. Early Evacuation should be called when there are hostiles on the evacuation shuttle that are threatening the lives of the station personnel and bridge personnel.
+  <Box>Said hostiles must be, in reasonable suspicion, unable to be taken down without significant loss of life to everyone currently on-board.</Box>
+
+  6. Early Evacuation must be called when there is a Violet Alert to prevent potential specimens from arriving aboard the shuttle.
+  <Box>If it is possible to defend the shuttle, this should be prioritized.</Box>
+
+</Document>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Updated Security to account for shift-start weaponry. Added information to Alert Levels and how they should be treated (in the job entries AND in the Alert Levels. Fixed up the priority of the children and removed the underscores. **ADDED EARLY EVACUATION INFORMATION!**

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I hate people that early evac for shits n giggles as command.


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added Early Evacuation Procedures to SOP.
- add: Added clarification for how Alert Levels are treated in SOP.