### PR TITLE
add blob starting money

### DIFF
--- a/Content.Server/_Goobstation/Blob/BlobCoreSystem.cs
+++ b/Content.Server/_Goobstation/Blob/BlobCoreSystem.cs
@@ -141,6 +141,8 @@ public sealed class BlobCoreSystem : EntitySystem
             if (actionUid != null)
                 component.Actions.Add(actionUid.Value);
         }
+
+        ChangeBlobPoint((uid, component), component.StartingMoney, store);
     }
 
     private void OnTerminating(EntityUid uid, BlobCoreComponent component, ref EntityTerminatingEvent args)

--- a/Content.Shared/_Goobstation/Blob/Components/BlobCoreComponent.cs
+++ b/Content.Shared/_Goobstation/Blob/Components/BlobCoreComponent.cs
@@ -36,6 +36,9 @@ public sealed partial class BlobCoreComponent : Component
     public FixedPoint2 CoreBlobTotalHealth = 400;
 
     [DataField]
+    public float StartingMoney = 250f; // enough for 2 resource nodes and a bit of defensive action
+
+    [DataField]
     public float AttackRate = 0.3f;
 
     [DataField]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
makes blobs spawn with 250 blobcoin

## Why / Balance
makes it less luck-reliant, you can build a basic base of 2 resource nodes (and a factory rather soon after, i tested this) this way
now you don't Just Die:tm: if you get spotted instantly
discord approves

## Media
tested, works

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: 250 starting points for blob.
