### PR TITLE
Small smartgun fix

### DIFF
--- a/Content.Client/_Goobstation/Weapons/LaserPointer/LaserPointerSystem.cs
+++ b/Content.Client/_Goobstation/Weapons/LaserPointer/LaserPointerSystem.cs
@@ -12,14 +12,12 @@ using Robust.Client.Player;
 using Robust.Client.State;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Timing;
 
 namespace Content.Client._Goobstation.Weapons.LaserPointer;
 
 public sealed class LaserPointerSystem : SharedLaserPointerSystem
 {
     [Dependency] private readonly IOverlayManager _overlay = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IEyeManager _eye = default!;
@@ -46,7 +44,7 @@ public sealed class LaserPointerSystem : SharedLaserPointerSystem
     {
         base.Update(frameTime);
 
-        if (!_timing.IsFirstTimePredicted)
+        if (!Timing.IsFirstTimePredicted)
             return;
 
         if (!TryComp(_player.LocalEntity, out HandsComponent? hands) ||

--- a/Content.Server/_Goobstation/Weapons/Ranged/LaserPointerSystem.cs
+++ b/Content.Server/_Goobstation/Weapons/Ranged/LaserPointerSystem.cs
@@ -2,7 +2,6 @@ using Content.Server.NPC.Components;
 using Content.Shared._Goobstation.Weapons.SmartGun;
 using Content.Shared.Wieldable.Components;
 using Robust.Server.GameStates;
-using Robust.Shared.Player;
 
 namespace Content.Server._Goobstation.Weapons.Ranged;
 
@@ -21,7 +20,6 @@ public sealed class LaserPointerSystem : SharedLaserPointerSystem
     {
         base.Update(frameTime);
 
-        var actorQuery = GetEntityQuery<ActorComponent>();
         var npcCombatQuery = GetEntityQuery<NPCRangedCombatComponent>();
         var query = EntityQueryEnumerator<LaserPointerComponent, WieldableComponent, TransformComponent>();
         while (query.MoveNext(out var uid, out var pointer, out var wieldable, out var xform))
@@ -29,7 +27,8 @@ public sealed class LaserPointerSystem : SharedLaserPointerSystem
             if (!wieldable.Wielded)
                 continue;
 
-            if (npcCombatQuery.HasComp(xform.ParentUid) || actorQuery.HasComp(xform.ParentUid))
+            if (npcCombatQuery.HasComp(xform.ParentUid) ||
+                Timing.CurTime - pointer.LastNetworkEventTime < pointer.MaxDelayBetweenNetworkEvents)
                 continue;
 
             AddOrRemoveLine(GetNetEntity(uid), pointer, wieldable, xform, null, null);

--- a/Content.Shared/_Goobstation/Weapons/SmartGun/LaserPointerComponent.cs
+++ b/Content.Shared/_Goobstation/Weapons/SmartGun/LaserPointerComponent.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using Content.Shared.Physics;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
@@ -24,4 +23,10 @@ public sealed partial class LaserPointerComponent : Component
 
     [DataField]
     public Color DefaultColor = Color.Red;
+
+    [ViewVariables]
+    public TimeSpan LastNetworkEventTime = TimeSpan.Zero;
+
+    [DataField]
+    public TimeSpan MaxDelayBetweenNetworkEvents = TimeSpan.FromSeconds(0.5);
 }

--- a/Content.Shared/_Goobstation/Weapons/SmartGun/SmartGunSystem.cs
+++ b/Content.Shared/_Goobstation/Weapons/SmartGun/SmartGunSystem.cs
@@ -24,6 +24,9 @@ public sealed class SmartGunSystem : EntitySystem
         if (comp.RequiresWield && !(TryComp(uid, out WieldableComponent? wieldable) && wieldable.Wielded))
             return;
 
+        if (gun.Target == Transform(uid).ParentUid)
+            return;
+
         foreach (var projectile in args.FiredProjectiles)
         {
             if (!TryComp(projectile, out HomingProjectileComponent? homing))

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/SMGs/smartgun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/SMGs/smartgun.yml
@@ -79,3 +79,7 @@
   - type: Item
     shape:
     - 0,0,2,1
+  - type: CursorOffsetRequiresWield
+  - type: EyeCursorOffset
+    maxOffset: 1.5
+    pvsIncrease: 0.15


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Made it so you can't track yourself using smartgun.
Fixed potential issue when you could theoretically break laser pointer if your client doesn't send network events (like if you have prediction disabled or something)
Also added zoom to smartgun, Half the zoom of hristov.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

Relying on client network events for laser pointer is bad. Now if no event was recieved from client in 0.5 seconds (and the gun is not wielded by an npc), it automatically resets laser pointer so that it points at wielder direction and has red color.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: Aviu
- add: You can now zoom slightly when wielding smart smg.