### PR TITLE
Add the tactical ability to attach a seclite to a helmet.

### DIFF
--- a/Content.Server/Clothing/Systems/SecurityHelmetSystem.cs
+++ b/Content.Server/Clothing/Systems/SecurityHelmetSystem.cs
@@ -1,0 +1,68 @@
+using Content.Shared.Clothing;
+using Content.Shared.Actions;
+using Content.Shared.Light.Components;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Inventory.Events;
+using Robust.Shared.Containers;
+
+namespace Content.Server.GameObjects.Systems
+{
+
+    public sealed class SecurityHelmetSystem : EntitySystem
+    {
+        [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
+        [Dependency] private readonly ItemSlotsSystem _itemSlotsSystem = default!;
+
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            // Listen for when a player uses an item on the helmet
+            SubscribeLocalEvent<SecurityHelmetComponent, GotEquippedEvent>(OnGotEquipped);
+            SubscribeLocalEvent<SecurityHelmetComponent, GotUnequippedEvent>(OnGotUnequipped);
+            SubscribeLocalEvent<SecurityHelmetComponent, EntRemovedFromContainerMessage>(OnSecliteRemoved);
+            SubscribeLocalEvent<SecurityHelmetComponent, EntInsertedIntoContainerMessage>(OnSecliteInserted);
+
+        }
+        private void OnSecliteRemoved(EntityUid uid, SecurityHelmetComponent component, EntRemovedFromContainerMessage args)
+        {
+            // If worn on head by the action taker then remove the securityhelmet.SecliteEntity action via RemoveAction.
+            if (component.Wearer != null)
+            {
+                _actionsSystem.RemoveAction((EntityUid) component.Wearer, component.SecliteEntity);
+            }
+        }
+        private void OnSecliteInserted(EntityUid uid, SecurityHelmetComponent component, EntInsertedIntoContainerMessage args)
+        {
+            // If worn on head by the action taker add the lightcomponent.toggleaction via addAction.
+            if (component.Wearer != null && TryComp(args.Entity, out HandheldLightComponent? lightComponent))
+            {
+                _actionsSystem.AddAction((EntityUid) component.Wearer, ref component.SecliteEntity, lightComponent.ToggleAction, args.Entity);
+            }
+        }
+        private void OnGotEquipped(EntityUid uid, SecurityHelmetComponent component, GotEquippedEvent args)
+        {
+            var secliteOption = _itemSlotsSystem.GetItemOrNull(uid, "item");
+
+            if (secliteOption != null &&
+              TryComp(secliteOption, out HandheldLightComponent? lightComponent))
+            {
+                component.Wearer = args.Equipee;
+                _actionsSystem.AddAction(args.Equipee, ref component.SecliteEntity, lightComponent.ToggleAction, (EntityUid) secliteOption);
+            }
+        }
+
+        private void OnGotUnequipped(EntityUid uid, SecurityHelmetComponent component, GotUnequippedEvent args)
+        {
+            var secliteOption = _itemSlotsSystem.GetItemOrNull(uid, "item");
+
+            if (secliteOption != null)
+            {
+                component.Wearer = null;
+                _actionsSystem.RemoveAction(args.Equipee, component.SecliteEntity);
+            }
+        }
+
+    }
+}

--- a/Content.Shared/Clothing/Components/SecurityHelmetComponent.cs
+++ b/Content.Shared/Clothing/Components/SecurityHelmetComponent.cs
@@ -1,0 +1,16 @@
+
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Clothing;
+
+[RegisterComponent]
+[NetworkedComponent]
+[AutoGenerateComponentState]
+public sealed partial class SecurityHelmetComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public EntityUid? SecliteEntity;
+
+    [DataField, AutoNetworkedField]
+    public EntityUid? Wearer;
+}

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsComponent.cs
@@ -21,7 +21,7 @@ namespace Content.Shared.Containers.ItemSlots
         ///     The dictionary that stores all of the item slots whose interactions will be managed by the <see
         ///     cref="ItemSlotsSystem"/>.
         /// </summary>
-        [DataField(readOnly:true)]
+        [DataField(readOnly: true)]
         public Dictionary<string, ItemSlot> Slots = new();
 
         // There are two ways to use item slots:
@@ -73,6 +73,9 @@ namespace Content.Shared.Containers.ItemSlots
 
         [DataField]
         public EntityWhitelist? Blacklist;
+
+        [DataField]
+        public bool OccludesLight = true;
 
         [DataField]
         public SoundSpecifier InsertSound = new SoundPathSpecifier("/Audio/Weapons/Guns/MagIn/revolver_magin.ogg");

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -74,7 +74,7 @@ namespace Content.Shared.Containers.ItemSlots
                     continue;
 
                 var item = Spawn(slot.StartingItem, Transform(uid).Coordinates);
-                    
+
                 if (slot.ContainerSlot != null)
                     _containers.Insert(item, slot.ContainerSlot);
             }
@@ -88,6 +88,7 @@ namespace Content.Shared.Containers.ItemSlots
             foreach (var (id, slot) in itemSlots.Slots)
             {
                 slot.ContainerSlot = _containers.EnsureContainer<ContainerSlot>(uid, id);
+                slot.ContainerSlot.OccludesLight = slot.OccludesLight;
             }
         }
 

--- a/Content.Shared/Tools/Components/SecliteComponent.cs
+++ b/Content.Shared/Tools/Components/SecliteComponent.cs
@@ -1,0 +1,8 @@
+
+namespace Content.Shared.Clothing;
+
+[RegisterComponent]
+public sealed partial class SecliteComponent : Component
+{
+
+}

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -36,6 +36,15 @@
     tags:
     - WhitelistChameleon
     - SecurityHelmet
+  - type: SecurityHelmet
+  - type: ItemSlots
+    slots:
+      item:
+        name: Seclite
+        occludesLight: false
+        whitelist:
+          components:
+          - Seclite
 
 #Mercenary Helmet
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -128,6 +128,7 @@
     quickEquip: false
     slots:
       - Belt
+  - type: Seclite
 
 - type: entity
   parent: FlashlightLantern


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
`ItemsSlotComponent` can now have an additional value specified through yml called `occludesLight`, true by default.
The helmet now has an `ItemsSlotComponent` and the container does not occlude light. The seclite can be equiped and unequiped by interacting with the helmet and alt clicking, the usual way. The light can be toggled on and off in the top left as an action.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It mianly gives security personnel a tactical advantage by no longer being requiring them to keep seclites in their hands and pockets; freeing up space.
## Technical details
<!-- Summary of code changes for easier review. -->
Both ItemsSlotComponent.cs and ItemsSlotSystems.cs have a minor update.
Creation of the SecurityHelmetComponent and the SecliteComponent.
Both Seclite and SecurityHelmet ymls have minor a update.
Helmets now have an ItemSlotComponent that can only equip seclites.
The wearer of the helmet with a seclite attached can perform the seclite light toggle action.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes

https://github.com/user-attachments/assets/1d9a467a-256d-47c3-8803-13540e680a15

/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Seclites can now be attached to helmets.
-->
