### PR TITLE
Unnerf elite syndie suit

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1453,7 +1453,7 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
   cost:
-    Telecrystal: 75 # goob
+    Telecrystal: 60 # goob
   categories:
   - UplinkWearables
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1453,7 +1453,7 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
   cost:
-    Telecrystal: 60 # goob
+    Telecrystal: 75 # goob
   categories:
   - UplinkWearables
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -588,7 +588,7 @@
     size: Huge
   - type: ClothingSpeedModifier # goobstation - duke nukies
     walkModifier: 1.0
-    sprintModifier: 1
+    sprintModifier: 1.0
   - type: HeldSpeedModifier
   - type: ToggleableClothing # Goobstation - Modsuits change
     clothingPrototypes: 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -588,7 +588,7 @@
     size: Huge
   - type: ClothingSpeedModifier # goobstation - duke nukies
     walkModifier: 1.0
-    sprintModifier: 0.9
+    sprintModifier: 1
   - type: HeldSpeedModifier
   - type: ToggleableClothing # Goobstation - Modsuits change
     clothingPrototypes: 


### PR DESCRIPTION
## About the PR
Removes movespeed penalty from elite suit ~~and makes it a bit cheaper~~. Only movespeed penalty removed.

## Why / Balance
Bounty.

Also it's as expensive as jugsuit, offers less protection than blood-red against most common damage types, and "less slowdown" is a lie cuz noone walks. In conclusion: trash, and why you'd buy this, except for one in a million singuloose strat (read: never).

## Technical details
Literally like 2 lines in yaml changed, it's faster to read the code than this PR

## Media
![{D6540F98-B8BA-456E-9580-E2B7FAD1D9BF}](https://github.com/user-attachments/assets/9774a913-618c-4448-b443-f1becdd30c88)
![{9B1D07B8-ED9B-404F-8280-88521D9F678F}](https://github.com/user-attachments/assets/3a2352ba-fef1-4189-918b-3b807a00481b)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Increased speed of elite syndicate suit by 11%
