### PR TITLE
fix dorms marker

### DIFF
--- a/Content.Server/_Goobstation/PlayerListener/DormNotifier.cs
+++ b/Content.Server/_Goobstation/PlayerListener/DormNotifier.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Content.Server.Afk;
@@ -42,8 +42,8 @@ public sealed class DormNotifier : EntitySystem
     private bool _enabled;
     private int _frequency = 10;
 
-    private int _timeout = 120;
-    private int _timeoutExpedited = 25;
+    private int _timeout = 180;
+    private int _timeoutExpedited = 60;
 
     public override void Initialize()
     {

--- a/Content.Server/_Goobstation/PlayerListener/DormNotifierMarkerComponent.cs
+++ b/Content.Server/_Goobstation/PlayerListener/DormNotifierMarkerComponent.cs
@@ -1,14 +1,14 @@
-﻿namespace Content.Server._Goobstation.PlayerListener;
+namespace Content.Server._Goobstation.PlayerListener;
 
 [RegisterComponent]
 public sealed partial class DormNotifierMarkerComponent : Component
 {
-    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public string Name = "";
 
     /// <summary>
     /// Tile range to check for players
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float ProximityRadius = 1;
 }

--- a/Content.Shared/_Goobstation/CCVar/CCVars.Goob.cs
+++ b/Content.Shared/_Goobstation/CCVar/CCVars.Goob.cs
@@ -95,17 +95,17 @@ public sealed partial class GoobCVars
 
     /// <summary>
     ///     Time given to be found to be engaging in dorm activity
-    ///     Default is 120.
+    ///     Default is 180.
     /// </summary>
     public static readonly CVarDef<int> DormNotifierPresenceTimeout =
-        CVarDef.Create("dorm_notifier.timeout", 120, CVar.SERVER, "Mark as condemned if present near a dorm marker for more than X amount of seconds.");
+        CVarDef.Create("dorm_notifier.timeout", 180, CVar.SERVER, "Mark as condemned if present near a dorm marker for more than X amount of seconds.");
 
     /// <summary>
     ///     Time given to be found engaging in dorm activity if any of the sinners are nude
-    ///     Default if 25.
+    ///     Default if 60.
     /// </summary>
     public static readonly CVarDef<int> DormNotifierPresenceTimeoutNude =
-        CVarDef.Create("dorm_notifier.timeout_nude", 25, CVar.SERVER, "Mark as condemned if present near a dorm marker for more than X amount of seconds while being nude.");
+        CVarDef.Create("dorm_notifier.timeout_nude", 60, CVar.SERVER, "Mark as condemned if present near a dorm marker for more than X amount of seconds while being nude.");
 
     /// <summary>
     ///     Broadcast to all players that a player has ragequit.


### PR DESCRIPTION
## About the PR
Makes dorms markers mappable, and increases the times a bit

## Why / Balance
Leonid uses them rn but they don't work properly (marker doesn't store radii/name data), and the timeouts are pretty short, making it possible to trigger them randomly. Both of these are adressed

## Technical details
Like a few vars here, few decorators there

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

No CL since this is a small, mostly mapping-related change