### PR TITLE
Blueshield Hardsuit Tweaks

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -48,7 +48,7 @@
 #bso hardsuit
 
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseCentCommContraband]
+  parent: [ClothingOuterHardsuitBase, BaseCentcommContraband]
   id: ClothingOuterHardsuitBlueshield
   name: blueshield hardsuit
   description: A hardsuit for protecting command staff.

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -48,10 +48,10 @@
 #bso hardsuit
 
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseCommandContraband]
+  parent: [ClothingOuterHardsuitBase, BaseCentCommContraband]
   id: ClothingOuterHardsuitBlueshield
   name: blueshield hardsuit
-  description: A hardsuit for the captains personal bodyguard.
+  description: A hardsuit for protecting command staff.
   components:
   - type: Sprite
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/bso.rsi
@@ -65,16 +65,16 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.75
-        Slash: 0.7
-        Piercing: 0.45
-        Heat: 0.9
-        Cold: 0.9
-        Radiation: 0.8
-        Caustic: 0.8
+        Blunt: 0.50
+        Slash: 0.50
+        Piercing: 0.50
+        Heat: 0.50
+        Cold: 0.50
+        Radiation: 0.50
+        Caustic: 0.50
   - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
+    walkModifier: 0.90
+    sprintModifier: 0.90
   - type: HeldSpeedModifier
   - type: ToggleableClothing # Goobstation - Modsuits change
     clothingPrototypes: 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Altered all protection values to 50%
Altered movement speed penalty to 10%
Changed description.

## Why / Balance
To match that of an ERT hardsuit.
Also, I'm getting paid to make this PR :godo:
![image](https://github.com/user-attachments/assets/bfec1a04-239d-4fbf-b697-c3b6d283fb28)

## Technical details
YAML

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Rebalanced stats of BSO hardsuit.
