### PR TITLE
Mansus Grasp Rework

### DIFF
--- a/Content.Server/_Goobstation/Heretic/Components/MansusGraspComponent.cs
+++ b/Content.Server/_Goobstation/Heretic/Components/MansusGraspComponent.cs
@@ -6,4 +6,6 @@ namespace Content.Server.Heretic.Components;
 public sealed partial class MansusGraspComponent : Component
 {
     [DataField] public string? Path = null;
+
+    [DataField] public TimeSpan CooldownAfterUse = TimeSpan.FromSeconds(10);
 }

--- a/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.Temperature.Systems;
 using Content.Shared._Shitmed.Targeting;
 using Content.Shared._White.BackStab;
 using Content.Shared._White.Standing;
+using Content.Shared.Actions;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Damage.Systems;
@@ -47,6 +48,7 @@ public sealed partial class MansusGraspSystem : EntitySystem
     [Dependency] private readonly HandsSystem _hands = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly BackStabSystem _backstab = default!;
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
 
     public override void Initialize()
     {
@@ -104,7 +106,8 @@ public sealed partial class MansusGraspSystem : EntitySystem
             }
         }
 
-        hereticComp.MansusGraspActive = false;
+        _actions.SetCooldown(hereticComp.MansusGrasp, ent.Comp.CooldownAfterUse);
+        hereticComp.MansusGrasp = EntityUid.Invalid;
         QueueDel(ent);
         args.Handled = true;
     }
@@ -116,7 +119,7 @@ public sealed partial class MansusGraspSystem : EntitySystem
         if (!args.CanReach
         || !args.ClickLocation.IsValid(EntityManager)
         || !TryComp<HereticComponent>(args.User, out var heretic) // not a heretic - how???
-        || !heretic.MansusGraspActive // no grasp - not special
+        || heretic.MansusGrasp != EntityUid.Invalid // no grasp - not special
         || HasComp<ActiveDoAfterComponent>(args.User) // prevent rune shittery
         || !tags.Contains("Write") || !tags.Contains("Pen")) // not a pen
             return;

--- a/Content.Shared/_Goobstation/Heretic/Components/HereticComponent.cs
+++ b/Content.Shared/_Goobstation/Heretic/Components/HereticComponent.cs
@@ -50,7 +50,7 @@ public sealed partial class HereticComponent : Component
     /// <summary>
     ///     Used to prevent double casting mansus grasp.
     /// </summary>
-    [ViewVariables(VVAccess.ReadOnly)] public bool MansusGraspActive = false;
+    [ViewVariables(VVAccess.ReadOnly)] public EntityUid MansusGrasp = EntityUid.Invalid;
 
     /// <summary>
     ///     Indicates if a heretic is able to cast advanced spells.

--- a/Resources/Prototypes/_Goobstation/Heretic/Actions/Heretic/basic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Actions/Heretic/basic.yml
@@ -21,7 +21,6 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: InstantAction
-    useDelay: 10
     itemIconStyle: NoItem
     icon:
       sprite: _Goobstation/Heretic/abilities_heretic.rsi


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
shit was annoying and weird you had to click on a something to deactivate.

## Why / Balance

## Technical details
MansusGraspActive is now MansusGrasp and is set to the action id to allow cooldown setting through c#

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Mansus grasp now can be deactivated through the action.
- tweak: Mansus grasp cooldown starts after use now. 

