### PR TITLE
BSO gets CentComms Headset but in Blue

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -44,6 +44,21 @@
 
 - type: entity
   parent: [ClothingHeadsetAlt, BaseCommandContraband]
+  id: ClothingHeadsetAltBSO
+  name: BlueShield over-ear headset
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyCentCom
+      - EncryptionKeyStationMaster
+  - type: Sprite
+    sprite: Clothing/Ears/Headsets/command.rsi
+  - type: Clothing
+    sprite: Clothing/Ears/Headsets/command.rsi
+
+- type: entity
+  parent: [ClothingHeadsetAlt, BaseCommandContraband]
   id: ClothingHeadsetAltCommand
   name: command over-ear headset
   components:

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -47,7 +47,7 @@
     eyes: ClothingEyesGlassesMedSec
     gloves: ClothingHandsGlovesCombat
     id: BlueshieldPDA
-    ears: ClothingHeadsetAltCommand
+    ears: ClothingHeadsetAltBSO
     belt: ClothingBeltSecurityFilled
     pocket1: UniqueBlueshieldOfficerLockerTeleporter
     pocket2: PinpointerNuclear


### PR DESCRIPTION
They should get access to the centcomm channel. While still looking blue. No custom Sprites

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Giving BSO CC key while keeping a blue headset.

## Why / Balance
So BSO as a CC personnel, should be given CC comms access. So NTR and CC themselves are able to talk to the BSO via the channel.

## Technical details
Copy and pasted ClothingHeadsetAltCommand entity and renamed it to ClothingHeadsetAltBSO, then added the EncryptionKeyCentCom. Keeping the blue sprite, while granting CC key, then changed to have ClothingHeadsetAltBSO to BSO starting gear.
Renamed it so the headset is called "BlueShield over-ear headset"

## Media
![image](https://github.com/user-attachments/assets/c996ab92-7ff1-4e80-855d-cb7b9af3ad51)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: CodeDJ
- add: BlueShield Headset, CentComm headset but BLUE!
