### PR TITLE
Emancizine

### DIFF
--- a/Content.Server/EntityEffects/Effects/MakeSentientFreeAgent.cs
+++ b/Content.Server/EntityEffects/Effects/MakeSentientFreeAgent.cs
@@ -1,0 +1,55 @@
+using Content.Server.Ghost.Roles.Components;
+using Content.Server.Speech.Components;
+using Content.Shared.EntityEffects;
+using Content.Shared.Mind.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.EntityEffects.Effects;
+
+public sealed partial class MakeSentientFreeAgent : EntityEffect
+{
+    [Dependency] private readonly PopupSystem _popup = default!;
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        => Loc.GetString("reagent-effect-guidebook-make-sentient-freeagent", ("chance", Probability));
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        var entityManager = args.EntityManager;
+        var uid = args.TargetEntity;
+
+        // Let affected entities speak normally to make this effect different from, say, the "random sentience" event
+        // This also works on entities that already have a mind
+        // We call this before the mind check to allow things like player-controlled mice to be able to benefit from the effect
+        entityManager.RemoveComponent<ReplacementAccentComponent>(uid);
+        entityManager.RemoveComponent<MonkeyAccentComponent>(uid);
+
+        // Stops from adding a ghost role to things like people who already have a mind
+        if (entityManager.TryGetComponent<MindContainerComponent>(uid, out var mindContainer) && mindContainer.HasMind)
+        {
+            return;
+        }
+
+        // Convert pre-existing ghost roles (if present) into Free Agents
+        if (entityManager.TryGetComponent(uid, out GhostRoleComponent? ghostRole))
+        {
+            // silly workaround, make this proper if/when MindRoles get added
+            if (ghostRole.RoleRules == Loc.GetString("ghost-role-information-freeagent-rules"))
+            {
+                return;
+            }
+
+            ghostRole.RoleDescription += " " + Loc.GetString("ghost-role-information-emancizine-converted-description");
+            ghostRole.RoleRules = Loc.GetString("ghost-role-information-freeagent-rules");
+
+            return;
+        }
+
+        ghostRole = entityManager.AddComponent<GhostRoleComponent>(uid);
+        entityManager.EnsureComponent<GhostTakeoverAvailableComponent>(uid);
+
+        var entityData = entityManager.GetComponent<MetaDataComponent>(uid);
+        ghostRole.RoleName = entityData.EntityName;
+        ghostRole.RoleDescription = Loc.GetString("ghost-role-information-emancizine-description");
+        ghostRole.RoleRules = Loc.GetString("ghost-role-information-freeagent-rules");
+    }
+}

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -50,6 +50,9 @@ ghost-role-information-giant-spider-rules = You are a [color=red][bold]Team Anta
 
 ghost-role-information-cognizine-description = Made conscious with the magic of cognizine.
 
+ghost-role-information-emancizine-description = Made conscious with the magic of emancizine; you have free will!
+ghost-role-information-emancizine-converted-description = Given free will with the magic of emancizine.
+
 ghost-role-information-hamster-name = Hamster
 ghost-role-information-hamster-description = A grumpy little ball of fluff.
 

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -276,6 +276,12 @@ reagent-effect-guidebook-make-sentient =
         *[other] make
     } the metabolizer sentient
 
+reagent-effect-guidebook-make-sentient-freeagent =
+    { $chance ->
+        [1] Makes
+        *[other] make
+    } the metabolizer sentient as a Free Agent
+
 reagent-effect-guidebook-make-polymorph =
     { $chance ->
         [1] Polymorphs

--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -97,6 +97,9 @@ reagent-desc-ethylredoxrazine = Neutralises the effects of alcohol in the blood 
 reagent-name-cognizine = cognizine
 reagent-desc-cognizine = A mysterious chemical which is able to make any non-sentient creature sentient.
 
+reagent-name-emancizine = emancizine
+reagent-desc-emancizine = A derivative of cognizine, and is able to make any non-sentient creature sentient, with free will. Can not be used in cooking, unlike cognizine. Use with great caution.
+
 reagent-name-ethyloxyephedrine = ethyloxyephedrine
 reagent-desc-ethyloxyephedrine = A mildly unstable medicine derived from desoxyephedrine, primarily used to combat narcolepsy.
 

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-bottles.yml
@@ -363,6 +363,21 @@
           Quantity: 30
 
 - type: entity
+  parent: BaseChemistryBottleFilled
+  id: EmancizineChemistryBottle
+  suffix: emancizine
+  components:
+  - type: Label
+    currentLabel: reagent-name-emancizine
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 30
+        reagents:
+        - ReagentId: Emancizine
+          Quantity: 30
+
+- type: entity
   id: PaxChemistryBottle
   suffix: pax
   parent: BaseChemistryBottleFilled

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -795,6 +795,7 @@
     - Pax
     - Ipecac
     - Cognizine
+    - Emancizine
     - Beer
     - SpaceGlue
     - SpaceLube

--- a/Resources/Prototypes/Hydroponics/randomChemicals.yml
+++ b/Resources/Prototypes/Hydroponics/randomChemicals.yml
@@ -10,6 +10,7 @@
     - Honk
     - BuzzochloricBees
     - Stimulants
+    - Emancizine
   - quantity: 5
     weight: 1
     reagents:

--- a/Resources/Prototypes/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/Procedural/salvage_loot.yml
@@ -27,6 +27,8 @@
         - proto: CloningPodMachineCircuitboard
           cost: 2
         - proto: CognizineChemistryBottle
+        - proto: EmancizineChemistryBottle
+          prob: 0.7
         - proto: FoodBoxDonkpocketCarp
           prob: 0.5
         - proto: CrateSalvageEquipment

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -948,6 +948,22 @@
           min: 5
 
 - type: reagent
+  id: Emancizine
+  name: reagent-name-emancizine
+  desc: reagent-desc-emancizine
+  group: Medicine
+  physicalDesc: reagent-physical-desc-enigmatic
+  flavor: magical
+  color: "#d6094a"
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:MakeSentientFreeAgent
+        conditions:
+        - !type:ReagentThreshold
+          min: 5
+
+- type: reagent
   id: Ethyloxyephedrine
   name: reagent-name-ethyloxyephedrine
   desc: reagent-desc-ethyloxyephedrine

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -381,6 +381,21 @@
     Cognizine: 1
 
 - type: reaction
+  id: Emancizine
+  impact: High
+  reactants:
+    Cognizine:
+      amount: 1
+    Vestine:
+      amount: 2
+    NorepinephricAcid:
+      amount: 1
+    MindbreakerToxin:
+      amount: 1
+  products:
+    Emancizine: 1
+
+- type: reaction
   id: Sigynate
   impact: Medium
   minTemp: 370
@@ -561,7 +576,7 @@
   id: Opporozidone
   minTemp: 400 #Maybe if a method of reducing reagent temp exists one day, this could be -50
   reactants:
-    Cognizine: 
+    Cognizine:
       amount: 1
     Plasma:
       amount: 2

--- a/Resources/Prototypes/_NF/Mail/Items/misc.yml
+++ b/Resources/Prototypes/_NF/Mail/Items/misc.yml
@@ -53,6 +53,19 @@
           Quantity: 15 # Surely three friends is enough.
 
 - type: entity
+  id: SyringeEmancizine
+  parent: Syringe
+  name: emancizine syringe
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 15
+        reagents:
+        - ReagentId: Emancizine
+          Quantity: 15 # Surely three evil-ish friends(?) is enough.
+
+- type: entity
   id: SyringeOpporozidone
   parent: Syringe
   name: opporozidone syringe


### PR DESCRIPTION
## About the PR
_(yes, this is basically just https://github.com/space-wizards/space-station-14/pull/34707 , which i'm the author of too.)_

Adds a new chemical: Emancizine. 
Works almost exactly like cognizine, but:
1. Instead of making non-antag ghost roles out of non-sentient mobs, instead makes free agent ghost roles.
2. If used on a mob that already has a ghost role, converts that ghost role into a free agent if it isn't already one.

1 unit of emancizine can be produced with:
1u cognizine, 2u vestine, 1u mindbreaker toxin, 1u norepinephric acid.

..which means 60u of vestine (4TC worth of vestine) and appropriate amounts of the other precursors
will yield 30u of emancizine, equivalent to 6 uses of it.

Has the same examine text ('enigmatic') as cognizine, but is tinted red.

## Why / Balance
Traitors usually have only one way to convert people onto their side, being mind control implants. Emancizine allows traitors to make free agents out of mobs, who can choose to either team up with the traitor(s) that made them sentient, or to betray them.

Emancizine can be found in bottles of 30 units (6 uses) each as salvage loot.
Emancizine can also very rarely be found as a random botanical chem, with the same rarity as omnizine, lexorin and nocturine,
and as a random chem from anomalies, with the same rarity as cognizine.

## Technical details
Adds a new reagent effect, MakeSentientFreeAgent, that does all of the effects listed at the start of the PR.
Uses a (tiny) bit of shitcode to figure out if ghostroles are free agents, should fix that when (if ever) MindRoles
get ported from wizden.

## Media
demo: https://www.youtube.com/watch?v=vIWoxpHKyp8

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Added Emancizine, a reagent alike to cognizine, that can make sentient creatures with free will (free agents), and convert existing non-sentient creatures into sentient free agents. 1 unit of emancizine is made with 1u of cognizine, mindbreaker toxin, & norepinephric acid each and 2u vestine.