### PR TITLE
Fix NukeOps Test

### DIFF
--- a/Content.IntegrationTests/Tests/GameRules/NukeOpsTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/NukeOpsTest.cs
@@ -225,13 +225,15 @@ public sealed class NukeOpsTest
         var totalSeconds = 30;
         var totalTicks = (int) Math.Ceiling(totalSeconds / server.Timing.TickPeriod.TotalSeconds);
         var increment = 5;
-        var resp = entMan.GetComponent<RespiratorComponent>(player);
         var damage = entMan.GetComponent<DamageableComponent>(player);
         for (var tick = 0; tick < totalTicks; tick += increment)
         {
             await pair.RunTicksSync(increment);
-            if (!entMan.HasComponent<SiliconComponent>(player)) // Goobstation
+            if (!entMan.HasComponent<SiliconComponent>(player)) // Goobstation - IPC
+            {
+                var resp = entMan.GetComponent<RespiratorComponent>(player);
                 Assert.That(resp.SuffocationCycles, Is.LessThanOrEqualTo(resp.SuffocationCycleThreshold));
+            }
             Assert.That(damage.TotalDamage, Is.EqualTo(FixedPoint2.Zero));
         }
 


### PR DESCRIPTION
## About the PR
Test were checking for SiliconComponent (for IPCs) after checking RespiratorComponent (IPCs don't have it)
