### PR TITLE
SS14: The penance for my sins update

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/FoodSequenceSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSequenceSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Tag;
 using Robust.Shared.Random;
 using Content.Shared.Item; // Goobstation - anythingburgers
 using Content.Shared.Chemistry.Components.SolutionManager; // Goobstation - anythingburgers
+using Content.Shared.Whitelist; //Goobstaion -anythingburgers
 using Content.Server.Singularity.Components; // Goobstation - anythingburgers
 
 namespace Content.Server.Nutrition.EntitySystems;
@@ -25,6 +26,7 @@ public sealed class FoodSequenceSystem : SharedFoodSequenceSystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedItemSystem _item = default!; // Goobstation - anythingburgers
     [Dependency] private readonly SharedTransformSystem _transform = default!; // Goobstation - anythingburgers
+    [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!; // Goobstation - anythingburgers
 
     public override void Initialize()
     {
@@ -35,6 +37,10 @@ public sealed class FoodSequenceSystem : SharedFoodSequenceSystem
 
     private void OnInteractUsing(Entity<FoodSequenceStartPointComponent> ent, ref InteractUsingEvent args)
     {
+        if (_whitelistSystem.IsBlacklistPass(ent.Comp.BlacklistedFood, args.Used)) //Goob
+            return;
+        args.Handled = true; //Goob
+
         if (ent.Comp.AcceptAll) // Goobstation - anythingburgers
             EnsureComp<FoodSequenceElementComponent>(args.Used);
 

--- a/Content.Shared/Nutrition/Components/FoodSequenceStartPointComponent.cs
+++ b/Content.Shared/Nutrition/Components/FoodSequenceStartPointComponent.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
 using Content.Shared.Nutrition.EntitySystems;
+using Content.Shared.Whitelist;
 using Robust.Shared.GameStates;
+
 
 namespace Content.Shared.Nutrition.Components;
 
@@ -21,6 +23,12 @@ public sealed partial class FoodSequenceStartPointComponent : Component
     /// </summary>
     [DataField]
     public bool AcceptAll = false; // Goobstation - anythingburgers
+
+    /// <summary>
+    /// Food blacklist
+    /// </summary>
+    [DataField]
+    public EntityWhitelist BlacklistedFood = new(); // Goobstation - anythingburgers
 
     /// <summary>
     /// The maximum number of layers of food that can be placed on this item.

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -30,6 +30,10 @@
     delay: 0.5
   - type: ExplosionResistance
     damageCoefficient: 0.9
+  - type: Tag #goobcontent
+    tags:
+      - WhitelistChameleon
+      - FoodSequenceBlacklist
 
 - type: entity
   parent: ClothingBackpack

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/burger.yml
@@ -48,6 +48,11 @@
     key: burger
     acceptAll: true # Goobstation - anythingburgers
     maxLayers: 12 # Goobstation - anythingburgers
+    blacklistedFood:
+      tags:
+      - FoodSequenceBlacklist
+      components:
+      - NukeDisk
     startPosition: 0, 0
     offset: 0, 0.1
     minLayerOffset: -0.05, 0

--- a/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pet_carrier.yml
@@ -22,6 +22,9 @@
   - type: InteractionOutline
   - type: Physics
   - type: MultiHandedItem
+  - type: Tag #goob content
+    tags:
+    - FoodSequenceBlacklist
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/_Goobstation/tags.yml
+++ b/Resources/Prototypes/_Goobstation/tags.yml
@@ -43,7 +43,7 @@
 
 - type: Tag
   id: ClarkePeripheralsControlModule
-  
+
 - type: Tag
   id: ClarkeRArm
 
@@ -106,6 +106,9 @@
 
 - type: Tag
   id: FelinidEmotes
+
+- type: Tag
+  id: FoodSequenceBlacklist
 
 - type: Tag
   id: FrozenIgnoreMindAction
@@ -287,7 +290,7 @@
 - type: Tag
   id: Tourniquet
 
-- type: Tag  
+- type: Tag
   id: ToySword
 
 - type: Tag


### PR DESCRIPTION
Fixed burger pet carrier round removal.

Prevents bags, pet carriers, or the nuke disc from being burgered on cutsom burgers. Also adds a new tag for blacklisting future items easily.