### PR TITLE
ai-powered c4

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/ghost/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_Goobstation/ghost/ghost-role-component.ftl
@@ -16,3 +16,6 @@ ghost-role-information-Hecu-rules = You are required to obey orders given by you
 
 ghost-role-information-lootbug-name = LootBug
 ghost-role-information-lootbug-description = Try not to be butchered by tiders.
+
+ghost-role-information-c4-name = Composition C-4
+ghost-role-information-c4-description = Assist your user with bombing things.

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -49,7 +49,8 @@ uplink-penguin-grenade-name = Grenade Penguin
 uplink-penguin-grenade-desc = A small, highly-aggressive penguin with a grenade strapped around its neck. Harvested by the Syndicate from icy shit-hole planets.
 
 uplink-c4-name = C-4
-uplink-c4-desc = Use it to breach walls, airlocks or sabotage equipment. It can be attached to almost all objects and has a modifiable timer with a minimum setting of 10 seconds.
+# Goobstation - C4 sentience
+uplink-c4-desc = Use it to breach walls, airlocks or sabotage equipment. It can be attached to almost all objects and has a modifiable timer with a minimum setting of 10 seconds. AI-powered.
 
 uplink-c4-bundle-name = C-4 bundle
 uplink-c4-bundle-desc = Because sometimes quantity is quality. Contains 8 C-4 plastic explosives.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -65,6 +65,30 @@
     maxIntensity: 30
     canCreateVacuum: false
   - type: ExplodeOnTrigger
+  # <Goobstation> - C4 sentience
+  - type: TypingIndicator
+    proto: robot
+  - type: Speech
+    speechVerb: Robotic
+    speechSounds: Pai
+  - type: GhostRole
+    # prob: 0.1 # uncomment if all c4 being sentient becomes too evil
+    name: ghost-role-information-c4-name
+    description: ghost-role-information-c4-description
+    rules: ghost-role-information-familiar-rules
+  - type: GhostTakeoverAvailable
+  - type: IntrinsicRadioReceiver
+  - type: IntrinsicRadioTransmitter
+    channels:
+    - Syndicate
+  - type: ActiveRadio
+    channels:
+    - Syndicate
+  - type: Vocal
+    sounds:
+      Unsexed: EmoteC4
+  - type: Emoting
+  # </Goobstation>
   - type: HolidayVisuals
     holidays:
       festive:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -72,7 +72,7 @@
     speechVerb: Robotic
     speechSounds: Pai
   - type: GhostRole
-    # prob: 0.1 # uncomment if all c4 being sentient becomes too evil
+    prob: 0.05 
     name: ghost-role-information-c4-name
     description: ghost-role-information-c4-description
     rules: ghost-role-information-familiar-rules

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -369,10 +369,11 @@
   category: Vocal
   icon: Interface/Emotes/beep.png
   chatMessages: ["chat-emote-msg-beep"]
-  whitelist: #Goobstation - IPCs
+  whitelist: #Goobstation - IPCs, C4 sentience
     components:
     - Silicon
     - BorgChassis
+    - Explosive
   chatTriggers:
     - beep
     - beeps

--- a/Resources/Prototypes/_Goobstation/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_Goobstation/Voice/speech_emote_sounds.yml
@@ -1,0 +1,9 @@
+- type: emoteSounds
+  id: EmoteC4
+  params:
+    variation: 0
+  sounds:
+    Beep:
+      path: /Audio/Machines/Nuke/general_beep.ogg
+    Scream:
+      path: /Audio/Machines/Nuke/general_beep.ogg


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- the syndicate has joined the AI bubble
- c4 now a guaranteed ghost role
- has syndicate radio
- can emote to c4 beep
- basically syndicate pai

## Why / Balance
Argument for Sentient C4 in Space Station 14

The introduction of sentient C4 in Space Station 14 would revolutionize gameplay, adding layers of complexity, humor, and ethical dilemmas that align perfectly with the game’s chaotic and unpredictable nature. Here’s why:

1. Enhanced Gameplay Dynamics: Sentient C4 could introduce a new layer of strategy. Imagine C4 that refuses to detonate unless it’s convinced of the mission’s worthiness, or that negotiates with players before exploding. This would force players to think creatively, whether through persuasion, bribery, or threats, adding depth to sabotage and defense

2. Comedic Potential: A sentient explosive with a personality could become a fan-favorite feature. Picture C4 cracking jokes as it counts down, expressing existential dread about its purpose, or even forming emotional bonds with players. This would inject humor into tense moments, making the game more memorable and engaging.

3. Moral and Ethical Dilemmas: Sentient C4 could force players to confront the morality of their actions. Is it right to use a self-aware explosive as a tool for destruction? Players might hesitate or even refuse to use it, leading to unexpected alliances or betrayals. This aligns with Space Station 14’s emphasis on emergent storytelling and player-driven narratives.

4. Unique Antagonist or Ally: Sentient C4 could serve as a wildcard entity, capable of switching sides or acting independently. It might sabotage its own detonation, warn others of impending danger, or even team up with players to achieve its own goals. This unpredictability would keep players on their toes and create unforgettable moments.

5. Lore Expansion: The existence of sentient C4 could open up new avenues for lore. How did it gain sentience? Is it a result of rogue AI, alien technology, or a mad scientist’s experiment? This could tie into existing storylines or inspire new ones, enriching the game’s universe.

6. Player Creativity: Sentient C4 would encourage players to experiment with its capabilities. Could it be reprogrammed, hacked, or convinced to join a cause? The possibilities are endless, fostering a culture of innovation and discovery within the community.

In conclusion, sentient C4 would not only enhance gameplay but also elevate Space Station 14’s reputation as a game that embraces chaos, creativity, and player agency. It’s a bold step forward that would leave a lasting impact on the community.

Stay explosive,
[Your Name]
Advocate for Chaotic Innovation
Space Station 14 Enthusiast
"If it’s not sentient, it’s not science."

## Media
tested, all works

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Syndicate C-4 is now AI-powered.
