### PR TITLE
Paradormal Activity Early Warning System

### DIFF
--- a/Content.Server/_Goobstation/PlayerListener/DormNotifier.cs
+++ b/Content.Server/_Goobstation/PlayerListener/DormNotifier.cs
@@ -1,0 +1,287 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using Content.Server.Afk;
+using Content.Server.Chat.Systems;
+using Content.Server.GameTicking.Events;
+using Content.Shared._Goobstation.CCVar;
+using Content.Shared.GameTicking;
+using Content.Shared.Humanoid;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Robust.Server.Containers;
+using Robust.Shared.Configuration;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+using Timer = Robust.Shared.Timing.Timer;
+
+namespace Content.Server._Goobstation.PlayerListener;
+
+/// <summary>
+///     Notifies if 2 or more players are near a marker for an extended amount of time
+///     To trigger, all conditions must be true:
+///     0. Mobs in proximity must be humanoid
+///     1. X(>1) amount of humanoids are in a Y distance of tiles away from a marker
+///     2. At least two humanoids are currently players
+///     3. None of the players are dead, crit, AFK or disconnected
+/// </summary>
+/// <remarks>
+///     Fires faster if at least 1 out of 2 or more players has nothing in their body clothing slot
+/// </remarks>
+public sealed class DormNotifier : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly IAfkManager _afk = default!;
+    [Dependency] private readonly ContainerSystem _container = default!;
+    [Dependency] private readonly ChatSystem _chat = default!;
+
+    private HashSet<CancellationTokenSource> _tokens = [];
+
+    private bool _enabled;
+    private int _frequency = 10;
+
+    private int _timeout = 120;
+    private int _timeoutGrave = 25;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        Subs.CVar(_cfg, GoobCVars.DormNotifier, value => _enabled = value, true);
+        Subs.CVar(_cfg, GoobCVars.DormNotifierFrequency, value => _frequency = value, true);
+        Subs.CVar(_cfg, GoobCVars.DormNotifierPresenceTimeout, value => _timeout = value, true);
+        Subs.CVar(_cfg, GoobCVars.DormNotifierPresenceTimeoutNude, value => _timeoutGrave = value, true);
+
+        SubscribeLocalEvent<RoundStartingEvent>(OnRoundStart);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRestartCleanup);
+    }
+
+    private int _clock;
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (!_enabled || _frequency <= 0)
+            return;
+
+        if (_clock <= _frequency)
+        {
+            _clock++;
+            return;
+        }
+
+        _clock = 0;
+        Check();
+    }
+
+    private void Check()
+    {
+        var query = EntityQueryEnumerator<DormNotifierMarkerComponent>();
+
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            CheckMarker(uid, comp);
+        }
+    }
+
+    private void CheckMarker(EntityUid uid, DormNotifierMarkerComponent comp)
+    {
+        var ents = _lookup.GetEntitiesInRange<HumanoidAppearanceComponent>(Transform(uid).Coordinates, comp.ProximityRadius);
+        var found = Validate(uid, ents, out var condemned);
+
+        if (found)
+        {
+            Condemn(uid, condemned);
+        }
+    }
+
+    private bool Validate(EntityUid marker, HashSet<Entity<HumanoidAppearanceComponent>> entities, [NotNullWhen(true)] out HashSet<EntityUid> condemned)
+    {
+        // "0. Mobs in proximity must be humanoid" is handled by Entity<HumanoidAppearanceComponent>
+        condemned = [];
+
+        // 1. X(>1) amount of humanoids are in a Y distance of tiles away from a marker
+        if (entities.Count < 2)
+            return false;
+
+        foreach (var ent in entities)
+        {
+            // 2. At least two humanoids are currently players
+            if (!TryComp<ActorComponent>(ent.Owner, out var actorComp))
+                continue;
+
+            // 3. None of the players are dead, crit, AFK or disconnected
+            if (TryComp<MobStateComponent>(ent.Owner, out var statecomp) &&
+                statecomp.CurrentState is MobState.Critical or MobState.Dead)
+                return false;
+
+            if (_afk.IsAfk(actorComp.PlayerSession))
+                return false;
+
+            // Disconnected is checked by having ActorComponent present, an entity loses it if the owner disconnects or changes entity.
+            condemned.Add(ent.Owner);
+        }
+
+        // X(>1) amount of humanoids are in a Y distance of tiles away from a marker
+        return condemned.Count > 1;
+    }
+
+    private void Condemn(EntityUid marker, HashSet<EntityUid> condemned)
+    {
+        var potential = new Condemnation(marker, condemned);
+
+        if (AlreadyCondemned(potential))
+            return;
+
+        if (!TryGetDormNotifierEntity(out var dnc))
+            return;
+
+        var expedited = DetermineExpedited(condemned);
+
+        dnc.Value.Comp.Potential.Add(potential);
+        QueueRecheck(TimeSpan.FromSeconds(expedited ? _timeoutGrave : _timeout), potential, expedited);
+    }
+
+    /// <summary>
+    /// Determine if this should use an expedited timer based on whether or not any of the mobs have nothing in their suit slot
+    /// </summary>
+    /// <returns></returns>
+    private bool DetermineExpedited(HashSet<EntityUid> sinners)
+    {
+        foreach (var sinner in sinners)
+        {
+            // No jumpsuit slot we dont care
+            //if (!_slots.TryGetSlot(sinner, "jumpsuit", out var slot))
+            if (!_container.TryGetContainer(sinner, "jumpsuit", out var cont))
+                continue;
+
+            // Sinner!
+            if (cont.Count == 0)
+                return true;
+        }
+
+        return false;
+    }
+
+    private void Recheck(Condemnation condemned, bool expedited = false)
+    {
+        try
+        {
+            var sinners = condemned.Condemned
+                .Select(con => new Entity<HumanoidAppearanceComponent>(con, Comp<HumanoidAppearanceComponent>(con)))
+                .ToHashSet();
+
+            bool valid = Validate(condemned.Marker, sinners, out var currentSinners);
+
+            if (!valid)
+            {
+                RemovePotentialCondemned(condemned);
+                return;
+            }
+        }
+        catch (KeyNotFoundException e)
+        {
+            Log.Warning("Entity didn't have HumanoidAppearanceComponent");
+        }
+
+        // It was expedited
+        if (expedited)
+        {
+            // But isn't now.
+            if (!DetermineExpedited(condemned.Condemned))
+            {
+                if (_timeout > _timeoutGrave)
+                {
+                    QueueRecheck(TimeSpan.FromSeconds(_timeout - _timeoutGrave), condemned);
+                    return;
+                }
+
+                Log.Warning("DormNotifierPresenceTimeoutNude is larger than DormNotifierPresenceTimeout!");
+                return;
+            }
+        }
+
+        Notify(condemned, expedited);
+    }
+
+    private void ApplyPermanently(Condemnation condemn)
+    {
+        RemovePotentialCondemned(condemn);
+        if (TryGetDormNotifierEntity(out var ent))
+            ent.Value.Comp.Condemned.Add(condemn);
+    }
+
+    private void RemovePotentialCondemned(Condemnation condemn)
+    {
+        if (TryGetDormNotifierEntity(out var ent))
+            ent.Value.Comp.Potential.Remove(condemn);
+    }
+
+    private void Notify(Condemnation condemn, bool expedited)
+    {
+        ApplyPermanently(condemn);
+        var names = condemn.Condemned.Select(uid => MetaData(uid).EntityName).ToList();
+        var sinners = string.Join(", ", names);
+
+        var message = expedited
+            ? Loc.GetString("dorm-condemned-expedited",
+                ("dorm", Comp<DormNotifierMarkerComponent>(condemn.Marker).Name),
+                ("sinners", sinners))
+            : Loc.GetString("dorm-condemned",
+                ("dorm", Comp<DormNotifierMarkerComponent>(condemn.Marker).Name));
+
+        _chat.DispatchGlobalAnnouncement(message, colorOverride: Color.Red);
+    }
+
+    private bool TryGetDormNotifierEntity([NotNullWhen(true)] out Entity<DormNotifierComponent>? entity)
+    {
+        entity = null;
+
+        var query = EntityQueryEnumerator<DormNotifierComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            entity = new Entity<DormNotifierComponent>(uid, comp);
+        }
+
+        return entity is not null;
+    }
+
+    private bool AlreadyCondemned(Condemnation condemnation)
+    {
+        if (!TryGetDormNotifierEntity(out var ent))
+            return false;
+
+        var master = ent.Value.Comp.Condemned.Concat(ent.Value.Comp.Potential);
+        var entities = new HashSet<int>(master.SelectMany(m => m.Condemned.Select(c => c.Id)));
+
+        return condemnation.Condemned.Any(con => entities.Contains(con.Id));
+    }
+
+    private void QueueRecheck(TimeSpan seconds, Condemnation potential, bool expedited = false)
+    {
+        var cts = new CancellationTokenSource();
+        _tokens.Add(cts);
+        Timer.Spawn(seconds, () => Recheck(potential, expedited), cts.Token);
+    }
+
+    private void OnRoundStart(RoundStartingEvent args)
+    {
+        var ent = Spawn(null, MapCoordinates.Nullspace);
+        EnsureComp<DormNotifierComponent>(ent);
+    }
+
+    /// <summary>
+    /// > Trigger timer to recheck
+    /// > Round ends
+    /// > Entity doesnt exist no mo
+    /// > Server dies
+    /// </summary>
+    private void OnRestartCleanup(RoundRestartCleanupEvent args)
+    {
+        foreach (var token in _tokens)
+        {
+            token.Cancel();
+        }
+    }
+}

--- a/Content.Server/_Goobstation/PlayerListener/DormNotifierComponent.cs
+++ b/Content.Server/_Goobstation/PlayerListener/DormNotifierComponent.cs
@@ -1,0 +1,21 @@
+﻿using System.Linq;
+
+namespace Content.Server._Goobstation.PlayerListener;
+
+[RegisterComponent]
+public sealed partial class DormNotifierComponent : Component
+{
+    [ViewVariables(VVAccess.ReadWrite)]
+    public HashSet<Condemnation> Potential = [];
+
+    /// <summary>
+    /// Stores sessions that have been found to be engaging in dorm activity
+    /// </summary>
+    public HashSet<Condemnation> Condemned = [];
+}
+
+public sealed class Condemnation(EntityUid marker, HashSet<EntityUid> condemned)
+{
+    public EntityUid Marker = marker;
+    public HashSet<EntityUid> Condemned = condemned;
+}

--- a/Content.Server/_Goobstation/PlayerListener/DormNotifierMarkerComponent.cs
+++ b/Content.Server/_Goobstation/PlayerListener/DormNotifierMarkerComponent.cs
@@ -1,0 +1,14 @@
+﻿namespace Content.Server._Goobstation.PlayerListener;
+
+[RegisterComponent]
+public sealed partial class DormNotifierMarkerComponent : Component
+{
+    [ViewVariables(VVAccess.ReadWrite)]
+    public string Name = "";
+
+    /// <summary>
+    /// Tile range to check for players
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    public float ProximityRadius = 1;
+}

--- a/Content.Shared/_Goobstation/CCVars/CCVars.Goob.cs
+++ b/Content.Shared/_Goobstation/CCVars/CCVars.Goob.cs
@@ -78,6 +78,35 @@ public sealed partial class GoobCVars
     public static readonly CVarDef<bool> SiloEnabled =
         CVarDef.Create("goob.silo_enabled", true, CVar.SERVER | CVar.REPLICATED);
 
+    #region Player Listener
+
+    /// <summary>
+    ///     Enable Dorm Notifier
+    /// </summary>
+    public static readonly CVarDef<bool> DormNotifier =
+        CVarDef.Create("dorm_notifier.enable", true, CVar.SERVER);
+
+    /// <summary>
+    ///     Check for dorm activity every X amount of ticks
+    ///     Default is 10.
+    /// </summary>
+    public static readonly CVarDef<int> DormNotifierFrequency =
+        CVarDef.Create("dorm_notifier.frequency", 10, CVar.SERVER);
+
+    /// <summary>
+    ///     Time given to be found to be engaging in dorm activity
+    ///     Default is 120.
+    /// </summary>
+    public static readonly CVarDef<int> DormNotifierPresenceTimeout =
+        CVarDef.Create("dorm_notifier.timeout", 120, CVar.SERVER, "Mark as condemned if present near a dorm marker for more than X amount of seconds.");
+
+    /// <summary>
+    ///     Time given to be found engaging in dorm activity if any of the sinners are nude
+    ///     Default if 25.
+    /// </summary>
+    public static readonly CVarDef<int> DormNotifierPresenceTimeoutNude =
+        CVarDef.Create("dorm_notifier.timeout_nude", 25, CVar.SERVER, "Mark as condemned if present near a dorm marker for more than X amount of seconds while being nude.");
+
     /// <summary>
     ///     Broadcast to all players that a player has ragequit.
     /// </summary>
@@ -90,6 +119,8 @@ public sealed partial class GoobCVars
     /// </summary>
     public static readonly CVarDef<float> PlayerRageQuitTimeThreshold =
         CVarDef.Create("player.ragequit.threshold", 30f);
+
+    #endregion PlayerListener
 
     #region Surgery
 

--- a/Resources/Locale/en-US/_Goobstation/playerlistener/dorm.ftl
+++ b/Resources/Locale/en-US/_Goobstation/playerlistener/dorm.ftl
@@ -1,0 +1,2 @@
+﻿dorm-condemned=Suspicious activity detected in {$dorm}, crew is hereby requested to investigate the disturbance.
+dorm-condemned-expedited=Unsanctioned extracurricular activity detected in {$dorm}, involving the next crew members: {$sinners}. Crew is commanded to resolve the issue.

--- a/Resources/Prototypes/_Goobstation/PlayerListener/Marker.yml
+++ b/Resources/Prototypes/_Goobstation/PlayerListener/Marker.yml
@@ -1,0 +1,10 @@
+﻿- type: entity
+  id: DormNotifierMarker
+  parent: MarkerBase
+  name: Dorm Notifier Marker
+  components:
+    - type: DormNotifierMarker
+    - type: Sprite
+      sprite: Markers/jobs.rsi
+      layers:
+      - state: green


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
![image](https://github.com/user-attachments/assets/0af415f2-9039-4750-97c1-f3e25b54d59f)

Adds a marker, "Dorm Activity Marker", which checks for humanoid player entities in X tiles from it, after which starts a timer. When the timer finishes - checks if they're still near the marker, if they are - notify everyone on server.

The conditions to trigger the message are as follows:
1. Mobs in proximity must be humanoid
2. X(>1) amount of humanoids are in a Y distance of tiles away from a marker
3. At least two humanoids are currently players
4. None of the humanoid mobs are dead, crit, AFK or disconnected

Additionally, if any of the condemned is nude, as in have a jumpsuit slot which is empty - it will also reveal their name, piercing identity blocking.
![image](https://github.com/user-attachments/assets/18b20600-395e-4ba0-a4ac-5433b51fd024)

Markers will have to be mapped in a different PR, but can be added dynamically in a round.
Markers have two VV'able fields - range and name. You can probably figure it out.

no cl
