### PR TITLE
Increase nukie explosive resist so people stop cheesing them

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -660,7 +660,7 @@
   - type: Clothing
     sprite: Clothing/Belt/militarywebbing.rsi
   - type: ExplosionResistance
-    damageCoefficient: 0.5
+    damageCoefficient: 0.05 #goobstation
 
 - type: entity
   parent: ClothingBeltMilitaryWebbing

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -584,7 +584,7 @@
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.5
+    damageCoefficient: 0.3 #goob
   - type: Armor
     modifiers:
       coefficients:
@@ -690,7 +690,7 @@
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.5
+    damageCoefficient: 0.2 #goob
   - type: Armor
     modifiers:
       coefficients:
@@ -726,7 +726,7 @@
     highPressureMultiplier: 0.2
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.3
+    damageCoefficient: 0.2 #goob
   - type: Armor
     modifiers:
       coefficients:


### PR DESCRIPTION

## About the PR
Nukie armor protects far more from explosions, as do chest rigs

## Why / Balance
Bombing is by far the lamest way to fight nukies, its still usefull against mechs and borgs though.

:cl:
- tweak: Increased nukie explosion resist