### PR TITLE
make limb severing bleed instead of bloodloss damage

### DIFF
--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -22,6 +22,7 @@ namespace Content.Server.Body.Systems;
 
 public sealed class BodySystem : SharedBodySystem
 {
+    [Dependency] private readonly BloodstreamSystem _bloodstream = default!; // Shitmed Change
     [Dependency] private readonly GhostSystem _ghostSystem = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly HumanoidAppearanceSystem _humanoidSystem = default!;
@@ -192,6 +193,14 @@ public sealed class BodySystem : SharedBodySystem
                 _humanoidSystem.RemoveMarking(target, marking.MarkingId, sync: false, humanoid: bodyAppearance);
 
         Dirty(target, bodyAppearance);
+    }
+
+    protected override void PartRemoveDamage(Entity<BodyComponent?> bodyEnt, Entity<BodyPartComponent> partEnt)
+    {
+        var bleeding = partEnt.Comp.SeverBleeding;
+        if (partEnt.Comp.IsVital)
+            bleeding *= 2f;
+        _bloodstream.TryModifyBleedAmount(bodyEnt, bleeding);
     }
 
     // Shitmed Change End

--- a/Content.Shared/Body/Part/BodyPartComponent.cs
+++ b/Content.Shared/Body/Part/BodyPartComponent.cs
@@ -31,11 +31,11 @@ public sealed partial class BodyPartComponent : Component, ISurgeryToolComponent
     public BodyPartSlot? ParentSlot;
 
     /// <summary>
-    ///     Shitmed Change: Amount of damage to deal when the part gets removed.
-    ///     Only works if IsVital is true.
+    /// Shitmed Change: Bleeding stacks to give when this body part is severed.
+    /// Doubled for <see cref="IsVital"/>. parts.
     /// </summary>
-    [DataField, AutoNetworkedField]
-    public FixedPoint2 VitalDamage = 100;
+    [DataField]
+    public float SeverBleeding = 4f;
 
     [DataField, AlwaysPushInheritance]
     public string ToolName { get; set; } = "A body part";

--- a/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Parts.cs
@@ -382,19 +382,9 @@ public partial class SharedBodySystem
         }
     }
 
-    private void PartRemoveDamage(Entity<BodyComponent?> bodyEnt, Entity<BodyPartComponent> partEnt)
+    // Shitmed Change: made virtual, bleeding damage is done on server
+    protected virtual void PartRemoveDamage(Entity<BodyComponent?> bodyEnt, Entity<BodyPartComponent> partEnt)
     {
-        if (!Resolve(bodyEnt, ref bodyEnt.Comp, logMissing: false))
-            return;
-
-        if (!_timing.ApplyingState
-            && partEnt.Comp.IsVital
-            && !GetBodyChildrenOfType(bodyEnt, partEnt.Comp.PartType, bodyEnt.Comp).Any()
-        )
-        {
-            var damage = new DamageSpecifier(Prototypes.Index<DamageTypePrototype>("Bloodloss"), partEnt.Comp.VitalDamage); // Shitmed Change
-            Damageable.TryChangeDamage(bodyEnt, damage, partMultiplier: 0f); // Shitmed Change
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR
title

applies to damage-caused severing (which probably wont matter as youll already be bleeding) and surgical amputation

## Why / Balance
bloodloss damage makes no sense when its heavy arterial **bleeding**
so now it does that, 6 bleeding stacks for limbs and 10 (max) for the head

now when delimbing people you need gauze to keep them from bleeding out, crazy

## Technical details
simple enough

## Media
evil surgery and evil execution vs urists
![01:07:21](https://github.com/user-attachments/assets/37a563db-fda2-4438-b4a6-02ba2db26b24)
![01:11:18](https://github.com/user-attachments/assets/c17c9db6-b40b-4d1a-96d6-5de583f6f061)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Losing a limb makes you bleed profusely instead of dealing bloodloss damage.
