### PR TITLE
make frezon great again

### DIFF
--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -99,7 +99,7 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 0.3 # Goobstation - Gas Prices
+  pricePerMole: 3 # Goobstation - Gas Prices
 
 # Assmos - /tg/ gases
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
returns old frezon prices

## Why / Balance
frezon currently sells for nothing so just keeping it at old values is probably good

## Media
webedit so server will crash and burn and run away

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Frezon sell price has been reverted to its old value: 0.3->3$/mol.
