### PR TITLE
Administration HUD Improvements

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -204,6 +204,7 @@
   - type: IdentityBlocker
     coverage: EYES
   - type: ShowJobIcons
+  - type: ShowMindShieldIcons # Goobstation
 
 - type: entity
   parent: ClothingEyesBase

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -69,6 +69,7 @@
   - type: Clothing
     sprite: Clothing/Eyes/Hud/command.rsi
   - type: ShowJobIcons
+  - type: ShowMindShieldIcons # Goobstation
 
 - type: entity
   parent: ClothingEyesBase

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -35,7 +35,7 @@
   id: CaptainGear
   equipment:
     shoes: ClothingShoesBootsLaceup
-    eyes: ClothingEyesGlassesSunglasses
+    eyes: ClothingEyesGlassesCommand #Goobstation
     gloves: ClothingHandsGlovesCaptain
     id: CaptainPDA
     ears: ClothingHeadsetAltCommand

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -58,7 +58,7 @@
 - type: startingGear
   id: HoPGear
   equipment:
-    eyes: ClothingEyesHudCommand
+    eyes: ClothingEyesHudCommand # Goobstation
     shoes: ClothingShoesColorBrown
     id: HoPPDA
     gloves: ClothingHandsGlovesHop

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -58,6 +58,7 @@
 - type: startingGear
   id: HoPGear
   equipment:
+    eyes: ClothingEyesHudCommand
     shoes: ClothingShoesColorBrown
     id: HoPPDA
     gloves: ClothingHandsGlovesHop

--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
@@ -10,6 +10,7 @@
     - id: HandheldFaxNanorep
     - id: RubberStampNanorep
     - id: Paper
+    - id: ClothingEyesHudCommand
       amount: !type:ConstantNumberSelector
         value: 5
 

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
@@ -37,6 +37,7 @@
 - type: startingGear
   id: NanotrasenRepresentativeGear
   equipment:
+    eyes: ClothingEyesHudCommand
     id: CentcomPDA
     ears: ClothingHeadsetAltCentCom
     pocket1: UniqueNanorepLockerTeleporter


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Administration HUDs and Glasses now show mindshield icons
HoP and NTR spawn with adminhuds
Captain spawns with admin glasses
NTR gets an adminhud in their locker

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Mindshield is important for HoP and cap to check before promotions, and NTR to check SOP is being followed.

## Technical details
<!-- Summary of code changes for easier review. -->
Add ShowMindShieldIcons component to both Administration glasses and Administration HUD

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: AdministrativeHUDs now show mindshield icons.
- tweak: Captain, NTR and HoP now spawn with Administrative HUDs, the captain with flashproof ones.

