### PR TITLE
Revert this fucking shit "insulate bingle (#1782)"

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
@@ -94,7 +94,6 @@
     color: "#008080"
     activateSound: null
     deactivateSound: null
-  - type: Insulated
 
 - type: entity
   id: MobBinglePrime


### PR DESCRIPTION
## About the PR
There is 0 reason these beings need this. They are already difficult once they get to multiply. 

## Why / Balance
Zombies, much slower, less dangerous, no stun do not get insultation. The much faster, 2 hit stun bingle does not need this, especially when they can spawn in an area that just benefits them. They are not that weak, they should lose more than they win. This is handholding. 

It removes any realistic way to fight them if you're forced to melee. AI becomes nullified when trying to defend against them since they can just beat a door down now with no repercussion. This just sucked. 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: removed insulation from bingle