### PR TITLE
more telepathy

### DIFF
--- a/Content.Server/_EinsteinEngines/Chat/TelepathicChatSystem.cs
+++ b/Content.Server/_EinsteinEngines/Chat/TelepathicChatSystem.cs
@@ -65,9 +65,10 @@ public sealed partial class TelepathicChatSystem : EntitySystem
         string messageWrap;
         string adminMessageWrap;
 
-        messageWrap = Loc.GetString("chat-manager-send-telepathic-chat-wrap-message",
-            ("telepathicChannelName", Loc.GetString("chat-manager-telepathic-channel-name")), ("message", message));
+        messageWrap = Loc.GetString("chat-manager-send-telepathic-chat-wrap-message-psychognomy",
+            ("source", source), ("message", message));
 
+        // Goobstation - Telepathy extension
         adminMessageWrap = Loc.GetString("chat-manager-send-telepathic-chat-wrap-message-admin",
             ("source", source), ("message", message));
 

--- a/Content.Server/_Goobstation/Blob/NPC/BlobPod/BlobPodSystem.cs
+++ b/Content.Server/_Goobstation/Blob/NPC/BlobPod/BlobPodSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.NPC.HTN;
 using Content.Server.NPC.Systems;
 using Content.Server.Popups;
 using Content.Shared.ActionBlocker;
+using Content.Shared._EinsteinEngines.Abilities.Psionics;
 using Content.Shared._Goobstation.Blob.Components;
 using Content.Shared._Goobstation.Blob.NPC.BlobPod;
 using Content.Shared.CombatMode;
@@ -64,6 +65,12 @@ public sealed class BlobPodSystem : SharedBlobPodSystem
         if (!HasComp<HumanoidAppearanceComponent>(args.Container.Owner) || !HasComp<ZombieBlobComponent>(args.Container.Owner))
             return;
 
+        if (!TryComp<ZombieBlobComponent>(args.Container.Owner, out var zombieComp))
+            return;
+
+        if (zombieComp.TelepathyAdded)
+            RemCompDeferred<TelepathyComponent>(args.Container.Owner);
+
         RemCompDeferred<ZombieBlobComponent>(args.Container.Owner);
     }
 
@@ -112,6 +119,7 @@ public sealed class BlobPodSystem : SharedBlobPodSystem
         ent.Comp.ZombifiedEntityUid = target;
 
         var zombieBlob = EnsureComp<ZombieBlobComponent>(target);
+        zombieBlob.TelepathyAdded = !EnsureComp<TelepathyComponent>(target, out _);
         zombieBlob.BlobPodUid = ent;
         if (HasComp<ActorComponent>(ent))
         {

--- a/Content.Server/_Goobstation/Blob/ZombieBlobSystem.cs
+++ b/Content.Server/_Goobstation/Blob/ZombieBlobSystem.cs
@@ -9,6 +9,7 @@ using Content.Server.NPC.Systems;
 using Content.Server.Speech.Components;
 using Content.Server.Temperature.Components;
 using Content.Shared.Atmos;
+using Content.Shared._EinsteinEngines.Abilities.Psionics;
 using Content.Shared._Goobstation.Blob;
 using Content.Shared._Goobstation.Blob.Components;
 using Content.Shared.Inventory;
@@ -224,6 +225,9 @@ public sealed class ZombieBlobSystem : SharedZombieBlobSystem
     {
         if (args.NewMobState == MobState.Dead)
         {
+            if (component.TelepathyAdded)
+                RemComp<TelepathyComponent>(uid);
+
             RemComp<ZombieBlobComponent>(uid);
         }
     }

--- a/Content.Shared/_Goobstation/Blob/Components/ZombieBlobComponent.cs
+++ b/Content.Shared/_Goobstation/Blob/Components/ZombieBlobComponent.cs
@@ -21,4 +21,7 @@ public sealed partial class ZombieBlobComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool CanShoot = false;
+
+    [DataField]
+    public bool TelepathyAdded = false;
 }

--- a/Resources/Prototypes/_Goobstation/Blob/blob_mobs.yml
+++ b/Resources/Prototypes/_Goobstation/Blob/blob_mobs.yml
@@ -100,6 +100,7 @@
     - type: GuideHelp
       guides:
       - Blob
+    - type: Telepathy
 
 # Blobbernaut
 - type: entity
@@ -194,6 +195,7 @@
     - type: GuideHelp
       guides:
       - Blob
+    - type: Telepathy
 
 # Observer
 - type: entity
@@ -261,3 +263,4 @@
     - type: Tag
       tags:
       - BypassInteractionRangeChecks
+    - type: Telepathy


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
telepathy now shows name of speaker
telepathy added to blob and blob minions

## Why / Balance
blob kinda needs it
this will allow abductors to talk with blob but i think it's okay and can lead to Fun:tm:
i don't see any way this could have negative effects on gameplay
people seem to be in support of this (as of moment of last edit, poll is 19/1 in favor)

## Media
tested, works

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Blob and blob minions now have telepathy.
- tweak: Telepathy now shows the name of the speaker.