### PR TITLE
Ported fire protection on examine from wizden

### DIFF
--- a/Content.Shared/Clothing/Components/FireProtectionComponent.cs
+++ b/Content.Shared/Clothing/Components/FireProtectionComponent.cs
@@ -14,4 +14,11 @@ public sealed partial class FireProtectionComponent : Component
     /// </summary>
     [DataField(required: true)]
     public float Reduction;
+
+    /// <summary>
+    /// LocId for message that will be shown on detailed examine.
+    /// Actually can be moved into system
+    /// </summary>
+    [DataField]
+    public LocId ExamineMessage = "fire-protection-reduction-value";
 }

--- a/Content.Shared/Clothing/EntitySystems/FireProtectionSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/FireProtectionSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Armor;
 using Content.Shared.Atmos;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Inventory;
@@ -14,10 +15,22 @@ public sealed class FireProtectionSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<FireProtectionComponent, InventoryRelayedEvent<GetFireProtectionEvent>>(OnGetProtection);
+        SubscribeLocalEvent<FireProtectionComponent, ArmorExamineEvent>(OnArmorExamine);
     }
 
     private void OnGetProtection(Entity<FireProtectionComponent> ent, ref InventoryRelayedEvent<GetFireProtectionEvent> args)
     {
         args.Args.Reduce(ent.Comp.Reduction);
+    }
+
+    private void OnArmorExamine(Entity<FireProtectionComponent> ent, ref ArmorExamineEvent args)
+    {
+        var value = MathF.Round((1f - ent.Comp.Reduction) * 100, 1);
+
+        if (value == 0)
+            return;
+
+        args.Msg.PushNewline();
+        args.Msg.AddMarkupOrThrow(Loc.GetString(ent.Comp.ExamineMessage, ("value", value)));
     }
 }

--- a/Resources/Locale/en-US/clothing/components/fire-protection-component.ftl
+++ b/Resources/Locale/en-US/clothing/components/fire-protection-component.ftl
@@ -1,0 +1,1 @@
+fire-protection-reduction-value = - [color=orange]Fire[/color] damage reduced by [color=lightblue]{$value}%[/color].


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Ports allowing you to see fire protection on examine from [this](https://github.com/space-wizards/space-station-14/pull/35183) pr.

## Why / Balance
See PR.

## Technical details
See PR.

## Media
See PR.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: You can now see how much a piece of clothing protects you from fire when you examine it.
