### PR TITLE
Fix hands

### DIFF
--- a/Resources/Prototypes/Body/Prototypes/dwarf.yml
+++ b/Resources/Prototypes/Body/Prototypes/dwarf.yml
@@ -33,9 +33,9 @@
       connections:
       - left hand
     right hand:
-      part: RightHandHuman
+      part: RightHandDwarf # Goob edit
     left hand:
-      part: LeftHandHuman
+      part: LeftHandDwarf # Goob edit
     right leg:
       part: RightLegHuman
       connections:

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -176,15 +176,15 @@
           types:
             Poison: 1
       # dwarves take less toxin damage and heal a marginal amount of brute
-      - !type:HealthChange
-        conditions:
-        - !type:ReagentThreshold
-          min: 15
-        - !type:OrganType
-          type: Dwarf
-        damage:
-          types:
-            Poison: 0.2
+      #- !type:HealthChange
+      #  conditions:
+      #  - !type:ReagentThreshold
+      #    min: 15
+      #  - !type:OrganType
+      #    type: Dwarf
+      #  damage:
+      #    types:
+      #      Poison: 0.2
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -202,8 +202,8 @@
           type: Dwarf
         damage:
           groups:
-            Brute: -0.5
-            Burn: -0.5
+            Brute: -1
+            Burn: -1
       - !type:ChemVomit
         probability: 0.04
         conditions:

--- a/Resources/Prototypes/_Floofstation/Body/Parts/resomi.yml
+++ b/Resources/Prototypes/_Floofstation/Body/Parts/resomi.yml
@@ -38,7 +38,7 @@
 - type: entity
   id: LeftHandResomi
   name: "left resomi hand"
-  parent: LeftHandHuman
+  parent: [PartHuman, BaseLeftHand] # Goob edit
   components:
   - type: Sprite
     sprite: _Floofstation/Mobs/Species/Resomi/parts.rsi
@@ -47,7 +47,7 @@
 - type: entity
   id: RightHandResomi
   name: "right resomi hand"
-  parent: RightHandHuman
+  parent: [PartHuman, BaseRightHand] # Goob edit
   components:
   - type: Sprite
     sprite: _Floofstation/Mobs/Species/Resomi/parts.rsi

--- a/Resources/Prototypes/_Goobstation/Body/Parts/hands.yml
+++ b/Resources/Prototypes/_Goobstation/Body/Parts/hands.yml
@@ -1,4 +1,22 @@
 - type: entity
+  id: LeftHandDwarf
+  name: "left dwarf hand"
+  parent: [PartHuman, BaseLeftHand]
+  components:
+  - type: Sprite
+    sprite: Mobs/Species/Human/parts.rsi
+    state: "l_hand"
+
+- type: entity
+  id: RightHandDwarf
+  name: "right dwarf hand"
+  parent: [PartHuman, BaseRightHand]
+  components:
+  - type: Sprite
+    sprite: Mobs/Species/Human/parts.rsi
+    state: "r_hand"
+
+- type: entity
   id: LeftHandFelinid
   name: "left felinid hand"
   parent: [PartHuman, BaseLeftHand]

--- a/Resources/Prototypes/_Goobstation/Body/Parts/hands.yml
+++ b/Resources/Prototypes/_Goobstation/Body/Parts/hands.yml
@@ -33,3 +33,21 @@
   - type: Sprite
     sprite: Mobs/Species/Human/parts.rsi
     state: "r_hand"
+
+- type: entity
+  id: LeftHandBananamen
+  name: "left bananamen hand"
+  parent: [PartHuman, BaseLeftHand]
+  components:
+  - type: Sprite
+    sprite: Mobs/Species/Human/parts.rsi
+    state: "l_hand"
+
+- type: entity
+  id: RightHandBananamen
+  name: "right bananamen hand"
+  parent: [PartHuman, BaseRightHand]
+  components:
+  - type: Sprite
+    sprite: Mobs/Species/Human/parts.rsi
+    state: "r_hand"

--- a/Resources/Prototypes/_Goobstation/Body/Prototypes/bananamen.yml
+++ b/Resources/Prototypes/_Goobstation/Body/Prototypes/bananamen.yml
@@ -31,9 +31,9 @@
       connections:
       - left hand
     right hand:
-      part: RightHandHuman
+      part: RightHandBananamen
     left hand:
-      part: LeftHandHuman
+      part: LeftHandBananamen
     right leg:
       part: RightLegHuman
       connections:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Fixed hands buffs being applied to bananamen and resomi.
Also removed dwarf hands buff and instead made them heal twice as much from ethanol and not be poisoned from it.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Ethanol healing is a cool dwarf gimmick, so it shouldn't be underwhelming. It made no sense that it poisoned them. And hands buff is intended to be human thing specifically.

## Technical details
<!-- Summary of code changes for easier review. -->

Bananamen used human hands and resomi hands were parented from human.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- fix: Fix resomi and bananamen receiving do-after modifier buff from their hands.
- tweak: Dwarves no longer have faster do-afters like humans but instead they are not poisoned by ethanol and heal twice as much by metabolizing it.