### PR TITLE
buff dragon rift

### DIFF
--- a/Content.Server/Dragon/Components/DragonRiftComponent.cs
+++ b/Content.Server/Dragon/Components/DragonRiftComponent.cs
@@ -33,8 +33,17 @@ public sealed partial class DragonRiftComponent : SharedDragonRiftComponent
     /// How long it takes for a new spawn to be added.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("spawnCooldown")]
-    public float SpawnCooldown = 30f;
+    public float SpawnCooldown = 24f; // Goobstation
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("spawn", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-    public string SpawnPrototype = "MobCarpDragon";
+    // Goobstation - Buff carp rift (nuked string proto)
+    [DataField("spawn")]
+    public EntProtoId SpawnPrototype = "MobCarpDragon";
+
+    // <Goobstation> - Buff carp rift
+    [DataField]
+    public float StrongSpawnChance = 0.15f;
+
+    [DataField("spawnStrong")]
+    public EntProtoId SpawnPrototypeStrong = "MobSharkDragon";
+    // </Goobstation>
 }

--- a/Content.Server/Dragon/DragonRiftSystem.cs
+++ b/Content.Server/Dragon/DragonRiftSystem.cs
@@ -11,6 +11,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Serialization.Manager;
 using System.Numerics;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Random; // Goobstation - Buff carp rift
 using Robust.Shared.Utility;
 
 namespace Content.Server.Dragon;
@@ -22,6 +23,7 @@ public sealed class DragonRiftSystem : EntitySystem
 {
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly DragonSystem _dragon = default!;
+    [Dependency] private readonly IRobustRandom _random = default!; // Goobstation - Buff carp rift
     [Dependency] private readonly ISerializationManager _serManager = default!;
     [Dependency] private readonly NavMapSystem _navMap = default!;
     [Dependency] private readonly NPCSystem _npc = default!;
@@ -78,7 +80,7 @@ public sealed class DragonRiftSystem : EntitySystem
             if (comp.SpawnAccumulator > comp.SpawnCooldown)
             {
                 comp.SpawnAccumulator -= comp.SpawnCooldown;
-                var ent = Spawn(comp.SpawnPrototype, xform.Coordinates);
+                var ent = Spawn(_random.Prob(comp.StrongSpawnChance) ? comp.SpawnPrototypeStrong : comp.SpawnPrototype, xform.Coordinates); // Goobstation - Buff carp rift
 
                 // Update their look to match the leader.
                 if (TryComp<RandomSpriteComponent>(comp.Dragon, out var randomSprite))

--- a/Resources/Locale/en-US/_Goobstation/ghost/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_Goobstation/ghost/ghost-role-component.ftl
@@ -22,3 +22,5 @@ ghost-role-information-c4-description = Assist your user with bombing things.
 
 ghost-role-information-derelict-cyborg-syndicate-name = Derelict Syndicate Cyborg
 ghost-role-information-derelict-cyborg-syndicate-description = You were lost during an assault on a station. After years of exposure to ion storms you find yourself near a space station.
+
+ghost-role-information-sentient-shark-name = Sentient Sharkminnow

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/carp.yml
@@ -1,0 +1,19 @@
+- type: entity
+  name: sharkminnow
+  id: MobSharkDragon
+  suffix: DragonBrood
+  parent: MobShark
+  components:
+    - type: GhostRole
+      allowMovement: true
+      allowSpeech: true
+      makeSentient: true
+      name: ghost-role-information-sentient-shark-name
+      description: ghost-role-information-sentient-carp-description
+      rules: ghost-role-information-space-dragon-summoned-carp-rules
+      raffle:
+        settings: short
+    - type: GhostTakeoverAvailable
+    - type: HTN
+      rootTask:
+        task: DragonCarpCompound


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
spawn cooldown 30s->24s
now has 15% chance to make a sharkminnow instead

## Why / Balance
it's currently pretty weak and can't really do anything to even one man with gun
it just needs a buff

## Media
tested

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Dragon carp rifts now have a 15% chance to spawn a sharkminnow instead.
- tweak: Dragon carp rift spawn spacing 30s->24s.
