### PR TITLE
Revert IPC Low Battery Audio

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -44,7 +44,7 @@
     itemSlot: cell_slot
   - type: EncryptionHolderRequiresLock
   - type: SiliconEmitSoundOnDrained
-    sound: "/Audio/_Goobstation/Voice/IPC/energy_low.ogg" # Goobstation - ipc audio
+    sound: "/Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg" # They need to be noticed more often
     minInterval: 8
     maxInterval: 12
     popUp: "silicon-power-low"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title

## Why / Balance
People sometimes go unnoticed that youre low on battery as IPC, this change will actually have a higher chance of alerting people that walks by. (It is either this or giving IPC binary comms or a way to alert people when out of power)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Revert to old low battery audio for IPC