### PR TITLE
Sabre buff (again)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -35,6 +35,9 @@
         Slash: 19 #cmon, it has to be at least BETTER than the rest. # Goob edit
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
+  - type: Reflect # change this and i will fucking GUT YOU. YOU HEAR ME AVIU??
+    reflectProb: .3
+    spread: 90
   - type: Item
     sprite: Objects/Weapons/Melee/captain_sabre.rsi
   - type: Tag
@@ -46,6 +49,7 @@
     weight: 0.0002 # 5,000 times less likely than 1 regular animal
   - type: PirateAccent
     # not putting a BlockMovement component here cause that's funny.
+
 
 - type: entity
   name: katana

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -35,9 +35,6 @@
         Slash: 19 #cmon, it has to be at least BETTER than the rest. # Goob edit
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
-  - type: Reflect # change this and i will fucking GUT YOU. YOU HEAR ME AVIU??
-    reflectProb: .3
-    spread: 90
   - type: Item
     sprite: Objects/Weapons/Melee/captain_sabre.rsi
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -35,6 +35,9 @@
         Slash: 19 #cmon, it has to be at least BETTER than the rest. # Goob edit
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
+  - type: Reflect # change this and i will fucking GUT YOU. YOU HEAR ME AVIU??
+    reflectProb: .3
+    spread: 90
   - type: Item
     sprite: Objects/Weapons/Melee/captain_sabre.rsi
   - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gave captains sabre a 30% reflect chance again.

## Why / Balance
Lets compare.

Energy Sword

- Easily accessible by any traitor, costs 37tc.
- Deals 30 damage a hit, increased sever chance.
- 50% energy reflect chance, small amount for other projectiles
- Fits into a pocket slot/storage implant, easily concealable

Captains Sabre

- Elite weapon, only one spawns for the MOST important person on the station.
- Deals 17 damage, less than a syndicate toolbox.
- No reflect chance, useless against anyone with a firearm that isn't a pistol.
- Either takes your ENTIRE belt slot, or a 4x2 in your inventory.
- Recieves nerf after fucking NERF


I don't think I have to elaborate further.

## Technical details
YAML. Literally three lines

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Captains sabre can reflect again.