### PR TITLE
Warden Shotgun Auto-recharge

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -821,6 +821,11 @@
   - type: Battery
     maxCharge: 1050 # Goobstation
     startingCharge: 1050
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 24
+    autoRechargePause: true
+    autoRechargePauseTime: 10
 
 - type: entity
   name: X-01 Multiphase # Goobstation - Changed the capitalization because it was annoying me.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The wardens shotgun now automatically recharges, after a ten second delay.
Code taken from [this](https://github.com/space-wizards/space-station-14/pull/32104) PR. (Upstream)

## Why / Balance
As explained by the original PR for wizden,
"This PR aims to change that by re-adding the self recharge without being as OP as it was.
The fact that you need to stop using the weapon for it to be able to recharge means that it still has substantial downtime, so while it has infinite ammo on paper, in practice you will need to either take cover for a whole minute or switch to another weapon every time your charges run dry if you are in a sustained firefight such as in a nukie round."

## Technical details
Added a self-recharge component to wardens shotgun.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:         
- tweak: Warden's shotgun now auto-recharges.
