### PR TITLE
Master

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -297,6 +297,7 @@
     tags:
       - CannotSuicide
       - FootstepSound
+      - Trash
   - type: NoSlip
   - type: MobPrice
     price: 500 # rat wealth


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a - Trash tag to Rat Servants so they can be easily collected using the TrashBag to be disposed of by Janitors

## Why / Balance
Main objective of this change is to provide a QoL improvement for Janitors. When a large Rat King swarm is killed with the current system Janitors would have to manually pickup and take dead servants to a bin. This will allow them to be treated similar to mice and bagged.

## Technical details
Added tag "- Trash" to lie 300 of regalrat.yml

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!--
:cl:
- tweak: Marked Rat Servants as the trash they truly are 
-->

