### PR TITLE
Ininite mouse/lag exploit patch

### DIFF
--- a/Content.Server/Animals/Systems/EggLayerSystem.cs
+++ b/Content.Server/Animals/Systems/EggLayerSystem.cs
@@ -39,7 +39,7 @@ public sealed class EggLayerSystem : EntitySystem
     {
         base.Update(frameTime);
         var query = EntityQueryEnumerator<EggLayerComponent>();
-        var eligibleEggLayers = new List<(EntityUid, EggLayerComponent)>(); // Goob - self-spawning
+        var eligibleEggLayers = new List<Entity<EggLayerComponent>>(); // Goob - self-spawning
         while (query.MoveNext(out var uid, out var eggLayer))
         {
             // Players should be using the action.
@@ -62,7 +62,7 @@ public sealed class EggLayerSystem : EntitySystem
         // Goob - self-spawning start
         foreach (var ent in eligibleEggLayers)
         {
-            TryLayEgg(ent.Item1, ent.Item2);
+            TryLayEgg(ent.Owner, ent.Comp);
         }
         // Goob - self-spawning end
     }

--- a/Content.Server/Animals/Systems/EggLayerSystem.cs
+++ b/Content.Server/Animals/Systems/EggLayerSystem.cs
@@ -39,6 +39,7 @@ public sealed class EggLayerSystem : EntitySystem
     {
         base.Update(frameTime);
         var query = EntityQueryEnumerator<EggLayerComponent>();
+        var eligibleEggLayers = new List<(EntityUid, EggLayerComponent)>(); // Goob - self-spawning
         while (query.MoveNext(out var uid, out var eggLayer))
         {
             // Players should be using the action.
@@ -56,9 +57,14 @@ public sealed class EggLayerSystem : EntitySystem
 
             // Hungerlevel check/modification is done in TryLayEgg()
             // so it's used for player controlled chickens as well.
-
-            TryLayEgg(uid, eggLayer);
+            eligibleEggLayers.Add((uid, eggLayer)); // Goob - self-spawning
         }
+        // Goob - self-spawning start
+        foreach (var ent in eligibleEggLayers)
+        {
+            TryLayEgg(ent.Item1, ent.Item2);
+        }
+        // Goob - self-spawning end
     }
 
     private void OnMapInit(EntityUid uid, EggLayerComponent component, MapInitEvent args)

--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -63,6 +63,7 @@ public sealed partial class HungerComponent : Component
 
 
     /// <summary>
+    /// Goobstation
     /// Starting hunger value the entity should be at, if set then it overrides the default hunger value randomization behaviour.
     /// </summary>
     [DataField("startingHunger"), ViewVariables(VVAccess.ReadOnly)]

--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -61,6 +61,14 @@ public sealed partial class HungerComponent : Component
     [AutoNetworkedField]
     public HungerThreshold CurrentThreshold;
 
+
+    /// <summary>
+    /// Starting hunger value the entity should be at, if set then it overrides the default hunger value randomization behaviour.
+    /// </summary>
+    [DataField("startingHunger"), ViewVariables(VVAccess.ReadOnly)]
+    [AutoNetworkedField]
+    public float? StartingHunger = null;
+
     /// <summary>
     /// A dictionary relating HungerThreshold to the amount of <see cref="HungerSystem.GetHunger">current hunger</see> needed for each one
     /// </summary>

--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -61,7 +61,6 @@ public sealed partial class HungerComponent : Component
     [AutoNetworkedField]
     public HungerThreshold CurrentThreshold;
 
-
     /// <summary>
     /// Goobstation
     /// Starting hunger value the entity should be at, if set then it overrides the default hunger value randomization behaviour.

--- a/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
@@ -44,6 +44,11 @@ public sealed class HungerSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, HungerComponent component, MapInitEvent args)
     {
+        if (component.StartingHunger is not null)
+        {
+            SetHunger(uid, (float) component.StartingHunger, component);
+            return;
+        }
         var amount = _random.Next(
             (int) component.Thresholds[HungerThreshold.Peckish] + 10,
             (int) component.Thresholds[HungerThreshold.Okay]);

--- a/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
@@ -44,11 +44,13 @@ public sealed class HungerSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, HungerComponent component, MapInitEvent args)
     {
+        // <goobstation> Starting hunger overwrite
         if (component.StartingHunger is not null)
         {
             SetHunger(uid, (float) component.StartingHunger, component);
             return;
         }
+        // </goobstation>
         var amount = _random.Next(
             (int) component.Thresholds[HungerThreshold.Peckish] + 10,
             (int) component.Thresholds[HungerThreshold.Okay]);

--- a/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
@@ -44,7 +44,7 @@ public sealed class HungerSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, HungerComponent component, MapInitEvent args)
     {
-        // <goobstation> Starting hunger overwrite
+        // <goobstation> Starting hunger override
         if (component.StartingHunger is not null)
         {
             SetHunger(uid, (float) component.StartingHunger, component);

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1739,7 +1739,7 @@
       Dead: 0
     baseDecayRate: 0.04
   - type: Hunger
-    startingHunger: 15
+    startingHunger: 15 # Goobstation change
     thresholds:
       Overfed: 35
       Okay: 25

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1739,6 +1739,7 @@
       Dead: 0
     baseDecayRate: 0.04
   - type: Hunger
+    startingHunger: 15
     thresholds:
       Overfed: 35
       Okay: 25
@@ -1825,7 +1826,7 @@
   - type: EggLayer # Goobstation
     eggSpawn:
     - id: MobMouse
-    hungerUsage: 10
+    hungerUsage: 20
     eggLayAction: MouseMultiply
 
 - type: entity


### PR DESCRIPTION
## About the PR
Mice no longer spawn gazillion mice 10 minutes into the round through exponential scaling

## Why / Balance
Lag. Fixes https://github.com/Goob-Station/Goob-Station/pull/1767

## Technical details
Rn mice spawn with 25 hunger, which lets them use their "spawn" ability 2 times. This will generate two mice that can do the same. This is *obviously* bad since it's gonna lag the server to hell after 30 minutes or less. As such, food requirement for spawning mice is changed to 20, and starting food amount is set to 15. This in combination with the original food rate consumption decrease makes it so that mice need to eat something (finite resource) before they start any multiplication attempts.

## Media
Roundstart:
![{F3E22CBA-7444-4E3A-8390-B18B68FDEF56}](https://github.com/user-attachments/assets/7eab2e4f-5fd8-4d49-9b03-9858441996c1)
After all food on the station has been exhausted, and population has stabilized
![{715A0E1A-E96A-4057-A4DC-46658AA7C05C}](https://github.com/user-attachments/assets/754bb706-7a80-4957-990e-4dc5be961db9)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

No changelog cuz this PR likely should be merged in the same update as https://github.com/Goob-Station/Goob-Station/pull/1767