### PR TITLE
Hotfix Lavaland planet

### DIFF
--- a/Content.Server/_Lavaland/Procedural/Systems/LavalandPlanetSystem.cs
+++ b/Content.Server/_Lavaland/Procedural/Systems/LavalandPlanetSystem.cs
@@ -260,6 +260,9 @@ public sealed class LavalandPlanetSystem : EntitySystem
         _mapManager.DoMapInitialize(lavalandMapId);
         _mapManager.SetMapPaused(lavalandMapId, false);
 
+        // also preload the planet itself
+        _biome.Preload(lavaland.Value, biome, Box2.CentredAroundZero(new Vector2(prototype.RestrictedRange, prototype.RestrictedRange)));
+
         // Finally add destination, only for Mining Shittles
         var dest = AddComp<FTLDestinationComponent>(lavalandMap);
         dest.Whitelist = new EntityWhitelist {Components = ["MiningShuttle"]};


### PR DESCRIPTION
## About the PR
Hotfixes LavalandPreloaderSystem by preloading it before round starts.
Literally nothing else

:cl: Rouden
- fix: Fixed a ton of lag when loading lavaland for the first time.
