### PR TITLE
downprice some guns/atmos cans/materials

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Weapons/Guns/SMGs/wt550.rsi
     state: icon
   product: CrateArmorySMG
-  cost: 9000
+  cost: 6000 # 3k per gun + 2 mags
   category: cargoproduct-category-name-armory
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
     state: icon
   product: CrateArmoryShotgun
-  cost: 7000
+  cost: 6000 # $3k per gun and 1.5 shell boxes
   category: cargoproduct-category-name-armory
   group: market
 
@@ -64,6 +64,6 @@
     sprite: Objects/Weapons/Guns/Pistols/mk58.rsi
     state: icon
   product: CrateArmoryPistols
-  cost: 5200
+  cost: 3200
   category: cargoproduct-category-name-armory
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Weapons/Guns/SMGs/wt550.rsi
     state: icon
   product: CrateArmorySMG
-  cost: 6000 # 3k per gun + 2 mags
+  cost: 6000 # Goobstation # 3k per gun + 2 mags
   category: cargoproduct-category-name-armory
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
     state: icon
   product: CrateArmoryShotgun
-  cost: 6000 # $3k per gun and 1.5 shell boxes
+  cost: 6000 # Goobstation # 3k per gun + 1.5 shell boxes
   category: cargoproduct-category-name-armory
   group: market
 
@@ -64,6 +64,6 @@
     sprite: Objects/Weapons/Guns/Pistols/mk58.rsi
     state: icon
   product: CrateArmoryPistols
-  cost: 3200
+  cost: 3200 # Goobstation # they're kinda bad compared to the other guns so should be cheap
   category: cargoproduct-category-name-armory
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -4,7 +4,7 @@
     sprite: Structures/Storage/canister.rsi
     state: grey
   product: AirCanister
-  cost: 1100
+  cost: 300
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Structures/Storage/canister.rsi
     state: blue
   product: OxygenCanister
-  cost: 1100
+  cost: 300
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -24,7 +24,7 @@
     sprite: Structures/Storage/canister.rsi
     state: blue
   product: LiquidOxygenCanister
-  cost: 2500
+  cost: 1000
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Structures/Storage/canister.rsi
     state: red
   product: NitrogenCanister
-  cost: 1100
+  cost: 300
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -44,7 +44,7 @@
     sprite: Structures/Storage/canister.rsi
     state: red
   product: LiquidNitrogenCanister
-  cost: 2500
+  cost: 1000
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -54,7 +54,7 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: CarbonDioxideCanister
-  cost: 2200 # Until someone fixes it co2 can be used to oneshot people so it's more expensive
+  cost: 400 # even though it's poisonous, it comes locked and only damages you slowly even with high amounts (tested)
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -64,7 +64,7 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: LiquidCarbonDioxideCanister
-  cost: 4000
+  cost: 1800 # much less deadly than the plasma can (this has been tested) even though this is cold+poison
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -74,7 +74,7 @@
     sprite: Structures/Storage/canister.rsi
     state: yellow
   product: StorageCanister
-  cost: 1010 # No gases in it so it's cheaper
+  cost: 210 # No gases in it so it's cheaper
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -96,7 +96,7 @@
     sprite: Structures/Storage/canister.rsi
     state: orange
   product: PlasmaCanister
-  cost: 4000
+  cost: 2500 # for reference, bagel's 3x1 roundstart plasma chamber contains ~16kmol for free, this is $2.5k for 1870mol, so $20k to nearly refill a 3x1 (some are 3x3) chamber
   category: cargoproduct-category-name-atmospherics
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -4,7 +4,7 @@
     sprite: Structures/Storage/canister.rsi
     state: grey
   product: AirCanister
-  cost: 300
+  cost: 250 # Goobstation - IF YOU SEE THIS IN A MERGE CONFLICT, USE THE GOOB VERSION
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Structures/Storage/canister.rsi
     state: blue
   product: OxygenCanister
-  cost: 300
+  cost: 250 # Goobstation
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -24,7 +24,7 @@
     sprite: Structures/Storage/canister.rsi
     state: blue
   product: LiquidOxygenCanister
-  cost: 1000
+  cost: 600 # Goobstation # you literally get infinite gas at atmos
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Structures/Storage/canister.rsi
     state: red
   product: NitrogenCanister
-  cost: 300
+  cost: 250 # Goobstation
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -44,7 +44,7 @@
     sprite: Structures/Storage/canister.rsi
     state: red
   product: LiquidNitrogenCanister
-  cost: 1000
+  cost: 600 # Goobstation
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -54,7 +54,7 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: CarbonDioxideCanister
-  cost: 400 # even though it's poisonous, it comes locked and only damages you slowly even with high amounts (tested)
+  cost: 400 # Goobstation # even though it's poisonous, it comes locked and only damages you slowly even with high amounts (tested)
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -64,7 +64,7 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: LiquidCarbonDioxideCanister
-  cost: 1800 # much less deadly than the plasma can (this has been tested) even though this is cold+poison
+  cost: 1600 # Goobstation # much less deadly than the plasma can (this has been tested) even though this is cold+poison
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -74,21 +74,22 @@
     sprite: Structures/Storage/canister.rsi
     state: yellow
   product: StorageCanister
-  cost: 210 # No gases in it so it's cheaper
+  cost: 210 # Goobstation # no gases in it so it's cheaper
   category: cargoproduct-category-name-atmospherics
   group: market
 
-#- type: cargoProduct
-#  name: "water vapor canister"
-#  id: AtmosphericsWaterVapor
-#  description: "Water vapor canister"
-#  icon:
-#    sprite: Structures/Storage/canister.rsi
-#    state: water_vapor
-#  product: WaterVaporCanister
-#  cost: 2600
-#  category: cargoproduct-category-name-atmospherics
-#  group: market
+# Goobstation
+- type: cargoProduct
+  name: "water vapor canister"
+  id: AtmosphericsWaterVapor
+  description: "Water vapor canister"
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: water_vapor
+  product: WaterVaporCanister
+  cost: 250
+  category: cargoproduct-category-name-atmospherics
+  group: market
 
 - type: cargoProduct
   id: AtmosphericsPlasma
@@ -96,7 +97,7 @@
     sprite: Structures/Storage/canister.rsi
     state: orange
   product: PlasmaCanister
-  cost: 2500 # for reference, bagel's 3x1 roundstart plasma chamber contains ~16kmol for free, this is $2.5k for 1870mol, so $20k to nearly refill a 3x1 (some are 3x3) chamber
+  cost: 2000 # Goobstation # for reference, bagel's 3x1 roundstart plasma chamber contains ~16kmol for free, this is $2k for 1870mol, so $16k to nearly refill a 3x1 (some are 3x3) chamber
   category: cargoproduct-category-name-atmospherics
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -44,7 +44,7 @@
     sprite: Objects/Materials/Sheets/metal.rsi
     state: plasteel_3
   product: CrateMaterialPlasteel
-  cost: 4800
+  cost: 1600
   category: cargoproduct-category-name-materials
   group: market
 
@@ -64,7 +64,7 @@
     sprite: Objects/Materials/Sheets/other.rsi
     state: plasma_3
   product: CrateMaterialPlasma
-  cost: 2000
+  cost: 1500
   category: cargoproduct-category-name-materials
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -34,7 +34,7 @@
     sprite: Objects/Materials/Sheets/metal.rsi
     state: brass_3
   product: CrateMaterialBrass
-  cost: 3000
+  cost: 2000 # Goobstation # this is mostly decorative
   category: cargoproduct-category-name-materials
   group: market
 
@@ -44,7 +44,7 @@
     sprite: Objects/Materials/Sheets/metal.rsi
     state: plasteel_3
   product: CrateMaterialPlasteel
-  cost: 1600
+  cost: 1000 # Goobstation # $3k/3 stacks
   category: cargoproduct-category-name-materials
   group: market
 
@@ -64,7 +64,7 @@
     sprite: Objects/Materials/Sheets/other.rsi
     state: plasma_3
   product: CrateMaterialPlasma
-  cost: 1500
+  cost: 1500 # Goobstation
   category: cargoproduct-category-name-materials
   group: market
 

--- a/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
@@ -68,12 +68,11 @@
   id: CrateMaterialPlasteel
   parent: CrateGenericSteel
   name: plasteel crate
-  description: 90 sheets of plasteel.
+  description: 30 sheets of plasteel.
   components:
   - type: StorageFill
     contents:
       - id: SheetPlasteel
-        amount: 3
 
 - type: entity
   id: CrateMaterialPlasma

--- a/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
@@ -68,11 +68,12 @@
   id: CrateMaterialPlasteel
   parent: CrateGenericSteel
   name: plasteel crate
-  description: 30 sheets of plasteel.
+  description: 30 sheets of plasteel. # Goobstation
   components:
   - type: StorageFill
     contents:
       - id: SheetPlasteel
+        #amount: 3 # Goobstation
 
 - type: entity
   id: CrateMaterialPlasma

--- a/Resources/Prototypes/Reagents/Materials/metals.yml
+++ b/Resources/Prototypes/Reagents/Materials/metals.yml
@@ -29,7 +29,7 @@
   name: materials-brass
   icon: { sprite: Objects/Materials/Sheets/metal.rsi, state: brass }
   color: "#b18b25"
-  price: 0.30 # $30 for 1 unit
+  price: 0.20 # Goobstation - Cargo repricing
 
 - type: material
   id: Plasteel
@@ -37,4 +37,4 @@
   name: materials-plasteel
   icon: { sprite: Objects/Materials/Sheets/metal.rsi, state: plasteel }
   color: "#696969" #Okay, this is epic
-  price: 0.5 # 1-1 mix of plasma and steel.
+  price: 0.3 # Goobstation - Cargo repricing


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
title
also lets you buy vapour canisters since it's probably the safest gas there is (it hurting slimes is a myth and is false)

## Why / Balance
many of those prices were literally 1984, especially atmos cans since gases are literally free and cans now sell for $200 but the prices are from $1k can era
also this is technically a wizden PR port and even wizdenners agreed with this

reasoning for many of the price changes are in comments in the diff

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Gas canisters, some guns and some materials are now cheaper to buy.
- add: You can now buy water vapour canisters.