### PR TITLE
Fixes abductor instagizmo

### DIFF
--- a/Content.Server/_Shitmed/Antags/Abductor/AbductorSystem.Gizmo.cs
+++ b/Content.Server/_Shitmed/Antags/Abductor/AbductorSystem.Gizmo.cs
@@ -72,11 +72,14 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
 
     private void OnGizmoDoAfter(Entity<AbductorGizmoComponent> ent, ref AbductorGizmoMarkDoAfterEvent args)
     {
-        if (args.Target is null) return;
+        if (args.Handled || args.Cancelled || args.Target is null)
+            return;
+
         ent.Comp.Target = GetNetEntity(args.Target);
         EnsureComp<AbductorVictimComponent>(args.Target.Value, out var victimComponent);
         victimComponent.LastActivation = _time.CurTime + TimeSpan.FromMinutes(5);
-
         victimComponent.Position ??= EnsureComp<TransformComponent>(args.Target.Value).Coordinates;
+
+        args.Handled = true;
     }
 }


### PR DESCRIPTION
## About the PR
Small doafter fix.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: Mocho
- fix: Abductors can no longer instantly gizmo their targets.
