### PR TITLE
Submarine Tweaks

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Markers/Spawners/Random/insuls.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Markers/Spawners/Random/insuls.yml
@@ -1,0 +1,15 @@
+- type: entity
+  id: RandomInsulsSpawner
+  name: random insuls spawner
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: red
+        - sprite: Clothing/Hands/Gloves/Color/yellow.rsi
+          state: icon
+    - type: RandomSpawner
+      chance: 0.5
+      prototypes:
+        - ClothingHandsGlovesConducting
+        - ClothingHandsGlovesColorYellow

--- a/Resources/Prototypes/_Goobstation/Entities/Markers/Spawners/Random/landmines.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Markers/Spawners/Random/landmines.yml
@@ -1,0 +1,18 @@
+- type: entity
+  id: RandomLandmineSpawner
+  name: random landmine spawner
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: red
+        - sprite: Objects/Misc/landmine.rsi
+          state: landmine
+    - type: RandomSpawner
+      chance: 0.90
+      prototypes:
+        - LandMineModular
+      rareChance: 0.10
+      rarePrototypes:
+      - LandMineExplosive
+      - LandMineKick

--- a/Resources/Prototypes/_Goobstation/Maps/submarine.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/submarine.yml
@@ -21,13 +21,15 @@
             Librarian: [ 1, 1 ]
           #command
             Captain: [ 1, 1 ]
+            NanotrasenRepresentative: [ 1, 1 ]
+            BlueshieldOfficer: [ 1, 1 ]
           #engineering
             AtmosphericTechnician: [ 2, 4 ]
             ChiefEngineer: [ 1, 1 ]
             StationEngineer: [ 4, 6 ]
             TechnicalAssistant: [ 1, 2 ]
           #medical
-            Chemist: [ 2, 2 ]
+            Chemist: [ 2, 4 ]
             ChiefMedicalOfficer: [ 1, 1 ]
             MedicalDoctor: [ 4, 5 ]
             MedicalIntern: [ 1, 2 ]
@@ -36,17 +38,17 @@
           #security
             Detective: [ 1, 1 ]
             HeadOfSecurity: [ 1, 1 ]
-            SecurityOfficer: [ 4, 6 ]
-            SecurityCadet: [ 1, 2 ]
+            SecurityOfficer: [ 4, 8 ]
+            SecurityCadet: [ 1, 4 ]
             Warden: [ 1, 1 ]
           #service
             Bartender: [ 2, 3 ]
-            Botanist: [ 2, 4 ]
+            Botanist: [ 2, 5 ]
             Boxer: [ 2, 2 ]
             Chef: [ 3, 4 ]
             Clown: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
-            Janitor: [ 2, 3 ]
+            Janitor: [ 2, 4 ]
             Lawyer: [ 2, 3 ]
             Mime: [ 1, 1 ]
             Musician: [ 2, 2 ]
@@ -57,7 +59,7 @@
             Chaplain: [ 1, 1 ]
             ResearchAssistant: [ 1, 2 ]
             ResearchDirector: [ 1, 1 ]
-            Scientist: [ 4, 5 ]
+            Scientist: [ 4, 6 ]
           #silicon
             StationAi: [ 1, 1 ]
             Borg: [ 3, 3 ]


### PR DESCRIPTION
## About the PR
- Added slots for BSO and NTR
- Added some extra slots for some jobs
- Mapped in some funny stuff here and there.
- Fixed submarine mining shuttle dock colliding with the cargo one (whoops)

Basically my first mapping PR, probably will pay off someone to take care of these from now on, I suck at mapping, put me back in the code caves coach.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
**Changelog** 
:cl: Mocho
- tweak: Added some extra slots for some jobs on Submarine
- tweak: Mapped in some funny stuff here and there for Submarine.
- fix: Added slots for BSO and NTR on Submarine.
- fix: Fixed submarine mining shuttle dock colliding with the cargo one (whoops).
