### PR TITLE
Made SM not suck (gas) (out of the chamber)

### DIFF
--- a/Content.Server/_Goobstation/Supermatter/Systems/SupermatterSystem.cs
+++ b/Content.Server/_Goobstation/Supermatter/Systems/SupermatterSystem.cs
@@ -347,6 +347,9 @@ public sealed class SupermatterSystem : SharedSupermatterSystem
         }
 
         sm.Damage = Math.Min(sm.DamageArchived + sm.DamageHardcap * sm.DelaminationPoint, totalDamage);
+
+        // Return the manipulated gas back to the mix 
+        _atmosphere.Merge(mix, absorbedGas);
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR
Supermatter no longer magically removes 15% of the gas mix from the chamber every second.

## Why / Balance
Pretty trivial bugfix, since it seems to be an unintended behaviour. It'll make things like Atlas SM work properly out-of-the-box (as I believe is intended), without need to hook up the distro to keep it topped off. Should decrease the likelihood of SM delamming itself 30 minutes in because someone set it up with a single can.

## Technical details
In SM code, `ProcessAtmos` removes gases from the mix, modifies them, and merges them back. `HandleDamage` removed gases, but didn't return them, resulting in 15% of gases being removed from the SM every second (since `sm.GasEfficiency` is `0.15f`). This fix simply mirrors code from `ProcessAtmos` in `HandleDamage`, and fixes the unclear and possibly unintended behaviour.

## Media
Atlas SM keeping stable ~56 moles of N2 for 15 minutes (SM was started almost roundstart).
![Screenshot 2025-01-17 082132](https://github.com/user-attachments/assets/ead2e5c1-ac57-4269-b6ba-c11ba0848126)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: SM no longer removes gases for no reason during normal operation
