### PR TITLE
fix contortionist's jumpsuit

### DIFF
--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -1,7 +1,6 @@
 - type: entity
   parent: ClothingUniformJumpsuitAtmos
   id: ClothingUniformJumpsuitAtmosSyndie
-  name: Contortionist's Jumpsuit
   components:
   - type: ClothingGrantComponent #Goobstation edit
     component:

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -1,6 +1,7 @@
 - type: entity
   parent: ClothingUniformJumpsuitAtmos
   id: ClothingUniformJumpsuitAtmosSyndie
+  suffix: Contortionistic
   components:
   - type: ClothingGrantComponent #Goobstation edit
     component:
@@ -10,7 +11,7 @@
 - type: entity  # Goobstation original
   parent: ClothingUniformJumpsuitAtmosSyndie
   id: ClothingUniformJumpsuitAtmosSyndieAdmin
-  suffix: Admin
+  suffix: Contortionistic, Admeme
   components:
   - type: ClothingGrantComponent
     component:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
removes the "contortionist's jumpsuit" name from it, it's now a regular atmos jumpsuit
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
it is supposed to be a stealth item
## Technical details
<!-- Summary of code changes for easier review. -->
yaml
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/7f462565-387b-4fe9-a282-a1368f0c2310)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: pheenty
- fix: The contortionist's jumpsuit no longer outs itself by the name.