### PR TITLE
Fix nightwatcher's rebirth

### DIFF
--- a/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Ash.cs
+++ b/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Ash.cs
@@ -97,7 +97,7 @@ public sealed partial class HereticAbilitySystem : EntitySystem
         if (!TryUseAbility(ent, args))
             return;
 
-        var power = ent.Comp.CurrentPath == "Ash" ? ent.Comp.PathStage : 2.5f;
+        var power = ent.Comp.CurrentPath == "Ash" ? ent.Comp.PathStage : 4f;
         var lookup = _lookup.GetEntitiesInRange(ent, power);
 
         foreach (var look in lookup)
@@ -120,7 +120,7 @@ public sealed partial class HereticAbilitySystem : EntitySystem
                     _dmg.TryChangeDamage(ent, dmgspec, true, false, dmgc);
                 }
 
-                if (!flam.OnFire)
+                if (flam.OnFire)
                     _flammable.AdjustFireStacks(look, power, flam, true);
 
                 if (TryComp<MobStateComponent>(look, out var mobstat))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The ashen path's nightwatcher's rebirth now engulfs people that are already caught on fire, like originally intended. 

## Why / Balance
The in game description says "a spell that burns all nearby heathens who are currently on fire, healing you for every victim afflicted". It seems to have done the same thing in ss13. Prior to this change it actually engulfed everyone not on fire, and anyone already ignited was safe, which is the opposite of what it was supposed to do. It was also very overpowered as you could literally kill everyone on screen in less than a second by tapping a button, and solo the station with this ability alone. Its still very powerful because the blade and the fireball ignite people, and it still heals a great amount, but people no longer instantly die while clueless. 
Also minorly buffed it for other paths as they don't have an easy way to ignite people.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Nigthwatcher's rebirth only engulfs people that are already ignited, like intended.
