### PR TITLE
Removing broken map and mode from pools (temporarily)

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -15,7 +15,7 @@
   - Meta
   - Oasis
   - Omega
-  - Origin
+  #- Origin # Goobstation - its broke
   - Saltern
   - Packed
   - Reach

--- a/Resources/Prototypes/_Goobstation/GameRules/Dynamic/dynamic.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/Dynamic/dynamic.yml
@@ -71,7 +71,7 @@
     - secret2
   name: gamemode-dynamic-title
   description: gamemode-dynamic-description
-  showInVote: true
+  showInVote: false #currently broken, and hasn't been fixed for over a month, and people LOVE voting for it
   rules:
     - Dynamic
     - BasicStationEventSchedulerNoAntag


### PR DESCRIPTION


## About the PR
Dynamic cannot be voted for, and origin cannot be rolled

## Why / Balance
Dynamic has been broken for over a month now, but can still be voted for which leads to people being funny and stalling the next round repeatedly. Origin also hasn't been able to load for some time now.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

