### PR TITLE
More printable ammo

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -95,8 +95,8 @@ uplink-speedloader-magnu-desc = Revolver speedloader with 6 armor-piercing catri
 uplink-mosin-ammo-name = Ammunition box (.30 rifle)
 uplink-mosin-ammo-desc = A box of 60 cartridges for the surplus rifle.
 
-uplink-sniper-ammo-name = Ammunition box (.60 antimateriel)
-uplink-sniper-ammo-desc = A box of 10 cartridges for the Hristov sniper rifle.
+uplink-sniper-ammo-name = Ammunition box (.60 antimateriel AP)
+uplink-sniper-ammo-desc = A box of 12 cartridges for the Hristov sniper rifle.
 
 # Utility
 uplink-holopara-kit-name = Holoparasite Kit

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/antimateriel.yml
@@ -2,7 +2,7 @@
   abstract: true
   parent: BaseItem
   id: BaseMagazineBoxAntiMateriel
-  name: ammunition box (.60 anti-materiel)
+  name: ammunition box (.60 anti-materiel AP)
   components:
   - type: BallisticAmmoProvider
     mayTransfer: true
@@ -28,7 +28,7 @@
 - type: entity
   parent: BaseMagazineBoxAntiMateriel
   id: MagazineBoxAntiMaterielBig
-  name: ammunition box (.60 anti-materiel)
+  name: ammunition box (.60 anti-materiel AP)
   components:
   - type: BallisticAmmoProvider
     capacity: 30
@@ -48,10 +48,24 @@
 - type: entity
   parent: BaseMagazineBoxAntiMateriel
   id: MagazineBoxAntiMateriel
-  name: ammunition box (.60 anti-materiel)
+  name: ammunition box (.60 anti-materiel AP)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeAntiMateriel
+  - type: Sprite
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
+  parent: BaseMagazineBoxAntiMateriel
+  id: MagazineBoxAntiMaterielNoAP
+  name: ammunition box (.60 anti-materiel)
+  components:
+  - type: BallisticAmmoProvider
+    proto: CartridgeAntiMaterielNoAP
   - type: Sprite
     layers:
     - state: base

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/antimateriel.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: [ BaseCartridge, BaseMajorContraband ]
   id: CartridgeAntiMateriel
-  name: cartridge (.60 anti-materiel)
+  name: cartridge (.60 anti-materiel AP)
   components:
   - type: Tag
     tags:
@@ -9,6 +9,27 @@
     - CartridgeAntiMateriel
   - type: CartridgeAmmo
     proto: BulletAntiMateriel
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Ammunition/Casings/large_casing.rsi
+    layers:
+    - state: base
+      map: ["enum.AmmoVisualLayers.Base"]
+  - type: Appearance
+  - type: SpentAmmoVisuals
+  - type: StaticPrice
+    price: 20
+
+- type: entity
+  parent: [ BaseCartridge, BaseMajorContraband ]
+  id: CartridgeAntiMaterielNoAP
+  name: cartridge (.60 anti-materiel)
+  components:
+  - type: Tag
+    tags:
+    - Cartridge
+    - CartridgeAntiMateriel
+  - type: CartridgeAmmo
+    proto: BulletAntiMaterielNoAP
   - type: Sprite
     sprite: Objects/Weapons/Guns/Ammunition/Casings/large_casing.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -2,7 +2,7 @@
   categories: [ HideSpawnMenu ]
   parent: BaseBullet
   id: BulletAntiMateriel
-  name: bullet (.60 anti-materiel)
+  name: bullet (.60 anti-materiel AP)
   components:
   - type: Projectile
     damage:
@@ -10,6 +10,23 @@
         Piercing: 75
         Structural: 226
     ignoreResistances: true # Goobstation
+    penetrationThreshold: 360
+    penetrationDamageTypeRequirement:
+    - Structural
+  - type: StaminaDamageOnCollide
+    damage: 60
+
+- type: entity
+  categories: [ HideSpawnMenu ]
+  parent: BaseBullet
+  id: BulletAntiMaterielNoAP
+  name: bullet (.60 anti-materiel)
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 75
+        Structural: 176
     penetrationThreshold: 360
     penetrationDamageTypeRequirement:
     - Structural

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -248,9 +248,11 @@
       - MagazineBoxCaselessRifle # Goobstation
       - MagazineLightRifleBoxEmpty # Goobstation
       - MagazineLightRifleBox # Goobstation
+      - MagazineLightRifleSubsonic # GoobStation
       - MagazineHighCaliberEmpty # Goobstation
       - MagazineHighCaliber # Goobstation
       - MagazineBoxHighCaliber # Goobstation
+      - MagazineBoxAntiMaterielNoAP # GoobStation
       - MagazineMagnumEmpty # Goobstation
       - MagazineMagnum # Goobstation
       - MagazineShotgunLeverRifleEmpty # Goobstation

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/security.yml
@@ -227,6 +227,13 @@
     Steel: 1600
 
 - type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazineLightRifleSubsonic
+  result: MagazineLightRifleSubsonic
+  materials:
+    Steel: 700
+
+- type: latheRecipe
   parent: BaseEmptyAmmoRecipe
   id: MagazineHighCaliberEmpty
   result: MagazineHighCaliberEmpty
@@ -239,6 +246,13 @@
   result: MagazineHighCaliber
   materials:
     Steel: 325
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: MagazineBoxAntiMaterielNoAP
+  result: MagazineBoxAntiMaterielNoAP
+  materials:
+    Steel: 1000
 
 - type: latheRecipe
   parent: BaseAmmoRecipe


### PR DESCRIPTION
## About the PR
Added .60 (Non AP) caliber ammo. Made it printable at an emaged lathe. 
Added Subsonic 30 ammo printable at emaged lathe.
Fixed the .60 ammo description in syndi store from "10" to "12" cartridges.

## Why / Balance
You are able to print every single ammo type but these two. Which feels like an oversight. So coherency.

## Technical details
Only yaml

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: .60 (Hristov ammo) printable at emaged lathe (non AP)
- add: subsonic .30 (WSPR ammo) printable at emaged lathe