### PR TITLE
Admin abuse tokens

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/servercurrency/server_currency.ftl
+++ b/Resources/Locale/en-US/_Goobstation/servercurrency/server_currency.ftl
@@ -73,7 +73,7 @@ gs-balanceui-shop-buy-token-hightier-antag-desc = Allows you become a Headrev, N
 gs-balanceui-shop-buy-token-midtier-antag-desc = Allows you become a Traitor, Changeling, Heretic, or any antagonist from a lower tier.
 gs-balanceui-shop-buy-token-lowtier-antag-desc = Allows you become a Thief or Blob.
 gs-balanceui-shop-buy-token-ghost-desc = Allows you request a ghost role antagonist to be spawned.
-gs-balanceui-shop-buy-token-admin-abuse-desc = Allows you to request an admin to abuse you. Admins are encouraged to go wild.
+gs-balanceui-shop-buy-token-admin-abuse-desc = Allows you to request an admin to abuse their powers against you. Admins are encouraged to go wild.
 
 gs-balanceui-admin-add-label = Add (or subtract) money:
 gs-balanceui-admin-add-player = Player name

--- a/Resources/Locale/en-US/_Goobstation/servercurrency/server_currency.ftl
+++ b/Resources/Locale/en-US/_Goobstation/servercurrency/server_currency.ftl
@@ -61,16 +61,19 @@ gs-balanceui-shop-buy-token-hightier-antag = Buy high tier antag token - {$price
 gs-balanceui-shop-buy-token-midtier-antag = Buy mid tier antag token - {$price} Goob Coins
 gs-balanceui-shop-buy-token-lowtier-antag = Buy low tier antag token - {$price} Goob Coins
 gs-balanceui-shop-buy-token-ghost = Buy ghost role token - {$price} Goob Coins
+gs-balanceui-shop-buy-token-admin-abuse = Buy admin abuse token - {$price} Goob Coins
 
 gs-balanceui-shop-token-hightier-antag = High tier antag token
 gs-balanceui-shop-token-midtier-antag = Mid tier antag token
 gs-balanceui-shop-token-lowtier-antag = Low tier antag token
 gs-balanceui-shop-token-ghost = Ghost role token
+gs-balanceui-shop-token-admin-abuse = Admin abuse token
 
 gs-balanceui-shop-buy-token-hightier-antag-desc = Allows you become a Headrev, Nukie, Wizard, Initial Infected, or any antagonist from a lower tier.
 gs-balanceui-shop-buy-token-midtier-antag-desc = Allows you become a Traitor, Changeling, Heretic, or any antagonist from a lower tier.
 gs-balanceui-shop-buy-token-lowtier-antag-desc = Allows you become a Thief or Blob.
 gs-balanceui-shop-buy-token-ghost-desc = Allows you request a ghost role antagonist to be spawned.
+gs-balanceui-shop-buy-token-admin-abuse-desc = Allows you to request an admin to abuse you. Admins are encouraged to go wild.
 
 gs-balanceui-admin-add-label = Add (or subtract) money:
 gs-balanceui-admin-add-player = Player name
@@ -80,5 +83,6 @@ gs-balanceui-remark-token-hightier-antag = Bought a high tier antag token.
 gs-balanceui-remark-token-midtier-antag = Bought a mid tier antag token.
 gs-balanceui-remark-token-lowtier-antag = Bought a low tier antag token.
 gs-balanceui-remark-token-ghost = Bought a ghost role token.
+gs-balanceui-remark-token-admin-abuse = Bought an admin abuse token.
 gs-balanceui-shop-click-confirm = Click again to confirm
 gs-balanceui-shop-purchased = Purchased {$item}

--- a/Resources/Prototypes/_Goobstation/ServerCurrency/token_listings.yml
+++ b/Resources/Prototypes/_Goobstation/ServerCurrency/token_listings.yml
@@ -35,5 +35,5 @@
   name: gs-balanceui-shop-buy-token-admin-abuse
   label: gs-balanceui-shop-token-admin-abuse
   description: gs-balanceui-shop-buy-token-admin-abuse-desc
-  price: 1000
+  price: 250
   adminNote: gs-balanceui-remark-token-admin-abuse

--- a/Resources/Prototypes/_Goobstation/ServerCurrency/token_listings.yml
+++ b/Resources/Prototypes/_Goobstation/ServerCurrency/token_listings.yml
@@ -29,3 +29,11 @@
   description: gs-balanceui-shop-buy-token-ghost-desc
   price: 500
   adminNote: gs-balanceui-remark-token-ghost
+
+- type: tokenListing
+  id: AdminAbuseToken
+  name: gs-balanceui-shop-buy-token-admin-abuse
+  label: gs-balanceui-shop-token-admin-abuse
+  description: gs-balanceui-shop-buy-token-admin-abuse-desc
+  price: 1000
+  adminNote: gs-balanceui-remark-token-admin-abuse


### PR DESCRIPTION
## About the PR
Adds admin abuse tokens for 1000 GC

## Why / Balance
Funny. 1000 GC was chosen so that people don't spam it too much, and so that admins feel like it's reasonable to do crazy stuff to fulfill the tokens.

Will lower the price if no one buys it, or if admins are lazy bums and just smite you on the spot too much (god at least refund the token then, will you? We all have bad days, no need to take it out on others)

## Media
![{E5EE6E5A-796F-4866-914F-724D5E952CA1}](https://github.com/user-attachments/assets/895595d1-312f-40f9-8508-09b83fbbe24f)
![{AA0CE0D9-AC79-40A3-AFDC-C252CAAD8317}](https://github.com/user-attachments/assets/8d24c022-7266-47e1-8892-7359c2ec394e)


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: You can buy admin abuse tokens now