### PR TITLE
Syndicate krav maga gloves

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Goobstation/store/uplink-catalog.ftl
@@ -76,6 +76,12 @@ uplink-dualetta-bundle-desc = Comes with 2 Dualetta pistols, 2 machine pistol ma
 uplink-anaconda-name = Anaconda
 uplink-anaconda-desc = The pride of the Cybersun arms concern, this heavy pistol is designed to feed itself with the built-in fabricator.
 
+uplink-kravgloves-name = Krav maga gloves
+uplink-kravgloves-desc = Gloves with krav maga nanites installed while disguised as regular black gloves.
+
+uplink-guerillagloves-name = Guerilla gloves
+uplink-guerillagloves-desc = Insulated combat gloves that allow the wearer to perform krav maga.
+
 uplink-bulk-mosin-name = Syndicate bulk rifle crate
 uplink-bulk-mosin-desc = 10 WW4-era rifles to arm you, your friends, and your cat. Saves 40% on shipping costs by buying in bulk.
 

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -188,6 +188,26 @@
   categories:
     - UplinkWeaponry
 
+- type: listing
+  id: UplinkGlovesKravmaga
+  name: uplink-kravgloves-name
+  description: uplink-kravgloves-desc
+  productEntity: ClothingHandsGlovesKravMagaStealthy
+  cost:
+    Telecrystal: 35
+  categories:
+  - UplinkWeaponry
+
+- type: listing
+  id: UplinkGlovesGuerilla
+  name: uplink-guerillagloves-name
+  description: uplink-guerillagloves-desc
+  productEntity: ClothingHandsGlovesGeurilla
+  cost:
+    Telecrystal: 40
+  categories:
+  - UplinkWeaponry
+
 # Wearables
 
 - type: listing

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/kravmagagloves.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/kravmagagloves.yml
@@ -14,3 +14,28 @@
   - type: ClothingGrantComponent
     component:
     - type: KravMaga
+
+- type: entity
+  parent: ClothingHandsGlovesKravMaga
+  id: ClothingHandsGlovesKravMagaStealthy
+  name: black gloves
+  description: Regular black gloves that do not keep you from frying.
+  components:
+  - type: Sprite
+    sprite: Clothing/Hands/Gloves/Color/black.rsi
+  - type: Fiber
+    fiberColor: fibers-black
+
+- type: entity
+  parent: [ ClothingHandsGlovesKravMaga , BaseSyndicateContraband ]
+  id: ClothingHandsGlovesGeurilla
+  name: guerilla gloves
+  description: These combat gloves come with the extra ability to perform Krav Maga martial art attacks.
+  components:
+  - type: Sprite
+    sprite: Clothing/Hands/Gloves/combat.rsi
+  - type: Clothing
+    sprite: Clothing/Hands/Gloves/combat.rsi
+  - type: Fiber
+    fiberMaterial: fibers-insulative
+    fiberColor: fibers-black


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added ClothingHandsGlovesKravMagaStealthy which are black gloves that provide krav maga for 35TC
Added ClothingHandsGlovesGeurilla (Geurilla gloves) which are insulated combat gloves that provide krav maga for 40TC
Keep in mind that gloves of the north star are 40TC
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Guerilla gloves are 40TC as they are meant to be a sidegrade to northstars
May up the price of both by 5TC after discussion
I added these in the first place because ss13 parity and in #1868 it mentions a krav maga implant for nukies but this wasn't actually added in the PR :trollface:
also sleeping carp is more powerful :trollface:

## Media
![image](https://github.com/user-attachments/assets/161f40ba-74f5-4d5a-aaa6-843add8cf944)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: JoeHammad
- add: Traitors and nukies can now buy gloves that provide krav maga, with a stealthy black glove version and loud insulated version
