### PR TITLE
pka fixes

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/RechargeBasicEntityAmmoSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/RechargeBasicEntityAmmoSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Examine;
 using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
@@ -50,7 +51,12 @@ public sealed class RechargeBasicEntityAmmoSystem : EntitySystem
                 continue;
             }
 
-            recharge.NextCharge = recharge.NextCharge.Value + TimeSpan.FromSeconds(recharge.RechargeCooldown);
+            // Goobstation
+            float multiplier = 1f;
+            var ev = new RechargeBasicEntityAmmoGetCooldownModifiersEvent(multiplier);
+            RaiseLocalEvent(uid, ref ev);
+
+            recharge.NextCharge = recharge.NextCharge.Value + TimeSpan.FromSeconds(recharge.RechargeCooldown * ev.Multiplier); // Goobstation
             Dirty(uid, recharge);
         }
     }
@@ -85,7 +91,12 @@ public sealed class RechargeBasicEntityAmmoSystem : EntitySystem
 
         if (recharge.NextCharge == null || recharge.NextCharge < _timing.CurTime)
         {
-            recharge.NextCharge = _timing.CurTime + TimeSpan.FromSeconds(recharge.RechargeCooldown);
+            // Goobstation
+            float multiplier = 1f;
+            var ev = new RechargeBasicEntityAmmoGetCooldownModifiersEvent(multiplier);
+            RaiseLocalEvent(uid, ref ev);
+
+            recharge.NextCharge = _timing.CurTime + TimeSpan.FromSeconds(recharge.RechargeCooldown * ev.Multiplier); // Goobstation
             Dirty(uid, recharge);
         }
     }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -315,6 +315,8 @@ public abstract partial class SharedGunSystem : EntitySystem
         if (gun.NextFire < curTime - fireRate || gun.ShotCounter == 0 && gun.NextFire < curTime)
             gun.NextFire = curTime;
 
+        bool isRechargingGun = HasComp<RechargeBasicEntityAmmoComponent>(gunUid); // Goobstation
+
         var shots = 0;
         var lastFire = gun.NextFire;
 
@@ -389,6 +391,13 @@ public abstract partial class SharedGunSystem : EntitySystem
             // triggers effects on the gun if it's empty
             var emptyGunShotEvent = new OnEmptyGunShotEvent();
             RaiseLocalEvent(gunUid, ref emptyGunShotEvent);
+
+            // Goobstation
+            if (isRechargingGun)
+            {
+                gun.NextFire = lastFire; // for empty PKAs, don't play no-ammo sound and don't trigger the reload
+                return;
+            }
 
             if (!gun.LockOnTargetBurst || gun.ShootCoordinates == null) // Goobstation
                 gun.Target = null;

--- a/Content.Shared/_Goobstation/Weapons/Ranged/RechargeBasicEntityAmmoGetCooldownModifiersEvent.cs
+++ b/Content.Shared/_Goobstation/Weapons/Ranged/RechargeBasicEntityAmmoGetCooldownModifiersEvent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared.Weapons.Ranged.Events;
+
+// todo: get event names closer to the length of the bible
+[ByRefEvent]
+public record struct RechargeBasicEntityAmmoGetCooldownModifiersEvent(
+    float Multiplier
+);

--- a/Content.Shared/_Lavaland/Weapons/Ranged/Upgrades/SharedGunUpgradeSystem.cs
+++ b/Content.Shared/_Lavaland/Weapons/Ranged/Upgrades/SharedGunUpgradeSystem.cs
@@ -39,10 +39,12 @@ public abstract partial class SharedGunUpgradeSystem : EntitySystem
         SubscribeLocalEvent<UpgradeableGunComponent, ExaminedEvent>(OnExamine);
         SubscribeLocalEvent<UpgradeableGunComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<UpgradeableGunComponent, GunRefreshModifiersEvent>(RelayEvent);
+        SubscribeLocalEvent<UpgradeableGunComponent, RechargeBasicEntityAmmoGetCooldownModifiersEvent>(RelayEvent);
         SubscribeLocalEvent<UpgradeableGunComponent, GunShotEvent>(RelayEvent);
         SubscribeLocalEvent<UpgradeableGunComponent, ProjectileShotEvent>(RelayEvent);
         SubscribeLocalEvent<GunUpgradeComponent, ExaminedEvent>(OnUpgradeExamine);
         SubscribeLocalEvent<GunUpgradeFireRateComponent, GunRefreshModifiersEvent>(OnFireRateRefresh);
+        SubscribeLocalEvent<GunUpgradeFireRateComponent, RechargeBasicEntityAmmoGetCooldownModifiersEvent>(OnFireRateRefreshRecharge);
         SubscribeLocalEvent<GunComponentUpgradeComponent, GunRefreshModifiersEvent>(OnCompsRefresh);
         SubscribeLocalEvent<GunUpgradeSpeedComponent, GunRefreshModifiersEvent>(OnSpeedRefresh);
         SubscribeLocalEvent<GunUpgradeComponentsComponent, GunShotEvent>(OnDamageGunShotComps);
@@ -157,6 +159,11 @@ public abstract partial class SharedGunUpgradeSystem : EntitySystem
     private void OnFireRateRefresh(Entity<GunUpgradeFireRateComponent> ent, ref GunRefreshModifiersEvent args)
     {
         args.FireRate *= ent.Comp.Coefficient;
+    }
+
+    private void OnFireRateRefreshRecharge(Entity<GunUpgradeFireRateComponent> ent, ref RechargeBasicEntityAmmoGetCooldownModifiersEvent args)
+    {
+        args.Multiplier /= ent.Comp.Coefficient;
     }
 
     private void OnCompsRefresh(Entity<GunComponentUpgradeComponent> ent, ref GunRefreshModifiersEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
now trying to fire pka while it hasn't recharged doesn't reset the normal reload
now firerate modkits affect ammo reload

## Why / Balance
mocho said it's ok

## Media
tested, works

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Firerate PKA modkits now affect PKA recharge speed.
- fix: Trying to fire a PKA while it hasn't charged its ammo yet no longer triggers its reload.