### PR TITLE
Removing two test heisenfails

### DIFF
--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -93,9 +93,10 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         EmbedAttach(embeddable, args.Target, args.Shooter, embeddable.Comp);
 
         // Raise a specific event for projectiles.
-        if (TryComp(embeddable, out ProjectileComponent? projectile))
+        if (TryComp(embeddable, out ProjectileComponent? projectile) && projectile.Weapon.HasValue) // Goobstation edit: un-heisenfailing tests
         {
-            var ev = new ProjectileEmbedEvent(projectile.Shooter!.Value, projectile.Weapon!.Value, args.Target);
+            // Goobstation edit: Shooter is nullable, so why are we using nullforgiving operator for shooter?
+            var ev = new ProjectileEmbedEvent(projectile.Shooter, projectile.Weapon!.Value, args.Target);
             RaiseLocalEvent(embeddable, ref ev);
         }
     }

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -96,7 +96,7 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         if (TryComp(embeddable, out ProjectileComponent? projectile) && projectile.Weapon.HasValue) // Goobstation edit: un-heisenfailing tests
         {
             // Goobstation edit: Shooter is nullable, so why are we using nullforgiving operator for shooter?
-            var ev = new ProjectileEmbedEvent(projectile.Shooter, projectile.Weapon!.Value, args.Target);
+            var ev = new ProjectileEmbedEvent(projectile.Shooter, projectile.Weapon.Value, args.Target);
             RaiseLocalEvent(embeddable, ref ev);
         }
     }

--- a/Content.Shared/_Goobstation/Wizard/Traps/SharedIceCubeSystem.cs
+++ b/Content.Shared/_Goobstation/Wizard/Traps/SharedIceCubeSystem.cs
@@ -60,7 +60,8 @@ public abstract class SharedIceCubeSystem : EntitySystem
 
     private void OnStartCollide(Entity<IceCubeComponent> ent, ref StartCollideEvent args)
     {
-        if (args.OtherBody.LinearVelocity.LengthSquared() < 0.01f)
+        if (args.OtherBody.LinearVelocity.LengthSquared() < 0.01f ||
+            !args.OtherBody.LinearVelocity.LengthSquared().IsValid()) // Tests heisenfail without this since an engine issue causes it to return NaN randomly
             return;
 
         var xform = Transform(args.OtherEntity);

--- a/Content.Shared/_Goobstation/Wizard/Traps/SharedIceCubeSystem.cs
+++ b/Content.Shared/_Goobstation/Wizard/Traps/SharedIceCubeSystem.cs
@@ -60,8 +60,8 @@ public abstract class SharedIceCubeSystem : EntitySystem
 
     private void OnStartCollide(Entity<IceCubeComponent> ent, ref StartCollideEvent args)
     {
-        if (args.OtherBody.LinearVelocity.LengthSquared() < 0.01f ||
-            !args.OtherBody.LinearVelocity.LengthSquared().IsValid()) // Tests heisenfail without this since an engine issue causes it to return NaN randomly
+        var lenSquared = args.OtherBody.LinearVelocity.LengthSquared();
+        if (lenSquared < 0.01f || !lenSquared.IsValid()) // Tests heisenfail without this since an engine issue causes it to return NaN randomly
             return;
 
         var xform = Transform(args.OtherEntity);


### PR DESCRIPTION
## About the PR
Get rid of two most commonly encountered heisenfails

## Technical details
As I noted in the comment in `SharedIceCubeSystem.cs`, for some reason engine just sometimes returns `NaN` as `LinearVelocity` vector in StartCollideEvent. I have no idea why it only happens to icecube, my assumption is that most other code uses `PhysicsSystem` to get linear velocity, and it's just some edge-case bug that flew under the radar. As such, just checking if it's valid solves the issue. Performance overhead from calculating `LengthSquared` twice should be minuscule. It's technically an issue that could be put into RT GH, but I can't really document it well enough.

The second heisenfail, less common since it was only introduced in 182b2db00d017086ca1ac6210189f17185601e61 is just an upstream coding mistake that got past review. For some reason the nullable types are assumed to be non-nullable with no reasoning as to why, so it fails once every 5-10 runs or so.

## Media
I ran like 26 iterations of `SpawnAndDeleteAllEntitiesInTheSameSpot` and it didn't throw an error once, so I'd say it's good enough
![{DF0159B0-718F-4E42-AAA8-0FD2579003F1}](https://github.com/user-attachments/assets/39582ab3-1994-459f-aad3-2757ad67123b)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.