### PR TITLE
fix gc over-earnings in command/sec roles

### DIFF
--- a/Content.Server/_Goobstation/ServerCurrency/ServerCurrencySystem.cs
+++ b/Content.Server/_Goobstation/ServerCurrency/ServerCurrencySystem.cs
@@ -26,7 +26,7 @@ namespace Content.Server._Goobstation.ServerCurrency
         [Dependency] private readonly IConfigurationManager _cfg = default!;
 
         private int _goobcoinsPerPlayer = 10;
-        private int _goobcoinsNonAntagMultiplier = 3;
+        private int _goobcoinsNonAntagMultiplier = 1;
         private int _goobcoinsServerMultiplier = 1;
         private int _goobcoinsMinPlayers;
 

--- a/Content.Shared/_Goobstation/CCVar/CCVars.Goob.cs
+++ b/Content.Shared/_Goobstation/CCVar/CCVars.Goob.cs
@@ -234,7 +234,7 @@ public sealed partial class GoobCVars
         CVarDef.Create("goob.coins_per_greentext", 5, CVar.SERVERONLY);
 
     public static readonly CVarDef<int> GoobcoinNonAntagMultiplier =
-        CVarDef.Create("goob.coins_non_antag_multiplier", 3, CVar.SERVERONLY);
+        CVarDef.Create("goob.coins_non_antag_multiplier", 1, CVar.SERVERONLY);
 
     public static readonly CVarDef<int> GoobcoinServerMultiplier =
         CVarDef.Create("goob.coins_server_multiplier", 1, CVar.SERVERONLY);


### PR DESCRIPTION
## About the PR
Set GC multi for non-antag roles to 1.
If you want this back, **MAKE IT MORE EXPLICIT**, thank you

## Why / Balance
https://github.com/Goob-Station/Goob-Station/pull/1910 messed up and gave command increased GC gain in most command roles. Slight issue - the 3x multi is still being applied. This results in up to 150(!!!) GC being earned per round, and if you main command you can get a ghostrole token in ~4 rounds.
This fix will still make these roles earn 3-5 times as much as most other ones, while not making it so you can earn enough antag tokens to get higher per-round chance of antag that by just playing a tider.

## Technical details
Just set var and cvar to 1. Not ripping up the system since it could be used in the future and set to more reasonable values. I don't think I missed anything.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed instances of some roles earning more GC than intended
