### PR TITLE
Storyteller minor update

### DIFF
--- a/Content.Server/_Goobstation/StationEvents/Components/GameDirectorComponent.cs
+++ b/Content.Server/_Goobstation/StationEvents/Components/GameDirectorComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Server._Goobstation.StationEvents.Metric;
 using Content.Shared.EntityTable.EntitySelectors;
+using Content.Shared.Random;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
@@ -73,6 +74,11 @@ public sealed partial class GameDirectorComponent : Component
     [DataField]
     public List<PossibleEvent> PossibleEvents = new();
     // Could have Chaos multipliers here, or multipliers per player (so stories are harder with more players).
+
+    /// <summary>
+    /// All the possible roundstart antags.
+    /// </summary>
+    public ProtoId<WeightedRandomPrototype> RoundStartAntagsWeightTable = "GameDirector";
 }
 
 /// <summary>

--- a/Content.Server/_Goobstation/StationEvents/GameDirectorSystem.cs
+++ b/Content.Server/_Goobstation/StationEvents/GameDirectorSystem.cs
@@ -16,6 +16,8 @@ using Content.Shared.GameTicking.Components;
 using Content.Shared.Ghost;
 using Content.Shared.Humanoid;
 using Content.Shared.Prototypes;
+using Content.Shared.Random;
+using Content.Shared.Random.Helpers;
 using Content.Shared.Tag;
 using JetBrains.Annotations;
 using Robust.Server.Player;
@@ -234,76 +236,26 @@ public sealed class GameDirectorSystem : GameRuleSystem<GameDirectorComponent>
             return;
 
         // Spawn antags based on GameDirectorComponent
-            var roundStartAntags = new List<EntityPrototype>();
-            var calmStartAntags = new List<EntityPrototype>();
-            foreach (var proto in GameTicker.GetAllGameRulePrototypes())
-            {
-                if (!proto.TryGetComponent<TagComponent>(out var tag, _factory))
-                    continue;
+        var weightList = _prototypeManager.Index(scheduler.RoundStartAntagsWeightTable);
 
-                if (!proto.TryGetComponent<GameRuleComponent>(out var gameRuleComp, _factory))
-                    continue;
+        if (!scheduler.DualAntags)
+        {
+            EntProtoId pick = weightList.Pick(_random);
+            LogMessage("Choosing roundstart antag");
+            LogMessage($"Roundstart antag chosen: {pick}");
+            GameTicker.AddGameRule(pick);
+        }
+        else
+        {
+            var pick = weightList.Pick(_random);
+            var pick2 = weightList.Pick(_random);
+            LogMessage("Choosing roundstart antag");
+            LogMessage($"Roundstart antag chosen: {pick}");
+            LogMessage($"Roundstart antag chosen: {pick2}");
 
-                if (gameRuleComp.MinPlayers > count)
-                    continue;
-
-                if (proto.HasComponent<DynamicRulesetComponent>())
-                    continue;
-
-                if (_tag.HasTag(tag, "MidroundAntag"))
-                    continue;
-
-                if (_tag.HasTag(tag, "RoundstartAntag"))
-                {
-                    roundStartAntags.Add(proto);
-                }
-                else if (_tag.HasTag(tag, "CalmAntag"))
-                {
-                    calmStartAntags.Add(proto);
-                }
-            }
-
-            if (!scheduler.DualAntags)
-            {
-                if (roundStartAntags.Count == 0)
-                {
-                    LogMessage("No valid roundstart antags found!");
-                    return;
-                }
-
-                LogMessage("Choosing roundstart antag");
-                var random = new Random();
-                var randomAntag = roundStartAntags[random.Next(roundStartAntags.Count)];
-                LogMessage($"Roundstart antag chosen: {randomAntag.ID}");
-
-                var ruleEnt = GameTicker.AddGameRule(randomAntag.ID);
-                GameTicker.StartGameRule(ruleEnt);
-            }
-            else
-            {
-                if (calmStartAntags.Count < 2)
-                {
-                    LogMessage("Not enough valid roundstart antags found!");
-                    return;
-                }
-
-                LogMessage("Choosing multiple roundstart antags");
-                var random = new Random();
-
-                var firstIndex = random.Next(calmStartAntags.Count);
-                var randomAntagFirst = calmStartAntags[firstIndex];
-                calmStartAntags.RemoveAt(firstIndex);
-
-                var randomAntagSecond = calmStartAntags[random.Next(calmStartAntags.Count)];
-
-                LogMessage($"Roundstart antags chosen: 1: {randomAntagFirst.ID} 2: {randomAntagSecond.ID}");
-
-                var ruleFirstEnt = GameTicker.AddGameRule(randomAntagFirst.ID);
-                var ruleSecondEnt = GameTicker.AddGameRule(randomAntagSecond.ID);
-
-                GameTicker.StartGameRule(ruleFirstEnt);
-                GameTicker.StartGameRule(ruleSecondEnt);
-            }
+            GameTicker.AddGameRule(pick);
+            GameTicker.AddGameRule(pick2);
+        }
     }
 
     /// <summary>

--- a/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
@@ -1,0 +1,11 @@
+- type: weightedRandom # All dual antag gamemodes are goobstation
+  id: GameDirector
+  weights:
+    Traitor: 0.25
+    Changeling: 0.10
+    Nukeops: 0.09
+    Revolutionary: 0.04
+    Zombie: 0.03
+    Heretic: 0.10
+    BlobGameMode: 0.04
+    Wizard: 0.08

--- a/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
@@ -9,3 +9,4 @@
     Heretic: 0.10
     BlobGameMode: 0.04
     Wizard: 0.08
+    HonkOps: 0.01

--- a/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
@@ -1,4 +1,4 @@
-- type: weightedRandom # All dual antag gamemodes are goobstation
+- type: weightedRandom
   id: GameDirector
   weights:
     Traitor: 0.25

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -202,6 +202,10 @@
     earliestStart: 50
     minimumPlayers: 20
     maxOccurrences: 2
+    chaos:
+      Hostile: 200
+      Death: 300
+      Medical: 200
   - type: BlobSpawnRule
     carrierBlobProtos:
     - SpawnPointGhostBlobRat

--- a/Resources/Prototypes/_Goobstation/_Pirates/game_ticking.yml
+++ b/Resources/Prototypes/_Goobstation/_Pirates/game_ticking.yml
@@ -8,8 +8,15 @@
     earliestStart: 20
     reoccurrenceDelay: 60
     minimumPlayers: 30
+    chaos:
+      Hostile: 50
+      Medical: 50
+      Death: 25
   - type: PendingPirateRule
     ransomPrototype: BikeHornRansom
+  - type: Tag
+    tags:
+    - MidroundAntag
 
 - type: entity
   parent: BaseGameRule
@@ -35,6 +42,9 @@
       - type: RandomMetadata
         nameSegments:
         - names_death_commando
+  - type: Tag
+    tags:
+    - MidroundAntag
 
 - type: entity
   parent: BikeHorn

--- a/Resources/Prototypes/_Shitmed/GameRules/events.yml
+++ b/Resources/Prototypes/_Shitmed/GameRules/events.yml
@@ -8,6 +8,9 @@
     weight: 7.5
     minimumPlayers: 10
     duration: 1
+    chaos: # Goobstation
+      Hostile: 75
+      Medical: 75
   - type: RuleGrids
   - type: LoadMapRule
     mapPath: /Maps/_Shitmed/Shuttles/ShuttleEvent/abductor_shuttle.yml
@@ -99,6 +102,9 @@
     weight: 7.5
     minimumPlayers: 20
     duration: 1
+    chaos: # Goobstation
+      Hostile: 150
+      Medical: 150
   - type: RuleGrids
   - type: LoadMapRule
     mapPath: /Maps/_Shitmed/Shuttles/ShuttleEvent/duo_abductor_shuttle.yml


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
pirates can spawn
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
roundstart antags are tied to weights again.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Pirates, Abductors and the Blob can now spawn as midround event in storyteller modes!
- fix: Nukie spam
