### PR TITLE
lavaland shuttle fix (hopium)

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -505,15 +505,15 @@ public sealed partial class ShuttleSystem
             var config = _dockSystem.GetDockingConfigAt(uid, target.EntityId, target, entity.Comp1.TargetAngle);
             var mapCoordinates = _transform.ToMapCoordinates(target);
 
-            // Couldn't dock somehow so just fallback to regular position FTL.
-            if (config == null)
-            {
-                TryFTLProximity(uid, target.EntityId);
-            }
-            else
-            {
+            // Goob/LL edit start
+            // Added a retry to getting a valid docking config, in case concurrent FTL arrivals took the reserved spot
+            if (config != null)
                 FTLDock((uid, xform), config);
-            }
+            else if ((config = _dockSystem.GetDockingConfig(uid, target.EntityId, entity.Comp1.PriorityTag)) != null)
+                FTLDock((uid, xform), config);
+            else
+                TryFTLProximity(uid, target.EntityId);
+            // Goob/LL edit end
 
             mapId = mapCoordinates.MapId;
         }

--- a/Content.Server/_Lavaland/Shuttles/Systems/DockingConsoleSystem.cs
+++ b/Content.Server/_Lavaland/Shuttles/Systems/DockingConsoleSystem.cs
@@ -234,14 +234,6 @@ public sealed class DockingConsoleSystem : SharedDockingConsoleSystem
                 TryComp<StationDataComponent>(stationMember.Station, out var stationData))
                 return _station.GetLargestGrid(stationData);
 
-            // This is like, total fallback here. Technically better than above one tho
-            if (HasComp<StationMemberComponent>(gridUid) &&
-                HasComp<BecomesStationComponent>(gridUid) &&
-                !HasComp<TradeStationComponent>(gridUid) &&
-                !HasComp<CargoShuttleComponent>(gridUid) &&
-                !HasComp<MiningShuttleComponent>(gridUid))
-                return gridUid;
-
             if (HasComp<LavalandStationComponent>(gridUid))
                 return gridUid;
 

--- a/Content.Server/_Lavaland/Shuttles/Systems/DockingConsoleSystem.cs
+++ b/Content.Server/_Lavaland/Shuttles/Systems/DockingConsoleSystem.cs
@@ -19,6 +19,8 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Utility;
 using Timer = Robust.Shared.Timing.Timer;
 using Content.Shared.Station.Components;
+using Content.Server.Cargo.Components;
+using Content.Shared.Cargo.Components;
 
 namespace Content.Server._Lavaland.Shuttles.Systems;
 
@@ -228,14 +230,17 @@ public sealed class DockingConsoleSystem : SharedDockingConsoleSystem
             if (xform.MapID != map)
                 continue;
 
-            if (TryComp<StationDataComponent>(gridUid, out var stationData))
+            if (TryComp<StationMemberComponent>(gridUid, out var stationMember) &&
+                TryComp<StationDataComponent>(stationMember.Station, out var stationData))
                 return _station.GetLargestGrid(stationData);
 
-            if (HasComp<BecomesStationComponent>(gridUid) &&
-                TryComp<StationMemberComponent>(gridUid, out var stationMember) &&
-                stationMember.Station == gridUid)
+            // This is like, total fallback here. Technically better than above one tho
+            if (HasComp<StationMemberComponent>(gridUid) &&
+                HasComp<BecomesStationComponent>(gridUid) &&
+                !HasComp<TradeStationComponent>(gridUid) &&
+                !HasComp<CargoShuttleComponent>(gridUid) &&
+                !HasComp<MiningShuttleComponent>(gridUid))
                 return gridUid;
-
 
             if (HasComp<LavalandStationComponent>(gridUid))
                 return gridUid;

--- a/Content.Server/_Lavaland/Shuttles/Systems/DockingConsoleSystem.cs
+++ b/Content.Server/_Lavaland/Shuttles/Systems/DockingConsoleSystem.cs
@@ -227,6 +227,9 @@ public sealed class DockingConsoleSystem : SharedDockingConsoleSystem
             if (xform.MapID != map)
                 continue;
 
+            if (TryComp<StationDataComponent>(gridUid, out var stationData))
+                return _station.GetLargestGrid(stationData);
+
             if (HasComp<BecomesStationComponent>(gridUid) ||
                 HasComp<LavalandStationComponent>(gridUid))
                 return gridUid;

--- a/Content.Server/_Lavaland/Shuttles/Systems/DockingConsoleSystem.cs
+++ b/Content.Server/_Lavaland/Shuttles/Systems/DockingConsoleSystem.cs
@@ -18,6 +18,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Utility;
 using Timer = Robust.Shared.Timing.Timer;
+using Content.Shared.Station.Components;
 
 namespace Content.Server._Lavaland.Shuttles.Systems;
 
@@ -229,6 +230,12 @@ public sealed class DockingConsoleSystem : SharedDockingConsoleSystem
 
             if (TryComp<StationDataComponent>(gridUid, out var stationData))
                 return _station.GetLargestGrid(stationData);
+
+            if (HasComp<BecomesStationComponent>(gridUid) &&
+                TryComp<StationMemberComponent>(gridUid, out var stationMember) &&
+                stationMember.Station == gridUid)
+                return gridUid;
+
 
             if (HasComp<LavalandStationComponent>(gridUid))
                 return gridUid;

--- a/Content.Server/_Lavaland/Shuttles/Systems/DockingConsoleSystem.cs
+++ b/Content.Server/_Lavaland/Shuttles/Systems/DockingConsoleSystem.cs
@@ -230,8 +230,7 @@ public sealed class DockingConsoleSystem : SharedDockingConsoleSystem
             if (TryComp<StationDataComponent>(gridUid, out var stationData))
                 return _station.GetLargestGrid(stationData);
 
-            if (HasComp<BecomesStationComponent>(gridUid) ||
-                HasComp<LavalandStationComponent>(gridUid))
+            if (HasComp<LavalandStationComponent>(gridUid))
                 return gridUid;
 
             var size = grid.LocalAABB.Size.LengthSquared();


### PR DESCRIPTION
## About the PR
Fixes, or at least attempts to limit occurences of one annoying bug

## Why / Balance
Bug, duh

## Technical details
There's two bugs that are getting fixed

### Concurrent FTL
Usually, on FTLtoDock the docking config is created on FTL init. As such, if two shuttles were to target the same dock, one will be forced to FTL nearby instead. This tweak makes it so that the shuttle will attempt to get a new docking config before FTLing nearby.

#### Repro
Open server and client in release mode, delete/obstruct salv dock, FTL from lavaland to station when arrivals shuttle is in transit (Arrivals->Station)
On master this will result in mining shuttle FTL to space nearby, on this branch the shuttle will choose another dock.

### Wrong warp
Mining shuttle system checked for `BecomesStationComponent`. This component is however applied to things like arrivals shuttle, station, cargo shuttle, ATS, and if the order in which they were processed was unlucky, it failed. Or rather, the function returned one of the wrong grids, which made the docking config creation fail. Now we use the same system arrivals shuttle uses, and if that somehow fails, we can still use the previous fallback, which should actually work now since we don't return early with a bad grid 

#### Repro
I found barratry to pretty consistently exhibit this bug before. Not anymore

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Mining shuttle works more often than it doesn't now.