### PR TITLE
Added RPD to RCD Module

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -294,6 +294,7 @@
   - type: ItemBorgModule
     items:
     - RCDRecharging
+    - RPDRecharging
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: rcd-module }
 

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -420,6 +420,19 @@
     rechargeDuration: 10
 
 - type: entity
+  id: RPDRecharging
+  parent: RPD
+  name: experimental RPD
+  description: A bluespace-enhanced rapid piping device that passively generates its own compressed matter.
+  suffix: AutoRecharge
+  components:
+  - type: LimitedCharges
+    maxCharges: 25
+    charges: 25
+  - type: AutoRecharge
+    rechargeDuration: 15
+
+- type: entity
   id: RCDExperimental
   parent: RCD
   suffix: Admeme


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a self-recharging RPD based on the self-recharging RCD to the RCD module for engineering cyborgs.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The RPD looks cool, and I thought "Why not add it to engineering cyborgs?" I nerfed the recharge rate from 10 seconds per compressed matter to 15 compared to the RCD, since it's a lot faster to RPD related stuff for free steel. It might not have been a good idea in retrospect, but you already get 50 free pipes from a fully charged RPD, and you get two more every 15 seconds, so it should be more than enough to rebuild rooms after they get bombed or help atmos with their atmosian shenanigans.
## Technical details
<!-- Summary of code changes for easier review. -->
I copied the existing code for the cyborg RCD, and used it on the RPD.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![RPD](https://github.com/user-attachments/assets/1aa86ec9-de07-4e0a-80cc-594317575a45)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added self-recharging RPD to Engineering Cyborg's RCD module.

