### PR TITLE
Bso ntr centcomm role access

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -812,5 +812,8 @@
     - NuclearOperative
     - SyndicateAgent
     - Wizard
+    # Goobstation
+    - NanotrasenRepresentative
+    - BlueshieldOfficer
   - type: NanoChatCard # DeltaV
     notificationsMuted: true

--- a/Resources/Prototypes/Roles/Jobs/CentComm/cburn.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/cburn.yml
@@ -12,6 +12,9 @@
   - AllAccess
   access:
   - CentralCommand
+  # Goobstation
+  - NanotrasenRepresentative
+  - BlueshieldOfficer
 
 - type: startingGear
   id: CBURNGear

--- a/Resources/Prototypes/Roles/Jobs/CentComm/deathsquad.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/deathsquad.yml
@@ -12,6 +12,9 @@
   - AllAccess
   access:
   - CentralCommand
+  # Goobstation
+  - NanotrasenRepresentative
+  - BlueshieldOfficer
 
 - type: startingGear
   id: DeathSquadGear

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -13,6 +13,9 @@
   - AllAccess
   access:
   - CentralCommand
+  # Goobstation
+  - NanotrasenRepresentative
+  - BlueshieldOfficer
 
 - type: startingGear
   id: ERTLeaderGear
@@ -103,6 +106,8 @@
   - AllAccess
   access:
   - CentralCommand
+  - NanotrasenRepresentative
+  - BlueshieldOfficer
   special:
   - !type:AddComponentSpecial
     components:
@@ -185,6 +190,8 @@
   - AllAccess
   access:
   - CentralCommand
+  - NanotrasenRepresentative
+  - BlueshieldOfficer
 
 - type: startingGear
   id: ERTEngineerGear
@@ -257,6 +264,8 @@
   - AllAccess
   access:
   - CentralCommand
+  - NanotrasenRepresentative
+  - BlueshieldOfficer
 
 - type: startingGear
   id: ERTSecurityGear
@@ -347,6 +356,8 @@
   - AllAccess
   access:
   - CentralCommand
+  - NanotrasenRepresentative
+  - BlueshieldOfficer
 
 - type: startingGear
   id: ERTMedicalGear
@@ -409,6 +420,8 @@
   - AllAccess
   access:
   - CentralCommand
+  - NanotrasenRepresentative
+  - BlueshieldOfficer
 
 - type: startingGear
   id: ERTJanitorGear

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -106,6 +106,7 @@
   - AllAccess
   access:
   - CentralCommand
+  # Goobstation
   - NanotrasenRepresentative
   - BlueshieldOfficer
   special:
@@ -190,6 +191,7 @@
   - AllAccess
   access:
   - CentralCommand
+  # Goobstation
   - NanotrasenRepresentative
   - BlueshieldOfficer
 
@@ -264,6 +266,7 @@
   - AllAccess
   access:
   - CentralCommand
+  # Goobstation
   - NanotrasenRepresentative
   - BlueshieldOfficer
 
@@ -356,6 +359,7 @@
   - AllAccess
   access:
   - CentralCommand
+  # Goobstation
   - NanotrasenRepresentative
   - BlueshieldOfficer
 
@@ -420,6 +424,7 @@
   - AllAccess
   access:
   - CentralCommand
+  # Goobstation
   - NanotrasenRepresentative
   - BlueshieldOfficer
 

--- a/Resources/Prototypes/Roles/Jobs/CentComm/official.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/official.yml
@@ -16,6 +16,9 @@
   - AllAccess
   access:
   - CentralCommand
+  # Goobstation
+  - NanotrasenRepresentative
+  - BlueshieldOfficer
 
 - type: startingGear
   id: CentcomGear

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/identification_cards.yml
@@ -20,6 +20,8 @@
     tags:
     - CentralCommand
     - SyndicateAgent
+    - NanotrasenRepresentative
+    - BlueshieldOfficer
 
 # Helldiver
 - type: entity
@@ -53,6 +55,8 @@
     - AllAccess
     tags:
     - CentralCommand
+    - NanotrasenRepresentative
+    - BlueshieldOfficer
 
 # Blueshield
 - type: entity
@@ -65,8 +69,8 @@
     - state: centcom
     - state: idcentcom
   - type: Item
-    heldPrefix: 
-    
+    heldPrefix:
+
   - type: PresetIdCard
     job: BlueshieldOfficer
   - type: Access

--- a/Resources/Prototypes/_Goobstation/Roles/GhostRoles/Fun/hecu.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/GhostRoles/Fun/hecu.yml
@@ -12,6 +12,8 @@
   - AllAccess
   access:
   - CentralCommand
+  - NanotrasenRepresentative
+  - BlueshieldOfficer
 
 - type: startingGear
   id: HECUOperativeGear


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
adds NTR and BSO access to

all ERT roles, HECU, centcomm official, CBURN, deathsquad roles and future agent and admin id card
<!-- What did you change? -->

## Why / Balance
fixes #1341 
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: All CentComm cards/roles now have NTR and BSO access aswell.
