### PR TITLE
fix changeling grab

### DIFF
--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
@@ -94,9 +94,7 @@ public sealed partial class ChangelingSystem
             _popup.PopupEntity(Loc.GetString("changeling-absorb-fail-unabsorbable"), uid, uid);
             return;
         }
-        if (((TryComp<PullableComponent>(target, out var pullable)) &&
-            (pullable.GrabStage <= GrabStage.Soft)) &&  // Agressive grab check
-            (!IsIncapacitated(target))) // If the target is incapacitated, no need to grab
+        if (!IsIncapacitated(target) && !IsHardGrabbed(target))
         {
             _popup.PopupEntity(Loc.GetString("changeling-absorb-fail-nograb"), uid, uid);
             return;
@@ -128,11 +126,7 @@ public sealed partial class ChangelingSystem
 
         var target = args.Args.Target.Value;
 
-        if (args.Cancelled ||
-            HasComp<AbsorbedComponent>(target) ||
-            ((TryComp<PullableComponent>(target, out var pullable)) &&
-            (pullable.GrabStage <= GrabStage.Soft)) &&  // Agressive grab check
-            (!IsIncapacitated(target))) // If the target is incapacitated, no need to grab
+        if (args.Cancelled || HasComp<AbsorbedComponent>(target) || (!IsIncapacitated(target) && !IsHardGrabbed(target)))
             return;
 
         PlayMeatySound(args.User, comp);

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
@@ -98,8 +98,8 @@ public sealed partial class ChangelingSystem
             (pullable.GrabStage <= GrabStage.Soft)) &&  // Agressive grab check
             (!IsIncapacitated(target))) // If the target is incapacitated, no need to grab
         {
-                _popup.PopupEntity(Loc.GetString("changeling-absorb-fail-nograb"), uid, uid);
-                return;
+            _popup.PopupEntity(Loc.GetString("changeling-absorb-fail-nograb"), uid, uid);
+            return;
         }
 
         if (!TryUseAbility(uid, comp, args))

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
@@ -358,9 +358,7 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
     /// </summary>
     public bool IsHardGrabbed(EntityUid uid)
     {
-        if (TryComp<PullableComponent>(uid, out var pullable) && pullable.GrabStage <= GrabStage.Soft)
-            return true;
-        return false;
+        return (TryComp<PullableComponent>(uid, out var pullable) && pullable.GrabStage <= GrabStage.Soft);
     }
 
     public float? GetEquipmentChemCostOverride(ChangelingComponent comp, EntProtoId proto)

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
@@ -41,6 +41,7 @@ using Content.Shared.Mind;
 using Content.Server.Objectives.Components;
 using Content.Server.Light.EntitySystems;
 using Content.Shared.StatusEffect;
+using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Cuffs;
 using Content.Shared.Fluids;
@@ -341,7 +342,7 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
     }
 
     /// <summary>
-    ///     Check if a target is crit/dead or cuffed. For absorbing.
+    ///     Check if the target is crit/dead or cuffed, for absorbing.
     /// </summary>
     public bool IsIncapacitated(EntityUid uid)
     {
@@ -349,6 +350,16 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
         || (TryComp<CuffableComponent>(uid, out var cuffs) && cuffs.CuffedHandCount > 0))
             return true;
 
+        return false;
+    }
+
+    /// <summary>
+    ///     Check if the target is hard-grabbed, for absorbing.
+    /// </summary>
+    public bool IsHardGrabbed(EntityUid uid)
+    {
+        if (TryComp<PullableComponent>(uid, out var pullable) && pullable.GrabStage <= GrabStage.Soft)
+            return true;
         return false;
     }
 

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
@@ -358,7 +358,7 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
     /// </summary>
     public bool IsHardGrabbed(EntityUid uid)
     {
-        return (TryComp<PullableComponent>(uid, out var pullable) && pullable.GrabStage <= GrabStage.Soft);
+        return (TryComp<PullableComponent>(uid, out var pullable) && pullable.GrabStage > GrabStage.Soft);
     }
 
     public float? GetEquipmentChemCostOverride(ChangelingComponent comp, EntProtoId proto)

--- a/Resources/Locale/en-US/_Goobstation/Changeling/abilities/changeling.ftl
+++ b/Resources/Locale/en-US/_Goobstation/Changeling/abilities/changeling.ftl
@@ -11,7 +11,7 @@ changeling-absorb-fail-unabsorbable = The target is not absorbable.
 changeling-absorb-end-self = Another organic absorbed. You are evolving.
 changeling-absorb-end-self-ling = Another changeling absorbed. You are evolving more rapidly.
 changeling-absorb-onexamine = [color=red]The body feels hollow.[/color]
-changeling-absorb-fail-nograb = You arent grabbing hard enough.
+changeling-absorb-fail-nograb = You aren't grabbing hard enough.
 
 changeling-absorbbiomatter-start = {THE($user)} starts absorbing the food!
 changeling-absorbbiomatter-bad-food = This food is not absorbable.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
changeling absorb now checks for hard grab OR incapacitated, instead of grab AND incapacitated, allowing absorbing dead bodies without grabbing them and alive grabbed people. also fixed a typo
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
fix basically, makes no sense why would ling need to grab a dead body, 13 parity
## Technical details
<!-- Summary of code changes for easier review. -->
tested, works as intended
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: pheenty
- fix: Changeling absord no longer requires grabbing dead bodies or killing grabbed ones.