### PR TITLE
lavaland gateway lite

### DIFF
--- a/Content.Server/Gateway/Components/GatewayComponent.cs
+++ b/Content.Server/Gateway/Components/GatewayComponent.cs
@@ -1,5 +1,7 @@
 using Content.Server.Gateway.Systems;
+using Content.Shared.Tag; // Goobstation
 using Robust.Shared.Audio;
+using Robust.Shared.Prototypes; // Goobstation
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 using Robust.Shared.Utility;
 
@@ -63,4 +65,11 @@ public sealed partial class GatewayComponent : Component
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     [AutoPausedField]
     public TimeSpan NextReady;
+
+    // Goobstation
+    /// <summary>
+    /// Restrict this gate's destinations and sources to gates tagged with this.
+    /// </summary>
+    [DataField]
+    public ProtoId<TagPrototype>? TagRestriction;
 }

--- a/Content.Server/Gateway/Systems/GatewaySystem.cs
+++ b/Content.Server/Gateway/Systems/GatewaySystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.UserInterface;
 using Content.Shared.Access.Systems;
 using Content.Shared.Gateway;
 using Content.Shared.Popups;
+using Content.Shared.Tag; // Goobstation
 using Content.Shared.Teleportation.Components;
 using Content.Shared.Teleportation.Systems;
 using Robust.Server.GameObjects;
@@ -24,6 +25,7 @@ public sealed class GatewaySystem : EntitySystem
     [Dependency] private readonly StationSystem _stations = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
+    [Dependency] private readonly TagSystem _tag = default!; // Goobstation
 
     public override void Initialize()
     {
@@ -96,7 +98,11 @@ public sealed class GatewaySystem : EntitySystem
 
         while (query.MoveNext(out var destUid, out var dest, out var destXform))
         {
-            if (!dest.Enabled || destUid == uid)
+            // Goobstation
+            if (!dest.Enabled
+                || destUid == uid
+                || (comp.TagRestriction != null && !_tag.HasTag(destUid, comp.TagRestriction.Value)) // if we have a tag restriction and destination doesn't have it, abort
+                || (dest.TagRestriction != null && !_tag.HasTag(uid, dest.TagRestriction.Value))) // if destination has a tag restriction but we don't have the tag, abort
                 continue;
 
             // Show destination if either no destination comp on the map or it's ours.

--- a/Resources/Maps/_Lavaland/Lavaland/outpost_lavaland.yml
+++ b/Resources/Maps/_Lavaland/Lavaland/outpost_lavaland.yml
@@ -1,6 +1,17 @@
 meta:
-  format: 6
-  postmapinit: false
+  format: 7
+  category: Grid
+  engineVersion: 247.2.0
+  forkId: ""
+  forkVersion: ""
+  time: 03/10/2025 11:35:22
+  entityCount: 2079
+maps: []
+grids:
+- 2
+orphans:
+- 2
+nullspace: []
 tilemap:
   0: Space
   16: FloorBasalt
@@ -42,7 +53,7 @@ entities:
           version: 6
         0,-1:
           ind: 0,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAgwAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAgwAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAgwAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAAQAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgwAAAAAAAQAAAAAAgwAAAAAAgwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAgwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAgwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAgwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAEAAAAAAAEAAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAgwAAAAAAAQAAAAAAgwAAAAAAgwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgwAAAAAAAQAAAAAAgwAAAAAAgwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
           version: 6
         -1,-1:
           ind: -1,-1
@@ -191,7 +202,7 @@ entities:
             90: 35,11
             164: 19,1
             172: 11,-5
-            190: 15,-1
+            222: 15,-5
         - node:
             color: '#765428FF'
             id: BrickTileWhiteCornerSw
@@ -201,6 +212,7 @@ entities:
             84: 33,15
             128: 7,-1
             173: 7,-5
+            223: 13,-5
         - node:
             color: '#765428FF'
             id: BrickTileWhiteInnerNe
@@ -245,6 +257,7 @@ entities:
             109: 27,4
             138: 7,1
             187: 10,-1
+            226: 13,-1
         - node:
             color: '#765428FF'
             id: BrickTileWhiteLineE
@@ -273,6 +286,10 @@ entities:
             178: 11,-4
             182: 10,-2
             191: 15,0
+            218: 15,-2
+            219: 15,-3
+            221: 15,-1
+            227: 15,-4
         - node:
             color: '#765428FF'
             id: BrickTileWhiteLineN
@@ -324,8 +341,6 @@ entities:
             118: 18,1
             119: 17,1
             120: 16,1
-            122: 14,-1
-            123: 13,-1
             124: 12,-1
             125: 11,-1
             126: 9,-1
@@ -335,6 +350,7 @@ entities:
             180: 9,-5
             181: 8,-5
             188: 29,9
+            224: 14,-5
         - node:
             color: '#765428FF'
             id: BrickTileWhiteLineW
@@ -362,6 +378,9 @@ entities:
             170: 10,-2
             177: 7,-4
             183: 10,-2
+            216: 13,-3
+            217: 13,-4
+            225: 13,-2
         - node:
             color: '#FFFFFFFF'
             id: WarnEndN
@@ -1445,18 +1464,6 @@ entities:
       parent: 2
 - proto: BasaltRandom
   entities:
-  - uid: 181
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 13.5,-4.5
-      parent: 2
-  - uid: 182
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 15.5,-5.5
-      parent: 2
   - uid: 183
     components:
     - type: Transform
@@ -2580,6 +2587,21 @@ entities:
     - type: Transform
       pos: 20.5,16.5
       parent: 2
+  - uid: 554
+    components:
+    - type: Transform
+      pos: 15.5,-2.5
+      parent: 2
+  - uid: 557
+    components:
+    - type: Transform
+      pos: 15.5,-3.5
+      parent: 2
+  - uid: 558
+    components:
+    - type: Transform
+      pos: 15.5,-1.5
+      parent: 2
 - proto: CableHV
   entities:
   - uid: 619
@@ -3692,42 +3714,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 17.5,-8.5
       parent: 2
-  - uid: 1011
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,-2.5
-      parent: 2
-  - uid: 1012
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,-2.5
-      parent: 2
-  - uid: 1013
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-2.5
-      parent: 2
-  - uid: 1014
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-3.5
-      parent: 2
-  - uid: 1015
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,-3.5
-      parent: 2
-  - uid: 1016
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,-3.5
-      parent: 2
   - uid: 1017
     components:
     - type: Transform
@@ -4166,18 +4152,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 30.5,-10.5
       parent: 2
-  - uid: 1165
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,-0.5
-      parent: 2
-  - uid: 1166
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,-0.5
-      parent: 2
 - proto: ChairOfficeDark
   entities:
   - uid: 524
@@ -4327,9 +4301,11 @@ entities:
   - uid: 1237
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.264828,-2.4892714
+      pos: 9.548402,-6.712015
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: ComputerCargoOrders
   entities:
   - uid: 296
@@ -4846,13 +4822,6 @@ entities:
     components:
     - type: Transform
       pos: 27.5,12.5
-      parent: 2
-- proto: DogBed
-  entities:
-  - uid: 1342
-    components:
-    - type: Transform
-      pos: 14.5,-2.5
       parent: 2
 - proto: DonkpocketBoxSpawner
   entities:
@@ -5522,24 +5491,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-9.5
-      parent: 2
-  - uid: 1506
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,-3.5
-      parent: 2
-  - uid: 1507
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,-4.5
-      parent: 2
-  - uid: 1508
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-5.5
       parent: 2
   - uid: 1509
     components:
@@ -8584,6 +8535,13 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
+- proto: GatewayActive
+  entities:
+  - uid: 556
+    components:
+    - type: Transform
+      pos: 14.5,-3.5
+      parent: 2
 - proto: GeneratorRTG
   entities:
   - uid: 10942
@@ -8670,24 +8628,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-5.5
-      parent: 2
-  - uid: 10956
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,-1.5
-      parent: 2
-  - uid: 10957
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,-1.5
-      parent: 2
-  - uid: 10958
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,-1.5
       parent: 2
   - uid: 10959
     components:
@@ -9235,11 +9175,6 @@ entities:
     - type: Transform
       pos: 7.5,-5.5
       parent: 2
-  - uid: 11113
-    components:
-    - type: Transform
-      pos: 15.5,-1.5
-      parent: 2
   - uid: 11114
     components:
     - type: Transform
@@ -9259,11 +9194,6 @@ entities:
     components:
     - type: Transform
       pos: 36.5,15.5
-      parent: 2
-  - uid: 11118
-    components:
-    - type: Transform
-      pos: 14.5,-1.5
       parent: 2
   - uid: 11119
     components:
@@ -9329,11 +9259,6 @@ entities:
     components:
     - type: Transform
       pos: 6.5,9.5
-      parent: 2
-  - uid: 11134
-    components:
-    - type: Transform
-      pos: 13.5,-1.5
       parent: 2
   - uid: 11135
     components:
@@ -9753,6 +9678,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,0.5
+      parent: 2
+  - uid: 553
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-4.5
       parent: 2
   - uid: 11253
     components:
@@ -10246,21 +10177,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,10.5
-      parent: 2
-  - uid: 11357
-    components:
-    - type: Transform
-      pos: 13.5,-3.5
-      parent: 2
-  - uid: 11358
-    components:
-    - type: Transform
-      pos: 14.5,-3.5
-      parent: 2
-  - uid: 11359
-    components:
-    - type: Transform
-      pos: 15.5,-3.5
       parent: 2
   - uid: 11360
     components:
@@ -11351,12 +11267,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 31.5,-10.5
       parent: 2
-  - uid: 11649
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,-0.5
-      parent: 2
 - proto: TelecomServerFilledCargo
   entities:
   - uid: 11679
@@ -11415,8 +11325,11 @@ entities:
   - uid: 11691
     components:
     - type: Transform
-      pos: 14.5,-2.5
+      pos: 12.483466,-6.516806
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: ToyFigurineCargoTech
   entities:
   - uid: 11692
@@ -11429,9 +11342,11 @@ entities:
   - uid: 11694
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 13.9712925,-3.259799
+      pos: 10.484664,-6.606778
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: TwoWayLever
   entities:
   - uid: 11696
@@ -11518,6 +11433,11 @@ entities:
     - type: Transform
       pos: 3.5,3.5
       parent: 2
+  - uid: 182
+    components:
+    - type: Transform
+      pos: 15.5,-5.5
+      parent: 2
   - uid: 192
     components:
     - type: Transform
@@ -11587,6 +11507,16 @@ entities:
     components:
     - type: Transform
       pos: 6.5,3.5
+      parent: 2
+  - uid: 552
+    components:
+    - type: Transform
+      pos: 14.5,-5.5
+      parent: 2
+  - uid: 555
+    components:
+    - type: Transform
+      pos: 13.5,-5.5
       parent: 2
   - uid: 11711
     components:

--- a/Resources/Maps/_Lavaland/Lavaland/outpost_lavaland.yml
+++ b/Resources/Maps/_Lavaland/Lavaland/outpost_lavaland.yml
@@ -8535,7 +8535,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-- proto: GatewayActive
+- proto: GatewayLavaland
   entities:
   - uid: 556
     components:

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -20,6 +20,7 @@
     - id: SalvageShuttleConsoleCircuitboard
     - id: AstroNavCartridge
     - id: CargoTechFabCircuitboard # Goobstation - Cargo Techfab
+    - id: GatewayFlatpackLavaland
 
 - type: entity
   id: LockerQuarterMasterFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -20,7 +20,6 @@
     - id: SalvageShuttleConsoleCircuitboard
     - id: AstroNavCartridge
     - id: CargoTechFabCircuitboard # Goobstation - Cargo Techfab
-    - id: GatewayFlatpackLavaland
 
 - type: entity
   id: LockerQuarterMasterFilled

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Devices/flatpack.yml
@@ -5,4 +5,4 @@
   description: A flatpack used to bluespace in a gateway for travel to Lavaland.
   components:
   - type: Flatpack
-    entity: GatewayActive
+    entity: GatewayLavaland

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Devices/flatpack.yml
@@ -1,0 +1,8 @@
+- type: entity
+  parent: BaseFlatpack
+  id: GatewayFlatpackLavaland
+  name: lavaland gateway flatpack # "lavaland" only in name since that's what it's used for, to be clear to players
+  description: A flatpack used to bluespace in a gateway for travel to Lavaland.
+  components:
+  - type: Flatpack
+    entity: GatewayActive

--- a/Resources/Prototypes/_Lavaland/Entities/Structures/Machines/gateway.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Structures/Machines/gateway.yml
@@ -1,0 +1,13 @@
+- type: entity
+  parent: BaseGateway
+  id: GatewayActive
+  suffix: Active
+  components:
+  - type: ActivatableUI
+    key: enum.GatewayUiKey.Key
+  - type: UserInterface
+    interfaces:
+      enum.GatewayUiKey.Key:
+        type: GatewayBoundUserInterface
+  - type: Gateway
+    enabled: true

--- a/Resources/Prototypes/_Lavaland/Entities/Structures/Machines/gateway.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Structures/Machines/gateway.yml
@@ -1,7 +1,8 @@
 - type: entity
   parent: BaseGateway
-  id: GatewayActive
-  suffix: Active
+  id: GatewayLavaland
+  name: Lavaland gateway
+  description: To hell you go.
   components:
   - type: ActivatableUI
     key: enum.GatewayUiKey.Key
@@ -11,3 +12,8 @@
         type: GatewayBoundUserInterface
   - type: Gateway
     enabled: true
+    tagRestriction: LavalandGateway
+  - type: Tag
+    tags:
+    - Structure
+    - LavalandGateway

--- a/Resources/Prototypes/_Lavaland/tags.yml
+++ b/Resources/Prototypes/_Lavaland/tags.yml
@@ -14,6 +14,9 @@
   id: GunUpgradeRange
 
 - type: Tag
+  id: LavalandGateway
+
+- type: Tag
   id: LavalandInterior5x5
 
 - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
#1986 but QM doesn't get a flatpack
effectively just makes it easy for admins to link a gateway to lavaland, simply spawn one flatpack

## Why / Balance
ease of lavaland gateway linking

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Lavaland now gets a gateway for easier gateway linking by admin.
