### PR TITLE
Jaunt Idiotproofing

### DIFF
--- a/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Ash.cs
+++ b/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Ash.cs
@@ -43,7 +43,6 @@ public sealed partial class HereticAbilitySystem : EntitySystem
             if (damageableComp.Damage.GetTotal() + damage.GetTotal() >= critThreshold)
             {
                 _popup.PopupEntity(Loc.GetString("heretic-ability-fail-lowhealth", ("damage", damage.GetTotal())), ent, PopupType.LargeCaution);
-                args.Handled = true;
                 return;
             }
         }

--- a/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Ash.cs
+++ b/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Ash.cs
@@ -1,18 +1,23 @@
-using Content.Server.Atmos.Components;
-using Content.Shared.Heretic;
-using Content.Shared.Mobs.Components;
-using Content.Shared.Mobs;
-using Content.Shared.Damage;
-using Content.Shared.Atmos;
-using Content.Server.Temperature.Components;
-using Content.Shared.Temperature.Components;
-using Content.Server.Body.Components;
 using Content.Shared._Shitmed.Targeting;
+using Content.Shared.Atmos;
+using Content.Shared.Damage;
+using Content.Shared.Heretic;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Temperature.Components;
+using Content.Server.Atmos.Components;
+using Content.Server.Body.Components;
+using Content.Server.Temperature.Components;
+using Content.Shared.Popups;
 
 namespace Content.Server.Heretic.Abilities;
 
 public sealed partial class HereticAbilitySystem : EntitySystem
 {
+    [Dependency] private readonly IEntityManager _entMan = default!;
+    [Dependency] private readonly MobThresholdSystem _mobThresholdSystem = default!;
+
     private void SubscribeAsh()
     {
         SubscribeLocalEvent<HereticComponent, EventHereticAshenShift>(OnJaunt);
@@ -31,6 +36,18 @@ public sealed partial class HereticAbilitySystem : EntitySystem
         var damage = args.Damage;
         if (damage != null && ent.Comp.CurrentPath == "Ash")
             damage *= float.Lerp(1f, 0.6f, ent.Comp.PathStage * 0.1f);
+
+        // If ent will hit their crit threshold, we don't let them jaunt and give them a popup saying so.
+        if (damage != null && _entMan.TryGetComponent<DamageableComponent>(ent, out var damageableComp) && _entMan.TryGetComponent<MobThresholdsComponent>(ent, out var thresholdsComp) && _mobThresholdSystem.TryGetThresholdForState(ent, MobState.Critical, out var critThreshold, thresholdsComp))
+        {
+            if (damageableComp.Damage.GetTotal() + damage.GetTotal() >= critThreshold)
+            {
+                _popup.PopupEntity(Loc.GetString("heretic-ability-fail-lowhealth", ("damage", damage.GetTotal())), ent, PopupType.LargeCaution);
+                args.Handled = true;
+                return;
+            }
+        }
+
         if (TryUseAbility(ent, args) && TryDoJaunt(ent, damage))
             args.Handled = true;
     }
@@ -45,8 +62,10 @@ public sealed partial class HereticAbilitySystem : EntitySystem
         var urist = _poly.PolymorphEntity(ent, "AshJaunt");
         if (urist == null)
             return false;
+
         if (damage != null)
             _dmg.TryChangeDamage(ent, damage, true, false, targetPart: TargetBodyPart.Torso);
+
         return true;
     }
 

--- a/Resources/Locale/en-US/_Goobstation/Heretic/abilities/heretic.ftl
+++ b/Resources/Locale/en-US/_Goobstation/Heretic/abilities/heretic.ftl
@@ -1,6 +1,7 @@
 heretic-ability-fail = Failed to cast
 heretic-ability-fail-magicitem = You cannot cast it without a focus!
 heretic-ability-fail-notarget = Couldn't find a valid target!
+heretic-ability-fail-lowhealth = This spell deals {$damage} damage, it would put you in critical condition if you casted it!
 
 heretic-magicitem-examine = [color=yellow]Allows you to use advanced spells while held or equipped.[/color]
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Makes it so that if you would go into crit by using jaunt, it won't let you.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

It would suck if you didn't read the whole description of the ability or forgot and accidentally crit yourself. I think a more ideal solution would be to make it so that it just requires confirmation so you still could do it (which would be great for if you have a friend where you're going, or if you injected yourself with enough chems to heal you up before), but this is a decent solution for now.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/ff02473a-8fa2-4302-b0af-5da36c3784f1)

I've tested that it still works if you aren't low on health and all of that.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Ashen Jaunt won't let you use it if it would crit you.