### PR TITLE
Slight cryochems rebalance

### DIFF
--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
@@ -23,6 +23,7 @@ using Content.Shared.Stealth.Components;
 using Content.Shared._Goobstation.Weapons.AmmoSelector;
 using Content.Shared.Actions;
 using Content.Shared.Movement.Pulling.Systems;
+using Content.Server.Traits.Assorted;
 
 namespace Content.Server.Changeling;
 
@@ -141,6 +142,7 @@ public sealed partial class ChangelingSystem
 
         var dmg = new DamageSpecifier(_proto.Index(AbsorbedDamageGroup), 200);
         _damage.TryChangeDamage(target, dmg, false, false);
+        EnsureComp<UnrevivableComponent>(target);
         _blood.ChangeBloodReagent(target, "FerrochromicAcid");
         _blood.SpillAllSolutions(target);
 

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -188,6 +188,7 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: medicine
   color: "#0091ff"
+  worksOnTheDead: true # Goobstation - Cryo rebalance
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: -5
@@ -204,11 +205,10 @@
             max: 213.0
           damage:
           # todo scale with temp like SS13
-            groups:
-              Airloss: -6
-              Brute: -4
-              Burn: -6
-              Toxin: -4
+            groups: # Goobstation - Cryo rebalance
+              Airloss: -3
+              Brute: -3
+              Burn: -3
 
 - type: reagent
   id: Doxarubixadone
@@ -218,6 +218,7 @@
   physicalDesc: reagent-physical-desc-bubbling
   flavor: medicine
   color: "#32cd32"
+  worksOnTheDead: true # Goobstation - Cryo rebalance
   metabolisms:
     Medicine:
       effects:
@@ -1303,16 +1304,21 @@
   metabolisms:
     Medicine:
       effects:
+        - !type:ModifyBloodLevel # Goobstation - Cryo rebalance
+          conditions:
+          - !type:Temperature
+            max: 213.0
+          amount: 10
         - !type:HealthChange
           conditions:
           - !type:Temperature
             max: 213.0
-          damage:
+          damage: # Goobstation - Cryo rebalance
             groups:
-              Brute: -4
-              Burn: -5
-            types:
-              Poison: -2
+              Airloss: -10.0
+              Brute: -5.0
+              Burn: -5.0
+              Toxin: -5.0
 
 - type: reagent
   id : Aloxadone
@@ -1330,11 +1336,11 @@
         conditions:
         - !type:Temperature
           max: 213.0
-        damage:
+        damage: # Goobstation - Cryo rebalance
           types:
-            Heat: -3.0
-            Shock: -3.0
-            Caustic: -1.0
+            Heat: -10.0
+            Shock: -10.0
+            Caustic: -10.0
 
 - type: reagent
   id : Mannitol # currently this is just a way to create psicodine


### PR DESCRIPTION
## About the PR
Now all cryo chems works on dead state. With this chems were rebalanced:
- Cryoxadone: (GAirloss: -G6, Brute: -4. GBurn: -6, GToxin: -4) -> (GAirloss: -3, GBrute: -3, GBurn: -3, GToxin: 0)
- Doxarubixadone: Nothing changed, but changeling absorb now ensures UnrevivableComponent to prevent ling victim revival
- Aloxadone: (THeat: -3, TShock: -3, TCaustic: -1) -> (THeat: -10, TShock: -10, TCaustic: -10)
- Necrosol: (GBrute: -4, GBurn: -5, TPoison: -2) -> (GAir: -10. GBrute: -5, GBurn: -5, GToxin: -5)

## Why / Balance
1. Shitmed and topical buffs made cryo chems useless in comparison - you can just heal someone with surgery/ointments or move brain to another body.
2. Cryo chems were nothing special and were not standardized - some of them worked on dead people and some not. Now all cryo chems work on dead people setting them apart from common chemicals.

:cl:
- tweak: All cryo chemicals now work on corpses.

