### PR TITLE
undisarmable wonderprod

### DIFF
--- a/Resources/Prototypes/_Shitmed/Entities/Objects/Weapons/Melee/wonderprod.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Objects/Weapons/Melee/wonderprod.yml
@@ -28,6 +28,7 @@
     - abductors-weapon-restricted-2
     - abductors-weapon-restricted-3
     - abductors-weapon-restricted-4
+  - type: DisarmMalus
   - type: ItemSwitch
     state: stun
     showLabel: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
can no longer rightclick and steal wonder batong
this is actually kind of a fix (see tech details)

## Why / Balance
prevent rightclick for 25% chance of abductor defeat before it becomes meta and entire playerbase does it so can't play abductor without getting rightclicked anymore

## Technical details
i also noticed it has the RestrictByUserTag component which is supposed to make the batong only usable by abductor, but it doesn't work, so this kinda works instead

## Media
trust

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Wonderprod can no longer be disarmed.
