### PR TITLE
dwarves feel ore

### DIFF
--- a/Content.Shared/Mining/MiningScannerSystem.cs
+++ b/Content.Shared/Mining/MiningScannerSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._NF.Mining.Components; // Frontier
 using Content.Shared.Inventory;
 using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Mining.Components;
@@ -8,7 +9,7 @@ using Robust.Shared.Timing;
 
 namespace Content.Shared.Mining;
 
-public sealed class MiningScannerSystem : EntitySystem
+public sealed partial class MiningScannerSystem : EntitySystem // Frontier: partial
 {
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly INetManager _net = default!;
@@ -22,6 +23,7 @@ public sealed class MiningScannerSystem : EntitySystem
         SubscribeLocalEvent<MiningScannerComponent, EntGotInsertedIntoContainerMessage>(OnInserted);
         SubscribeLocalEvent<MiningScannerComponent, EntGotRemovedFromContainerMessage>(OnRemoved);
         SubscribeLocalEvent<MiningScannerComponent, ItemToggledEvent>(OnToggled);
+        NFInitialize(); // Frontier
     }
 
     private void OnInserted(Entity<MiningScannerComponent> ent, ref EntGotInsertedIntoContainerMessage args)
@@ -85,8 +87,17 @@ public sealed class MiningScannerSystem : EntitySystem
         {
             if (viewer.QueueRemoval)
             {
-                RemCompDeferred(uid, viewer);
-                continue;
+                // Frontier: innate mining scanner
+                if (TryComp<InnateMiningScannerViewerComponent>(uid, out var innateViewer))
+                {
+                    SetupInnateMiningViewerComponent((uid, innateViewer));
+                }
+                else
+                {
+                    // End Frontier: innate mining scanner
+                    RemCompDeferred(uid, viewer);
+                    continue;
+                } // Frontier
             }
 
             if (_timing.CurTime < viewer.NextPingTime)

--- a/Content.Shared/_NF/Mining/Components/InnateMiningScannerViewerComponent.cs
+++ b/Content.Shared/_NF/Mining/Components/InnateMiningScannerViewerComponent.cs
@@ -1,0 +1,22 @@
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+using Content.Shared.Mining;
+
+namespace Content.Shared._NF.Mining.Components;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(MiningScannerSystem))]
+public sealed partial class InnateMiningScannerViewerComponent : Component
+{
+    [DataField, ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
+    public float ViewRange;
+
+    [DataField, AutoNetworkedField]
+    public float AnimationDuration = 1.5f;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan PingDelay = TimeSpan.FromSeconds(5);
+
+    [DataField, AutoNetworkedField]
+    public SoundSpecifier? PingSound = null;
+
+}

--- a/Content.Shared/_NF/Mining/MiningScannerSystem.Innate.cs
+++ b/Content.Shared/_NF/Mining/MiningScannerSystem.Innate.cs
@@ -1,0 +1,33 @@
+using Content.Shared.Mining.Components;
+using Content.Shared._NF.Mining.Components;
+
+namespace Content.Shared.Mining;
+
+public sealed partial class MiningScannerSystem : EntitySystem
+{
+
+    /// <inheritdoc/>
+    public void NFInitialize()
+    {
+        SubscribeLocalEvent<InnateMiningScannerViewerComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(Entity<InnateMiningScannerViewerComponent> ent, ref ComponentStartup args)
+    {
+        if (!HasComp<MiningScannerViewerComponent>(ent))
+        {
+            SetupInnateMiningViewerComponent(ent);
+        }
+    }
+
+    private void SetupInnateMiningViewerComponent(Entity<InnateMiningScannerViewerComponent> ent)
+    {
+        var comp = EnsureComp<MiningScannerViewerComponent>(ent);
+        comp.ViewRange = ent.Comp.ViewRange;
+        comp.PingDelay = ent.Comp.PingDelay;
+        comp.PingSound = ent.Comp.PingSound;
+        comp.QueueRemoval = false;
+        comp.NextPingTime = _timing.CurTime + ent.Comp.PingDelay;
+        Dirty(ent.Owner, comp);
+    }
+}

--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -68,6 +68,9 @@
   - type: FootPrints # WD EDIT
     leftBarePrint: "footprint-left-bare-dwarf"
     rightBarePrint: "footprint-right-bare-dwarf"
+  - type: InnateMiningScannerViewer # Frontier
+    pingSound: null
+    viewRange: 3 # Goob value
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/ServerInfo/Guidebook/Mobs/Dwarf.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Dwarf.xml
@@ -5,7 +5,7 @@
     <GuideEntityEmbed Entity="MobDwarf" Caption=""/>
   </Box>
 
-  Dwarves are similar to humans in most respect, but tolerate alcohol better and are healed by it.
+  Dwarves are similar to humans in most respect, but tolerate alcohol better and are healed by it. They are also able to feel nearby ore in 3 tile radius.
 
 
 </Document>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
ported dwarf innate mineral scanner from frontier, but changed distance to 3 (still very good in lavaland)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
dwarves being good miners is good
Rouden agreed
## Technical details
<!-- Summary of code changes for easier review. -->
tested, works
https://github.com/new-frontiers-14/frontier-station-14/pull/2112
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/e7ce9fd0-5ed3-4c00-9839-722766dd96af)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: pheenty
- add: Dwarves now have innate mineral scanner. Rock and Stone!