### PR TITLE
Hotfix - moths no longer eat before equipping items in hand

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSystem.cs
@@ -34,6 +34,7 @@ using Content.Shared.Containers.ItemSlots;
 using Robust.Server.GameObjects;
 using Content.Shared.Whitelist;
 using Content.Shared.Destructible;
+using Content.Shared.Clothing.EntitySystems;
 
 namespace Content.Server.Nutrition.EntitySystems;
 
@@ -69,7 +70,8 @@ public sealed class FoodSystem : EntitySystem
 
         // TODO add InteractNoHandEvent for entities like mice.
         // run after openable for wrapped/peelable foods
-        SubscribeLocalEvent<FoodComponent, UseInHandEvent>(OnUseFoodInHand, after: new[] { typeof(OpenableSystem), typeof(ServerInventorySystem) });
+        SubscribeLocalEvent<FoodComponent, UseInHandEvent>(OnUseFoodInHand,
+            after: new[] { typeof(OpenableSystem), typeof(ServerInventorySystem), typeof(ClothingSystem) }); // Goob - moths eating things in their hands when quick equipping
         SubscribeLocalEvent<FoodComponent, AfterInteractEvent>(OnFeedFood);
         SubscribeLocalEvent<FoodComponent, GetVerbsEvent<AlternativeVerb>>(AddEatVerb);
         SubscribeLocalEvent<FoodComponent, ConsumeDoAfterEvent>(OnDoAfter);


### PR DESCRIPTION
## About the PR
If you press Z while holding insuls, mothpeople will eat it. Now that's no longer the case, and they'll be quick-equipped first

## Technical details
There's been a bunch of bugs relating to item use order, gotta work on it. For now a hotfix so you don't eat your heretic medalion, insuls, whatever

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.