### PR TITLE
bulk mosin crate

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Goobstation/store/uplink-catalog.ftl
@@ -76,6 +76,9 @@ uplink-dualetta-bundle-desc = Comes with 2 Dualetta pistols, 2 machine pistol ma
 uplink-anaconda-name = Anaconda
 uplink-anaconda-desc = The pride of the Cybersun arms concern, this heavy pistol is designed to feed itself with the built-in fabricator.
 
+uplink-bulk-mosin-name = Syndicate bulk rifle crate
+uplink-bulk-mosin-desc = 10 WW4-era rifles to arm you, your friends, and your cat. Saves 40% on shipping costs by buying in bulk.
+
 # Ammo
 
 uplink-blast-grenade-name = Blast Grenade

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -46,6 +46,8 @@
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
+  - type: Item # Goobstation - Bulk mosin crate
+    size: Large
 
 - type: entity
   name: Hristov

--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Crates/syndicate.yml
@@ -34,9 +34,13 @@
   suffix: Filled
   parent: CrateSyndicate
   name: Syndicate bulk rifle crate
-  description: Contains cheap rifles. A lot of cheap rifles.
+  description: Just use more rifles, comrade.
   components:
     - type: StorageFill
       contents:
         - id: WeaponSniperMosin
           amount: 10
+        - id: ClothingHeadHatUshanka
+          amount: 5
+        - id: DrinkVodkaBottleFull
+          amount: 3

--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Crates/syndicate.yml
@@ -28,3 +28,15 @@
       - id: DoubleEmergencyNitrogenTankFilled
       - id: ToolboxSyndicateFilled
       - id: PlushieNuke
+
+- type: entity
+  id: CrateSyndicateBulkMosin
+  suffix: Filled
+  parent: CrateSyndicate
+  name: Syndicate bulk rifle crate
+  description: Contains cheap rifles. A lot of cheap rifles.
+  components:
+    - type: StorageFill
+      contents:
+        - id: WeaponSniperMosin
+          amount: 10

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -179,6 +179,16 @@
   categories:
   - UplinkWeaponry
 
+- type: listing
+  id: UplinkBulkMosin
+  name: uplink-bulk-mosin-name
+  description: uplink-bulk-mosin-desc
+  productEntity: CrateSyndicateBulkMosin
+  cost:
+    Telecrystal: 25
+  categories:
+    - UplinkWeaponry
+
 # Wearables
 
 - type: listing


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
see media
also makes mosin 4x2 in inventory
only 5 ushankas to not spam entities too much but if told it's fine i'll make it 10

## Why / Balance
funny
balanced since you aren't really killing anyone with mosins so them being this cheap is fine
the bonus items are just for extra funny

mosin being 4x4 was just bad should've been 4x2

## Media
![image](https://github.com/user-attachments/assets/802d899b-4162-4794-a517-c23a22aa44f1)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Syndicate bulk mosin crate.
- tweak: Mosins are now 4x2.
