### PR TITLE
Lavaland bluespace ore fix

### DIFF
--- a/Content.Shared/_Lavaland/Procedural/Prototypes/LavalandMapPrototype.cs
+++ b/Content.Shared/_Lavaland/Procedural/Prototypes/LavalandMapPrototype.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared._Lavaland.Weather;
+using Content.Shared._Lavaland.Weather;
 using Content.Shared.Atmos;
 using Content.Shared.Parallax.Biomes;
 using Content.Shared.Parallax.Biomes.Markers;
@@ -58,6 +58,7 @@ public sealed partial class LavalandMapPrototype : IPrototype
         "OreSilver",
         "OrePlasma",
         "OreUranium",
+        "BSCrystal",
         "OreBananium",
         "OreArtifactFragment",
         "OreDiamond",

--- a/Resources/Prototypes/_Lavaland/Procedural/lavaland_planets.yml
+++ b/Resources/Prototypes/_Lavaland/Procedural/lavaland_planets.yml
@@ -30,4 +30,4 @@
   - OreBananium
   - OreArtifactFragment
   - OreDiamond
-  #- BSCrystal
+  - BSCrystal


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
bluespace ore can spawn in lavaland again

## Why / Balance
its meant to be there

## Technical details
BSCrystal added to the markers
its also not commented anymore
it wasnt my fault i swear

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Bluespace ore can appear in Lavaland again
