### PR TITLE
Combat larp - Ranged parrying/Library of Ruina-style firearm counter

### DIFF
--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Administration.Logs;
 using Content.Server.Effects;
 using Content.Server.Weapons.Ranged.Systems;
+using Content.Shared._Goobstation.Combat;
 using Content.Shared.Camera;
 using Content.Shared.Damage;
 using Content.Shared.Database;
@@ -32,16 +33,29 @@ public sealed class ProjectileSystem : SharedProjectileSystem
             return;
 
         var target = args.OtherEntity;
+
+        // Goob edit from here
         // it's here so this check is only done once before possible hit
-        var attemptEv = new ProjectileReflectAttemptEvent(uid, component, false);
-        RaiseLocalEvent(target, ref attemptEv);
-        if (attemptEv.Cancelled)
+        var attemptReflectEv = new ProjectileReflectAttemptEvent(uid, component, false);
+        RaiseLocalEvent(target, ref attemptReflectEv);
+        if (attemptReflectEv.Cancelled)
         {
             SetShooter(uid, component, target);
             _guns.SetTarget(uid, null, out _); // Goobstation
             component.IgnoredEntities.Clear(); // Goobstation
             return;
         }
+
+        var attemptParryEv = new ProjectileParryAttemptEvent(uid, target, component, false);
+
+        RaiseLocalEvent(uid, ref attemptParryEv);
+        if (attemptParryEv.Cancelled)
+        {
+            Del(uid);
+            return;
+        }
+
+        // Goob edit to here
 
         var ev = new ProjectileHitEvent(component.Damage, target, component.Shooter);
         RaiseLocalEvent(uid, ref ev);

--- a/Content.Server/_Goobstation/Combat/RangedParrySystem.cs
+++ b/Content.Server/_Goobstation/Combat/RangedParrySystem.cs
@@ -3,22 +3,16 @@ using Content.Server.Hands.Systems;
 using Content.Server.Popups;
 using Content.Shared._Goobstation.CCVar;
 using Content.Shared._Goobstation.Combat;
-using Content.Shared.Audio;
-using Content.Shared.Damage;
-using Content.Shared.Damage.Events;
 using Content.Shared.Damage.Systems;
 using Content.Shared.FixedPoint;
 using Content.Shared.Hands.Components;
 using Content.Shared.Movement.Components;
-using Content.Shared.Movement.Systems;
 using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Melee;
 using Content.Shared.Wieldable.Components;
 using Robust.Server.Audio;
 using Robust.Shared.Audio;
-using Robust.Shared.Player;
 using Robust.Shared.Configuration;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server._Goobstation.Combat;
@@ -50,9 +44,9 @@ public sealed class RangedParrySystem : EntitySystem
     ////    If rolls against the melee user - hit.
     //// !WARNING ////
 
-    private float _stamDamageValueBase = 11f;
-    private float _stamDamageLowerBound = 2f;
-    private float _parryRandomThreshold = 22.0f;
+    private float _stamDamageValueBase;
+    private float _stamDamageLowerBound;
+    private float _parryRandomThreshold;
     private float _baseMovementSpeed = MovementSpeedModifierComponent.DefaultBaseSprintSpeed;
 
     private SoundPathSpecifier _parrySound = new ("/Audio/Weapons/block_metal1.ogg");
@@ -173,12 +167,9 @@ public sealed class RangedParrySystem : EntitySystem
 
     private bool CastDie(float damage, float speed)
     {
-        //                      22          -    12
         var odds = _parryRandomThreshold - damage * 2;
         odds += odds * (speed - _baseMovementSpeed) / _baseMovementSpeed;
         odds = Math.Clamp(odds / _parryRandomThreshold, 0.0f, 1.0f);
-
-        Console.WriteLine($"Odds {odds}, speed modifier {(speed - _baseMovementSpeed) / _baseMovementSpeed}, damage modifier {_parryRandomThreshold - damage * 2}");
 
         return _rand.Prob(odds);
     }

--- a/Content.Server/_Goobstation/Combat/RangedParrySystem.cs
+++ b/Content.Server/_Goobstation/Combat/RangedParrySystem.cs
@@ -1,0 +1,173 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Content.Server.Hands.Systems;
+using Content.Server.Popups;
+using Content.Shared._Goobstation.CCVar;
+using Content.Shared._Goobstation.Combat;
+using Content.Shared.Audio;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Events;
+using Content.Shared.Damage.Systems;
+using Content.Shared.FixedPoint;
+using Content.Shared.Hands.Components;
+using Content.Shared.Movement.Components;
+using Content.Shared.Movement.Systems;
+using Content.Shared.Projectiles;
+using Content.Shared.Weapons.Melee;
+using Robust.Server.Audio;
+using Robust.Shared.Audio;
+using Robust.Shared.Player;
+using Robust.Shared.Configuration;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+namespace Content.Server._Goobstation.Combat;
+
+
+
+
+/// <summary>
+///     This system is responsible for managing Library of Ruina/Limbus Company-style ranged attack deflection, or "Ranged Parry".
+/// </summary>
+public sealed class RangedParrySystem : EntitySystem
+{
+    //// !WARNING ////
+    ////    At base level this allows melee weapons to destroy a ranged attack if the melee weapon deals more damage.
+    ////    While in Library of Ruina, this works only if your melee "dice roll" has a higher number than the ranged one, we don't have dices
+    ////    Nor they will be really necessary.
+    ////
+    ////    Currently the idea is such:
+    ////    Ranged Parry probability is scaled on target speed, summarized damage (excluding structural) and swing speed of the target's melee, and the player's maximum allowed running velocity.
+    ////    Successful parries apply stun to target. Failed do nothing, target takes damage from projectile. This makes sure that no-one can stack reflects from standing still with parrying.
+    ////
+    ////    Melee user will be at maximum advantage at high running speed with a high damage melee.
+    ////    Ranged parry will should almost never proc against a bola'd juggernaut suit.
+    ////
+    ////    Example:
+    ////    Projectile deals 16 damage, melee in active hand of target deals 17 damage. Target has no movement penalties
+    ////    Since damage on both parts is almost equal, roll a chance to parry heavily weighed towards failing.
+    ////    If rolls for the melee user - destroy projectile, nullify damage, **apply stun** to target based on (the absence of) damage difference.
+    ////    If rolls against the melee user - hit.
+    //// !WARNING ////
+
+    private float _stamDamageValueBase = 11f;
+    private float _stamDamageLowerBound = 2f;
+    private float _parryRandomThreshold = 22.0f;
+    private float _baseMovementSpeed = MovementSpeedModifierComponent.DefaultBaseSprintSpeed;
+
+    private SoundPathSpecifier _parrySound = new ("/Audio/Weapons/block_metal1.ogg");
+
+    [Dependency] private readonly HandsSystem _handsSystem = default!;
+    [Dependency] private readonly PopupSystem _popupSystem = default!;
+    [Dependency] private readonly StaminaSystem _stam = default!;
+    [Dependency] private readonly IConfigurationManager _configuration = default!;
+    [Dependency] private readonly AudioSystem _audio = default!;
+    [Dependency] private readonly IRobustRandom _rand = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ProjectileComponent, ProjectileParryAttemptEvent>(OnProjectileParryAttempt);
+
+        Subs.CVar(_configuration, GoobCVars.RangedParryStamDmgValueBase, value =>
+        {
+            _stamDamageValueBase = value;
+            _parryRandomThreshold = value * 2;
+        },
+            true);
+        Subs.CVar(_configuration, GoobCVars.RangedParryStamDmgValueLower, value => _stamDamageLowerBound = value, true);
+    }
+
+    private void OnProjectileParryAttempt(EntityUid ent, ProjectileComponent comp, ref ProjectileParryAttemptEvent ev)
+    {
+        var rangedSummation = GetTotalDamage(comp.Damage.DamageDict);
+        if (rangedSummation <= 0)
+            return;
+
+        if (!TryGetMeleeSummation(ev.Target, out var meleeSummation))
+            return;
+
+        var damage = CalculateParryStamDamage(meleeSummation.Value, rangedSummation);
+
+        var speed = _baseMovementSpeed;
+
+        if (TryComp(ev.Target, out MovementSpeedModifierComponent? movement))
+            speed = movement.CurrentSprintSpeed;
+
+        if (meleeSummation > rangedSummation && CastDie(damage, speed))
+        {
+            var auParams = AudioParams.Default;
+            auParams.Pitch += damage * 3;
+
+            _popupSystem.PopupEntity($"Parried! Took {damage} damage!", ev.Target);
+            _audio.PlayPvs(_parrySound, ev.Target, auParams);
+
+            _stam.TakeStaminaDamage(ev.Target, value: damage);
+
+            ev.Cancelled = true;
+        }
+    }
+
+    private bool TryGetMeleeSummation(EntityUid target, [NotNullWhen(true)] out int? summation)
+    {
+        summation = null;
+
+        if (!HasComp<HandsComponent>(target))
+            return false;
+
+        var activeItem = _handsSystem.GetActiveItem(target);
+
+        // No active item, can't parry shit!
+        if (activeItem == null)
+            return false;
+
+        // It's not a melee weapon
+        if (!TryComp(activeItem, out MeleeWeaponComponent? meleeComp))
+            return false;
+
+        summation = GetTotalDamage(meleeComp.Damage.DamageDict);
+        return true;
+    }
+
+    private int GetTotalDamage(Dictionary<string, FixedPoint2> damage, bool includeStructural = false)
+    {
+        int dmg = 0;
+
+        foreach (var kvp in damage)
+        {
+            if (kvp.Key != "Structural" || includeStructural)
+                dmg += kvp.Value.Int();
+        }
+
+        return dmg;
+    }
+
+    // Gain stamina damage inverse proportional to the difference between melee and ranged summation.
+    private float CalculateParryStamDamage(int meleeSummation, int rangedSummation)
+    {
+        var difference = Math.Abs(meleeSummation - rangedSummation);
+
+        var value = _stamDamageValueBase - difference;
+
+        value = Math.Max(0, value);
+
+        if (difference >= 8)
+        {
+            value = _stamDamageLowerBound;
+        }
+
+        return value;
+    }
+
+    private bool CastDie(float damage, float speed)
+    {
+        //                      22          -    12
+        var odds = _parryRandomThreshold - damage * 2;
+        odds += odds * (speed - _baseMovementSpeed) / _baseMovementSpeed;
+        odds = Math.Clamp(odds / _parryRandomThreshold, 0.0f, 1.0f);
+
+        Console.WriteLine($"Odds {odds}, speed modifier {(speed - _baseMovementSpeed) / _baseMovementSpeed}, damage modifier {_parryRandomThreshold - damage * 2}");
+
+        return _rand.Prob(odds);
+    }
+}

--- a/Content.Server/_Goobstation/Combat/RangedParrySystem.cs
+++ b/Content.Server/_Goobstation/Combat/RangedParrySystem.cs
@@ -89,18 +89,18 @@ public sealed class RangedParrySystem : EntitySystem
         if (TryComp(ev.Target, out MovementSpeedModifierComponent? movement))
             speed = movement.CurrentSprintSpeed;
 
-        if (meleeSummation > rangedSummation && CastDie(damage, speed))
-        {
-            var auParams = AudioParams.Default;
-            auParams.Pitch += damage * 3;
+        if (!(meleeSummation > rangedSummation) || !CastDie(damage, speed))
+            return;
 
-            _popupSystem.PopupEntity($"Parried! Took {damage} damage!", ev.Target);
-            _audio.PlayPvs(_parrySound, ev.Target, auParams);
+        var auParams = AudioParams.Default;
+        auParams.Pitch += damage * 3;
 
-            _stam.TakeStaminaDamage(ev.Target, value: damage);
+        _popupSystem.PopupEntity($"Parried!", ev.Target);
+        _audio.PlayPvs(_parrySound, ev.Target, auParams);
 
-            ev.Cancelled = true;
-        }
+        _stam.TakeStaminaDamage(ev.Target, value: damage);
+
+        ev.Cancelled = true;
     }
 
     private bool TryGetMeleeSummation(EntityUid target, [NotNullWhen(true)] out float? summation)
@@ -137,7 +137,7 @@ public sealed class RangedParrySystem : EntitySystem
 
     private int GetTotalDamage(Dictionary<string, FixedPoint2> damage, bool includeStructural = false)
     {
-        int dmg = 0;
+        var dmg = 0;
 
         foreach (var kvp in damage)
         {

--- a/Content.Shared/_Goobstation/CCVars/CCVars.Goob.cs
+++ b/Content.Shared/_Goobstation/CCVars/CCVars.Goob.cs
@@ -83,13 +83,13 @@ public sealed partial class GoobCVars
     ///     Ceiling for a dice roll will always be twice this value.
     /// </summary>
     public static readonly CVarDef<float> RangedParryStamDmgValueBase =
-        CVarDef.Create("goob.rangedparry_stam_damage_value_base", 11f, CVar.SERVERONLY);
+        CVarDef.Create("goob.rangedparry_stam_damage_value_base", 15f, CVar.SERVERONLY);
 
     /// <summary>
     ///     Ranged parry stam damage lower bound
     /// </summary>
     public static readonly CVarDef<float> RangedParryStamDmgValueLower =
-        CVarDef.Create("goob.rangedparry_stam_damage_lower_bound", 2f, CVar.SERVERONLY);
+        CVarDef.Create("goob.rangedparry_stam_damage_lower_bound", 4f, CVar.SERVERONLY);
 
     #region Player Listener
 

--- a/Content.Shared/_Goobstation/CCVars/CCVars.Goob.cs
+++ b/Content.Shared/_Goobstation/CCVars/CCVars.Goob.cs
@@ -78,6 +78,19 @@ public sealed partial class GoobCVars
     public static readonly CVarDef<bool> SiloEnabled =
         CVarDef.Create("goob.silo_enabled", true, CVar.SERVER | CVar.REPLICATED);
 
+    /// <summary>
+    ///     Base stam damage dealt on closest parry damage-wise, will always be -1 due to melee having to be above ranged.
+    ///     Ceiling for a dice roll will always be twice this value.
+    /// </summary>
+    public static readonly CVarDef<float> RangedParryStamDmgValueBase =
+        CVarDef.Create("goob.rangedparry_stam_damage_value_base", 11f, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Ranged parry stam damage lower bound
+    /// </summary>
+    public static readonly CVarDef<float> RangedParryStamDmgValueLower =
+        CVarDef.Create("goob.rangedparry_stam_damage_lower_bound", 2f, CVar.SERVERONLY);
+
     #region Player Listener
 
     /// <summary>

--- a/Content.Shared/_Goobstation/Combat/RangedParry.Events.cs
+++ b/Content.Shared/_Goobstation/Combat/RangedParry.Events.cs
@@ -1,0 +1,6 @@
+﻿using Content.Shared.Projectiles;
+
+namespace Content.Shared._Goobstation.Combat;
+
+[ByRefEvent]
+public record struct ProjectileParryAttemptEvent(EntityUid ProjUid, EntityUid Target, ProjectileComponent Component, bool Cancelled);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Melee weapons can now "parry" projectiles at the cost of stamina, if their summarized (excluding structural) damage is greater than that of the projectile (also excluding structural). "Parrying" destroys the projectile.
Melee weapon user takes stun damage after a parry.
Parry chance is based off damage the melee weapon does in one swing and current running speed.
Stun damage is based (inversely) on the difference between the damage a projectile makes and the damage the melee weapon does - so if a .35 auto bullet does 16 damage, and your weapon does 17 - you take max stun damage.

The greater the difference - the less stun you take.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
cap saber reflect discourse grew stale

Stun damage is because parry chance is also tied to movement speed - as the user eats more bullets - they get gradually more stamina damage to the point of losing speed.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="171" alt="Content Client_DEAMfv4gqB" src="https://github.com/user-attachments/assets/27925607-b442-4dcf-93f3-87827c8e95af" />
video maybe soon if I don't forget

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Melee weapons can now destroy incoming projectiles based on damage difference between the weapon and the projectile, plus melee weapon wielder's movement speed.
-->
