### PR TITLE
Fix heretic gear

### DIFF
--- a/Content.Shared/_Goobstation/Heretic/Systems/HereticClothingSystem.cs
+++ b/Content.Shared/_Goobstation/Heretic/Systems/HereticClothingSystem.cs
@@ -14,10 +14,15 @@ public sealed class HereticClothingSystem : EntitySystem
 
     private void OnEquipAttempt(Entity<HereticClothingComponent> ent, ref BeingEquippedAttemptEvent args)
     {
-        if (HasComp<HereticComponent>(args.EquipTarget))
+        if (IsTargetValid(args.EquipTarget) && (args.EquipTarget == args.Equipee || IsTargetValid(args.Equipee)))
             return;
 
         args.Cancel();
         args.Reason = Loc.GetString("heretic-clothing-component-fail");
+    }
+
+    private bool IsTargetValid(EntityUid target)
+    {
+        return HasComp<HereticComponent>(target) || HasComp<GhoulComponent>(target);
     }
 }

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Clothing/Neck/specific.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Clothing/Neck/specific.yml
@@ -6,7 +6,6 @@
   suffix: MagicItem
   components:
     - type: HereticMagicItem
-    - type: HereticClothing
     - type: Sprite
       sprite: _Goobstation/Heretic/amber_focus.rsi
       state: icon
@@ -31,3 +30,4 @@
       drawOverlay: false
       lightRadius: 0
       toggleAction: null
+    - type: HereticClothing

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Clothing/OuterClothing/armor.yml
@@ -4,7 +4,6 @@
   name: ominous armor
   description: A ragged, dusty set of robes. Strange eyes line the inside.
   components:
-  - type: HereticClothing
   - type: Sprite
     sprite: _Goobstation/Heretic/eldritch_armor.rsi
     state: icon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Now you can't valid a heretic by equipping heretic gear on them. Removed the restriction of wearing amber focus and heretic armor by non-heretics, since it's kinda silly, they still can't wear eldritch medallion because it gives thermals. Also ghouls can wear ashen eyes medallions.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- fix; Non-heretics can't equip heretic gear on heretics anymore (if they can't wear it themselves).
- fix: Ghouls can wear heretic medallion.
- tweak: Everyone can wear heretic gear once again with an exception of eldritch medallion.