### PR TITLE
Wizard no longer causes the round to end

### DIFF
--- a/Content.Server/_Goobstation/Wizard/Systems/WizardRuleSystem.cs
+++ b/Content.Server/_Goobstation/Wizard/Systems/WizardRuleSystem.cs
@@ -193,7 +193,6 @@ public sealed class WizardRuleSystem : GameRuleSystem<WizardRuleComponent>
         {
             _gameTicker.EndGameRule(uid, gameRule);
         }
-        _roundEnd.EndRound();
     }
 
     public IEnumerable<Entity<StationDataComponent>> GetWizardTargetStations()


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed round ending when wizard dies

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This change will allow to play after the wizard dies, allowing other antags and non-antags to win the round or at least continue it.

## Technical details
<!-- Summary of code changes for easier review. -->
Removed a single line

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
One line change, no media required

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Militore
- remove: Wizards death no longer causes round end