### PR TITLE
downprice dimension pot

### DIFF
--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -615,6 +615,6 @@
   description: uplink-dimension-pot-desc
   productEntity: DimensionPot
   cost:
-    Telecrystal: 70
+    Telecrystal: 40
   categories:
   - UplinkDeception


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
see CL

## Why / Balance
70 TC is way too overpriced, every single person i ask about it agrees

it doesn't really do much and if people do gib pot or something, admin issue
even then, it's easily (and this is intentional) metagameable and it's easy to drag its own user with it by just dragging it

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Syndicate dimension pot 70 TC -> 40 TC.
