### PR TITLE
[bounty] DaW to IPCs hotbar x2

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -4,6 +4,24 @@
   name: Urist McPositronic
   description: A positronic brain in a metal body.
   components:
+  - type: HarpySinger
+  - type: Instrument
+    allowPercussion: true
+    allowProgramChange: true
+    program: 52
+  - type: SwappableInstrument
+    instrumentList:
+      "Daw": { 0: 0 }
+  - type: UserInterface
+    interfaces:
+      enum.InstrumentUiKey.Key:
+        type: InstrumentBoundUserInterface
+      enum.VoiceMaskUIKey.Key:
+        type: VoiceMaskBoundUserInterface
+      enum.HumanoidMarkingModifierKey.Key:
+        type: HumanoidMarkingModifierBoundUserInterface
+      enum.StrippingUiKey.Key:
+        type: StrippableBoundUserInterface
   - type: PowerCellSlot
     cellSlotId: cell_slot
     fitsInCharger: true
@@ -34,15 +52,15 @@
     messagePerceivedByOthers: hugging-success-generic-others
   - type: NpcFactionMember
     factions:
-      - NanoTrasen
+    - NanoTrasen
   - type: StandingState
   - type: Damageable
     damageContainer: Silicon
     damageModifierSet: IPC
   - type: MobState
     allowedStates:
-      - Alive
-      - Dead
+    - Alive
+    - Dead
   - type: MobThresholds
     thresholds:
       0: Alive
@@ -54,12 +72,12 @@
     proto: robot
   - type: Destructible
     thresholds:
-      - trigger:
-          !type:DamageTypeTrigger
-          damageType: Blunt
-          damage: 400
-        behaviors:
-          - !type:GibBehavior { }
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Blunt
+        damage: 400
+      behaviors:
+      - !type:GibBehavior { }
   - type: SlowOnDamage
     speedModifierThresholds:
       60: 0.7
@@ -70,7 +88,7 @@
     templateId: ipc
   - type: GuideHelp
     guides:
-      - IPC
+    - IPC
   - type: Silicon
     entityType: enum.SiliconType.Player
     batteryPowered: true
@@ -96,9 +114,9 @@
   - type: DeadStartupButton
     sound:
       path: /Audio/_EinsteinEngines/Effects/Silicon/startup.ogg
-# Erro de linter
-#   - type: Wires
-#     layoutId: IPC
+  # Erro de linter
+  #   - type: Wires
+  #     layoutId: IPC
   - type: EmitBuzzWhileDamaged
   - type: CanHostGuardian
   - type: WeldingHealable


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
added built-in Digital Audio Workstation (DaW) to IPCs hotbar, that allows them to play music like harpys without holding anything
...for some reason...

## Why / Balance
Money duh
![attachment](https://github.com/user-attachments/assets/6fb98e49-e158-413e-bb3b-1549c83a2933)


## Technical details
there are some minor problems, but fixing them will take way too long, and ive already spent a whole day on this thing fixing other stuff...

## Media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes

**Changelog**
:cl:
- add: Added a built-in DaW in IPCs.
