### PR TITLE
add jaunter to salvage closet

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -26,6 +26,7 @@
       - id: WeaponProtoKineticAccelerator
       - id: OreBag
       - id: Pickaxe
+      - id: LavalandJaunter
       - id: LavalandEquipmentExplorerSuit
       - id: ShelterCapsule
       - id: ClothingMaskGasExplorer
@@ -58,6 +59,7 @@
       - id: WeaponProtoKineticAccelerator
       - id: OreBag
       - id: Pickaxe
+      - id: LavalandJaunter
       - id: LavalandEquipmentExplorerSuit
       - id: ShelterCapsule
       - id: ClothingMaskGasExplorer


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
there is now a jaunter in the salvage closet
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
if newbie duffelbag can have it, may as well have it in the salvage lockers too
also it is not enjoyable to fall down a pit

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: shoebill
- tweak: Jaunters can now be found in Salvage equipment closets.
