### PR TITLE
Added mining hardsuit to QMs locker.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -3,6 +3,7 @@
   table: !type:AllSelector
     children:
     - id: BoxEncryptionKeyCargo
+    - id: ClothingOuterHardsuitSalvage
     - id: BoxFolderQmClipboard
     - id: CargoBountyComputerCircuitboard
     - id: CargoRequestComputerCircuitboard


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added mining hardsuit to QMs locker.

## Why / Balance
QM spawns with no hardsuit, has to buy it for 15k spesos. I wanna fuck around with salv, not beg to be let into EVA to get a shitty suit.

## Technical details
Self-explanatory

## Media
No pictures, but it works probably. Trust me bro.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added the mining hardsuit to QMs locker.
