### PR TITLE
fix stealth

### DIFF
--- a/Content.Client/Stealth/StealthSystem.cs
+++ b/Content.Client/Stealth/StealthSystem.cs
@@ -85,7 +85,7 @@ public sealed class StealthSystem : SharedStealthSystem
         reference.X = -reference.X;
         var visibility = GetVisibility(uid, component);
 
-        // Goobstation - Proper invisibility: chnages -1 to -1.5
+        // Goobstation - Proper invisibility: changes -1 to -1.5
         // actual visual visibility effect is limited to -1.5 to 1.
         visibility = Math.Clamp(visibility, -1.5f, 1f);
 

--- a/Content.Client/Stealth/StealthSystem.cs
+++ b/Content.Client/Stealth/StealthSystem.cs
@@ -85,8 +85,9 @@ public sealed class StealthSystem : SharedStealthSystem
         reference.X = -reference.X;
         var visibility = GetVisibility(uid, component);
 
-        // actual visual visibility effect is limited to +/- 1.
-        visibility = Math.Clamp(visibility, -1f, 1f);
+        // Goobstation - Proper invisibility: chnages -1 to -1.5
+        // actual visual visibility effect is limited to -1.5 to 1.
+        visibility = Math.Clamp(visibility, -1.5f, 1f);
 
         _shader.SetParameter("reference", reference);
         _shader.SetParameter("visibility", visibility);

--- a/Content.Shared/Stealth/Components/StealthComponent.cs
+++ b/Content.Shared/Stealth/Components/StealthComponent.cs
@@ -11,12 +11,14 @@ namespace Content.Shared.Stealth.Components;
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 [Access(typeof(SharedStealthSystem))]
+[AutoGenerateComponentState] // Goobstation
 public sealed partial class StealthComponent : Component
 {
     /// <summary>
     /// Whether or not the stealth effect should currently be applied.
     /// </summary>
     [DataField("enabled")]
+    [AutoNetworkedField] // Goobstation
     public bool Enabled = true;
 
     /// <summary>
@@ -51,6 +53,7 @@ public sealed partial class StealthComponent : Component
     /// </summary>
     [DataField("lastVisibility")]
     [Access(typeof(SharedStealthSystem), Other = AccessPermissions.None)]
+    [AutoNetworkedField] // Goobstation
     public float LastVisibility = 1;
 
 
@@ -59,6 +62,7 @@ public sealed partial class StealthComponent : Component
     /// accumulating any visibility change.
     /// </summary>
     [DataField("lastUpdate", customTypeSerializer:typeof(TimeOffsetSerializer))]
+    [AutoNetworkedField] // Goobstation
     public TimeSpan? LastUpdated;
 
     // Goobstation - Proper invisibility
@@ -66,12 +70,14 @@ public sealed partial class StealthComponent : Component
     /// Minimum visibility. Note that the visual effect caps out at -1.5, but this value is allowed to be larger or smaller.
     /// </summary>
     [DataField("minVisibility")]
+    [AutoNetworkedField] // Goobstation
     public float MinVisibility = -1.5f;
 
     /// <summary>
     /// Maximum visibility. Note that the visual effect caps out at +1, but this value is allowed to be larger or smaller.
     /// </summary>
     [DataField("maxVisibility")]
+    [AutoNetworkedField] // Goobstation
     public float MaxVisibility = 1.5f;
 
     /// <summary>
@@ -79,21 +85,4 @@ public sealed partial class StealthComponent : Component
     /// </summary>
     [DataField("examinedDesc")]
     public string ExaminedDesc = "stealth-visual-effect";
-}
-
-[Serializable, NetSerializable]
-public sealed class StealthComponentState : ComponentState
-{
-    public readonly float Visibility;
-    public readonly TimeSpan? LastUpdated;
-    public readonly float MaxVisibility; // Shitmed Change
-    public readonly bool Enabled;
-
-    public StealthComponentState(float stealthLevel, TimeSpan? lastUpdated, float maxVisibility, bool enabled)
-    {
-        Visibility = stealthLevel;
-        LastUpdated = lastUpdated;
-        MaxVisibility = maxVisibility; // Shitmed Change
-        Enabled = enabled;
-    }
 }

--- a/Content.Shared/Stealth/Components/StealthComponent.cs
+++ b/Content.Shared/Stealth/Components/StealthComponent.cs
@@ -44,7 +44,7 @@ public sealed partial class StealthComponent : Component
     public float ExamineThreshold = 0.5f;
 
     /// <summary>
-    /// Last set level of visibility. The visual effect ranges from 1 (fully visible) and -1 (fully hidden). Values
+    /// Last set level of visibility. The visual effect ranges from 1 (fully visible) and -1.5 (fully hidden). Values // Goobstation - Proper invisibility
     /// outside of this range simply act as a buffer for the visual effect (i.e., a delay before turning invisible). To
     /// get the actual current visibility, use <see cref="SharedStealthSystem.GetVisibility(EntityUid, StealthComponent?)"/>
     /// If you don't have anything else updating the stealth, this will just stay at a constant value, which can be useful.
@@ -61,11 +61,12 @@ public sealed partial class StealthComponent : Component
     [DataField("lastUpdate", customTypeSerializer:typeof(TimeOffsetSerializer))]
     public TimeSpan? LastUpdated;
 
+    // Goobstation - Proper invisibility
     /// <summary>
-    /// Minimum visibility. Note that the visual effect caps out at -1, but this value is allowed to be larger or smaller.
+    /// Minimum visibility. Note that the visual effect caps out at -1.5, but this value is allowed to be larger or smaller.
     /// </summary>
     [DataField("minVisibility")]
-    public float MinVisibility = -1f;
+    public float MinVisibility = -1.5f;
 
     /// <summary>
     /// Maximum visibility. Note that the visual effect caps out at +1, but this value is allowed to be larger or smaller.

--- a/Content.Shared/Stealth/Components/StealthOnMoveComponent.cs
+++ b/Content.Shared/Stealth/Components/StealthOnMoveComponent.cs
@@ -20,5 +20,19 @@ namespace Content.Shared.Stealth.Components
         /// </summary>
         [DataField("movementVisibilityRate")]
         public float MovementVisibilityRate = 0.2f;
+
+        // <Goobstation> Goobstation - Proper invisibility
+        /// <summary>
+        /// How much to penalize minimum visibility depending on velocity.
+        /// </summary>
+        [DataField]
+        public float InvisibilityPenalty = 1f;
+
+        /// <summary>
+        /// Don't penalize minimum visibility beyond this amount.
+        /// </summary>
+        [DataField]
+        public float MaxInvisibilityPenalty = 0.5f;
+        // </Goobstation>
     }
 }

--- a/Content.Shared/Stealth/Components/StealthOnMoveComponent.cs
+++ b/Content.Shared/Stealth/Components/StealthOnMoveComponent.cs
@@ -7,18 +7,21 @@ namespace Content.Shared.Stealth.Components
     ///     based on the entity's (lack of) movement.
     /// </summary>
     [RegisterComponent, NetworkedComponent]
+    [AutoGenerateComponentState] // Goobstation
     public sealed partial class StealthOnMoveComponent : Component
     {
         /// <summary>
         /// Rate that effects how fast an entity's visibility passively changes.
         /// </summary>
-        [DataField("passiveVisibilityRate")]
+        [DataField]
+        [AutoNetworkedField] // Goobstation
         public float PassiveVisibilityRate = -0.15f;
 
         /// <summary>
         /// Rate for movement induced visibility changes. Scales with distance moved.
         /// </summary>
-        [DataField("movementVisibilityRate")]
+        [DataField]
+        [AutoNetworkedField] // Goobstation
         public float MovementVisibilityRate = 0.2f;
 
         // <Goobstation> Goobstation - Proper invisibility
@@ -26,12 +29,14 @@ namespace Content.Shared.Stealth.Components
         /// How much to penalize minimum visibility depending on velocity.
         /// </summary>
         [DataField]
+        [AutoNetworkedField] // Goobstation
         public float InvisibilityPenalty = 1f;
 
         /// <summary>
         /// Don't penalize minimum visibility beyond this amount.
         /// </summary>
         [DataField]
+        [AutoNetworkedField] // Goobstation
         public float MaxInvisibilityPenalty = 0.5f;
         // </Goobstation>
     }

--- a/Content.Shared/Stealth/SharedStealthSystem.cs
+++ b/Content.Shared/Stealth/SharedStealthSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Examine;
 using Content.Shared.Mobs;
 using Content.Shared.Stealth.Components;
+using Robust.Shared.Physics.Components; // Goobstation
 using Robust.Shared.GameStates;
 using Robust.Shared.Timing;
 
@@ -127,10 +128,18 @@ public abstract class SharedStealthSystem : EntitySystem
         ModifyVisibility(uid, delta);
     }
 
+    // Goobstation - Proper invisibility
     private void OnGetVisibilityModifiers(EntityUid uid, StealthOnMoveComponent component, GetVisibilityModifiersEvent args)
     {
-        var mod = args.SecondsSinceUpdate * component.PassiveVisibilityRate;
-        args.FlatModifier += mod;
+        var limit = args.Stealth.MinVisibility;
+        if (TryComp<PhysicsComponent>(uid, out var phys))
+        {
+            limit += Math.Min(component.MaxInvisibilityPenalty, phys.LinearVelocity.Length() * component.InvisibilityPenalty);
+        }
+        if (args.Stealth.LastVisibility > limit) {
+            var mod = args.SecondsSinceUpdate * component.PassiveVisibilityRate;
+            args.FlatModifier += mod;
+        }
     }
 
     /// <summary>

--- a/Content.Shared/Stealth/SharedStealthSystem.cs
+++ b/Content.Shared/Stealth/SharedStealthSystem.cs
@@ -115,13 +115,10 @@ public abstract class SharedStealthSystem : EntitySystem
     {
         var limit = args.Stealth.MinVisibility;
         if (TryComp<PhysicsComponent>(uid, out var phys))
-        {
             limit += Math.Min(component.MaxInvisibilityPenalty, phys.LinearVelocity.Length() * component.InvisibilityPenalty);
-        }
-        if (args.Stealth.LastVisibility > limit) {
-            var mod = args.SecondsSinceUpdate * component.PassiveVisibilityRate;
-            args.FlatModifier += mod;
-        }
+
+        if (args.Stealth.LastVisibility > limit)
+            args.FlatModifier += args.SecondsSinceUpdate * component.PassiveVisibilityRate;
     }
 
     /// <summary>

--- a/Content.Shared/Stealth/SharedStealthSystem.cs
+++ b/Content.Shared/Stealth/SharedStealthSystem.cs
@@ -15,8 +15,6 @@ public abstract class SharedStealthSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<StealthComponent, ComponentGetState>(OnStealthGetState);
-        SubscribeLocalEvent<StealthComponent, ComponentHandleState>(OnStealthHandleState);
         SubscribeLocalEvent<StealthOnMoveComponent, MoveEvent>(OnMove);
         SubscribeLocalEvent<StealthOnMoveComponent, GetVisibilityModifiersEvent>(OnGetVisibilityModifiers);
         SubscribeLocalEvent<StealthComponent, EntityPausedEvent>(OnPaused);
@@ -98,22 +96,6 @@ public abstract class SharedStealthSystem : EntitySystem
             return;
 
         component.LastUpdated = _timing.CurTime;
-    }
-
-    private void OnStealthGetState(EntityUid uid, StealthComponent component, ref ComponentGetState args)
-    {
-        args.State = new StealthComponentState(component.LastVisibility, component.LastUpdated, component.MaxVisibility, component.Enabled); // Shitmed Change
-    }
-
-    private void OnStealthHandleState(EntityUid uid, StealthComponent component, ref ComponentHandleState args)
-    {
-        if (args.Current is not StealthComponentState cast)
-            return;
-
-        SetEnabled(uid, cast.Enabled, component);
-        component.LastVisibility = cast.Visibility;
-        component.LastUpdated = cast.LastUpdated;
-        component.MaxVisibility = cast.MaxVisibility; // Shitmed Change
     }
 
     private void OnMove(EntityUid uid, StealthOnMoveComponent component, ref MoveEvent args)

--- a/Resources/Prototypes/Anomaly/behaviours.yml
+++ b/Resources/Prototypes/Anomaly/behaviours.yml
@@ -161,6 +161,7 @@
   description: anomaly-behavior-invisibility
   components:
   - type: Stealth
+    minVisibility: -1 # Goobstation - Proper invisibility
     maxVisibility: 1.2
   - type: StealthOnMove
     passiveVisibilityRate: -0.37
@@ -217,6 +218,7 @@
     rangeMax: 1
     effect: PuddleSparkle
   - type: Stealth
+    minVisibility: -1 # Goobstation - Proper invisibility
     maxVisibility: 1.2
   - type: StealthOnMove
     passiveVisibilityRate: -0.37

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -158,6 +158,7 @@
     components:
     # Goobstation - Proper invisibility
     - type: Stealth
+      maxVisibility: 0.1
       hadOutline: true
     - type: StealthOnMove
       invisibilityPenalty: 3

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -156,9 +156,14 @@
   - type: ComponentToggler
     parent: true
     components:
+    # Goobstation - Proper invisibility
     - type: Stealth
-      minVisibility: 0.1
-      lastVisibility: 0.1
+      hadOutline: true
+    - type: StealthOnMove
+      invisibilityPenalty: 3
+      maxInvisibilityPenalty: 1.6
+      passiveVisibilityRate: -1 # cloak very fast
+      movementVisibilityRate: 0.15 # only some cloak if moving
   - type: PowerCellDraw
     drawRate: 1.8 # 200 seconds on the default cell
   - type: ToggleCellDraw

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -294,10 +294,10 @@
   components:
   - type: Stealth
     hadOutline: true
+    minVisibility: -1 # Goobstation - Proper invisibility
   - type: StealthOnMove
     passiveVisibilityRate: -0.10
     movementVisibilityRate: 0.10
-    minVisibility: -1 # Goobstation - Proper invisibility
 
 - type: artifactEffect
   id: EffectExplosionScary

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -297,6 +297,7 @@
   - type: StealthOnMove
     passiveVisibilityRate: -0.10
     movementVisibilityRate: 0.10
+    minVisibility: -1 # Goobstation - Proper invisibility
 
 - type: artifactEffect
   id: EffectExplosionScary


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
makes stealth things capable of *full* full cloak while stationary, affects every stealth thing (including ninja) except ones mentioned below

note: this is all configurable, i just set the defaults to let everything go full stealth if stationary (no full stealth if moving)

does not affect: anomalies, artifacts

## Why / Balance
currently everything stealth is just useless because you get spotted instantly and people hate it, this makes them actually viable but not too strong

if this is too evil can just configure only certain prototypes to (not) have this, it's all configurable

"but this will make stealth op" no it won't, current options with stealth:
you use stealth against an unrobust player: you win both with and without stealth
you use stealth against a robust player: you lose both with (they will see you) and without stealth (they will kill you)
therefore without this change stealth is useless

## Technical details
check diff it's small
also auto-networks StealthComponent and StealthOnMoveComponent because this is needed for this to actually be properly configurable

## Media
https://github.com/user-attachments/assets/49eebc40-82fb-4bd7-ad39-ade1b3a9111f

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: All stealth items are now capable of full stealth while stationary.
