### PR TITLE
Nukie base QOL

### DIFF
--- a/Resources/Maps/_Goobstation/Nonstations/nukieplanet-honkops.yml
+++ b/Resources/Maps/_Goobstation/Nonstations/nukieplanet-honkops.yml
@@ -1321,6 +1321,13 @@ entities:
     - type: Transform
       pos: -6.5,-10.5
       parent: 2
+- proto: BiomassReclaimer
+  entities:
+  - uid: 2448
+    components:
+    - type: Transform
+      pos: -8.5,-10.5
+      parent: 2
 - proto: BlastDoor
   entities:
   - uid: 94
@@ -5616,6 +5623,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: -3.5,-19.5
       parent: 2
+- proto: GeneratorBasic
+  entities:
+  - uid: 2449
+    components:
+    - type: Transform
+      pos: 31.5,-8.5
+      parent: 2
+  - uid: 2450
+    components:
+    - type: Transform
+      pos: 30.5,-8.5
+      parent: 2
 - proto: GeneratorBasic15kW
   entities:
   - uid: 837
@@ -5623,12 +5642,10 @@ entities:
     - type: Transform
       pos: 31.5,-10.5
       parent: 2
-- proto: GeneratorRTG
-  entities:
   - uid: 838
     components:
     - type: Transform
-      pos: 30.5,-10.5
+      pos: 29.5,-8.5
       parent: 2
   - uid: 839
     components:
@@ -5643,7 +5660,17 @@ entities:
   - uid: 841
     components:
     - type: Transform
-      pos: 29.5,-8.5
+      pos: 30.5,-10.5
+      parent: 2
+  - uid: 2451
+    components:
+    - type: Transform
+      pos: 31.5,-9.5
+      parent: 2
+  - uid: 2452
+    components:
+    - type: Transform
+      pos: 30.5,-9.5
       parent: 2
 - proto: GravityGeneratorMini
   entities:
@@ -6289,7 +6316,7 @@ entities:
       angularDamping: 0
       linearDamping: 0
       canCollide: False
-- proto: HydroponicsTrayEmpty
+- proto: hydroponicsTray
   entities:
   - uid: 964
     components:
@@ -9256,6 +9283,11 @@ entities:
     - type: Transform
       pos: -7.5,-1.5
       parent: 2
+  - uid: 2446
+    components:
+    - type: Transform
+      pos: -10.5,-10.5
+      parent: 2
 - proto: TableReinforced
   entities:
   - uid: 1456
@@ -9514,6 +9546,19 @@ entities:
     - type: Transform
       pos: 28.515644,-30.613081
       parent: 2
+- proto: TwoWayLever
+  entities:
+  - uid: 2447
+    components:
+    - type: Transform
+      pos: -7.5,-13.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        1242:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
 - proto: VendingMachineBooze
   entities:
   - uid: 1501

--- a/Resources/Maps/_Goobstation/Nonstations/nukieplanet.yml
+++ b/Resources/Maps/_Goobstation/Nonstations/nukieplanet.yml
@@ -67,6 +67,10 @@ entities:
         - 0
         - 0
         - 0
+        - 0
+        - 0
+        - 0
+        - 0
     - type: LoadedMap
   - uid: 2
     components:
@@ -725,6 +729,10 @@ entities:
           - 0
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
         - volume: 2500
           immutable: True
           temperature: 248.15
@@ -741,11 +749,19 @@ entities:
           - 0
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
         - volume: 2500
           temperature: 293.14365
           moles:
           - 21.711672
           - 81.677246
+          - 0
+          - 0
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -1308,6 +1324,13 @@ entities:
     components:
     - type: Transform
       pos: -6.5,-10.5
+      parent: 2
+- proto: BiomassReclaimer
+  entities:
+  - uid: 2399
+    components:
+    - type: Transform
+      pos: -8.5,-10.5
       parent: 2
 - proto: BlastDoor
   entities:
@@ -4641,7 +4664,7 @@ entities:
     - type: Transform
       pos: 24.5,-15.5
       parent: 2
-- proto: FloraTreeConifer01
+- proto: FloraTreeConifer
   entities:
   - uid: 716
     components:
@@ -4743,15 +4766,11 @@ entities:
     - type: Transform
       pos: 31.977348,-23.940697
       parent: 2
-- proto: FloraTreeConifer02
-  entities:
   - uid: 733
     components:
     - type: Transform
       pos: 10.992382,-20.738451
       parent: 2
-- proto: FloraTreeConifer03
-  entities:
   - uid: 734
     components:
     - type: Transform
@@ -4767,7 +4786,7 @@ entities:
     - type: Transform
       pos: 26.703283,-24.807884
       parent: 2
-- proto: FloraTreeSnow01
+- proto: FloraTreeSnow
   entities:
   - uid: 737
     components:
@@ -4835,8 +4854,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 8.884738,9.986916
       parent: 2
-- proto: FloraTreeSnow02
-  entities:
   - uid: 748
     components:
     - type: Transform
@@ -4880,8 +4897,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 20.93752,-1.8255849
       parent: 2
-- proto: FloraTreeSnow03
-  entities:
   - uid: 756
     components:
     - type: Transform
@@ -4912,8 +4927,6 @@ entities:
     - type: Transform
       pos: 18.031408,-23.565697
       parent: 2
-- proto: FloraTreeSnow04
-  entities:
   - uid: 762
     components:
     - type: Transform
@@ -4924,8 +4937,6 @@ entities:
     - type: Transform
       pos: 17.833273,-21.095894
       parent: 2
-- proto: FloraTreeSnow06
-  entities:
   - uid: 764
     components:
     - type: Transform
@@ -5396,6 +5407,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: -3.5,-19.5
       parent: 2
+- proto: GeneratorBasic
+  entities:
+  - uid: 2402
+    components:
+    - type: Transform
+      pos: 30.5,-8.5
+      parent: 2
+  - uid: 2403
+    components:
+    - type: Transform
+      pos: 31.5,-8.5
+      parent: 2
 - proto: GeneratorBasic15kW
   entities:
   - uid: 837
@@ -5403,27 +5426,35 @@ entities:
     - type: Transform
       pos: 31.5,-10.5
       parent: 2
-- proto: GeneratorRTG
-  entities:
   - uid: 838
     components:
     - type: Transform
-      pos: 30.5,-10.5
+      pos: 29.5,-8.5
       parent: 2
   - uid: 839
     components:
     - type: Transform
-      pos: 32.5,-9.5
+      pos: 32.5,-8.5
       parent: 2
   - uid: 840
     components:
     - type: Transform
-      pos: 32.5,-8.5
+      pos: 32.5,-9.5
       parent: 2
   - uid: 841
     components:
     - type: Transform
-      pos: 29.5,-8.5
+      pos: 30.5,-10.5
+      parent: 2
+  - uid: 2400
+    components:
+    - type: Transform
+      pos: 31.5,-9.5
+      parent: 2
+  - uid: 2401
+    components:
+    - type: Transform
+      pos: 30.5,-9.5
       parent: 2
 - proto: GravityGeneratorMini
   entities:
@@ -6069,7 +6100,7 @@ entities:
       angularDamping: 0
       linearDamping: 0
       canCollide: False
-- proto: HydroponicsTrayEmpty
+- proto: hydroponicsTray
   entities:
   - uid: 964
     components:
@@ -6392,7 +6423,7 @@ entities:
   - uid: 1013
     components:
     - type: Transform
-      pos: -3.8367076,-14.575489
+      pos: -3.5601501,-14.375952
       parent: 2
     - type: Physics
       angularDamping: 0
@@ -8988,6 +9019,11 @@ entities:
     - type: Transform
       pos: -7.5,-1.5
       parent: 2
+  - uid: 2397
+    components:
+    - type: Transform
+      pos: -10.5,-10.5
+      parent: 2
 - proto: TableReinforced
   entities:
   - uid: 1456
@@ -9246,6 +9282,19 @@ entities:
     - type: Transform
       pos: 28.515644,-30.613081
       parent: 2
+- proto: TwoWayLever
+  entities:
+  - uid: 2398
+    components:
+    - type: Transform
+      pos: -7.5,-13.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        1242:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
 - proto: VendingMachineBooze
   entities:
   - uid: 1501


### PR DESCRIPTION
## About the PR
Adds: a biomass extractor for the biomass fabricator, a linked lever for the industrial reagent grinder, the hydroponics trays no longer start unusable, and there is now just enough power for both the hellfire burner and freezer to run (previously not enough for EITHER). Also adds it on the honkops map.

## Why / Balance
It's cool having nukies get more/easier access to sandbox stuff, and it's already discouraged by nukies having a very limited time to do so.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![Screenshot (885)](https://github.com/user-attachments/assets/43bb6792-9a3e-492c-82b2-bf10abcd2c99)
![Screenshot (886)](https://github.com/user-attachments/assets/a885f313-14f4-4a6d-87d5-7e2ee605a8ef)



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->