### PR TITLE
Glorp Accent for Abductor

### DIFF
--- a/Content.Server/_Goobstation/Speech/Components/GlorpAccentComponent.cs
+++ b/Content.Server/_Goobstation/Speech/Components/GlorpAccentComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server.Speech.Components
+{
+    [RegisterComponent]
+    public sealed partial class GlorpAccentComponent : Component
+    {
+    }
+}

--- a/Content.Server/_Goobstation/Speech/EntitySystems/GlorpAccentSystem.cs
+++ b/Content.Server/_Goobstation/Speech/EntitySystems/GlorpAccentSystem.cs
@@ -1,0 +1,137 @@
+using Content.Server.Speech.Components;
+using System.Text.RegularExpressions;
+
+namespace Content.Server.Speech.EntitySystems;
+
+public sealed class GlorpAccentSystem : EntitySystem
+{
+    [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
+    private static readonly string[] StartingLetters = { "n", "x", "z", "v", "g" };
+    private static readonly string[] Suffixes = { "narp", "lorp", "leeb", "orp", "orple", "ip", "op", "eegle" };
+    private static readonly string[] RandomInserts = { "Glupshitto", "Glorpshit" };
+    private static readonly HashSet<string> WhitelistedWords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "discrimination", "inferior", "surgery", "probing", "neanderthal", "animal",
+        "tool", "heart", "zoo", "subject", "organ", "skill", "issue"
+    };
+    private static readonly Regex WordRegex = new(@"\b\w+\b", RegexOptions.IgnoreCase);
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GlorpAccentComponent, AccentGetEvent>(OnAccentGet);
+    }
+
+    private string GenerateRandomAlienWord()
+    {
+        var start = StartingLetters[Random.Shared.Next(StartingLetters.Length)];
+        var suffix = Suffixes[Random.Shared.Next(Suffixes.Length)];
+        return start + suffix;
+    }
+
+    private string AdjustCapitalization(string word, bool allCaps)
+    {
+        if (allCaps)
+            return word.ToUpper();
+        return char.ToUpper(word[0]) + word.Substring(1).ToLower();
+    }
+
+    private bool IsWhitelisted(string word)
+    {
+        // whitelist check
+        if (WhitelistedWords.Contains(word.ToLower()))
+            return true;
+
+        // plurality check
+        if (word.Length > 1 && word.EndsWith("s", StringComparison.OrdinalIgnoreCase))
+        {
+            var singular = word.Substring(0, word.Length - 1);
+            if (WhitelistedWords.Contains(singular.ToLower()))
+                return true;
+        }
+
+        return false;
+    }
+
+    private string ProcessWord(string originalWord, bool allCaps)
+    {
+        // whitelist plus plurality
+        if (IsWhitelisted(originalWord))
+        {
+            return $"\"{AdjustCapitalization(originalWord, allCaps)}\"";  // apply quotes and caps
+        }
+
+        // if note whitelisted replace with some real glorp shit
+        var alienWord = GenerateRandomAlienWord();
+        return AdjustCapitalization(alienWord, allCaps);
+    }
+
+    private string ReplaceWithRandomAlienWords(string message, bool allCaps)
+    {
+        var words = new List<string>();
+        var previousWord = string.Empty;
+
+        foreach (Match match in WordRegex.Matches(message))
+        {
+            var currentWord = match.Value;
+            var processedWord = ProcessWord(currentWord, allCaps);
+
+            // checks if two whitelisted words are next to eachother
+            if (IsWhitelisted(previousWord) && IsWhitelisted(currentWord))
+            {
+                // combine under single quotes
+                var combined = $"{AdjustCapitalization(previousWord, allCaps)} {AdjustCapitalization(currentWord, allCaps)}";
+                words[words.Count - 1] = $"\"{combined}\"";
+            }
+            else
+            {
+                words.Add(processedWord);
+            }
+
+            previousWord = currentWord;
+        }
+
+        // adds glupshitto and glorpshit randomly
+        if (Random.Shared.NextDouble() < 0.25) // percent chance
+        {
+            var randomInsert = RandomInserts[Random.Shared.Next(RandomInserts.Length)];
+            var randomPosition = Random.Shared.Next(words.Count + 1);
+            words.Insert(randomPosition, AdjustCapitalization(randomInsert, allCaps));
+        }
+
+        return string.Join(" ", words);
+    }
+
+    public string Accentuate(string message, GlorpAccentComponent component)
+    {
+        var msg = message;
+
+        // all caps check
+        var allCaps = IsAllCaps(msg);
+        msg = _replacement.ApplyReplacements(msg, "glorp_accent");
+        msg = ReplaceWithRandomAlienWords(msg, allCaps);
+
+        return msg;
+    }
+
+    private bool IsAllCaps(string message)
+    {
+        var hasLetters = false;
+        foreach (var c in message)
+        {
+            if (char.IsLetter(c))
+            {
+                hasLetters = true;
+                if (char.IsLower(c))
+                    return false;
+            }
+        }
+        return hasLetters;
+    }
+
+    private void OnAccentGet(EntityUid uid, GlorpAccentComponent component, AccentGetEvent args)
+    {
+        args.Message = Accentuate(args.Message, component);
+    }
+}

--- a/Content.Server/_Goobstation/Speech/EntitySystems/GlorpAccentSystem.cs
+++ b/Content.Server/_Goobstation/Speech/EntitySystems/GlorpAccentSystem.cs
@@ -12,7 +12,8 @@ public sealed class GlorpAccentSystem : EntitySystem
     private static readonly HashSet<string> WhitelistedWords = new(StringComparer.OrdinalIgnoreCase)
     {
         "discrimination", "inferior", "surgery", "probing", "neanderthal", "animal",
-        "tool", "heart", "zoo", "subject", "organ", "skill", "issue"
+        "tool", "heart", "zoo", "subject", "organ", "skill", "issue", "extract", "remove", "eyes",
+        "sleep", "bruh", "skibidi", "ohio", "brazil", "shitsec"
     };
     private static readonly Regex WordRegex = new(@"\b\w+\b", RegexOptions.IgnoreCase);
 

--- a/Content.Server/_Goobstation/Speech/EntitySystems/GlorpAccentSystem.cs
+++ b/Content.Server/_Goobstation/Speech/EntitySystems/GlorpAccentSystem.cs
@@ -34,6 +34,8 @@ public sealed class GlorpAccentSystem : EntitySystem
     {
         if (allCaps)
             return word.ToUpper();
+        if (string.IsNullOrEmpty(word))
+            return word;
         return char.ToUpper(word[0]) + word.Substring(1).ToLower();
     }
 

--- a/Resources/Prototypes/_Shitmed/Entities/Mobs/Species/abductor.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Mobs/Species/abductor.yml
@@ -9,7 +9,7 @@
   abstract: true
   components:
   - type: Absorbable # BLOOD FOR THE BLOOD GOD
-  - type: Muted
+  - type: GlorpAccent # GoobStation - Glorpshit
   - type: HumanoidAppearance
     species: Abductor
   - type: Icon


### PR DESCRIPTION
## About the PR

Adds Glorp accent to the Abductor.

## Why / Balance

Because it would be really funny for the abductor to yell at people in an incomprehensible language, with very certain words coming through like "Skill issue" plus more that can be added.

## Technical details

Just adds the Glorp Accent system and component, and modifies the abductor YAML to replace muted with the glorp accent.
Replaces every word you say with a psuedorandomized table of glorp-like words, with a few specific words in a white list which are surrounded in quotes, also randomly adds "glorpshit" and "glupshitto" for more funni comedy

## Media

https://github.com/user-attachments/assets/4c05c483-5734-4f38-ad5c-f9ea4f3fe11b



## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl: Koi
- tweak: The Abductor now speaks in a near-incomprehensible Glorp accent! But it appears he has picked up on a few colloquial words... Xarple Voople Zip Gnarp!