### PR TITLE
[Hotfix] Fix infinite mice electric bogaloo

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -35,6 +35,7 @@ using Content.Shared.Prying.Components;
 using Content.Shared.Traits.Assorted;
 using Robust.Shared.Audio.Systems;
 using Content.Shared.Ghost.Roles.Components;
+using Content.Server.Animals.Components;
 
 namespace Content.Server.Zombies;
 
@@ -102,6 +103,7 @@ public sealed partial class ZombieSystem
         RemComp<HungerComponent>(target);
         RemComp<ThirstComponent>(target);
         RemComp<ReproductiveComponent>(target);
+        RemComp<EggLayerComponent>(target); // Goobstation - very funny haha it lags server to hell
         RemComp<ReproductivePartnerComponent>(target);
         RemComp<LegsParalyzedComponent>(target);
         RemComp<ComplexInteractionComponent>(target);


### PR DESCRIPTION
## About the PR
Zombies can't lay eggs now.

## Why / Balance
Targeted fix, prevents infinite mice. Stops LAG. Chose to remove egglayer on zombify since it fixes potential future problems most reliably I think. 

## Media
I just spawned and zombified these mice and they didn't lay eggs for 20 minutes, and they don't have egglayer component, so all is good I think
![{AE2354B1-0B9E-4172-80C3-95418FB8BD9D}](https://github.com/user-attachments/assets/fcd55600-b34a-495c-b83a-20fff99ed6a5)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Idk no more egglaying zombies

**Changelog** SX-7
:cl:
- fix: Fixed infinite zombie mice bug
