### PR TITLE
Bring back spin emote

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/emotes.ftl
+++ b/Resources/Locale/en-US/_Goobstation/emotes.ftl
@@ -1,7 +1,9 @@
 emote-menu-category-farts = Farts
 
 chat-emote-name-flip = Do a flip
+chat-emote-name-spin = Spin
 chat-emote-name-jump = Jump
 
 chat-emote-msg-flip = does a flip!
+chat-emote-msg-spin = spins!
 chat-emote-msg-jump = jumps!

--- a/Resources/Prototypes/_Goobstation/Actions/emotes.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/emotes.yml
@@ -13,6 +13,18 @@
   event: !type:AnimationFlipEmoteEvent
 
 - type: emote
+  id: Spin
+  name: chat-emote-name-spin
+  category: Invalid # Don't show in the emote wheel
+  chatMessages: ["chat-emote-msg-spin"]
+  chatTriggers:
+  - spin
+  - spins
+  - spins.
+  - spins!
+  event: !type:AnimationSpinEmoteEvent
+
+- type: emote
   id: Jump
   name: chat-emote-name-jump
   chatMessages: ["chat-emote-msg-jump"]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Re-added spin emote, it won't show in the emote wheel though.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

So I can do spin-flip.

## Technical details
<!-- Summary of code changes for easier review. -->

Invalid category so emote wheel ignores it.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- add: Spin emote is back. Though it's not available in the emote wheel, you have to bind it or type it manually.