### PR TITLE
Robust baseball bat

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
@@ -22,6 +22,11 @@
       types:
         Blunt: 5
         Structural: 10
+  - type: MeleeThrowOnHit # goob - home run!
+    speed: 5
+    lifetime: 0.25
+  - type: StaminaDamageOnHit # goob - bat makes you hurt and tired (but not as much as the real stun stick)
+    damage: 7.5 # goob - 9 hits to stamcrit someone with armor vest + helmet
   - type: Item
     size: Normal
   - type: Tool


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Baseball bat now has knockback on hit and applies minor stamina damage.

## Why / Balance
The baseball bat was a fairly uninteresting and bland weapon - quite literally mop 2.0 (the exact same damage, only difference being structural) and barely ahead of a toolbox in terms of usefulness in a fight.

## Technical details
Its all yaml.
Baseball bat now uses "type: MeleeThrowOnHit" and "type: StaminaDamageOnHit" 
Stamina damage is set to 7.5 (9 hits to stam-crit someone with a vest + helmet).
MeleeThrowOnHit is set to 5 speed and 0.25 lifetime.

## Media
https://github.com/user-attachments/assets/127def2a-17dc-4d21-a0e2-fb8e19a1a36e

## Requirements
Confirm the following by placing an X in the brackets [X]:
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: the_biggestbruh
- tweak: Baseball bat is now more robust. Get that home run!
