### PR TITLE
Make Wizard Traps More Visible

### DIFF
--- a/Resources/Prototypes/_Goobstation/Wizard/traps.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/traps.yml
@@ -11,7 +11,7 @@
     drawdepth: FloorEffects
     sprite: _Goobstation/Wizard/Objects/trap.rsi
     state: icon
-    color: '#FFFFFF05'
+    color: '#FFFFFF0e'
   - type: Fixtures
     fixtures:
       fix1:
@@ -43,7 +43,7 @@
     mode: SnapgridCenter
   components:
   - type: Sprite
-    color: '#FFFF0005'
+    color: '#FFFF000e'
   - type: WizardTrap
     stunTime: 0
     effect: StunTrapFlashEffect
@@ -58,7 +58,7 @@
     mode: SnapgridCenter
   components:
   - type: Sprite
-    color: '#FF000005'
+    color: '#FF00000e'
   - type: WizardTrap
     effect: FlameTrapFlashEffect
   - type: FlameTrap
@@ -72,7 +72,7 @@
     mode: SnapgridCenter
   components:
   - type: Sprite
-    color: '#00FF0005'
+    color: '#00FF000e'
   - type: WizardTrap
     effect: DamageTrapFlashEffect
   - type: DamageTrap
@@ -90,7 +90,7 @@
     mode: SnapgridCenter
   components:
   - type: Sprite
-    color: '#00FFFF05'
+    color: '#00FFFF0e'
   - type: WizardTrap
     stunTime: 0
     effect: ChillTrapFlashEffect


### PR DESCRIPTION
## About the PR
Wizard trap opacity from 2% > 5%

## Why / Balance
Previously invisible on white tiles, now just barely visible.

## Technical details
Changed color values in traps.yml.

## Media
![image](https://github.com/user-attachments/assets/58bdee33-87c4-479f-b0f2-6f08f9cac266)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- tweak: Wizard traps now have an opacity of 5%
