### PR TITLE
Improved the formatting of a few things related to patches

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/medical_patch.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/medical_patch.yml
@@ -2,7 +2,7 @@
   parent: BaseHealingItem
   id: BaseMedicalPatch
   name: base patch
-  description: put this on your boo boo
+  description: A patch for applying medicine over time to patients.
   abstract: true
   components:
   - type: Sprite
@@ -37,7 +37,7 @@
   parent: BaseMedicalPatch
   id: MedicalPatchBasic
   name: patch
-  description: put this on your boo boo
+  description: A basic patch for applying medicine over time to patients.
   components:
   - type: Sprite
     sprite: _Goobstation/Objects/Medical/medical_patch.rsi
@@ -63,8 +63,8 @@
 - type: entity
   parent: BaseHealingItem
   id: UsedMedicalPatch
-  name: patch used
-  description: EEEEWWWWWWW
+  name: used patch
+  description: ...ew.
   components:
   - type: Sprite
     sprite: _Goobstation/Objects/Medical/medical_patch.rsi
@@ -80,8 +80,7 @@
 - type: entity
   parent: UsedMedicalPatch
   id: UsedMedicalPatchMakeshift
-  name: patch used
-  description: EEEEWWWWWWW
+  name: used patch
   components:
   - type: Sprite
     sprite: _Goobstation/Objects/Medical/medical_patch.rsi
@@ -91,7 +90,7 @@
   parent: MedicalPatchBasic
   id: MedicalPatchRapid
   name: rapid patch
-  description:  has racing cars drawn on
+  description: A patch used for more rapid application of medicine. It has race cars drawn on it.
   components:
   - type: Sprite
     sprite: _Goobstation/Objects/Medical/medical_patch.rsi
@@ -109,7 +108,7 @@
   parent: MedicalPatchBasic
   id: MedicalPatchTherapeutic
   name: therapeutic patch
-  description:  used to apply small doses over a long time
+  description: A patch that applies a dose over a longer period of time than other patches.
   components:
   - type: Sprite
     sprite: _Goobstation/Objects/Medical/medical_patch.rsi
@@ -127,7 +126,7 @@
   parent: MedicalPatchBasic
   id: MedicalPatchLarge
   name: large patch
-  description: put this on your Big boo boo
+  description: A larger, higher-capacity patch, used for the really big boo-boos. Not recommended with easily-overdosed chemicals.
   components:
   - type: Sprite
     sprite: _Goobstation/Objects/Medical/medical_patch.rsi
@@ -150,7 +149,7 @@
   parent: BaseMedicalPatch
   id: MedicalPatchMakeshift
   name: makeshift patch
-  description: does not look hygienic
+  description: This doesn't look hygienic. Hopefully it does the job.
   components:
   - type: Sprite
     state: MakeshiftPatch
@@ -215,14 +214,14 @@
     entity: MedicalPatchMakeshift
 
 - type: construction
-  name: Makeshift Patch
+  name: makeshift patch
   id: MedicalPatchMakeshift
   graph: MedicalPatchMakeshift
   startNode: start
   targetNode: medicalPatchMakeshift
   category: construction-category-tools
   objectType: Item
-  description: a little better then nothing
+  description: A little better then nothing. Apply a chemical to it and wear it for treatment over time.
   icon:
     sprite: _Goobstation/Objects/Medical/medical_patch.rsi
     state: MakeshiftPatch
@@ -242,14 +241,14 @@
     entity: MedicalPatchMakeshift
 
 - type: construction
-  name: Silk Makeshift Patch
+  name: silk makeshift patch
   id: SilkPatchMakeshift
   graph: SilkPatchMakeshift
   startNode: start
   targetNode: silkPatchMakeshift
   category: construction-category-tools
   objectType: Item
-  description: a little better then nothing
+  description: A little better then nothing. Apply a chemical to it and wear it for treatment over time.
   icon:
     sprite: _Goobstation/Objects/Medical/medical_patch.rsi
     state: MakeshiftPatch

--- a/Resources/ServerInfo/_Goobstation/Guidebook/Medical/Medicalpatches.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/Medical/Medicalpatches.xml
@@ -1,32 +1,37 @@
 <Document>
 # Patches
 
-Patches are a simple and effective way to slowly administer medication to a patient without risking an overdose.
-They can be made with the medfab and filled with the chemmaster. They can be directly applied to a patient and will fall off by themselves once empty.
+Patches are a simple and effective way to administer medication to a patient over time with lower risk of an overdose.
+They can be made at a medical techfab and filled via a ChemMaster. They can be directly applied to a patient and will fall off by themselves once empty.
 
 <GuideEntityEmbed Entity="MedicalPatchBasic" Rotation="0"/>
 
-There are 5 types of patches:
+There are 6 types of patches:
 - Basic
 - Rapid
-- Prefilled
 - Large
+- Therapeutic
+- Prefilled
 - Makeshift
 
 ## Basic
-The basic patch holds 40 units of chems and transfers 1 unit at a time.
+The (basic) patch holds 40 units of chemicals and transfers 1 unit every second.
 
 ## Rapid
-The rapid patch holds 40 units and transfers chemicals twice as fast.
-
-## Prefilled
-Some medkits contain prefilled patches. These hold 30 units and transfers 0.25 units per second. They cannot be filled or emptied
+The rapid patch holds 40 units and transfers 2 units every second.
 
 ## Large
-The large patch holds 60 units and transfers them one unit at a time.
-However the large patch also transfers 15% of its chemicals upon use (10 units if full).
+The large patch holds 60 units and transfers 1 unit every second.
+However, the large patch also transfers 15% of its chemicals immediately when applied (10 units if full).
+
+## Therapeutic
+The therapeutic patch holds 40 units and transfers 0.5 units every second.
+
+## Prefilled
+NanoMed Plus machines and some medkits contain prefilled patches for treating Brute or Burn damage.
+These hold 30 units and transfer 0.25 units per second, but cannot be refilled or emptied. Not reusable.
 
 ## Makeshift
-The makeshift patch can hold 15 units and transfer 1 unit every 2 seconds.
-However it can be crafted by hand and filled manually without a chemmaster
+This rudimentary patch can hold 20 units and transfers 1 unit every 2 seconds.
+However, it can be made by hand with cloth and filled manually without a ChemMaster. Not reusable.
 </Document>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Medical patches now have a better guidebook entry and different descriptions.

## Why / Balance
The previous guidebook was inaccurate and did not cover content comprehensively enough, and the descriptions of the patches were a bit jarring to look at and not very helpful or informative. This improves both of those.

## Technical details
Changed a yml and an xml. I also removed the out-of-place capital letters in the name of the makeshift patch's crafting recipe.

## Media
![image](https://github.com/user-attachments/assets/ecae0e05-6a12-4494-9c0a-6b789a4cfa97)
![image](https://github.com/user-attachments/assets/ee2cf3b2-073c-4008-915f-df8d12fa0f7b)
![image](https://github.com/user-attachments/assets/bd153374-755c-4579-a705-e89857b2c9e6)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None that I'm aware of. It was only yml and xml changes.

**Changelog**
:cl:
- tweak: Improved the description and guidebook entry of medical patches.