### PR TITLE
yowies can metabolize six chemicals at once

### DIFF
--- a/Resources/Prototypes/_Goobstation/Body/Organs/yowie.yml
+++ b/Resources/Prototypes/_Goobstation/Body/Organs/yowie.yml
@@ -36,6 +36,7 @@
   components:
   - type: Metabolizer
     metabolizerTypes: [Yowie]
+    maxReagents: 6
 
 - type: entity
   id: OrganYowieLungs


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I changed Yowie's medicine metabolism from 2 to 6.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I was talking to someone on the Discord about Yowies, and they mentioned they'd play Yowie if they had the same 6 metabolism that slime people have. I thought the idea of a Yowie collecting 6 different drugs to make mega omnizine was funny. I'm not sure if this would make them too powerful, since they'd be able to metabolize 6 actual medicines to heal a bunch of damage. But, if slimepeople can do it while wearing armored hardsuits, Yowies without hardsuits might be fine.

## Technical details
<!-- Summary of code changes for easier review. -->
I added one line of code under the Yowie heart.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Yowies can metabolize 6 chemicals at once.