### PR TITLE
pen recipe in autolathe

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -17,7 +17,7 @@
     - Pen
   - type: PhysicalComposition #Goobstation - Recycle update
     materialComposition:
-      Plastic: 12
+      Steel: 25
   - type: EmitSoundOnUse
     sound:
       path: /Audio/Items/pen_click.ogg

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -208,6 +208,7 @@
       - ClothingHeadHatCone
       - FreezerElectronics
       - ToolboxMechanical # Goobstation - Recycle update
+      - Pen # Goobstation - Allow pen printing
   - type: EmagLatheRecipes
     emagStaticRecipes:
       - BoxLethalshot

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/tools.yml
@@ -18,6 +18,6 @@
 - type: latheRecipe
   id: Pen
   result: Pen
-  completeTime: 1
+  completetime: 1
   materials:
     Steel: 25 # should probably cost less than matter bins or whatever

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/tools.yml
@@ -14,3 +14,10 @@
     Plastic: 500
     Cloth: 200
     Steel: 100
+
+- type: latheRecipe
+  id: Pen
+  result: Pen
+  completeTime: 1
+  materials:
+    Steel: 25 # should probably cost less than matter bins or whatever


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
allows autolathe to print pens for 0.25 steel each

## Why / Balance
why could they not before

## Media
tested, works

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: You can now print pens at an autolathe.
