### PR TITLE
make IPCs take radiation

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -29,6 +29,7 @@
     damageContainers:
     - Inorganic
     - Silicon
+    - SiliconRadiation # Goobstation - Make IPCs take radiation
 
 - type: entity
   parent: [ClothingEyesBase, ShowMedicalIcons]

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -182,6 +182,7 @@
       damageContainers:
       - Inorganic
       - Silicon
+      - SiliconRadiation # Goobstation - Make IPCs take radiation
     - type: InteractionPopup
       interactSuccessString: petting-success-syndicate-cyborg
       interactFailureString: petting-failure-syndicate-cyborg

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -52,6 +52,7 @@
   - type: BlindHealing
     damageContainers:
       - Silicon
+      - SiliconRadiation # Goobstation - Make IPCs take radiation
   - type: StackPrice
     price: 2
 

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -222,6 +222,13 @@
         - ReagentId: Carbon
           Quantity: 1
         canReact: false
+  - type: Healing # Goobstation - Make IPCs take radiation
+    delay: 1.0
+    damageContainers:
+    - SiliconRadiation
+    damage:
+      types:
+        Radiation: -5.0
 
 - type: entity
   parent: SheetPlasteel

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -40,10 +40,12 @@
     delay: 0.6
     damageContainers:
     - Silicon
+    - SiliconRadiation # Goobstation - Make IPCs take radiation
     damage:
       types: # these are all split across multiple types
         Heat: -3.0
         Shock: -3.0
+        Radiation: -1.5 # Goobstation - Make IPCs take radiation, shouldn't be easy to heal
         Ion: -3.0 # Goobstation
   # EE Change End
   # FIXME: Used isnt actually implemented so its still unlimited.

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -45,7 +45,6 @@
       types: # these are all split across multiple types
         Heat: -3.0
         Shock: -3.0
-        Radiation: -1.5 # Goobstation - Make IPCs take radiation, shouldn't be easy to heal
         Ion: -3.0 # Goobstation
   # EE Change End
   # FIXME: Used isnt actually implemented so its still unlimited.

--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -108,6 +108,7 @@
   - type: WeldingHealing # EE IPCs
     damageContainers:
       - Silicon
+      - SiliconRadiation # Goobstation - Make IPCs take radiation
     fuelCost: 5
     damage:
       types:

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -23,7 +23,7 @@
       soundHit:
         path: /Audio/Effects/hit_kick.ogg
     - type: Damageable
-      damageContainer: Silicon
+      damageContainer: SiliconRadiation # Goobstation - Make IPCs take radiation
       damageModifierSet: IPC
     - type: InteractionOutline
     - type: MovementSpeedModifier

--- a/Resources/Prototypes/_Goobstation/Damage/containers.yml
+++ b/Resources/Prototypes/_Goobstation/Damage/containers.yml
@@ -5,3 +5,12 @@
   - Brute
   - Burn
 
+- type: damageContainer
+  id: SiliconRadiation
+  supportedGroups:
+    - Brute
+    - Electronic
+  supportedTypes:
+    - Heat
+    - Shock
+    - Radiation


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- makes IPCs take radiation damage
- makes plasteel heal 5 radiation on IPCs

## Why / Balance
IPCs currently have like one downside and many major upsides such as being able to ignore space and non-hot atmos and ignore several damage categories so this makes sense to make them not as OP

properly hard to heal since plasteel is fairly rare, but you can still just go and eat reinforced tables

## Media
tested, works

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: IPCs now take radiation damage. Plasteel can be used to heal it.
