### PR TITLE
Medical cyborgs do surgery faster and can do surgery through clothing

### DIFF
--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -167,6 +167,9 @@
     - Biological
   - type: SurgeryTarget # Shitmed
   - type: Sanitized # Shitmed
+  - type: SurgeryIgnoreClothing
+  - type: SurgerySpeedModifier
+    speedModifier: 1.75
 
   # Visual
   inventoryTemplateId: borgDutch

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -169,7 +169,7 @@
   - type: Sanitized # Shitmed
   - type: SurgeryIgnoreClothing
   - type: SurgerySpeedModifier
-    speedModifier: 1.75
+    speedModifier: 1.5
 
   # Visual
   inventoryTemplateId: borgDutch


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gave medical cyborgs the 1.5x surgery medical interns have. Gave medical cyborgs the ignore clothing ability abductors have.

## Why / Balance
Medical cyborgs are robots designed specifically to heal people, so it makes sense they'd do it faster. Not being able to strip people means when patients pile up in medical, and people need surgery to be healed, you have to ask someone with hands to strip them first. Now medical cyborgs can help medical when they're overwhelmed with patients. 

I gave them the 1.75x surgery modifier that doctors and chemists have at first, but then I saw how quickly you could remove someone's heart with a roundstart surgery module, so I went with 1.5x speed. Being able to surgery through clothes might be too powerful if they're emagged, but at least it requires people to be lying down, unlike walking up to someone with a borg hypo and injecting them with 15u of mutagen.

## Technical details
Added - type: SurgeryIgnoreClothing and - type: SurgerySpeedModifier to borg_types.yml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/176c5b44-e8d4-4efc-98cb-886065006725


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Medical cyborgs can do surgery through clothing and do surgery faster.