### PR TITLE
Revert IPC Rad Damage

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Damage/modifier_sets.yml
@@ -5,4 +5,4 @@
     Cold: 0.2
     Heat: 2
     Shock: 2.5
-    Radiation: 0.5 # Goobstation - Make IPCs take radiation
+    Radiation: 0 # Goobstation - Revert Rad On IPC


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Title

## Why / Balance
To stop IPC from fighting over rad suit against other species and using up even more precious mats on cables

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Revert the IPC Rad PR