### PR TITLE
mice dodge

### DIFF
--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -179,7 +179,9 @@ namespace Content.Shared.Damage
         public DamageSpecifier? TryChangeDamage(EntityUid? uid, DamageSpecifier damage, bool ignoreResistances = false,
             bool interruptsDoAfters = true, DamageableComponent? damageable = null, EntityUid? origin = null,
             // Shitmed Change
-            bool? canSever = true, bool? canEvade = false, float? partMultiplier = 1.00f, TargetBodyPart? targetPart = null)
+            bool? canSever = true, bool? canEvade = false, float? partMultiplier = 1.00f, TargetBodyPart? targetPart = null,
+            // Goobstation
+            bool heavyAttack = false)
         {
             if (!uid.HasValue || !_damageableQuery.Resolve(uid.Value, ref damageable, false))
             {
@@ -192,7 +194,7 @@ namespace Content.Shared.Damage
                 return damage;
             }
 
-            var before = new BeforeDamageChangedEvent(damage, origin, targetPart, canEvade ?? false); // Shitmed Change
+            var before = new BeforeDamageChangedEvent(damage, origin, targetPart, canEvade ?? false, heavyAttack); // Shitmed Change // Goobstation
             RaiseLocalEvent(uid.Value, ref before);
 
             if (before.Cancelled)
@@ -402,6 +404,7 @@ namespace Content.Shared.Damage
         EntityUid? Origin = null,
         TargetBodyPart? TargetPart = null, // Shitmed Change
         bool CanEvade = false, // Lavaland Change
+        bool HeavyAttack = false, // Goobstation
         bool Cancelled = false);
 
     /// <summary>

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -673,7 +673,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             RaiseLocalEvent(entity, attackedEvent);
             var modifiedDamage = DamageSpecifier.ApplyModifierSets(damage + hitEvent.BonusDamage + attackedEvent.BonusDamage, hitEvent.ModifiersList);
 
-            var damageResult = Damageable.TryChangeDamage(entity, modifiedDamage, origin: user, canEvade: true, partMultiplier: component.HeavyPartDamageMultiplier); // Shitmed Change
+            var damageResult = Damageable.TryChangeDamage(entity, modifiedDamage, origin: user, canEvade: true, partMultiplier: component.HeavyPartDamageMultiplier, heavyAttack: true); // Shitmed Change // Goobstation
 
             var comboEv = new ComboAttackPerformedEvent(user, entity, meleeUid, ComboAttackType.HarmLight);
             RaiseLocalEvent(user, comboEv);

--- a/Content.Shared/_Goobstation/Weapons/DodgeWideswing/DodgeWideswingComponent.cs
+++ b/Content.Shared/_Goobstation/Weapons/DodgeWideswing/DodgeWideswingComponent.cs
@@ -1,0 +1,29 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Localization;
+
+namespace Content.Shared._Goobstation.Weapons.DodgeWideswing;
+
+/// <summary>
+/// Makes this entity have a chance to dodge a wideswing attack, converting the incoming damage into stamina damage.
+/// </summary>
+[RegisterComponent]
+public sealed partial class DodgeWideswingComponent : Component
+{
+    [DataField]
+    public float Chance = 1f;
+
+    /// <summary>
+    /// How much stamina damage to apply per damage from source.
+    /// </summary>
+    [DataField]
+    public float StaminaRatio = 1f;
+
+    /// <summary>
+    /// Whether to still evade if knocked down.
+    /// </summary>
+    [DataField]
+    public bool WhenKnockedDown = false;
+
+    [DataField]
+    public LocId? PopupId = "wideswing-dodge-generic";
+}

--- a/Content.Shared/_Goobstation/Weapons/DodgeWideswing/DodgeWideswingSystem.cs
+++ b/Content.Shared/_Goobstation/Weapons/DodgeWideswing/DodgeWideswingSystem.cs
@@ -1,0 +1,34 @@
+using Content.Shared.Damage;
+using Content.Shared.Damage.Systems;
+using Content.Shared.Popups;
+using Content.Shared.Stunnable;
+using Robust.Shared.Random;
+
+namespace Content.Shared._Goobstation.Weapons.DodgeWideswing;
+
+public sealed class DodgeWideswingSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly StaminaSystem _stamina = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DodgeWideswingComponent, BeforeDamageChangedEvent>(OnDamageChanged);
+    }
+
+    private void OnDamageChanged(EntityUid uid, DodgeWideswingComponent component, ref BeforeDamageChangedEvent args)
+    {
+        if (args.HeavyAttack && (!HasComp<KnockedDownComponent>(uid) || component.WhenKnockedDown) && _random.Prob(component.Chance))
+        {
+            _stamina.TakeStaminaDamage(uid, args.Damage.GetTotal().Float() * component.StaminaRatio, source: args.Origin, immediate: false);
+
+            if (component.PopupId != null)
+                _popup.PopupPredicted(Loc.GetString(component.PopupId, ("target", uid)), uid, args.Origin);
+
+            args.Cancelled = true;
+        }
+    }
+}

--- a/Resources/Locale/en-US/_Goobstation/damage/dodge-wideswing.ftl
+++ b/Resources/Locale/en-US/_Goobstation/damage/dodge-wideswing.ftl
@@ -1,0 +1,1 @@
+wideswing-dodge-generic = {THE($target)} swiftly evades the broad swing!

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1860,7 +1860,8 @@
         sprite:
           sprite: Objects/Consumable/Food/skewer.rsi
           state: skewer-rat
-  - type: NightVision # Goobstation - Start
+  # <Goobstation>
+  - type: NightVision
     color: "#808080"
     activateSound: null
     deactivateSound: null
@@ -1877,11 +1878,17 @@
         Quantity: 1
   - type: MeleeChemicalInjector
     transferAmount: 1
-    solution: melee # Goobstation - End
-  - type: GibThisGuy  #Goobstation
+    solution: melee
+  - type: GibThisGuy
     ocNames:
     - BombasterDS
-    - Gallagin 
+    - Gallagin
+  - type: DodgeWideswing
+    staminaRatio: 1 # mice are small so can probably evade without much stamina drain
+  - type: Stamina
+    critThreshold: 20
+  - type: LayingDown
+  # </Goobstation>
 
 - type: entity
   parent: MobMouse


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- mice can now dodge wideswing
- a dodged wideswing does stamina damage instead
- mice can now be knocked down
- mice now have 20 stamina

## Why / Balance
they're small so makes sense they should be able to dodge broad attacks
makes mice more trolly
allows you to actually be nimble as a mouse and dodge hits because without this it's impossible

## Media
tested, works

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Mice now dodge wideswing. It does stamina damage to them instead.
