### PR TITLE
Fix ritual of knowledge and nightwatcher's rebirth

### DIFF
--- a/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Ash.cs
+++ b/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Ash.cs
@@ -99,6 +99,7 @@ public sealed partial class HereticAbilitySystem : EntitySystem
 
         var power = ent.Comp.CurrentPath == "Ash" ? ent.Comp.PathStage : 4f;
         var lookup = _lookup.GetEntitiesInRange(ent, power);
+        var healAmount = -10f - power;
 
         foreach (var look in lookup)
         {
@@ -111,12 +112,13 @@ public sealed partial class HereticAbilitySystem : EntitySystem
                 if (flam.OnFire && TryComp<DamageableComponent>(ent, out var dmgc))
                 {
                     // heals everything by base + power for each burning target
-                    _stam.TryTakeStamina(ent, -(10 + power));
+                    _stam.TryTakeStamina(ent, healAmount);
                     var dmgdict = dmgc.Damage.DamageDict;
                     DamageSpecifier healSpecifier = new();
+
                     foreach (var key in dmgdict.Keys)
                     {
-                        healSpecifier.DamageDict[key] = -10f - power;
+                        healSpecifier.DamageDict[key] = -dmgdict[key] < healAmount ? healAmount : -dmgdict[key];
                     }
 
                     _dmg.TryChangeDamage(ent, healSpecifier, true, false, dmgc);

--- a/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Ash.cs
+++ b/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Ash.cs
@@ -113,11 +113,13 @@ public sealed partial class HereticAbilitySystem : EntitySystem
                     // heals everything by base + power for each burning target
                     _stam.TryTakeStamina(ent, -(10 + power));
                     var dmgdict = dmgc.Damage.DamageDict;
+                    DamageSpecifier healSpecifier = new();
                     foreach (var key in dmgdict.Keys)
-                        dmgdict[key] -= 10f + power;
+                    {
+                        healSpecifier.DamageDict[key] = -10f - power;
+                    }
 
-                    var dmgspec = new DamageSpecifier() { DamageDict = dmgdict };
-                    _dmg.TryChangeDamage(ent, dmgspec, true, false, dmgc);
+                    _dmg.TryChangeDamage(ent, healSpecifier, true, false, dmgc);
                 }
 
                 if (flam.OnFire)

--- a/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Knowledge.cs
+++ b/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Knowledge.cs
@@ -6,6 +6,7 @@ using Content.Shared.Tag;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using System.Text;
+using Robust.Server.Containers;
 
 namespace Content.Server.Heretic.Ritual;
 
@@ -21,6 +22,7 @@ public sealed partial class RitualKnowledgeBehavior : RitualCustomBehavior
     private EntityLookupSystem _lookup = default!;
     private HereticSystem _heretic = default!;
     private TagSystem _tag = default!;
+    private ContainerSystem _container = default!;
 
     [ValidatePrototypeId<DatasetPrototype>]
     public const string EligibleTagsDataset = "EligibleTags";
@@ -33,6 +35,7 @@ public sealed partial class RitualKnowledgeBehavior : RitualCustomBehavior
         _lookup = args.EntityManager.System<EntityLookupSystem>();
         _heretic = args.EntityManager.System<HereticSystem>();
         _tag = args.EntityManager.System<TagSystem>();
+        _container = args.EntityManager.System<ContainerSystem>();
 
         outstr = null;
 
@@ -50,6 +53,9 @@ public sealed partial class RitualKnowledgeBehavior : RitualCustomBehavior
         foreach (var look in lookup)
         {
             if (!args.EntityManager.TryGetComponent<TagComponent>(look, out var tags))
+                continue;
+
+            if (_container.IsEntityInContainer(look))
                 continue;
 
             _missingTags.RemoveWhere(tag =>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Ritual of knowledge now checks if entity is in container.
Nightwatcher's rebirth now deals (- 10 - PathStage) damage to you for each burning entity, instead of dealing (your current damage - 10 - PathStage) damage to you for each burning entity, which can easily lead to gibbing or delimbing.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl: MJ Sailor
- fix: Nightwatcher's rebirth now won't delimb or gib you.
- fix: Fixed ritual of knowledge stealing your clothes and organs.
