### PR TITLE
making bluespace crystals doubles the value instead of 50xing the value

### DIFF
--- a/Resources/Prototypes/_Goobstation/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/Materials/materials.yml
@@ -5,4 +5,4 @@
   unit: materials-unit-piece
   icon: { sprite: _Goobstation/Objects/Materials/materials.rsi, state: bluespace_crystal }
   color: "#80ffff"
-  price: 30
+  price: 1.175


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the value of making bluespace crystals to double the value of the raw materials instead of roughly 50x the value of the raw materials.

## Why / Balance
Being able to turn 235 spesos into 12,500 spesos means that salvage + protolathe = infinite money. It makes bounties pointless, because a little bit of mining sets you up with spesos for life. I considered making the value exactly the same as the input, but I figure making bluespace crystals still takes a lot of time and a protolathe. If the maintainers would rather make the input and output the same to put this exploit to rest once and for all, change the price in the file to .5875

## Technical details
I changed the price of a bluespace crystal from 3000 spesos to 470 spesos.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Making bluespace crystals doubles the value of the materials instead of 50xing the value
