### PR TITLE
Are you ready for the new blueshield order?

### DIFF
--- a/Resources/Prototypes/_Goobstation/Access/misc.yml
+++ b/Resources/Prototypes/_Goobstation/Access/misc.yml
@@ -1,0 +1,10 @@
+- type: accessGroup
+  id: HeadOffices
+  tags:
+  - Captain
+  - HeadOfPersonnel
+  - ChiefEngineer
+  - ChiefMedicalOfficer
+  - HeadOfSecurity
+  - ResearchDirector
+  - Quartermaster

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -22,6 +22,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-ntr-centcom
   canBeAntag: false
+  accessGroups:
+  - HeadOffices
   access:
   - Security
   - Brig
@@ -32,6 +34,11 @@
   - Medical
   - Research
   - Command
+  - Cargo
+  - Hydroponics
+  - Bar
+  - Janitor
+  - Atmospherics
   - CentralCommand
   - BlueshieldOfficer
   special:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Blueshield now has access to additional departments such as :

-  Cargo
- Botany
- Bar
- Janitorial
- Atmospherics
- Every heads office.

## Why / Balance
Because the guy who protects the heads not having access to their offices is dumb and stupid.
Also, I thought if I made another blueshield PR it *might* wake up piras from their slumber.

## Technical details
Created a new access group, "HeadOffices", which allows access to all heads offices. Gave it to blueshield.

## Media
No image needed, just trust me bro :godo:

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added new accesses to the blueshields ID card.
