### PR TITLE
untime killer tomato life

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
@@ -197,13 +197,15 @@
   - type: Appearance
   - type: Produce
     seedId: killerTomato
-  - type: PassiveDamage # Slight passive damage. 35 hp \ 5 min \ 60 sec = 0.08
-    allowedStates:
-    - Alive
-    - Dead
-    damageCap: 50
-    damage:
-      types:
-        Blunt: 0.11
+  # Goobstation - Remove killer tomato timed live
+  # billions must die
+  #- type: PassiveDamage # Slight passive damage. 35 hp \ 5 min \ 60 sec = 0.08
+  #  allowedStates:
+  #  - Alive
+  #  - Dead
+  #  damageCap: 50
+  #  damage:
+  #    types:
+  #      Blunt: 0.11
   - type: StaticPrice
     price: 400


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
removes passive damage from killer tomatos

## Why / Balance
poll on discord was highly in favor of doing this

readded fun
make killer tomatos not useless
if sec doesn't see botanist stockpiling them it's sec skill issue and they should die
also we have AI now so even more so

if this turns out bad later, i'll instead make their lifetime scale off potency with a new PR

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Killer tomatoes no longer take damage over time.