### PR TITLE
remove c4 blacklist

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -12,9 +12,9 @@
     stickPopupSuccess: comp-sticky-success-stick-bomb
     unstickPopupStart: comp-sticky-start-unstick-bomb
     unstickPopupSuccess: comp-sticky-success-unstick-bomb
-    blacklist: # can't stick it to other items
-      components:
-      - Item
+#    blacklist: # can't stick it to other items # nuh uh # Goobstation - Remove C4 item blacklist
+#      components:
+#      - Item
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
let c4 stick to items

## Why / Balance
billions must die, also c4 spear or c4 mice funny
surely nothing would go wrong

i couldn't find any too sus usage of this and neither could chat, but we can still just revert this if things DO go wrong

## Media
tested

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: C4 can now be planted on items, like mice or spears.