### PR TITLE
Increase amag price to 25 TC

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -778,7 +778,7 @@
   description: uplink-access-breaker-desc
   productEntity: AccessBreaker
   cost:
-    Telecrystal: 20 # goob - keeping the 20 price since it's just damn good
+    Telecrystal: 25 # goob - keeping the 25 price since it's just damn good
   categories:
   - UplinkDisruption
 


### PR DESCRIPTION
## About the PR
Up amag price 20->25TC

## Why / Balance
20 TC is kinda too low, also lets you buy too much other stuff. This is *especially* because amag is REALLY good, opens doors, lockers, consoles, you can run into AI with antimov rn which is... problematic due to metafriending. Overall price is 40TC which is the same as before. Not touching emag since it has minimal use rn, unless you wanna print ammo in which case it's worth even if it was 30 or 40TC

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.