### PR TITLE
HECU is now space equipped 

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Back/specific.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Back/specific.yml
@@ -63,10 +63,10 @@
   components:
   - type: StorageFill
     contents:
-      - id: BoxMagazinePistolSubMachineGun
-      - id: MindShieldImplanter
+      - id: WeaponSubMachineGunDrozd
       - id: Zipties
       - id: Zipties
       - id: MedkitAdvancedFilled
       - id: WeaponPistolEchis
       - id: Flash
+      - id: ClothingOuterVestWeb

--- a/Resources/Prototypes/_Goobstation/Roles/GhostRoles/Fun/hecu.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/GhostRoles/Fun/hecu.yml
@@ -21,15 +21,21 @@
     jumpsuit: ClothingUniformHecu
     back: ClothingBackpackMercFilledHECU
     mask: ClothingMaskGasExplorer
+    head: ClothingHeadHelmetEVA
     eyes: ClothingEyesGlassesMedSec
     ears: ClothingHeadsetAltCentCom
     gloves: ClothingHandsGlovesCombat
-    outerClothing: ClothingOuterVestWeb
+    outerClothing: ClothingOuterHardsuitEVA
     shoes: ClothingShoesBootsCombatFilled
-    head: ClothingHeadHelmetMerc
     id: HecuPDA
     belt: ClothingBeltMercWebbing
-    pocket1: MagazinePistolSubMachineGun
-    pocket2: MagazinePistolSubMachineGun
-  inhand:
-  - WeaponSubMachineGunDrozd
+    pocket2: PinpointerStation
+    suitstorage: JetpackMiniFilled
+  storage:
+    belt:
+    - ClothingHeadHelmetMerc
+    - MagazinePistolSubMachineGun
+    - MagazinePistolSubMachineGun
+    - MagazinePistolSubMachineGun
+    - MagazinePistolSubMachineGun
+    - MagazinePistolSubMachineGun


### PR DESCRIPTION
Added EVA suit and helm, jetpack and station pinpointer. Reorganized HECU inventory.

## About the PR
HECU now has EVA suit and helm, A mini jetpack and s station pinpointer. I have moved around the inventory of HECU to fit stuff in nicely.

## Why / Balance
HECU cant breathe in space, So i allowed them to.
Also gave them a jetpack and a station pinpointer, Cargo/Salv sometimes doesn't listen to comms. They now have a independent way to get to the station.
The only time we see HECU is that spawn, and doesn't overly affect any other time HECU spawns, Just remove the EVA suit :)

## Technical details
Changed starting gear and `ClothingBackpackMercFilledHECU`:

Changed `outerClothing` to `ClothingOuterHardsuitEVA`
Changed `head` to `ClothingHeadHelmetEVA`
Removed the giant `BoxMagazinePistolSubMachineGun` from the bag.
Moved the total 5 `MagazinePistolSubMachineGun` from pockets/bag and the `ClothingHeadHelmetMerc` helm into the belt storage.
Moved the `WeaponSubMachineGunDrozd` and `ClothingOuterVestWeb` to `ClothingBackpackMercFilledHECU`
Removed `MindShieldImplanter` as HECU is already mindshielded
Changed `pocket2` to `PinpointerStation`

## Media
Don't think it is needed. Pretty self explanatory.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: CodeDJ
- tweak: HECU Operative is now space equipped to reach the station.
