### PR TITLE
make flesh ascension good

### DIFF
--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Mobs/NPC/polymorph.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Mobs/NPC/polymorph.yml
@@ -74,6 +74,15 @@
   components:
   - type: Bloodstream
     bloodMaxVolume: 1984
+    bleedReductionAmount: 2
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Blunt
+        damage: 3000 # no gibbing at 400
+      behaviors:
+      - !type:GibBehavior
   - type: NpcFactionMember
     factions:
     - Heretic
@@ -118,17 +127,19 @@
     thresholds:
       0: Alive
       1500: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      0: 1.0 # it's an unstoppable flesh abomination
   - type: Damageable
     damageContainer: Biological
   - type: StatusEffects
     allowed:
-    - SlowedDown
     - RadiationProtection
   - type: MeleeWeapon
     hidden: false
     altDisarm: false
     autoAttack: true
-    attackRate: 2.5
+    attackRate: 3
     damage:
       types:
        Blunt: 20
@@ -181,5 +192,12 @@
   - type: Flammable
     damage:
       types: {}
+  - type: Temperature
+    damageCap: 0 # immune to temperature damage
   - type: Puller
     needsHands: false
+  - type: InteractionPopup
+    successChance: 1
+    interactSuccessString: hugging-success-generic
+    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
+    messagePerceivedByOthers: hugging-success-generic-others


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- makes it actually take no fire damage like it says
- fixes slowdown on any amount of damage
- no more permableed
- doesn't gib on 400 blunt anymore (it has 1500 hp)
- attacks slightly faster
- huggable

## Why / Balance
flesh ascension is currently kinda bad since you lose all abilities and gear, and even despite that it still dies to man with gun, this makes it worth it
also the ascension description straight up lies to you about a few things

## Media
all tested, works

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Flesh ascension no longer takes temperature damage, slows down on a small amount of damage, or gibs on 400 blunt.
- tweak: Flesh ascension now attacks slightly faster, recovers quickly from bleed, and is huggable
