### PR TITLE
remove bingle announcement

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/bingleEvent.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/bingleEvent.yml
@@ -3,9 +3,6 @@
   parent: BaseStationEventShortDelay
   components:
   - type: StationEvent
-    startAnnouncement: bingle-station-announcement
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
     earliestStart: 20
     weight: 8
     duration: 50


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
title

## Why / Balance
announcement is very attention-grabbing so right now when bingles spawn, the whole of crew and sec mobilises to immediately go kill them and they can't do anything
observed this every time i've seen bingles spawn

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Bingles are no longer announced.