### PR TITLE
random gib trait

### DIFF
--- a/Content.Shared/_Goobstation/Traits/Assorted/RandomGibComponent.cs
+++ b/Content.Shared/_Goobstation/Traits/Assorted/RandomGibComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Traits.Assorted;
+
+/// <summary>
+/// Rolls a chance to gib the entity every second.
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(RandomGibSystem))]
+public sealed partial class RandomGibComponent : Component
+{
+    [DataField]
+    public float Chance = 1 / 3600f; // ~63.2% chance of having gibbed an hour in
+}

--- a/Content.Shared/_Goobstation/Traits/Assorted/RandomGibSystem.cs
+++ b/Content.Shared/_Goobstation/Traits/Assorted/RandomGibSystem.cs
@@ -1,0 +1,32 @@
+using Content.Shared.Body.Systems;
+using Robust.Shared.Random;
+using System;
+
+namespace Content.Shared.Traits.Assorted;
+
+public sealed class RandomGibSystem : EntitySystem
+{
+    [Dependency] private readonly SharedBodySystem _body = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    private TimeSpan _updateTime = TimeSpan.FromSeconds(1);
+    private TimeSpan _updateCounter = TimeSpan.FromSeconds(0);
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        _updateCounter += TimeSpan.FromSeconds(frameTime);
+        if (_updateCounter < _updateTime)
+            return;
+        _updateCounter -= _updateTime;
+
+        var query = EntityQueryEnumerator<RandomGibComponent>();
+
+        while (query.MoveNext(out var uid, out var randomGib))
+        {
+            if (_random.Prob(randomGib.Chance))
+                _body.GibBody(uid);
+        }
+    }
+}

--- a/Resources/Locale/en-US/_Goobstation/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Goobstation/traits/traits.ftl
@@ -4,6 +4,9 @@ trait-scottish-desc = Your scottish pride is as strong as your accent!
 trait-wheelchair-bound-name = Wheelchair Bound
 trait-wheelchair-bound-desc = You cannot move without your wheelchair. Wheelchair included.
 
+trait-volatile-name = Volatile
+trait-volatile-desc = You have an extremely rare disease that makes you gib at random, at any time.
+
 trait-bogan-name = Bogan accent
 trait-bogan-desc = You learned this from a mythical creature.
 

--- a/Resources/Prototypes/_Goobstation/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Goobstation/Traits/disabilities.yml
@@ -10,3 +10,11 @@
     - type: BuckleOnMapInit
       prototype: VehicleWheelchair
     - type: LegsStartParalyzed
+
+- type: trait
+  id: Volatile
+  name: trait-volatile-name
+  description: trait-volatile-desc
+  category: Disabilities
+  components:
+    - type: RandomGib


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
adds "volatile" character trait that has an 1/3600 chance to gib you per second

## Why / Balance
funny

## Media
tested, works

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: "Volatile" character trait that makes it so that you may randomly gib at any time. 
