### PR TITLE
Move disablers into security belts

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -53,6 +53,7 @@
     - id: Handcuffs
     - id: HoloprojectorSecurity
     - id: RadioHandheldSecurity
+    - id: WeaponDisabler #Goobstation
 
 - type: entity
   id: ClothingBeltSecurityFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -346,7 +346,7 @@
     - id: HoloprojectorSecurity
     - id: RubberStampHos
     - id: SecurityTechFabCircuitboard
-    - id: WeaponDisabler
+    #- id: WeaponDisabler #Goobstation (Disablers in belts)
     - id: WantedListCartridge
 # Hardsuit table, used for suit storage as well
 - type: entityTable

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -7,7 +7,7 @@
     contents:
       - id: FlashlightSeclite
       - id: WeaponEnergyShotgun
-      - id: WeaponDisabler
+      #- id: WeaponDisabler #Goobstation (Disablers in belts)
       - id: ClothingBeltSecurityFilled
       - id: Flash
       - id: ClothingEyesGlassesSecurity
@@ -37,7 +37,7 @@
     contents:
       - id: FlashlightSeclite
       - id: WeaponEnergyShotgun # Goobstation
-      - id: WeaponDisabler
+      #- id: WeaponDisabler #Goobstation (Disablers in belts)
       - id: ClothingBeltSecurityFilled
       - id: Flash
       - id: ClothingEyesGlassesSecurity
@@ -65,7 +65,7 @@
     contents:
       - id: FlashlightSeclite
         prob: 0.8
-      - id: WeaponDisabler
+      #- id: WeaponDisabler #Goobstation (Disablers in belts)
       - id: ClothingUniformJumpsuitSecGrey
         prob: 0.3
       - id: ClothingHeadHelmetBasic

--- a/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -134,7 +134,7 @@
     ears: ClothingHeadsetAltSecurity
     eyes: ClothingEyesGlassesSecurity
     outerClothing: ClothingOuterCoatHoSTrench
-    pocket1: WeaponDisabler
+    #pocket1: WeaponDisabler #Goobstation (Disablers in belts)
     pocket2: MagazinePistolSubMachineGunTopMounted
   inhand:
   - WeaponSubMachineGunWt550
@@ -152,7 +152,7 @@
     back: ClothingBackpackSatchelLeather
     ears: ClothingHeadsetAltSecurity
     eyes: ClothingEyesGlassesSecurity
-    pocket1: WeaponDisabler
+    #pocket1: WeaponDisabler #Goobstation (Disablers in belts)
     pocket2: MagazinePistolSubMachineGunTopMounted
   inhand:
   - WeaponSubMachineGunWt550
@@ -354,7 +354,7 @@
     ears: ClothingHeadsetAltSecurityRegular # Goobstation
     eyes: ClothingEyesGlassesSecurity
     outerClothing: ClothingOuterWinterWarden
-    pocket1: WeaponDisabler
+    #pocket1: WeaponDisabler #Goobstation (Disablers in belts)
     pocket2: Zipties
   inhand:
   - FlashlightSeclite

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -33,7 +33,7 @@
     id: SecurityCadetPDA
     ears: ClothingHeadsetAltSecurityRegular # Goobstation
     belt: ClothingBeltSecurityFilled
-    pocket1: WeaponDisabler
+    #pocket1: WeaponDisabler #Goobstation (Disablers in belts)
     pocket2: BookSecurity
   storage:
     back:

--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
@@ -27,7 +27,6 @@
   id: LockerFillBlueshieldOfficer
   table: !type:AllSelector
     children:
-    - id: WeaponDisabler
     - id: ClothingHeadHelmetSwat
     - id: Flash
     - id: FlashlightSeclite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added disablers to the contents of filled secbelts
Removed disablers from anywhere there was also a security belt (lockers and cadets)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
QoL for officers who should grab a disabler anyway, cadets spawn with disablers but officers do not, officers should spawn with disablers so that they are further discouraged from using lethal force.

## Technical details
<!-- Summary of code changes for easier review. -->
Changed content tables for some lockers and security belts


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Added disablers to security belts by default. Anywhere you could find a disabler and a belt the disabler was removed (because its in the belt now).
-->
