### PR TITLE
fix most sharp things not being usable in surgeries

### DIFF
--- a/Content.Server/Kitchen/Components/SharpComponent.cs
+++ b/Content.Server/Kitchen/Components/SharpComponent.cs
@@ -14,6 +14,12 @@ public sealed partial class SharpComponent : Component
     public float ButcherDelayModifier = 1.0f;
 
     /// <summary>
+    /// Shitmed: Whether this item had <c>SurgeryToolComponent</c> before sharp was added.
+    /// </summary>
+    [DataField]
+    public bool HadSurgeryTool;
+
+    /// <summary>
     /// Shitmed: Whether this item had <c>ScalpelComponent</c> before sharp was added.
     /// </summary>
     [DataField]

--- a/Content.Server/_Shitmed/Medical/Surgery/GhettoSurgerySystem.cs
+++ b/Content.Server/_Shitmed/Medical/Surgery/GhettoSurgerySystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Kitchen.Components;
 using Content.Shared._Shitmed.Medical.Surgery.Tools;
+using Robust.Shared.Audio;
 
 namespace Content.Server._Shitmed.Medical.Surgery;
 
@@ -18,6 +19,17 @@ public sealed partial class GhettoSurgerySystem : EntitySystem
 
     private void OnSharpInit(Entity<SharpComponent> ent, ref MapInitEvent args)
     {
+        if (EnsureComp<SurgeryToolComponent>(ent, out var tool))
+        {
+            ent.Comp.HadSurgeryTool = true;
+        }
+        else
+        {
+            tool.StartSound = new SoundPathSpecifier("/Audio/_Shitmed/Medical/Surgery/scalpel1.ogg");
+            tool.EndSound = new SoundPathSpecifier("/Audio/_Shitmed/Medical/Surgery/scalpel2.ogg");
+            Dirty(ent.Owner, tool);
+        }
+
         if (EnsureComp<ScalpelComponent>(ent, out var scalpel))
         {
             ent.Comp.HadScalpel = true;

--- a/Content.Shared/_Shitmed/Surgery/Tools/CauteryComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Tools/CauteryComponent.cs
@@ -2,11 +2,11 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared._Shitmed.Medical.Surgery.Tools;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class CauteryComponent : Component, ISurgeryToolComponent
 {
     public string ToolName => "a cautery";
     public bool? Used { get; set; } = null;
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float Speed { get; set; } = 1f;
 }

--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -85,11 +85,6 @@
     price: 0
   - type: Scalpel # Shitmed
     speed: 0.45
-  - type: SurgeryTool # Shitmed
-    startSound:
-      path: /Audio/_Shitmed/Medical/Surgery/scalpel1.ogg
-    endSound:
-      path: /Audio/_Shitmed/Medical/Surgery/scalpel2.ogg
   - type: ThrowableBlocked # Goobstation
     behavior: Damage
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -25,6 +25,17 @@
       malus: 0.6
     - type: Execution
       doAfterDuration: 4.0
+    - type: Scalpel # Shitmed
+      speed: 0.75
+    - type: Cautery # Shitmed: you have to be very, very careful to cauterize with it
+      speed: 0.2
+    - type: SurgeryTool # Shitmed
+      startSound:
+        path: /Audio/Weapons/ebladehum.ogg
+      endSound:
+        path: /Audio/Weapons/eblade1.ogg
+        params:
+          variation: 0.250
   - type: ItemToggleHot
   - type: ItemToggleSize
     activatedSize: Huge
@@ -83,17 +94,6 @@
       - Energy
   - type: IgnitionSource
     temperature: 700
-  - type: Scalpel # Shitmed
-    speed: 0.75
-  - type: Cautery # Shitmed: you have to be very, very careful to cauterize with it
-    speed: 0.2
-  - type: SurgeryTool # Shitmed
-    startSound:
-      path: /Audio/Weapons/ebladehum.ogg
-    endSound:
-      path: /Audio/Weapons/eblade1.ogg
-      params:
-        variation: 0.250
 
 - type: entity
   name: energy sword

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -29,11 +29,6 @@
       path: /Audio/Items/Culinary/chop.ogg
   - type: Scalpel # Shitmed
     speed: 0.65
-  - type: SurgeryTool # Shitmed
-    startSound:
-      path: /Audio/_Shitmed/Medical/Surgery/scalpel1.ogg
-    endSound:
-      path: /Audio/_Shitmed/Medical/Surgery/scalpel2.ogg
 
 - type: entity
   name: kitchen knife


### PR DESCRIPTION
## About the PR
it didnt add SurgeryTool so you wouldnt be able to actually use it in a surgery even with Scalpel and BoneSaw

also fixed esword interactions, the components were on esword instead of only when toggled on :trollface:

rest in piss george gimme, killed because caps saber didnt work for surgery

## Why / Balance
:bug:

## Technical details
same as other thing
networked CauteryComponent.Speed so when it gets added to esword client doesnt mispredict 1x speed

CC0-1.0, use it anywhere

## Media
cap sabre which doesnt have SurgeryTool in the yml works now
![10:06:41](https://github.com/user-attachments/assets/808f71c8-c063-45f4-b983-37ddd8964243)

glass shard etc with partially specified values are the same
![10:06:50](https://github.com/user-attachments/assets/0e458757-a1cf-43a2-87d4-18e71e32c694)

esword isnt usable when off
![10:10:46](https://github.com/user-attachments/assets/1df05b5f-61e4-40a5-a5c4-f966471f476c)

correct stats when on
![10:10:39](https://github.com/user-attachments/assets/7d954585-b3aa-4fc3-8545-88416a263442)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed all sharp objects not being usable for ghetto surgery.
