### PR TITLE
Kinetic crusher buffs and tweaks (not mald trust)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -113,7 +113,6 @@
     color: "#ffeead"
     enabled: false
     radius: 4
-  - type: PressureDamageChange # Lavaland Change: Pressure damage change for kinetic weapons
 
 - type: entity
   parent: [BaseWeaponCrusher, BaseSecurityCargoContraband]
@@ -142,12 +141,12 @@
     capacity: 1
     count: 1
   - type: MeleeWeapon
-    attackRate: 1.2 # Lavaland Change
+    attackRate: 0.8 # Lavaland Change (slightly faster than fireaxe, still weaker damage wise)
     wideAnimationRotation: -135
     damage:
       types:
-        Blunt: 13 # Lavaland Change: no damage when unwielded
-        Slash: 7
+        Blunt: 10 # Lavaland Change: no damage when unwielded2
+        Slash: 5
     soundHit:
       collection: MetalThud
   - type: Wieldable
@@ -163,8 +162,8 @@
   - type: DamageBoostOnMarker
     boost:
       types: # Totals to 70 damage when hitting marked targets
-        Blunt: 34
-        Slash: 16
+        Blunt: 32
+        Slash: 18
     backstabBoost: # And 30 extra for a backstab. Adding up to 100
       types:
         Blunt: 19
@@ -185,7 +184,7 @@
     attackRate: 2
     damage:
       types:
-        Slash: 15
+        Slash: 12.5
   - type: Tag
     tags:
     - Knife

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/crushers.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/crushers.yml
@@ -26,7 +26,6 @@
     capacity: 1
     count: 1
   - type: DisarmMalus
-  - type: PressureDamageChange
   - type: MegafaunaWeaponLooter
 
 - type: entity
@@ -58,11 +57,11 @@
     capacity: 1
     count: 1
   - type: MeleeWeapon
-    attackRate: 0.8
+    attackRate: 0.65 # insane reach
     wideAnimationRotation: -135
     damage:
       types:
-        Blunt: 9
+        Blunt: 10
         Slash: 5
     soundHit:
       collection: MetalThud
@@ -81,8 +80,8 @@
   - type: DamageBoostOnMarker
     boost:
       types: # Totals to 60 damage when hitting marked targets
-        Blunt: 31
-        Slash: 14
+        Blunt: 30
+        Slash: 15
     backstabBoost: # And 20 extra for a backstab. Adding up to 80
       types:
         Blunt: 11
@@ -100,11 +99,11 @@
   - type: UseDelay
     delay: 1
   - type: MeleeWeapon
-    attackRate: 1.2
+    attackRate: 0.70 # slightly slower than the fireaxe
     wideAnimationRotation: -135
     damage:
       types:
-        Blunt: 15
+        Blunt: 17.5
     soundHit:
       collection: MetalThud
     angle: 0
@@ -143,7 +142,7 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Slash: 5
+        Slash: 5 
     soundHit:
       collection: MetalThud
     angle: 0
@@ -175,10 +174,10 @@
   - type: UseDelay
     delay: 1
   - type: MeleeWeapon
-    attackRate: 1.5
+    attackRate: 1.0 # slightly slower than a combat/utility knife, but in return is slightly stronger than one
     damage:
       types:
-        Slash: 15
+        Slash: 12.5
     soundHit:
       collection: MetalThud
     angle: 0
@@ -192,7 +191,7 @@
   - type: DamageBoostOnMarker
     boost:
       types: # Totals to 50 damage when hitting marked targets
-        Slash: 25
+        Slash: 27.5
         Blunt: 10
     backstabBoost: # And 20 extra for a backstab
       types:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Crushers are no longer affected by pressure damage wise (destabiliser shots cannot hit normal mobs or players)

## Why / Balance
No reason for the crushers to be literally glass-shard levels of damage (less damage than a crowbar???), they also can't land destabiliser shots on people or non-lavaland mobs so they won't be going around insta-killing either

## Technical details
Tweaks to the damage values and also attack speed. Pressure damage modifier was removed from the crushers.
Kinetic Crusher damage now totals to 15 (from 20), attackRate = 0.8 (slightly faster than fireaxe)
Kinetic Spear damage now totals to 15 (from 14), attackRate = 0.65 (2 tile reach btw)
Kinetic Hammer damage now totals to 17.5 (from 15), attackRate = 0.70 (slightly slower than fireaxe)
Claws were untouched (5 damage without the pressure nerf btw)
Kinetic Machete damage now totals to 12.5 (from 15), attackRate = 1.0 (slower than utility/combat knives, still slightly stronger)
Kinetic Crusher Knife damage now totals to 12.5 (this is unused anyways)

## Media
![image_2025-02-23_025854171](https://github.com/user-attachments/assets/af577301-a1c7-4442-bab1-8f4fdf1832a4)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: the_biggestbruh
- tweak: The Kinetic Crushers' damage values are no longer affected by pressure. (Nanotrasen misplaced their styrofoam display models with the field-ready ones. oops.)
- tweak: The Kinetic Crushers' damage and attack speed values were adjusted.
