### PR TITLE
Allow Disabler SMGs to fit into security belts

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -508,13 +508,13 @@
   description: Advanced weapon that exhausts organic targets, weakening them until they collapse.
   components:
   - type: Item
-    size: Normal
+    size: Normal #Goobstation
     shape:
-    - 0,0,2,1
+    - 0,0,2,1 #Goobstation
   - type: Tag
     tags:
       - Taser
-      - SecBeltEquip
+      - SecBeltEquip #Goobstation
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/disabler_smg.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -508,10 +508,13 @@
   description: Advanced weapon that exhausts organic targets, weakening them until they collapse.
   components:
   - type: Item
-    size: Large
+    size: Normal
+    shape:
+    - 0,0,2,1
   - type: Tag
     tags:
       - Taser
+      - SecBeltEquip
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/disabler_smg.rsi
     layers:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Change Disabler SMGs to be a medium 3x2 item, so that they can fit inside security belts

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It makes sense that the disabler SMG should clip into a belt, its one handed and only slightly larger than a disabler, this takes up the space of 2 disablers.

I also want to implement security equipment loadouts where you can start with different stuff in your belt, inspired by SS13's Goonstation (https://wiki.ss13.co/Security_Objects#Security_Weapons_Vendor) to increase customisation in how security combat plays, and the SMG needs to fit in the belt to work with this.

## Technical details
<!-- Summary of code changes for easier review. -->
Change the item size on DisablerSMG to a 3x2 medium item
Also adds SecBeltEquip tag to disabler SMG

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/fc7d3033-b1ce-45f1-992f-c338aff675ed)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Disabler SMGs are now a 3x2 medium item that can fit inside security belts
