### PR TITLE
remove roundend on wiz death

### DIFF
--- a/Content.Server/_Goobstation/Wizard/Components/EndRoundOnWizardDeathRuleComponent.cs
+++ b/Content.Server/_Goobstation/Wizard/Components/EndRoundOnWizardDeathRuleComponent.cs
@@ -1,8 +1,0 @@
-using Content.Server._Goobstation.Wizard.Systems;
-
-namespace Content.Server._Goobstation.Wizard.Components;
-
-[RegisterComponent, Access(typeof(WizardRuleSystem))]
-public sealed partial class EndRoundOnWizardDeathRuleComponent : Component
-{
-}

--- a/Content.Server/_Goobstation/Wizard/Components/RuleOnWizardDeathRuleComponent.cs
+++ b/Content.Server/_Goobstation/Wizard/Components/RuleOnWizardDeathRuleComponent.cs
@@ -1,0 +1,11 @@
+using Content.Server._Goobstation.Wizard.Systems;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Goobstation.Wizard.Components;
+
+[RegisterComponent, Access(typeof(WizardRuleSystem))]
+public sealed partial class RuleOnWizardDeathRuleComponent : Component
+{
+    [DataField(required: true)]
+    public EntProtoId Rule = default!;
+}

--- a/Content.Server/_Goobstation/Wizard/Systems/WizardRuleSystem.cs
+++ b/Content.Server/_Goobstation/Wizard/Systems/WizardRuleSystem.cs
@@ -190,7 +190,7 @@ public sealed class WizardRuleSystem : GameRuleSystem<WizardRuleComponent>
         while (endQuery.MoveNext(out var uid, out var ruleOnDeath, out var gameRule))
         {
             _gameTicker.EndGameRule(uid, gameRule);
-            _gameTicker.AddGameRule(ruleOnDeath.Rule);
+            _gameTicker.StartGameRule(ruleOnDeath.Rule);
         }
     }
 

--- a/Content.Server/_Goobstation/Wizard/Systems/WizardRuleSystem.cs
+++ b/Content.Server/_Goobstation/Wizard/Systems/WizardRuleSystem.cs
@@ -8,7 +8,6 @@ using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
 using Content.Server.Mind;
 using Content.Server.Roles;
-using Content.Server.RoundEnd;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Shared._Goobstation.Wizard;
@@ -37,7 +36,6 @@ public sealed class WizardRuleSystem : GameRuleSystem<WizardRuleComponent>
     [Dependency] private readonly AntagSelectionSystem _antag = default!;
     [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly RoleSystem _role = default!;
-    [Dependency] private readonly RoundEndSystem _roundEnd = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly AtmosphereSystem _atmos = default!;
@@ -158,7 +156,7 @@ public sealed class WizardRuleSystem : GameRuleSystem<WizardRuleComponent>
 
     private void CheckRoundShouldEnd()
     {
-        if (!_gameTicker.IsGameRuleActive<EndRoundOnWizardDeathRuleComponent>() ||
+        if (!_gameTicker.IsGameRuleActive<RuleOnWizardDeathRuleComponent>() ||
             !_gameTicker.IsGameRuleActive<WizardRuleComponent>())
             return;
 
@@ -188,12 +186,12 @@ public sealed class WizardRuleSystem : GameRuleSystem<WizardRuleComponent>
         if (!endRound)
             return;
 
-        var endQuery = EntityQueryEnumerator<EndRoundOnWizardDeathRuleComponent, GameRuleComponent>();
-        while (endQuery.MoveNext(out var uid, out _, out var gameRule))
+        var endQuery = EntityQueryEnumerator<RuleOnWizardDeathRuleComponent, GameRuleComponent>();
+        while (endQuery.MoveNext(out var uid, out var ruleOnDeath, out var gameRule))
         {
             _gameTicker.EndGameRule(uid, gameRule);
+            _gameTicker.AddGameRule(ruleOnDeath.Rule);
         }
-        _roundEnd.EndRound();
     }
 
     public IEnumerable<Entity<StationDataComponent>> GetWizardTargetStations()

--- a/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
@@ -128,7 +128,7 @@
   showInVote: false
   rules:
     - Wizard
-    - EndRoundOnWizardDeath
+    # - EndRoundOnWizardDeath # nuh uh
     - BasicStationEventScheduler
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation

--- a/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
@@ -118,7 +118,25 @@
   id: SleepersOnWizardDeath
   components:
   - type: RuleOnWizardDeathRule
-    rule: SleeperAgents
+    rule: SleeperAgentsWizard
+
+- type: entity
+  parent: BaseTraitorRule
+  id: SleeperAgentsWizard
+  components:
+  - type: StationEvent
+  - type: AntagSelection
+    definitions:
+    - prefRoles: [ TraitorSleeper ]
+      fallbackRoles: [ Traitor ]
+      min: 4
+      max: 6
+      playerRatio: 10
+      blacklist:
+        components:
+        - AntagImmune
+      mindRoles:
+      - MindRoleTraitorSleeper
 
 - type: gamePreset
   id: Wizard

--- a/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
@@ -115,9 +115,10 @@
 
 - type: entity
   parent: BaseGameRule
-  id: EndRoundOnWizardDeath
+  id: SleepersOnWizardDeath
   components:
-  - type: EndRoundOnWizardDeathRule
+  - type: RuleOnWizardDeathRule
+    rule: SleeperAgents
 
 - type: gamePreset
   id: Wizard
@@ -128,7 +129,7 @@
   showInVote: false
   rules:
     - Wizard
-    # - EndRoundOnWizardDeath # nuh uh
+    - SleepersOnWizardDeath
     - BasicStationEventScheduler
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation

--- a/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
@@ -132,4 +132,4 @@
     - BasicStationEventScheduler
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
-    # - SubGamemodesRule
+    - SubGamemodesRule


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
title

## Why / Balance
why does round even end on wiz death, it doesn't for blob and such, not even for nukies
currently most wizard rounds are just wizard dying instantly which stops all the side antags and crew that wanted to do things from being able to do anything
i don't think i've seen any person express a favorable opinion about roundend on wizard death ever

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The round no longer ends on wizard death.