### PR TITLE
Shorten blobbernaut raffle timer

### DIFF
--- a/Resources/Prototypes/_Goobstation/Blob/blob_mobs.yml
+++ b/Resources/Prototypes/_Goobstation/Blob/blob_mobs.yml
@@ -121,7 +121,7 @@
       description: ghost-role-information-blobbernaut-description
       rules: You are an antagonist, defend your blob core!
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: Blobbernaut
     - type: Physics


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Blobbernauts now have a 10 second raffle like carps instead of 25 seconds

## Why / Balance
Blobbernaut npcs tend to walk off blob tiles and die before the raffle ends, or sometimes just walks into the abyss of space

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
