### PR TITLE
Mining points and ore rebalance (+ Bananium fix)

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Materials/materials.yml
@@ -50,7 +50,7 @@
   - type: Stack
     stackType: BSCrystalUnprocessed
   - type: UnclaimedOre
-    miningPoints: 100
+    miningPoints: 250
 
 - type: entity
   parent: MaterialBSCrystalUnprocessed

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Materials/ore.yml
@@ -14,7 +14,7 @@
   - type: Stack
     stackType: GoldOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 7
+    miningPoints: 12
 
 - type: entity
   parent: GoldOreUnprocessed
@@ -34,7 +34,7 @@
   - type: Stack
     stackType: DiamondOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 100
+    miningPoints: 1000 # rarest ore in the game, only 1 yield, used for endgame schematics
 
 - type: entity
   parent: DiamondOreUnprocessed
@@ -54,7 +54,7 @@
   - type: Stack
     stackType: SteelOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 1
+    miningPoints: 3 # very abundant, is used up more than coal (coal 0.1, iron 0.33)
 
 - type: entity
   id: SteelOre1Unprocessed
@@ -94,7 +94,7 @@
   - type: Stack
     stackType: SilverOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 5
+    miningPoints: 12
 
 - type: entity
   parent: SilverOreUnprocessed
@@ -114,7 +114,7 @@
   - type: Stack
     stackType: SpaceQuartzUnprocessed
   - type: UnclaimedOre
-    miningPoints: 1.35
+    miningPoints: 3.5 # slightly rarer than iron and coal
 
 - type: entity
   parent: SpaceQuartzUnprocessed
@@ -134,7 +134,7 @@
   - type: Stack
     stackType: UraniumOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 6
+    miningPoints: 24 # used for fuel, lategame schematics, artifacts ect
 
 - type: entity
   parent: UraniumOreUnprocessed
@@ -154,7 +154,7 @@
   - type: Stack
     stackType: BananiumOreUnprocessed
   - type: UnclaimedOre
-    miningPoints: 30 # We might as well give bananium a purpose no?
+    miningPoints: 69 # nice
 
 - type: entity
   parent: BananiumOreUnprocessed
@@ -174,7 +174,7 @@
   - type: Stack
     stackType: CoalUnprocessed
   - type: UnclaimedOre
-    miningPoints: 1
+    miningPoints: 1 # very abundant, used up much less in steel (0.1 coal, 0.33 iron)
 
 - type: entity
   parent: CoalUnprocessed

--- a/Resources/Prototypes/_Lavaland/Procedural/lavaland_planets.yml
+++ b/Resources/Prototypes/_Lavaland/Procedural/lavaland_planets.yml
@@ -27,7 +27,7 @@
   - OreSilver
   - OrePlasma
   - OreUranium
-  #- OreBananium
+  - OreBananium
   - OreArtifactFragment
   - OreDiamond
   - BSCrystal

--- a/Resources/Prototypes/ore.yml
+++ b/Resources/Prototypes/ore.yml
@@ -105,7 +105,7 @@
     OreUranium: 1
     BSCrystal: 0.5 # to account for higher points (250)
     OreBananium: 0.25 # to account for it being a useless meme ore
-    OreDiamond: 0.1 # to account for its much higher points (750), as well as its use in endgame schematics
+    OreDiamond: 0.1 # to account for its much higher points (1000), as well as its use in endgame schematics
   # Lavaland Change End
     OreArtifactFragment: 0.5
 

--- a/Resources/Prototypes/ore.yml
+++ b/Resources/Prototypes/ore.yml
@@ -62,6 +62,12 @@
   id: OreDiamond
   oreEntity: DiamondOre1Unprocessed # Lavaland Change
   minOreYield: 1
+  maxOreYield: 1
+
+- type: ore
+  id: BSCrystal
+  oreEntity: MaterialBSCrystal1Unprocessed # lavaland change
+  minOreYield: 1
   maxOreYield: 2
 
 - type: ore
@@ -93,11 +99,13 @@
     OreSteel: 10
     OreCoal: 10
     OreSpaceQuartz: 8
-    OreGold: 2
     OrePlasma: 4
-    OreSilver: 1
+    OreSilver: 2 # previously rarer than gold, even though they are both typically used in similar amounts for crafting
+    OreGold: 2
     OreUranium: 1
-    OreBananium: 0.5
+    BSCrystal: 0.5 # to account for higher points (250)
+    OreBananium: 0.25 # to account for it being a useless meme ore
+    OreDiamond: 0.1 # to account for its much higher points (750), as well as its use in endgame schematics
   # Lavaland Change End
     OreArtifactFragment: 0.5
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Mining Points rewards for most ores have been increased
Some ore weight/rarities adjusted
Bananium should spawn in Lavaland now

## Why / Balance
Currently, the rewards for mining is very unrewarding.

A haul that's enough to sustain the entire station for maybe 10-15 minutes (621 mining points btw) is barely enough for you to buy a brute/burn medkit (or like 6 beer bottles if you're a raging alcoholic).

With this PR, it should instead net you around 1350 mining points - which, if you were to get the most expensive items from the vendor possible, is enough for a brand new kinetic crusher or PKA variant (along with a beer bottle as a nice reward) or alternatively an upgrade for your PKA alongside a miscellaneous item or two.

## Technical details
All of it is yaml.
Bananium added into the ore spawn pool for lavaland (someone forgot to remove the comment for it bruh)
Ore weight and mining points payout can be seen in the file changes (this would be a wall of text if I pasted it all)
Bluespace Crystals were added into the ore.yml containing weights and yields alongside the other materials (it was previously used in the asteroids yml. bruh.)

## Media
The haul in question worth 621 mining points:
![image_2025-02-27_173636367](https://github.com/user-attachments/assets/0f636f59-8a60-4adb-ba68-3408a08ccc97)
![image_2025-02-27_173841544](https://github.com/user-attachments/assets/56c55263-034d-4326-b69d-662f412cb8e3)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: the_biggestbruh
- tweak: Mining points payout for various ores have been increased. Rock and Stone!
- tweak: Silver and gold veins are now as common as eachother.
- tweak: Diamonds and bluespace crystal veins have been made rarer (due to the increased points payout).
- fix: Bananium should now appear in Lavaland as intended.
