### PR TITLE
Abductor Unique Blood

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/flavors/flavor-profiles.ftl
+++ b/Resources/Locale/en-US/_Goobstation/flavors/flavor-profiles.ftl
@@ -2,3 +2,4 @@ flavor-base-futuristic = futuristic
 flavor-base-offensive = offensive
 flavor-base-sigma = sigma
 flavor-complex-fentanyl = burning tar
+flavor-base-alienblood = alien

--- a/Resources/Locale/en-US/_Goobstation/reagents/meta/biological.ftl
+++ b/Resources/Locale/en-US/_Goobstation/reagents/meta/biological.ftl
@@ -1,0 +1,2 @@
+reagent-name-alien-blood = alien blood
+reagent-desc-alien-blood = The creature this bled from is not of this galaxy. Maybe it's grape flavoured.

--- a/Resources/Locale/en-US/_Goobstation/reagents/meta/physical-desc.ftl
+++ b/Resources/Locale/en-US/_Goobstation/reagents/meta/physical-desc.ftl
@@ -2,3 +2,4 @@ reagent-physical-desc-calming = calming
 reagent-physical-desc-stasizium = static
 reagent-physical-desc-sigma = sigma
 reagent-physical-desc-ling = living
+reagent-physical-desc-alien = alien

--- a/Resources/Prototypes/_Goobstation/Flavors/flavors.yml
+++ b/Resources/Prototypes/_Goobstation/Flavors/flavors.yml
@@ -22,3 +22,8 @@
   id: fentanyl
   flavorType: Complex
   description: flavor-complex-fentanyl
+
+- type: flavor
+  id: alienblood
+  flavorType: Base
+  description: flavor-base-alienblood

--- a/Resources/Prototypes/_Goobstation/Reagents/biological.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/biological.yml
@@ -1,0 +1,11 @@
+- type: reagent
+  parent: Blood
+  id: AlienBlood
+  name: reagent-name-alien-blood
+  group: Biological
+  desc: reagent-desc-alien-blood
+  flavor: alienblood
+  color: "#4B076D"
+  recognizable: true
+  physicalDesc: reagent-physical-desc-alien
+  slippery: false

--- a/Resources/Prototypes/_Shitmed/Entities/Mobs/Species/abductor.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Mobs/Species/abductor.yml
@@ -47,6 +47,8 @@
         Brute: -0.14
   - type: Targeting
   - type: SurgeryTarget
+  - type: Bloodstream
+    bloodReagent: AlienBlood
 
 - type: entity
   parent: BaseSpeciesDummy


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a unique blood type for abductors.

## Why / Balance
Because I felt that an alien species based off of the grey aliens bleeding the same blood as humans was weird.
Also, it allows you to tell which blood is abductor blood easily because it's purple.

In the future, this blood type could have some unique stuff to it, but right now it's just recolored insect blood :p

## Technical details
Changed the blood type from default to AlienBlood
Created new biological reagent folder.
Added new alienblood reagent into the folder.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Abductors now have a unique bloodtype.
