### PR TITLE
SMES Fix and Value Increase

### DIFF
--- a/Content.Server/Power/Components/BatteryComponent.cs
+++ b/Content.Server/Power/Components/BatteryComponent.cs
@@ -34,7 +34,7 @@ namespace Content.Server.Power.Components
         /// The price per one joule. Default is 1 credit for 10kJ.
         /// </summary>
         [DataField]
-        public float PricePerJoule = 0.0002f;
+        public float PricePerJoule = 0.0003f;
     }
 
     /// <summary>

--- a/Content.Server/Power/Components/BatteryComponent.cs
+++ b/Content.Server/Power/Components/BatteryComponent.cs
@@ -34,7 +34,7 @@ namespace Content.Server.Power.Components
         /// The price per one joule. Default is 1 credit for 10kJ.
         /// </summary>
         [DataField]
-        public float PricePerJoule = 0.0001f;
+        public float PricePerJoule = 0.0002f;
     }
 
     /// <summary>

--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -99,7 +99,7 @@
 - type: entity
   parent: BaseSMES
   id: SMESBasic
-  suffix: Basic, 8MJ
+  suffix: Basic, 16MJ
   components:
   - type: Battery
      # Goobstation - SMES buff
@@ -117,7 +117,7 @@
 - type: entity
   parent: BaseSMES
   id: SMESAdvanced
-  suffix: Advanced, 16MJ
+  suffix: Advanced, 32MJ
   name: advanced SMES
   description: An even-higher-capacity superconducting magnetic energy storage (SMES) unit.
   components:
@@ -141,8 +141,9 @@
   - type: Machine
     board: SMESAdvancedMachineCircuitboard
   - type: Battery
-    maxCharge: 16000000
-    startingCharge: 16000000
+     # Goobstation - SMES buff
+    maxCharge: 32000000
+    startingCharge: 32000000
   - type: PowerMonitoringDevice
     group: SMES
     sourceNode: input


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Tripled Joule price, resulting in a normal, filled SMES to be valued at about 5.1k.
Updated SMES names to match power value.
Increased Adv. SMES capacity to align with #402.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Makes power selling more viable.
Adv. SMES is no longer an SMES clone that costs more.

## Technical details
<!-- Summary of code changes for easier review. -->
Changed numbers.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] This PR does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Adv. SMES capacity buffed (2x)
- tweak: Increased sell price of filled SMES
