### PR TITLE
Discord notif for ragequits, solve for constant reconnection

### DIFF
--- a/Content.Server/Discord/WebhookPayload.cs
+++ b/Content.Server/Discord/WebhookPayload.cs
@@ -5,6 +5,8 @@ namespace Content.Server.Discord;
 // https://discord.com/developers/docs/resources/channel#message-object-message-structure
 public struct WebhookPayload
 {
+    // Why is this here?
+    // Why not make WebhookPayloadExtensions like a proper human being instead of shitting up what's not yours
     [JsonPropertyName("UserID")] // Frontier, this is used to identify the players in the webhook
     public Guid? UserID { get; set; }
     /// <summary>

--- a/Content.Server/_Goobstation/PlayerListener/RageQuitNotifySystem.Discord.cs
+++ b/Content.Server/_Goobstation/PlayerListener/RageQuitNotifySystem.Discord.cs
@@ -1,0 +1,59 @@
+﻿using Content.Server.Discord;
+using Content.Server.GameTicking;
+using Content.Shared._Goobstation.CCVar;
+using Robust.Shared.Network;
+
+namespace Content.Server._Goobstation.PlayerListener;
+
+public sealed partial class RageQuitNotifySystem
+{
+    [Dependency] private readonly DiscordWebhook _discord = default!;
+    [Dependency] private readonly GameTicker _ticker = default!;
+    private WebhookData? _webhook;
+
+    private void InitializeDiscord()
+    {
+        Subs.CVar(_cfg, GoobCVars.PlayerRageQuitDiscordWebhook,
+            value =>
+            {
+                if (!string.IsNullOrEmpty(value))
+                {
+                    _discord.TryGetWebhook(value, val => _webhook = val);
+                }
+            },
+            true);
+    }
+
+    // Inform of a ragequit on discord
+    private async void NotifyWebhook(INetChannel channel)
+    {
+        try
+        {
+            if (_webhook is null)
+                return;
+
+            var hook = _webhook.Value.ToIdentifier();
+
+            // ToString gives us milliseconds, and we don't really need it.
+            var time =
+                $"{_ticker.RoundDuration().Hours}:{_ticker.RoundDuration().Minutes}:{_ticker.RoundDuration().Seconds}";
+
+            var message = Loc.GetString("rage-quit-notify-discord",
+                ("round", _ticker.RoundId),
+                ("time", time),
+                ("player", channel.UserName));
+
+            var payload = new WebhookPayload
+            {
+                Content = message,
+            };
+
+            await _discord.CreateMessage(hook, payload);
+        }
+        // Doing `async void` without catching exceptions is LE BAD, okay?
+        catch (Exception e)
+        {
+            Log.Error($"Failed to send ragequit information to webhook!\n{e.Message}");
+        }
+    }
+}

--- a/Content.Server/_Goobstation/PlayerListener/RageQuitNotifySystem.Discord.cs
+++ b/Content.Server/_Goobstation/PlayerListener/RageQuitNotifySystem.Discord.cs
@@ -34,9 +34,11 @@ public sealed partial class RageQuitNotifySystem
 
             var hook = _webhook.Value.ToIdentifier();
 
+            var duration = _ticker.RoundDuration();
+
             // ToString gives us milliseconds, and we don't really need it.
             var time =
-                $"{_ticker.RoundDuration().Hours}:{_ticker.RoundDuration().Minutes}:{_ticker.RoundDuration().Seconds}";
+                $"{duration.Hours}:{duration.Minutes}:{duration.Seconds}";
 
             var message = Loc.GetString("rage-quit-notify-discord",
                 ("round", _ticker.RoundId),

--- a/Content.Server/_Goobstation/PlayerListener/RageQuitNotifySystem.Discord.cs
+++ b/Content.Server/_Goobstation/PlayerListener/RageQuitNotifySystem.Discord.cs
@@ -55,7 +55,7 @@ public sealed partial class RageQuitNotifySystem
         // Doing `async void` without catching exceptions is LE BAD, okay?
         catch (Exception e)
         {
-            Log.Error($"Failed to send ragequit information to webhook!\n{e.Message}");
+            Log.Error($"Failed to send ragequit information to webhook!\n{e}");
         }
     }
 }

--- a/Content.Server/_Goobstation/PlayerListener/RageQuitNotifySystem.cs
+++ b/Content.Server/_Goobstation/PlayerListener/RageQuitNotifySystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Server.Chat.Managers;
+using Content.Server.Discord;
 using Content.Server.GameTicking.Events;
 using Content.Shared._Goobstation.CCVar;
 using Content.Shared.Chat;
@@ -19,7 +20,7 @@ namespace Content.Server._Goobstation.PlayerListener;
 ///     2. The damage threshold has degraded the state of the mob (Alive->Crit, Crit->Dead, Alive->Dead)
 ///     2. The player has left the game in X or less amount of seconds after condition 2 became true
 /// </summary>
-public sealed class RageQuitNotifySystem : EntitySystem
+public sealed partial class RageQuitNotifySystem : EntitySystem
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IServerNetManager _network = default!;
@@ -32,6 +33,8 @@ public sealed class RageQuitNotifySystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
+        InitializeDiscord();
+
         Subs.CVar(_cfg, GoobCVars.PlayerRageQuitNotify, value => _notify = value, invokeImmediately: true);
         Subs.CVar(_cfg, GoobCVars.PlayerRageQuitTimeThreshold, value => _timer = value, invokeImmediately: true);
 
@@ -49,7 +52,7 @@ public sealed class RageQuitNotifySystem : EntitySystem
     private void OnRoundStarting(RoundStartingEvent args)
     {
         _ent = Spawn(null, MapCoordinates.Nullspace);
-        AddComp<PlayerListenerComponent>(_ent);
+        EnsureComp<PlayerListenerComponent>(_ent);
     }
 
     private void OnDisconnect(object? sender, NetChannelArgs args)
@@ -59,6 +62,8 @@ public sealed class RageQuitNotifySystem : EntitySystem
 
         var callout = GetCallout(args.Channel);
         _chat.ChatMessageToAll(ChatChannel.OOC, callout, callout, _ent, false, true, colorOverride: Color.FromHex("#fff0ff", Color.Honeydew));
+        NotifyWebhook(args.Channel);
+        ClearTimer(args.Channel.UserId);
     }
 
     private void OnActorMobStateChanged(Entity<ActorComponent> ent, ref MobStateChangedEvent args)
@@ -88,7 +93,12 @@ public sealed class RageQuitNotifySystem : EntitySystem
 
     private void ClearTimer(ICommonSession target)
     {
-        GetPendingRageQuitList().Remove(target.UserId);
+        ClearTimer(target.UserId);
+    }
+
+    private void ClearTimer(NetUserId target)
+    {
+        GetPendingRageQuitList().Remove(target);
     }
 
     private bool IsPendingRageQuit(NetUserId target)

--- a/Content.Server/_Goobstation/PlayerListener/RageQuitNotifySystem.cs
+++ b/Content.Server/_Goobstation/PlayerListener/RageQuitNotifySystem.cs
@@ -1,5 +1,4 @@
 ﻿using Content.Server.Chat.Managers;
-using Content.Server.Discord;
 using Content.Server.GameTicking.Events;
 using Content.Shared._Goobstation.CCVar;
 using Content.Shared.Chat;

--- a/Content.Shared/_Goobstation/CCVars/CCVars.Goob.cs
+++ b/Content.Shared/_Goobstation/CCVars/CCVars.Goob.cs
@@ -82,14 +82,20 @@ public sealed partial class GoobCVars
     ///     Broadcast to all players that a player has ragequit.
     /// </summary>
     public static readonly CVarDef<bool> PlayerRageQuitNotify =
-        CVarDef.Create("player.ragequit.notify", true, CVar.SERVERONLY);
+        CVarDef.Create("ragequit.notify", true, CVar.SERVERONLY);
 
     /// <summary>
     ///     Time between being eligible for a "rage quit" after reaching a damage threshold.
     ///     Default is 5f.
     /// </summary>
     public static readonly CVarDef<float> PlayerRageQuitTimeThreshold =
-        CVarDef.Create("player.ragequit.threshold", 30f);
+        CVarDef.Create("ragequit.threshold", 30f);
+
+    /// <summary>
+    ///     Log ragequits to a discord webhook, set to empty to disable.
+    /// </summary>
+    public static readonly CVarDef<string> PlayerRageQuitDiscordWebhook =
+        CVarDef.Create("ragequit.discord_webhook", "", CVar.SERVERONLY);
 
     #region Surgery
 

--- a/Content.Shared/_Goobstation/CCVars/CCVars.Goob.cs
+++ b/Content.Shared/_Goobstation/CCVars/CCVars.Goob.cs
@@ -89,13 +89,13 @@ public sealed partial class GoobCVars
     ///     Default is 5f.
     /// </summary>
     public static readonly CVarDef<float> PlayerRageQuitTimeThreshold =
-        CVarDef.Create("ragequit.threshold", 30f);
+        CVarDef.Create("ragequit.threshold", 30f, CVar.SERVERONLY);
 
     /// <summary>
     ///     Log ragequits to a discord webhook, set to empty to disable.
     /// </summary>
     public static readonly CVarDef<string> PlayerRageQuitDiscordWebhook =
-        CVarDef.Create("ragequit.discord_webhook", "", CVar.SERVERONLY);
+        CVarDef.Create("ragequit.discord_webhook", "", CVar.SERVERONLY | CVar.CONFIDENTIAL);
 
     #region Surgery
 

--- a/Resources/Locale/en-US/_Goobstation/playerlistener/ragequit.ftl
+++ b/Resources/Locale/en-US/_Goobstation/playerlistener/ragequit.ftl
@@ -1,1 +1,2 @@
 ﻿rage-quit-notify = {$player} has rage quit the server.
+rage-quit-notify-discord = Round {$round}@{$time}: {$player} has rage quit the server.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
OOC messages are not used in the relay, send them to a webhook instead
Renames cvars so that they could be properly set in the server config file.
Solves for users connecting and disconnecting multiple times in a 30 second timespan.

:cl:
- tweak: ragequit messages can now be sent to a discord webhook