### PR TITLE
Artifacts can no longer spawn singularities/tesla

### DIFF
--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -666,9 +666,11 @@
   components:
   - type: PortalArtifact
 
+# Goobstation: lame roundenders. virtually unspawnable via 10,000 depth
+
 - type: artifactEffect
   id: EffectSingulo
-  targetDepth: 10
+  targetDepth: 10000
   effectHint: artifact-effect-hint-destruction
   components:
   - type: SpawnArtifact
@@ -678,7 +680,7 @@
 
 - type: artifactEffect
   id: EffectTesla
-  targetDepth: 10
+  targetDepth: 10000
   effectHint: artifact-effect-hint-destruction
   components:
   - type: SpawnArtifact


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Artifacts can no longer spawn singularities/tesla.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
While this is actually a fairly rare case, not only do some scientists not know the risk of going to 9+ depth, it is incredibly unfun for everyone involved to have an artifact randomly decide to end the round. Sentient artifacts can also trigger this...

## Technical details
<!-- Summary of code changes for easier review. -->
Increased target depth of these effects to 10,000. They're still in the game but should no longer be triggerable by normal means.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
:cl: 
- tweak: Alien artifacts can no longer summon a singularity or tesla.