### PR TITLE
pierce armor resists syringe gun

### DIFF
--- a/Content.Server/Chemistry/Components/BaseSolutionInjectOnEventComponent.cs
+++ b/Content.Server/Chemistry/Components/BaseSolutionInjectOnEventComponent.cs
@@ -1,4 +1,5 @@
-﻿using Content.Shared.FixedPoint;
+﻿using Content.Shared.Damage; // Goobstation - Armor resisting syringe gun
+using Content.Shared.FixedPoint;
 using Content.Shared.Inventory;
 
 namespace Content.Server.Chemistry.Components;
@@ -37,10 +38,17 @@ public abstract partial class BaseSolutionInjectOnEventComponent : Component
     public string Solution = "default";
 
     /// <summary>
-    /// Whether this will inject through hardsuits or not.
+    /// Whether this will inject through armor or not. // Goobstation - Armor resisting syringe gun
     /// </summary>
     [DataField]
     public bool PierceArmor = true;
+
+    // Goobstation - Armor resisting syringe gun
+    /// <summary>
+    /// The maximum armor resistance values this can penetrate through
+    /// </summary>
+    [DataField]
+    public DamageModifierSet MaxArmorResistances = new() {Coefficients = new() {["Piercing"] = 0.9f}};
 
     /// <summary>
     /// Contents of popup message to display to the attacker when injection
@@ -50,7 +58,7 @@ public abstract partial class BaseSolutionInjectOnEventComponent : Component
     /// Passed values: $weapon and $target
     /// </remarks>
     [DataField]
-    public LocId BlockedByHardsuitPopupMessage = "melee-inject-failed-hardsuit";
+    public LocId BlockedByArmorPopupMessage = "melee-inject-failed-armor"; // Goobstation - Armor resisting syringe gun
 
     /// <summary>
     /// If anything covers any of these slots then the injection fails.

--- a/Resources/Locale/en-US/weapons/melee/melee.ftl
+++ b/Resources/Locale/en-US/weapons/melee/melee.ftl
@@ -1,4 +1,5 @@
-melee-inject-failed-hardsuit = Your {$weapon} cannot inject through hardsuits!
+# Goobstation - Armor resisting syringe gun
+melee-inject-failed-armor = Your {$weapon} cannot inject through armor!
 
 melee-balloon-pop = {CAPITALIZE(THE($balloon))} popped!
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
makes syringe gun be resisted by not hardsuits but instead any armor with at least 10% pierce resist

## Why / Balance
can one-shot-kill anyone not wearing a hardsuit specifically (???) with syringe gun
if the 10% pierce resist threshold is found to be too little (i don't think you should be able to syringe anyone with any armor), it can be made larger

## Technical details
see diff

## Media
tested, works

## Breaking changes
renames one thing, see diff

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Hardsuits resisting syringe gun.
- add: Any armor with at least 10% pierce resist now resists syringe gun.

remove: Removed fun!
