### PR TITLE
increase ripley punch damage

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -180,7 +180,8 @@
     attackRate: 1
     damage:
       types:
-        Blunt: 14 #intentionally shit so people realize that going into combat with the ripley is usually a bad idea.
+        Blunt: 25 # Goobstation - Make ripley punch hard
+        Structural: 30 # Goobstation - Make ripley punch hard
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.25
     baseSprintSpeed: 3.6


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
14 blunt -> 25 blunt + 30 structural

## Why / Balance
it's a big mech why does it hit as hard as a toolbox

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Ripley punch damage increased 14 blunt -> 25 blunt + 30 structural.
