### PR TITLE
fix the game

### DIFF
--- a/Content.Shared/Roles/JobPrototype.cs
+++ b/Content.Shared/Roles/JobPrototype.cs
@@ -82,7 +82,7 @@ namespace Content.Shared.Roles
         public bool? OverrideConsoleVisibility { get; private set; } = null;
 
         [DataField("canBeAntag")]
-        public bool CanBeAntag { get; private set; } = true;
+        public bool CanBeAntag { get; private set; } = false; // Goobstation - Fix the game
 
         /// <summary>
         ///     The "weight" or importance of this job. If this number is large, the job system will assign this job

--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -6,7 +6,7 @@
   startingGear: PassengerGear
   icon: "JobIconPassenger"
   supervisors: job-supervisors-everyone
-  canBeAntag: false # GOOBSTATION: THE RECKONING COMES
+  canBeAntag: true # Goobstation - Fix the game
   access:
   - Maintenance
 

--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -6,6 +6,7 @@
   startingGear: ClownGear
   icon: "JobIconClown"
   supervisors: job-supervisors-hop
+  canBeAntag: true # Goobstation - Fix the game
   access:
   - Theatre
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -6,6 +6,7 @@
   startingGear: MimeGear
   icon: "JobIconMime"
   supervisors: job-supervisors-hop
+  canBeAntag: true # Goobstation - Fix the game
   access:
   - Theatre
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -6,7 +6,7 @@
   startingGear: ServiceWorkerGear
   icon: "JobIconServiceWorker"
   supervisors: job-supervisors-service
-  canBeAntag: false # GOOBSTATION: THE RECKONING COMES. DONT TRY AND BYPASS IT.
+  canBeAntag: true # Goobstation - Fix the game
   access:
   - Service
   - Maintenance


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
it seems that #1174 may have broken the game, this PR fixes it

## Why / Balance
worldwide

## Breaking changes
breaks your bones

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Only tiders can now roll antag. Jobs are for losers.
