### PR TITLE
improve contortionist jumpsuit

### DIFF
--- a/Resources/Locale/en-US/_Starlight/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Starlight/store/uplink-catalog.ftl
@@ -1,2 +1,6 @@
 uplink-contortionist-jumpsuit-name = Contortionist's Jumpsuit
 uplink-contortionist-jumpsuit-desc = It looks like an Atmos jumpsuit, but it really is. This jumpsuit allows the agent to slip through the vents. Make sure you don't have a backpack or suit on you, and you need your hands to be empty.
+
+# Goobstation
+uplink-contortionist-jumpsuit-advanced-name = Contortionist's Bluespace Jumpsuit
+uplink-contortionist-jumpsuit-advanced-desc = An Atmos jumpsuit that allows you to crawl through the vents even with gear on, uses bluespace technology.

--- a/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_StarLight/Catalog/uplink_catalog.yml
@@ -6,6 +6,21 @@
   cost:
     Telecrystal: 30 # Goobstation edit
   categories:
+  - UplinkWearables
+  # Goobstation - nuh uh
+  #conditions:
+  #- !type:BuyerJobCondition
+  #  whitelist:
+  #  - AtmosphericTechnician
+
+- type: listing
+  id: uplinkContortionistJumpsuitAdvanced
+  name: uplink-contortionist-jumpsuit-advanced-name
+  description: uplink-contortionist-jumpsuit-advanced-desc
+  productEntity: ClothingUniformJumpsuitAtmosSyndieAdvanced
+  cost:
+    Telecrystal: 60
+  categories:
   - UplinkJob
   conditions:
   - !type:BuyerJobCondition

--- a/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_StarLight/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -10,8 +10,8 @@
 
 - type: entity  # Goobstation original
   parent: ClothingUniformJumpsuitAtmosSyndie
-  id: ClothingUniformJumpsuitAtmosSyndieAdmin
-  suffix: Contortionistic, Admeme
+  id: ClothingUniformJumpsuitAtmosSyndieAdvanced
+  suffix: Contortionistic, Inventory
   components:
   - type: ClothingGrantComponent
     component:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- no longer atmos job-specific
- add atmos-specific contortionist jumpsuit for 60 TC that allows inventory

## Why / Balance
why was it atmos-specific
new one because fun, it's a doafter to enter vents anyway and you can be locked in with a crowbar+wrench so i think it's fine

## Media
tested, works

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Contortionist's bluespace jumpsuit: atmos job-specific contortionist's jumpsuit that allows inventory.
- tweak: Contortionist's jumpsuit is no longer atmos job-specific.
