### PR TITLE
Bluespace syringes are valid syringe gun ammo

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -549,6 +549,7 @@
     tags:
     - Syringe
     - Trash
+    - SyringeGunAmmo # Goobstation - This should be fine, given that PR #1626 caused syringes to inject over time
   - type: PhysicalComposition #Goobstation - Recycle update
     materialComposition:
       Steel: 25


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Bluespace syringes can now be put in syringe gun ammunition slots.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Given that syringes inject over time (see) [pull #1626](https://github.com/Goob-Station/Goob-Station/pull/1626) and can be pulled out before emptying their contents, I felt this is fine to implement. 

## Technical details
<!-- Summary of code changes for easier review. -->
I added the SyringeGunAmmo tag to the bluespace syringe in the yml. This is incredibly simple so I don't see the need to add media to this PR.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. --> N/A

**Changelog**
:cl:
- tweak: Bluespace syringes are now valid ammo for syringe guns.