### PR TITLE
fix edagger examine being evil

### DIFF
--- a/Content.Server/_Shitmed/Medical/Surgery/GhettoSurgerySystem.cs
+++ b/Content.Server/_Shitmed/Medical/Surgery/GhettoSurgerySystem.cs
@@ -53,10 +53,13 @@ public sealed partial class GhettoSurgerySystem : EntitySystem
 
     private void OnSharpShutdown(Entity<SharpComponent> ent, ref ComponentShutdown args)
     {
-        if (ent.Comp.HadScalpel)
+        if (!ent.Comp.HadSurgeryTool)
+            RemComp<SurgeryToolComponent>(ent);
+
+        if (!ent.Comp.HadScalpel)
             RemComp<ScalpelComponent>(ent);
 
-        if (ent.Comp.HadBoneSaw)
+        if (!ent.Comp.HadBoneSaw)
             RemComp<BoneSawComponent>(ent);
     }
 }


### PR DESCRIPTION
## About the PR
previously turning off edagger didnt remove surgery stuff now it does so you cant do surgery with an edagger turned off

## Technical details
condition wasnt inverted, forgot surgerytool removal
