### PR TITLE
Buffed Advanced SME

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -141,8 +141,8 @@
   - type: Machine
     board: SMESAdvancedMachineCircuitboard
   - type: Battery
-    maxCharge: 16000000
-    startingCharge: 16000000
+    maxCharge: 24000000 # Goobstation
+    startingCharge: 24000000 # Goobstation
   - type: PowerMonitoringDevice
     group: SMES
     sourceNode: input


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Buffed the capacity of the advanced SMES from 16000000 to 24000000

## Why / Balance
Because the advanced SMES having the EXACT same capacity as the normal smes is... needless to say dumb.

## Technical details
i didn't test it so just trust me that it works.

## Media
no screenshot, trust me it works.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion --> 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Advanced SMESs now actually have a higher capacity than normal, instead of having the same cap.
