### PR TITLE
Apply preferred borg name to Station AI

### DIFF
--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -140,10 +140,10 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
             DoJobSpecials(job, jobEntity);
             _identity.QueueIdentityUpdate(jobEntity);
             // #Goobstation - Borg Preferred Name
-            if (profile != null && prototype.ID == "Borg")
+            if (profile != null && (prototype.ID == "Borg" || prototype.ID == "StationAi"))
             {
                 var name = profile.BorgName;
-                if (TryComp<NameIdentifierComponent>(jobEntity, out var nameIdentifier))
+                if ((TryComp<NameIdentifierComponent>(jobEntity, out var nameIdentifier)) && (prototype.ID !="StationAi"))
                     name = $"{name} {nameIdentifier.FullIdentifier}";
 
                 _metaSystem.SetEntityName(jobEntity, name);

--- a/Resources/Locale/en-US/_Goobstation/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/_Goobstation/preferences/ui/humanoid-profile-editor.ftl
@@ -1,2 +1,2 @@
-humanoid-profile-editor-borgname-label = Preferred Borg Name:
+humanoid-profile-editor-borgname-label = Preferred Silicon Name:
 humanoid-profile-editor-antag-roll-before-jobs = Keep in mind that all antags except for initial infected and sleeper agent are rolled before jobs.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Preferred Cyborg name is now applied to the Station AI.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Customisability, there is presently no way to customise your AI name.

## Technical details
<!-- Summary of code changes for easier review. -->
Add station AI check to the borg name adder, while making sure the AI doesnt get a designator.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Preferred borg name is now applied to Station AIs.

