### PR TITLE
make hardlight bow not stupid op against blob

### DIFF
--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -69,7 +69,6 @@ public sealed class ProjectileSystem : SharedProjectileSystem
             if (!args.OurBody.LinearVelocity.IsLengthZero())
                 _sharedCameraRecoil.KickCamera(target, args.OurBody.LinearVelocity.Normalized());
         }
-
         // Goobstation start
         if (component.Penetrate)
             component.IgnoredEntities.Add(target);
@@ -77,7 +76,7 @@ public sealed class ProjectileSystem : SharedProjectileSystem
             component.DamagedEntity = true;
         // Goobstation end
 
-        if (component.DeleteOnCollide)
+        if (component.DeleteOnCollide || (component.NoPenetrateMask & args.OtherFixture.CollisionLayer) != 0) // Goobstation - Make x-ray arrows not penetrate blob
             QueueDel(uid);
 
         if (component.ImpactEffect != null && TryComp(uid, out TransformComponent? xform))

--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -69,6 +69,7 @@ public sealed class ProjectileSystem : SharedProjectileSystem
             if (!args.OurBody.LinearVelocity.IsLengthZero())
                 _sharedCameraRecoil.KickCamera(target, args.OurBody.LinearVelocity.Normalized());
         }
+
         // Goobstation start
         if (component.Penetrate)
             component.IgnoredEntities.Add(target);

--- a/Content.Shared/Projectiles/ProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.cs
@@ -1,7 +1,9 @@
 using Content.Shared.Damage;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared.Projectiles;
 
@@ -83,6 +85,12 @@ public sealed partial class ProjectileComponent : Component
     // Goobstation start
     [DataField]
     public bool Penetrate;
+
+    /// <summary>
+    ///     Collision mask of what not to penetrate if <see cref="Penetrate"/> is true.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(FlagSerializer<CollisionMask>))]
+    public int NoPenetrateMask = 0;
 
     [NonSerialized]
     public List<EntityUid> IgnoredEntities = new();

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -301,6 +301,9 @@
         mask:
         - Opaque
       fly-by: *flybyfixture
+  - type: Reflective # Goobstation - Make emitter bolts reflect as energy
+    reflective:
+    - Energy
   - type: Projectile
 #   soundHit:  Waiting on serv3
     damage:

--- a/Resources/Prototypes/_Goobstation/Blob/blob_tiles.yml
+++ b/Resources/Prototypes/_Goobstation/Blob/blob_tiles.yml
@@ -327,7 +327,7 @@
             - !type:DoActsBehavior
               acts: [ "Destruction" ]
     - type: Reflect
-      reflectProb: 0.6
+      reflectProb: 0.9
       spread: 20
       reflects:
         - Energy

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Bow/hardlight_arrows.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Bow/hardlight_arrows.yml
@@ -151,6 +151,8 @@
     color: "#1AE51A"
   - type: Projectile
     penetrate: true
+    noPenetrateMask:
+    - BlobImpassable
     damage:
       types:
         Heat: 35


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- adds support for having penetrating projectiles not penetrate certain entities
- make hardlight bow x-ray arrows not penetrate blob tiles (hits first and despawns)
- makes emitter bolts reflect as energy shots
- raise reflective tile reflect 60%->90%

## Why / Balance
x-ray arrow change:
- without this, x-ray arrows penetrate and kill all normal blob tiles in a line, and kill strong/reflective tiles in 2 hits, and core in 4 hits

emitter bolt change is basically just a fix

reflect change:
- even with the x-ray change, hardlight bow arrows oneshot or 2-shot blob tiles, so it's just an infinite ammo long-range blob destroyer dealing heat damage which blob below delta size simply can't counter; therefore
- reflective tiles have 100 hp as opposed to strong tiles' 150hp, but only have 60% reflect, which is just kinda bad; due to their cost it's somewhat better to just spam strong tiles
- their prototype description says they have 90% reflect so maybe there's a mistake

tl;dr makes reflective tiles not worse than strong tiles and allows blob to actually do something against hardlight bow

## Technical details
see diff it's small

## Media
tested, works, trust

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Blob reflective tile reflect 60% -> 90%.
- tweak: Hardlight bow x-ray arrows will no longer penetrate blob tiles.
- fix: Emitter bolts now properly reflect as energy projectiles.