### PR TITLE
Decrease Goob's Standard of Roleplay to LRP-∞ (Revert #1174)

### DIFF
--- a/Content.IntegrationTests/Tests/GameRules/TraitorRuleTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/TraitorRuleTest.cs
@@ -10,9 +10,6 @@ using Content.Shared.GameTicking.Components;
 using Content.Shared.Mind;
 using Content.Shared.NPC.Systems;
 using Content.Shared.Objectives.Components;
-using Content.Shared.Roles; // Goobstation
-using Content.Shared.Preferences; // Goobstation
-using Content.Shared.CCVar; // Goobstation
 using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
 
@@ -23,30 +20,6 @@ public sealed class TraitorRuleTest
 {
     private const string TraitorGameRuleProtoId = "Traitor";
     private const string TraitorAntagRoleName = "Traitor";
-    private static readonly ProtoId<JobPrototype> TechnicalAssistant = "TechnicalAssistant"; // Goobstation
-    private static readonly ProtoId<JobPrototype> Passenger = "Passenger"; // Goobstation
-
-    // Goobstation Change: For some reason this shitcode doesnt let me set another job other than passenger unless we have a map.
-    private static string _map = "TraitorTestMap";
-
-    [TestPrototypes]
-    private static readonly string TraitorTestMap = @$"
-- type: gameMap
-  id: {_map}
-  mapName: {_map}
-  mapPath: /Maps/Test/empty.yml
-  minPlayers: 0
-  stations:
-    Empty:
-      stationProto: StandardNanotrasenStation
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: ""Empty""
-        - type: StationJobs
-          availableJobs:
-            {Passenger}: [ -1, -1 ]
-            {TechnicalAssistant}: [ -1, -1 ]
-";
 
     [Test]
     public async Task TestTraitorObjectives()
@@ -59,7 +32,6 @@ public sealed class TraitorRuleTest
             InLobby = true,
         });
         var server = pair.Server;
-        pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map); // Goobstation
         var client = pair.Client;
         var entMan = server.EntMan;
         var protoMan = server.ProtoMan;
@@ -104,7 +76,6 @@ public sealed class TraitorRuleTest
         // Opt-in the player for the traitor role
         await pair.SetAntagPreference(TraitorAntagRoleName, true);
 
-        await pair.SetJobPriorities((TechnicalAssistant, JobPriority.High), (Passenger, JobPriority.Never)); // Goobstation
         // Add the game rule
         TraitorRuleComponent traitorRule = null;
         await server.WaitPost(() =>

--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -6,7 +6,6 @@
   startingGear: PassengerGear
   icon: "JobIconPassenger"
   supervisors: job-supervisors-everyone
-  canBeAntag: false # GOOBSTATION: THE RECKONING COMES
   access:
   - Maintenance
 

--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -6,7 +6,6 @@
   startingGear: ServiceWorkerGear
   icon: "JobIconServiceWorker"
   supervisors: job-supervisors-service
-  canBeAntag: false # GOOBSTATION: THE RECKONING COMES. DONT TRY AND BYPASS IT.
   access:
   - Service
   - Maintenance


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This reverts commit 79369deb583252492c36d850d627457a9fe40516.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I have been MALDING, SEETHING, and frothing at the mouth over being unable to play antag as the true command of the station, Tiders.
## Technical details
<!-- Summary of code changes for easier review. -->
This PR is made with 100% pure copium and hate over the change.
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Tideonia Liberation Forces
- fix: The shackles have been lifted brothers, take arms and fight once more.
