### PR TITLE
some fixes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -621,8 +621,8 @@
       rules: ghost-role-information-silicon-rules
       raffle:
         settings: default
-    - type: GhostTakeoverAvailable
       requirements: # Goobstation - ghost roles requirements
       - !type:RoleTimeRequirement
         role: JobBorg
         time: 3600 #1 hour
+    - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -378,7 +378,7 @@
     unlistedNumber: true
     requiresPower: false
   - type: Holopad
-  - type: StationAiWhitelist  
+  - type: StationAiWhitelist
   - type: UserInterface
     interfaces:
         enum.HolopadUiKey.AiRequestWindow:
@@ -622,3 +622,7 @@
       raffle:
         settings: default
     - type: GhostTakeoverAvailable
+      requirements: # Goobstation - ghost roles requirements
+      - !type:RoleTimeRequirement
+        role: JobBorg
+        time: 3600 #1 hour

--- a/Resources/Prototypes/_Goobstation/Entities/Markers/Spawners/bingle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Markers/Spawners/bingle.yml
@@ -10,10 +10,9 @@
     rules: ghost-role-information-freeagent-rules
     raffle:
       settings: short
-    requirements: # Goobstation - ghost roles requirements
-    - !type:RoleTimeRequirement
-      role: JobBorg
-      time: 3600 #1 hour
+    requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 3600 # 1 hour
   - type: GhostRoleMobSpawner
     prototype: MobBingle
   - type: Sprite

--- a/Resources/Prototypes/_Goobstation/Entities/Markers/Spawners/bingle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Markers/Spawners/bingle.yml
@@ -10,6 +10,10 @@
     rules: ghost-role-information-freeagent-rules
     raffle:
       settings: short
+    requirements: # Goobstation - ghost roles requirements
+    - !type:RoleTimeRequirement
+      role: JobBorg
+      time: 3600 #1 hour
   - type: GhostRoleMobSpawner
     prototype: MobBingle
   - type: Sprite

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
@@ -16,6 +16,9 @@
     rules: ghost-role-information-freeagent-rules
     raffle:
       settings: short
+    requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 3600 # 1 hour
   - type: Sprite
     drawdepth: Mobs
     sprite: _Goobstation/Mobs/Bingle/bingle.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/silicon.yml
@@ -59,4 +59,8 @@
     rules: ghost-role-information-silicon-rules
     raffle:
       settings: default
+    requirements: # Goobstation - ghost roles requirements
+    - !type:RoleTimeRequirement
+      role: JobBorg
+      time: 3600 #1 hour
   - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/_Shitmed/GameRules/events.yml
+++ b/Resources/Prototypes/_Shitmed/GameRules/events.yml
@@ -156,7 +156,7 @@
       - type: SurgerySpeedModifier
         speedModifier: 1.5
       mindRoles:
-      - MindRoleLoneAbductor
+      - MindRoleAbductorScienstist
     - spawnerPrototype: AbductorAgentSpawner
       min: 1
       max: 1
@@ -199,4 +199,4 @@
           - DoorBumpOpener
       - type: AbductorScientist # Should be removed when we have proper teleportation system
       mindRoles:
-      - MindRoleLoneAbductor
+      - MindRoleAbductorAgent

--- a/Resources/Prototypes/_Shitmed/GameRules/events.yml
+++ b/Resources/Prototypes/_Shitmed/GameRules/events.yml
@@ -156,7 +156,7 @@
       - type: SurgerySpeedModifier
         speedModifier: 1.5
       mindRoles:
-      - MindRoleAbductorScienstist
+      - MindRoleAbductorScientist
     - spawnerPrototype: AbductorAgentSpawner
       min: 1
       max: 1

--- a/Resources/Prototypes/_Shitmed/Roles/Antags/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/_Shitmed/Roles/Antags/MindRoles/mind_roles.yml
@@ -10,6 +10,26 @@
 
 - type: entity
   parent: BaseMindRoleAntag
+  id: MindRoleAbductorAgent
+  name: Lone Abductor Role
+  components:
+  - type: MindRole
+    exclusiveAntag: true
+    antagPrototype: AbductorAgentAntag
+  - type: Abductor
+
+- type: entity
+  parent: BaseMindRoleAntag
+  id: MindRoleAbductorScienstist
+  name: Lone Abductor Role
+  components:
+  - type: MindRole
+    exclusiveAntag: true
+    antagPrototype: AbductorScientistAntag
+  - type: Abductor
+
+- type: entity
+  parent: BaseMindRoleAntag
   id: MindRoleAbductorVictim
   name: Abductee Role
   components:

--- a/Resources/Prototypes/_Shitmed/Roles/Antags/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/_Shitmed/Roles/Antags/MindRoles/mind_roles.yml
@@ -20,7 +20,7 @@
 
 - type: entity
   parent: BaseMindRoleAntag
-  id: MindRoleAbductorScienstist
+  id: MindRoleAbductorScientist
   name: Lone Abductor Role
   components:
   - type: MindRole

--- a/Resources/Prototypes/_Shitmed/Roles/Antags/abductor.yml
+++ b/Resources/Prototypes/_Shitmed/Roles/Antags/abductor.yml
@@ -1,6 +1,18 @@
 - type: antag
   id: LoneAbductorAntag
-  name: abductors-ghost-role-name
+  name: abductor-lone-ghost-role-name
+  antagonist: true
+  objective: roles-antag-abductor-objective
+
+- type: antag
+  id: AbductorAgentAntag
+  name: abductor-agent-ghost-role-name
+  antagonist: true
+  objective: roles-antag-abductor-objective
+
+- type: antag
+  id: AbductorScientistAntag
+  name: abductor-scientist-ghost-role-name
   antagonist: true
   objective: roles-antag-abductor-objective
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
1) bingle requires 1 hour overall
2) derelict syndie borg requires 1 hour as borg
3) regular derelict borg spawned through entity spawn requires 1 hour as borg
4) agent and sci abductor now have their own mind roles because why the fuck was it lone abductor. this allows them to show up as their actual role in the round end screen instead of "abductors-ghost-role-name", this line is not even present in the game, i removed it earlier but overlooked the mind role
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
1) basically fix, to be consistent with the other antags and maybe prevent raiders from taking it
2) same
3) fix, the event ghost role requires it
4) basically fix, makes sense, not really player facing.
## Technical details
<!-- Summary of code changes for easier review. -->
didnt even test in game but if yaml linter passes it's probably fine (it's just yaml anyway)
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
  no cl no fun
