### PR TITLE
rare staff of change bingle transformation

### DIFF
--- a/Resources/Prototypes/_Goobstation/Wizard/Random/polymorph.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/Random/polymorph.yml
@@ -181,6 +181,7 @@
     MobSmallPurpleSnake: 0.5
     MobStickman: 1
     MobCreature: 1
+    MobBingle: 1
 
 - type: weightedRandomEntity
   id: WabbajackSpecial

--- a/Resources/Prototypes/_Goobstation/Wizard/Random/polymorph.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/Random/polymorph.yml
@@ -19,6 +19,7 @@
     WabbajackXeno: 1
     WabbajackSpecies: 1
     WabbajackAnimal: 1
+    WabbajackSpecial: 0.05 # for high-impact transmutations, approximately 1/160 chance with 8 groups
 
 - type: weightedRandomEntity
   id: WabbajackMonkey
@@ -180,3 +181,8 @@
     MobSmallPurpleSnake: 0.5
     MobStickman: 1
     MobCreature: 1
+
+- type: weightedRandomEntity
+  id: WabbajackSpecial
+  weights:
+    MobBinglePrime: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
makes staff of change have a chance to turn you into a bingle or bingle prime (which will also spawn the pit)

## Why / Balance
funny
also bingle is good for having ghost roles which we lack right now
also allows you to go funny binglezard gimmick
made discord vote, currently **heavily** in favor

## Media
tested, works

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no CL, it'll be a surprise