### PR TITLE
Fix antagrolling

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -140,8 +140,9 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
 
         foreach (var (uid, antag) in rules)
         {
-            if (!RobustRandom.Prob(LateJoinRandomChance))
-                continue;
+            // Goob edit
+            // if (!RobustRandom.Prob(LateJoinRandomChance))
+            //    continue;
 
             if (!antag.Definitions.Any(p => p.LateJoinAdditional))
                 continue;
@@ -149,6 +150,12 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
             DebugTools.AssertNotEqual(antag.SelectionTime, AntagSelectionTime.PrePlayerSpawn); // Goob edit
 
             if (!TryGetNextAvailableDefinition((uid, antag), out var def))
+                continue;
+
+            // Goobstation
+            if (!RobustRandom.Prob(def.Value.PlayerRatio == 0
+                    ? LateJoinRandomChance
+                    : Math.Clamp(1f / def.Value.PlayerRatio, 0f, 1f)))
                 continue;
 
             if (TryMakeAntag((uid, antag), args.Player, def.Value))

--- a/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
@@ -293,7 +293,7 @@ public sealed partial class StationJobsSystem
             var profile = profiles[player];
             if (profile.PreferenceUnavailable != PreferenceUnavailableMode.SpawnAsOverflow)
             {
-                _pendingAntag.PendingAntags.Remove(player);
+                _pendingAntag.PendingAntags.Remove(player); // Goobstation
                 assignedJobs.Add(player, (null, EntityUid.Invalid));
                 continue;
             }

--- a/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
@@ -291,9 +291,9 @@ public sealed partial class StationJobsSystem
             }
 
             var profile = profiles[player];
-            if (profile.PreferenceUnavailable != PreferenceUnavailableMode.SpawnAsOverflow &&
-                !_pendingAntag.PendingAntags.ContainsKey(player)) // Goob edit - spawn as overflow if rolled antag
+            if (profile.PreferenceUnavailable != PreferenceUnavailableMode.SpawnAsOverflow)
             {
+                _pendingAntag.PendingAntags.Remove(player);
                 assignedJobs.Add(player, (null, EntityUid.Invalid));
                 continue;
             }

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -100,7 +100,7 @@
   - type: LoadMapRule
     mapPath: /Maps/_Goobstation/Nonstations/nukieplanet.yml # goob edit
   - type: AntagSelection
-    selectionTime: BeforeJobs
+    selectionTime: PrePlayerSpawn
     definitions:
     - prefRoles: [ NukeopsCommander ]
       fallbackRoles: [ Nukeops, NukeopsMedic ]

--- a/Resources/Prototypes/_Goobstation/GameRules/Dynamic/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/Dynamic/roundstart.yml
@@ -177,7 +177,7 @@
   - type: LoadMapRule
     mapPath: /Maps/_Goobstation/Nonstations/nukieplanet.yml
   - type: AntagSelection
-    selectionTime: BeforeJobs
+    selectionTime: PrePlayerSpawn
     definitions:
     - prefRoles: [ NukeopsCommander ]
       fallbackRoles: [ Nukeops, NukeopsMedic ]

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -67,7 +67,7 @@
   - type: LoadMapRule
     mapPath: /Maps/_Goobstation/Nonstations/nukieplanet.yml
   - type: AntagSelection
-    selectionTime: BeforeJobs
+    selectionTime: PrePlayerSpawn
     definitions:
     - prefRoles: [ NukeopsCommander ]
       fallbackRoles: [ Nukeops, NukeopsMedic ]
@@ -207,7 +207,7 @@
   - type: LoadMapRule
     mapPath: /Maps/_Goobstation/Nonstations/nukieplanet-honkops.yml
   - type: AntagSelection
-    selectionTime: BeforeJobs
+    selectionTime: PrePlayerSpawn
     definitions:
     - prefRoles: [ NukeopsCommander ]
       fallbackRoles: [ Nukeops, NukeopsMedic ]

--- a/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
@@ -11,7 +11,7 @@
     - WizardSurviveObjective
   - type: AntagSelection
     useCharacterNames: true
-    selectionTime: BeforeJobs
+    selectionTime: PrePlayerSpawn
     agentName: wizard-roundend-name
     definitions:
     - spawnerPrototype: SpawnPointWizard


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

You no longer always become an assistant if you roll and have "stay in lobby" preferred option. This way you lose your antag roll but you can't abuse it by rolling antag with people readied up and then rolling again as a latejoiner.
Changed nukies and wiz roll behaivor to PrePlayerSpawn from BeforeJobs. Because, for example, if a person rolls wiz and has "stay in lobby" option, wiz wouldn't spawn most likely if they roll it but are not assigned to any job. It should work as before for wiz and nukies.

Tested wiz and traitor game presets while having no jobs priorities enabled and all antags enabled and "stay in lobby" option selected. Spawned as wizard successfully but didn't spawn as a traitor, as intended.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Current system can be abused.

## Technical details
<!-- Summary of code changes for easier review. -->

Don't spawn a person as assistant if they roll and exclude then from PendingAntags to prevent unexpected behavior.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
