### PR TITLE
the fall of firelock meta

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -18,7 +18,7 @@
     - type: InteractionOutline
     - type: Damageable
       damageContainer: StructuralInorganic
-      damageModifierSet: StructuralMetallicStrong
+      damageModifierSet: StrongMetallic
     - type: RCDDeconstructable
       cost: 4
       delay: 6


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
makes firelocks be same as airlocks in terms of damage

## Why / Balance
firelocks were 25% tankier than rwall before
they should realistically be same as airlocks since both are tanky space-grade doors
you might think firelocks would be tankier than doors but they're made of cheapium (basically same construction as doors) so no

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Firelocks are no longer made out of concentrated reinforcedwallium.
