### PR TITLE
Blueshield mapping

### DIFF
--- a/Resources/Maps/_Goobstation/marathon.yml
+++ b/Resources/Maps/_Goobstation/marathon.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 03/13/2025 02:55:23
+  time: 03/13/2025 21:26:33
   entityCount: 22582
 maps:
 - 1

--- a/Resources/Maps/_Goobstation/marathon.yml
+++ b/Resources/Maps/_Goobstation/marathon.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 03/09/2025 12:23:05
-  entityCount: 22569
+  time: 03/13/2025 02:55:23
+  entityCount: 22582
 maps:
 - 1
 grids:
@@ -122,11 +122,11 @@ entities:
           version: 6
         -1,1:
           ind: -1,1
-          tiles: LgAAAAAAfgAAAAAAXQAAAAACfgAAAAAAHwAAAAACegAAAAACegAAAAACfgAAAAAAfgAAAAAAfgAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAALgAAAAAAXQAAAAABXQAAAAAAfgAAAAAAHwAAAAACegAAAAADegAAAAABfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAfgAAAAAAHwAAAAACegAAAAACegAAAAACegAAAAADegAAAAADbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbQAAAAAAfgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAfgAAAAAAHwAAAAABHwAAAAAAHwAAAAAAHwAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAHwAAAAACXQAAAAACXQAAAAADXQAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAADXQAAAAADXQAAAAABXQAAAAABfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAAAXQAAAAACXQAAAAAAXQAAAAABfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAABXQAAAAACXQAAAAACXQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAADAAAAAACDAAAAAACDAAAAAACDAAAAAADDAAAAAABDAAAAAADDAAAAAACfgAAAAAAfgAAAAAAHwAAAAADXQAAAAADXQAAAAACXQAAAAAAfgAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAfgAAAAAAXQAAAAACXQAAAAACXQAAAAAAXQAAAAABTQAAAAAAXQAAAAAAXQAAAAABXQAAAAABXQAAAAAAXQAAAAACTQAAAAAAXQAAAAABXQAAAAAAXQAAAAADXQAAAAADXQAAAAABXQAAAAAAXQAAAAADXQAAAAABTQAAAAAATQAAAAAATQAAAAAATQAAAAADTQAAAAADTQAAAAAATQAAAAADTQAAAAAATQAAAAAAXQAAAAACXQAAAAACXQAAAAABXQAAAAAAXQAAAAAAXQAAAAABXQAAAAABXQAAAAAATQAAAAAAXQAAAAACXQAAAAABXQAAAAABXQAAAAACXQAAAAABTQAAAAAAXQAAAAABXQAAAAACXQAAAAACXQAAAAACXQAAAAABXQAAAAABHwAAAAABHwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAADHwAAAAADfgAAAAAAfgAAAAAATQAAAAABHwAAAAABHwAAAAACfgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfgAAAAAAKAAAAAADHwAAAAABfgAAAAAATQAAAAABTQAAAAACHwAAAAACHwAAAAADfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAACHwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAAAHwAAAAABfgAAAAAAHwAAAAADHwAAAAADHwAAAAADHwAAAAACHwAAAAACHwAAAAADHwAAAAADfgAAAAAAHwAAAAACHwAAAAABfgAAAAAAHwAAAAAAegAAAAAC
+          tiles: LgAAAAAAfgAAAAAAXQAAAAACfgAAAAAAHwAAAAACegAAAAACegAAAAACfgAAAAAAfgAAAAAAfgAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAALgAAAAAAXQAAAAABXQAAAAAAfgAAAAAAHwAAAAACegAAAAADegAAAAABfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAfgAAAAAAHwAAAAACegAAAAACegAAAAACegAAAAADegAAAAADbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAHwAAAAABHwAAAAAAHwAAAAAAHwAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAHwAAAAACXQAAAAACXQAAAAADXQAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAADXQAAAAADXQAAAAABXQAAAAABfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAAAXQAAAAACXQAAAAAAXQAAAAABfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAABXQAAAAACXQAAAAACXQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAADAAAAAACDAAAAAACDAAAAAACDAAAAAADDAAAAAABDAAAAAADDAAAAAACfgAAAAAAfgAAAAAAHwAAAAADXQAAAAADXQAAAAACXQAAAAAAfgAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAfgAAAAAAXQAAAAACXQAAAAACXQAAAAAAXQAAAAABTQAAAAAAXQAAAAAAXQAAAAABXQAAAAABXQAAAAAAXQAAAAACTQAAAAAAXQAAAAABXQAAAAAAXQAAAAADXQAAAAADXQAAAAABXQAAAAAAXQAAAAADXQAAAAABTQAAAAAATQAAAAAATQAAAAAATQAAAAADTQAAAAADTQAAAAAATQAAAAADTQAAAAAATQAAAAAAXQAAAAACXQAAAAACXQAAAAABXQAAAAAAXQAAAAAAXQAAAAABXQAAAAABXQAAAAAATQAAAAAAXQAAAAACXQAAAAABXQAAAAABXQAAAAACXQAAAAABTQAAAAAAXQAAAAABXQAAAAACXQAAAAACXQAAAAACXQAAAAABXQAAAAABHwAAAAABHwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAADHwAAAAADfgAAAAAAfgAAAAAATQAAAAABHwAAAAABHwAAAAACfgAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfQAAAAAAfgAAAAAAKAAAAAADHwAAAAABfgAAAAAATQAAAAABTQAAAAACHwAAAAACHwAAAAADfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAACHwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAHwAAAAAAHwAAAAABfgAAAAAAHwAAAAADHwAAAAADHwAAAAADHwAAAAACHwAAAAACHwAAAAADHwAAAAADfgAAAAAAHwAAAAACHwAAAAABfgAAAAAAHwAAAAAAegAAAAAC
           version: 6
         -2,1:
           ind: -2,1
-          tiles: fgAAAAAAbAAAAAAAfgAAAAAAPAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAPAAAAAAAfgAAAAAALgAAAAAALgAAAAAALgAAAAAALgAAAAAALgAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAfgAAAAAAfgAAAAAAbQAAAAAAfgAAAAAALgAAAAAALgAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAfgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAegAAAAADegAAAAABfgAAAAAAfgAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAegAAAAAAegAAAAADfgAAAAAAYgAAAAACYgAAAAABYgAAAAACYgAAAAACfgAAAAAALgAAAAAALgAAAAAALgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAegAAAAADegAAAAACfgAAAAAAYgAAAAAAYgAAAAAAYgAAAAACYgAAAAAAfgAAAAAALgAAAAAALgAAAAAALgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAADgAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAALgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAXQAAAAAATQAAAAAAXQAAAAADXQAAAAACXQAAAAABXQAAAAAAXQAAAAACXQAAAAADXQAAAAABXQAAAAACXQAAAAAAXQAAAAADXQAAAAAAXQAAAAACXQAAAAADTQAAAAAAXQAAAAADTQAAAAAAXQAAAAACXQAAAAACXQAAAAADTQAAAAAAXQAAAAACXQAAAAAAXQAAAAADXQAAAAABXQAAAAAAXQAAAAABXQAAAAADXQAAAAADXQAAAAAAXQAAAAAAXQAAAAACTQAAAAAAXQAAAAACXQAAAAACXQAAAAAAXQAAAAABXQAAAAABXQAAAAABXQAAAAABXQAAAAABXQAAAAABXQAAAAADXQAAAAAAXQAAAAABXQAAAAAAXQAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAABXQAAAAACXQAAAAACXQAAAAAAXQAAAAACXQAAAAABXQAAAAABXQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAXQAAAAABXQAAAAACXQAAAAADXQAAAAAAXQAAAAABXQAAAAACXQAAAAADfgAAAAAAfgAAAAAAegAAAAABegAAAAADegAAAAADegAAAAADegAAAAAAfgAAAAAAXQAAAAABXQAAAAACXQAAAAACXQAAAAACXQAAAAABXQAAAAAAXQAAAAADXQAAAAACfgAAAAAAfgAAAAAAegAAAAACegAAAAACegAAAAAAegAAAAAAegAAAAAAfgAAAAAA
+          tiles: fgAAAAAAbAAAAAAAfgAAAAAAPAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAKAAAAAAAPAAAAAAAfgAAAAAALgAAAAAALgAAAAAALgAAAAAALgAAAAAALgAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAfgAAAAAAfgAAAAAAbQAAAAAAfgAAAAAALgAAAAAALgAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAegAAAAADegAAAAABfgAAAAAAfgAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAegAAAAAAegAAAAADfgAAAAAAYgAAAAACYgAAAAABYgAAAAACYgAAAAACfgAAAAAALgAAAAAALgAAAAAALgAAAAAAfgAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAegAAAAADegAAAAACfgAAAAAAYgAAAAAAYgAAAAAAYgAAAAACYgAAAAAAfgAAAAAALgAAAAAALgAAAAAALgAAAAAAfgAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAADgAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAALgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAXQAAAAAAXQAAAAAATQAAAAAAXQAAAAADXQAAAAACXQAAAAABXQAAAAAAXQAAAAACXQAAAAADXQAAAAABXQAAAAACXQAAAAAAXQAAAAADXQAAAAAAXQAAAAACXQAAAAADTQAAAAAAXQAAAAADTQAAAAAAXQAAAAACXQAAAAACXQAAAAADTQAAAAAAXQAAAAACXQAAAAAAXQAAAAADXQAAAAABXQAAAAAAXQAAAAABXQAAAAADXQAAAAADXQAAAAAAXQAAAAAAXQAAAAACTQAAAAAAXQAAAAACXQAAAAACXQAAAAAAXQAAAAABXQAAAAABXQAAAAABXQAAAAABXQAAAAABXQAAAAABXQAAAAADXQAAAAAAXQAAAAABXQAAAAAAXQAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAABXQAAAAACXQAAAAACXQAAAAAAXQAAAAACXQAAAAABXQAAAAABXQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAXQAAAAAAXQAAAAABXQAAAAACXQAAAAADXQAAAAAAXQAAAAABXQAAAAACXQAAAAADfgAAAAAAfgAAAAAAegAAAAABegAAAAADegAAAAADegAAAAADegAAAAAAfgAAAAAAXQAAAAABXQAAAAACXQAAAAACXQAAAAACXQAAAAABXQAAAAAAXQAAAAADXQAAAAACfgAAAAAAfgAAAAAAegAAAAACegAAAAACegAAAAAAegAAAAAAegAAAAAAfgAAAAAA
           version: 6
         -3,0:
           ind: -3,0
@@ -1899,6 +1899,14 @@ entities:
             id: CheckerNWSE
           decals:
             1019: 3,-28
+        - node:
+            color: '#008200FF'
+            id: ConcreteTrimLineN
+          decals:
+            3114: -20,23
+            3115: -19,23
+            3116: -18,23
+            3118: -17,23
         - node:
             color: '#FFFFFFFF'
             id: Delivery
@@ -8848,6 +8856,16 @@ entities:
       - 608
       - 13352
       - 13166
+  - uid: 7926
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -20.5,22.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 7897
+      - 7885
 - proto: AirAlarmElectronics
   entities:
   - uid: 90
@@ -9117,6 +9135,19 @@ entities:
     - type: Transform
       pos: -10.5,15.5
       parent: 2
+- proto: AirlockBlueshieldOfficerCommandGlassLocked
+  entities:
+  - uid: 7883
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -16.5,24.5
+      parent: 2
+    - type: AccessReader
+      access:
+      - - BlueshieldOfficer
+      - - Captain
+      - - NanotrasenRepresentative
 - proto: AirlockBrigGlassLocked
   entities:
   - uid: 139
@@ -12458,6 +12489,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,10.5
       parent: 2
+  - uid: 7925
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -15.5,23.5
+      parent: 2
 - proto: APCElectronics
   entities:
   - uid: 678
@@ -13801,6 +13838,16 @@ entities:
     - type: Transform
       pos: -50.5,50.5
       parent: 2
+  - uid: 1502
+    components:
+    - type: Transform
+      pos: -19.5,21.5
+      parent: 2
+  - uid: 7911
+    components:
+    - type: Transform
+      pos: -16.5,21.5
+      parent: 2
 - proto: BedsheetBlue
   entities:
   - uid: 931
@@ -13821,6 +13868,13 @@ entities:
     components:
     - type: Transform
       pos: -6.5,-33.5
+      parent: 2
+- proto: BedsheetCentcom
+  entities:
+  - uid: 7913
+    components:
+    - type: Transform
+      pos: -19.5,21.5
       parent: 2
 - proto: BedsheetCMO
   entities:
@@ -13877,6 +13931,13 @@ entities:
     components:
     - type: Transform
       pos: -50.5,50.5
+      parent: 2
+- proto: BedsheetNT
+  entities:
+  - uid: 7912
+    components:
+    - type: Transform
+      pos: -16.5,21.5
       parent: 2
 - proto: BedsheetOrange
   entities:
@@ -14737,11 +14798,6 @@ entities:
       parent: 2
 - proto: BoxLightMixed
   entities:
-  - uid: 1097
-    components:
-    - type: Transform
-      pos: -18.55563,22.412413
-      parent: 2
   - uid: 1098
     components:
     - type: Transform
@@ -16826,16 +16882,6 @@ entities:
     - type: Transform
       pos: -21.5,20.5
       parent: 2
-  - uid: 1502
-    components:
-    - type: Transform
-      pos: -20.5,20.5
-      parent: 2
-  - uid: 1503
-    components:
-    - type: Transform
-      pos: -19.5,20.5
-      parent: 2
   - uid: 1504
     components:
     - type: Transform
@@ -16860,26 +16906,6 @@ entities:
     components:
     - type: Transform
       pos: -19.5,18.5
-      parent: 2
-  - uid: 1509
-    components:
-    - type: Transform
-      pos: -18.5,20.5
-      parent: 2
-  - uid: 1510
-    components:
-    - type: Transform
-      pos: -17.5,20.5
-      parent: 2
-  - uid: 1511
-    components:
-    - type: Transform
-      pos: -16.5,20.5
-      parent: 2
-  - uid: 1512
-    components:
-    - type: Transform
-      pos: -15.5,20.5
       parent: 2
   - uid: 1513
     components:
@@ -31011,6 +31037,86 @@ entities:
     - type: Transform
       pos: -7.5,-44.5
       parent: 2
+  - uid: 5831
+    components:
+    - type: Transform
+      pos: -15.5,19.5
+      parent: 2
+  - uid: 5832
+    components:
+    - type: Transform
+      pos: -16.5,19.5
+      parent: 2
+  - uid: 5833
+    components:
+    - type: Transform
+      pos: -17.5,19.5
+      parent: 2
+  - uid: 5834
+    components:
+    - type: Transform
+      pos: -18.5,19.5
+      parent: 2
+  - uid: 5835
+    components:
+    - type: Transform
+      pos: -20.5,19.5
+      parent: 2
+  - uid: 5836
+    components:
+    - type: Transform
+      pos: -21.5,19.5
+      parent: 2
+  - uid: 7910
+    components:
+    - type: Transform
+      pos: -14.5,19.5
+      parent: 2
+  - uid: 7930
+    components:
+    - type: Transform
+      pos: -15.5,23.5
+      parent: 2
+  - uid: 7931
+    components:
+    - type: Transform
+      pos: -16.5,23.5
+      parent: 2
+  - uid: 7932
+    components:
+    - type: Transform
+      pos: -17.5,23.5
+      parent: 2
+  - uid: 7933
+    components:
+    - type: Transform
+      pos: -17.5,22.5
+      parent: 2
+  - uid: 7934
+    components:
+    - type: Transform
+      pos: -19.5,22.5
+      parent: 2
+  - uid: 7935
+    components:
+    - type: Transform
+      pos: -18.5,22.5
+      parent: 2
+  - uid: 7940
+    components:
+    - type: Transform
+      pos: -11.5,34.5
+      parent: 2
+  - uid: 7941
+    components:
+    - type: Transform
+      pos: -10.5,34.5
+      parent: 2
+  - uid: 7942
+    components:
+    - type: Transform
+      pos: -9.5,34.5
+      parent: 2
 - proto: CableApcStack
   entities:
   - uid: 4339
@@ -31695,35 +31801,10 @@ entities:
     - type: Transform
       pos: -21.5,20.5
       parent: 2
-  - uid: 4475
-    components:
-    - type: Transform
-      pos: -20.5,20.5
-      parent: 2
-  - uid: 4476
-    components:
-    - type: Transform
-      pos: -19.5,20.5
-      parent: 2
-  - uid: 4477
-    components:
-    - type: Transform
-      pos: -18.5,20.5
-      parent: 2
-  - uid: 4478
-    components:
-    - type: Transform
-      pos: -17.5,20.5
-      parent: 2
-  - uid: 4479
-    components:
-    - type: Transform
-      pos: -16.5,20.5
-      parent: 2
   - uid: 4480
     components:
     - type: Transform
-      pos: -15.5,20.5
+      pos: -21.5,19.5
       parent: 2
   - uid: 4481
     components:
@@ -37595,6 +37676,41 @@ entities:
     - type: Transform
       pos: 0.5,84.5
       parent: 2
+  - uid: 7886
+    components:
+    - type: Transform
+      pos: -18.5,19.5
+      parent: 2
+  - uid: 7889
+    components:
+    - type: Transform
+      pos: -20.5,19.5
+      parent: 2
+  - uid: 7890
+    components:
+    - type: Transform
+      pos: -17.5,19.5
+      parent: 2
+  - uid: 7893
+    components:
+    - type: Transform
+      pos: -19.5,19.5
+      parent: 2
+  - uid: 7894
+    components:
+    - type: Transform
+      pos: -15.5,19.5
+      parent: 2
+  - uid: 7901
+    components:
+    - type: Transform
+      pos: -16.5,19.5
+      parent: 2
+  - uid: 7902
+    components:
+    - type: Transform
+      pos: -14.5,19.5
+      parent: 2
 - proto: CableHVStack
   entities:
   - uid: 5655
@@ -37634,6 +37750,31 @@ entities:
       parent: 2
 - proto: CableMV
   entities:
+  - uid: 4475
+    components:
+    - type: Transform
+      pos: -16.5,19.5
+      parent: 2
+  - uid: 4476
+    components:
+    - type: Transform
+      pos: -18.5,19.5
+      parent: 2
+  - uid: 4477
+    components:
+    - type: Transform
+      pos: -19.5,19.5
+      parent: 2
+  - uid: 4478
+    components:
+    - type: Transform
+      pos: -20.5,19.5
+      parent: 2
+  - uid: 4479
+    components:
+    - type: Transform
+      pos: -21.5,19.5
+      parent: 2
   - uid: 5662
     components:
     - type: Transform
@@ -38479,36 +38620,6 @@ entities:
     - type: Transform
       pos: -21.5,20.5
       parent: 2
-  - uid: 5831
-    components:
-    - type: Transform
-      pos: -20.5,20.5
-      parent: 2
-  - uid: 5832
-    components:
-    - type: Transform
-      pos: -19.5,20.5
-      parent: 2
-  - uid: 5833
-    components:
-    - type: Transform
-      pos: -18.5,20.5
-      parent: 2
-  - uid: 5834
-    components:
-    - type: Transform
-      pos: -17.5,20.5
-      parent: 2
-  - uid: 5835
-    components:
-    - type: Transform
-      pos: -16.5,20.5
-      parent: 2
-  - uid: 5836
-    components:
-    - type: Transform
-      pos: -15.5,20.5
-      parent: 2
   - uid: 5837
     components:
     - type: Transform
@@ -38517,7 +38628,7 @@ entities:
   - uid: 5838
     components:
     - type: Transform
-      pos: -13.5,20.5
+      pos: -15.5,23.5
       parent: 2
   - uid: 5839
     components:
@@ -43179,6 +43290,36 @@ entities:
     - type: Transform
       pos: -17.5,-60.5
       parent: 2
+  - uid: 7127
+    components:
+    - type: Transform
+      pos: -17.5,19.5
+      parent: 2
+  - uid: 7908
+    components:
+    - type: Transform
+      pos: -15.5,19.5
+      parent: 2
+  - uid: 7909
+    components:
+    - type: Transform
+      pos: -14.5,19.5
+      parent: 2
+  - uid: 7927
+    components:
+    - type: Transform
+      pos: -14.5,21.5
+      parent: 2
+  - uid: 7928
+    components:
+    - type: Transform
+      pos: -14.5,22.5
+      parent: 2
+  - uid: 7929
+    components:
+    - type: Transform
+      pos: -14.5,23.5
+      parent: 2
 - proto: CableMVStack
   entities:
   - uid: 6771
@@ -44255,6 +44396,16 @@ entities:
     - type: Transform
       pos: 42.5,37.5
       parent: 2
+  - uid: 7922
+    components:
+    - type: Transform
+      pos: -17.5,21.5
+      parent: 2
+  - uid: 7923
+    components:
+    - type: Transform
+      pos: -16.5,21.5
+      parent: 2
 - proto: CarpetChapel
   entities:
   - uid: 6975
@@ -44611,6 +44762,16 @@ entities:
     components:
     - type: Transform
       pos: 9.5,-14.5
+      parent: 2
+  - uid: 7920
+    components:
+    - type: Transform
+      pos: -19.5,21.5
+      parent: 2
+  - uid: 7921
+    components:
+    - type: Transform
+      pos: -18.5,21.5
       parent: 2
 - proto: CarpetOrange
   entities:
@@ -45062,12 +45223,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -19.5,19.5
-      parent: 2
-  - uid: 7127
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,20.5
       parent: 2
   - uid: 7128
     components:
@@ -49027,479 +49182,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -26.5,42.5
       parent: 2
-- proto: ChairOfficeDark
-  entities:
-  - uid: 7883
-    components:
-    - type: Transform
-      pos: -23.5,16.5
-      parent: 2
-  - uid: 7884
-    components:
-    - type: Transform
-      pos: -40.5,9.5
-      parent: 2
-  - uid: 7885
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -40.5,11.5
-      parent: 2
-  - uid: 7886
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,39.5
-      parent: 2
-  - uid: 7887
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -50.5,29.5
-      parent: 2
-  - uid: 7888
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -49.5,29.5
-      parent: 2
-  - uid: 7889
-    components:
-    - type: Transform
-      pos: -52.5,30.5
-      parent: 2
-  - uid: 7890
-    components:
-    - type: Transform
-      pos: -42.5,46.5
-      parent: 2
-  - uid: 7891
-    components:
-    - type: Transform
-      pos: -28.5,57.5
-      parent: 2
-  - uid: 7892
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,49.5
-      parent: 2
-  - uid: 7893
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,50.5
-      parent: 2
-  - uid: 7894
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,51.5
-      parent: 2
-  - uid: 7895
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -33.5,48.5
-      parent: 2
-  - uid: 7896
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -30.5,48.5
-      parent: 2
-  - uid: 7897
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -30.5,50.5
-      parent: 2
-  - uid: 7898
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -33.5,50.5
-      parent: 2
-  - uid: 7899
-    components:
-    - type: Transform
-      pos: -32.5,53.5
-      parent: 2
-  - uid: 7900
-    components:
-    - type: Transform
-      pos: -33.5,53.5
-      parent: 2
-  - uid: 7901
-    components:
-    - type: Transform
-      pos: -21.5,35.5
-      parent: 2
-  - uid: 7902
-    components:
-    - type: Transform
-      pos: -31.5,22.5
-      parent: 2
-  - uid: 7903
-    components:
-    - type: Transform
-      pos: -9.5,36.5
-      parent: 2
-  - uid: 7904
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,35.5
-      parent: 2
-  - uid: 7905
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,34.5
-      parent: 2
-  - uid: 7906
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,33.5
-      parent: 2
-  - uid: 7907
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,33.5
-      parent: 2
-  - uid: 7908
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,34.5
-      parent: 2
-  - uid: 7909
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,35.5
-      parent: 2
-  - uid: 7910
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,32.5
-      parent: 2
-  - uid: 7911
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,32.5
-      parent: 2
-  - uid: 7912
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -8.5,32.5
-      parent: 2
-  - uid: 7913
-    components:
-    - type: Transform
-      pos: 4.5,31.5
-      parent: 2
-  - uid: 7914
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,32.5
-      parent: 2
-  - uid: 7915
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -11.5,44.5
-      parent: 2
-  - uid: 7916
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -14.5,42.5
-      parent: 2
-  - uid: 7917
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,44.5
-      parent: 2
-  - uid: 7918
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,45.5
-      parent: 2
-  - uid: 7919
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,42.5
-      parent: 2
-  - uid: 7920
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 17.5,33.5
-      parent: 2
-  - uid: 7921
-    components:
-    - type: Transform
-      pos: 13.5,22.5
-      parent: 2
-  - uid: 7922
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-34.5
-      parent: 2
-  - uid: 7923
-    components:
-    - type: Transform
-      pos: 4.095898,-45.486774
-      parent: 2
-  - uid: 7924
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-28.5
-      parent: 2
-  - uid: 7925
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-27.5
-      parent: 2
-  - uid: 7926
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -8.465216,-36.41406
-      parent: 2
-  - uid: 7927
-    components:
-    - type: Transform
-      pos: 2.8055086,-45.39959
-      parent: 2
-  - uid: 7928
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.516525,-31.38681
-      parent: 2
-  - uid: 7929
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.450798,-48.444862
-      parent: 2
-  - uid: 7930
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -30.5,-1.5
-      parent: 2
-  - uid: 7931
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 24.5,1.5
-      parent: 2
-  - uid: 7932
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 29.5,2.5
-      parent: 2
-  - uid: 7933
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 31.5,2.5
-      parent: 2
-  - uid: 7934
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 30.5,1.5
-      parent: 2
-  - uid: 7935
-    components:
-    - type: Transform
-      pos: 17.5,0.5
-      parent: 2
-  - uid: 7936
-    components:
-    - type: Transform
-      pos: 16.5,0.5
-      parent: 2
-  - uid: 7937
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 32.5,12.5
-      parent: 2
-  - uid: 7938
-    components:
-    - type: Transform
-      pos: 45.5,22.5
-      parent: 2
-  - uid: 7939
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -64.5,43.5
-      parent: 2
-  - uid: 7940
-    components:
-    - type: Transform
-      pos: -60.5,44.5
-      parent: 2
-  - uid: 7941
-    components:
-    - type: Transform
-      pos: -24.534996,-43.467594
-      parent: 2
-  - uid: 7942
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,75.5
-      parent: 2
-  - uid: 7943
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,75.5
-      parent: 2
-  - uid: 7944
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 20.5,1.5
-      parent: 2
-  - uid: 7945
-    components:
-    - type: Transform
-      pos: -27.5,16.5
-      parent: 2
-  - uid: 7946
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 30.5,20.5
-      parent: 2
-- proto: ChairOfficeLight
-  entities:
-  - uid: 7947
-    components:
-    - type: Transform
-      pos: 18.503437,14.498728
-      parent: 2
-  - uid: 7948
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -66.47906,-63.39059
-      parent: 2
-  - uid: 7949
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -28.5,59.5
-      parent: 2
-  - uid: 7950
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -50.5,52.5
-      parent: 2
-  - uid: 7951
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -8.5,-6.5
-      parent: 2
-  - uid: 7952
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-6.5
-      parent: 2
-  - uid: 7953
-    components:
-    - type: Transform
-      pos: -17.5,-1.5
-      parent: 2
-  - uid: 7954
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,-5.5
-      parent: 2
-  - uid: 7955
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -32.5,-16.5
-      parent: 2
-  - uid: 7956
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -34.5,-16.5
-      parent: 2
-  - uid: 7957
-    components:
-    - type: Transform
-      pos: -17.5,-14.5
-      parent: 2
-  - uid: 7958
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,-21.5
-      parent: 2
-  - uid: 7959
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 26.5,15.5
-      parent: 2
-  - uid: 7960
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 28.5,15.5
-      parent: 2
-  - uid: 7961
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 25.5,10.5
-      parent: 2
-  - uid: 7962
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 25.5,9.5
-      parent: 2
-  - uid: 7963
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,23.5
-      parent: 2
-  - uid: 7964
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 17.504675,15.6658
-      parent: 2
 - proto: ChairWood
   entities:
   - uid: 7965
@@ -52592,11 +52274,6 @@ entities:
     - type: Transform
       pos: -15.474685,-24.424994
       parent: 2
-  - uid: 8284
-    components:
-    - type: Transform
-      pos: -18.578043,23.546242
-      parent: 2
 - proto: ClothingOuterCoatPirate
   entities:
   - uid: 8285
@@ -52835,13 +52512,6 @@ entities:
     - type: Transform
       pos: 24.447042,42.46136
       parent: 2
-- proto: ClothingUniformColorRainbow
-  entities:
-  - uid: 8324
-    components:
-    - type: Transform
-      pos: -17.507723,23.466288
-      parent: 2
 - proto: ClothingUniformJumpskirtColorBlack
   entities:
   - uid: 8325
@@ -52973,6 +52643,12 @@ entities:
       parent: 2
 - proto: ComfyChair
   entities:
+  - uid: 7919
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -19.5,22.5
+      parent: 2
   - uid: 8344
     components:
     - type: Transform
@@ -54698,6 +54374,8 @@ entities:
     - type: Transform
       pos: -33.5,-9.5
       parent: 2
+    - type: ItemToggle
+      activated: True
   - uid: 8599
     components:
     - type: Transform
@@ -54884,6 +54562,13 @@ entities:
     components:
     - type: Transform
       pos: 15.5,-4.5
+      parent: 2
+- proto: DefaultStationBeaconCentcommOffice
+  entities:
+  - uid: 7936
+    components:
+    - type: Transform
+      pos: -17.5,22.5
       parent: 2
 - proto: DefaultStationBeaconCERoom
   entities:
@@ -60777,6 +60462,13 @@ entities:
     - type: Transform
       pos: -29.5,-45.5
       parent: 2
+- proto: DresserBlueshieldOfficerFilled
+  entities:
+  - uid: 7916
+    components:
+    - type: Transform
+      pos: -17.5,23.5
+      parent: 2
 - proto: DresserCaptainFilled
   entities:
   - uid: 9645
@@ -60818,6 +60510,13 @@ entities:
     components:
     - type: Transform
       pos: -26.5,48.5
+      parent: 2
+- proto: DresserNanorepFilled
+  entities:
+  - uid: 7917
+    components:
+    - type: Transform
+      pos: -18.5,23.5
       parent: 2
 - proto: DresserQuarterMasterFilled
   entities:
@@ -62760,11 +62459,6 @@ entities:
       parent: 2
 - proto: FireExtinguisher
   entities:
-  - uid: 9866
-    components:
-    - type: Transform
-      pos: -16.508755,22.474913
-      parent: 2
   - uid: 9867
     components:
     - type: Transform
@@ -64404,11 +64098,6 @@ entities:
     - type: Transform
       pos: -39.56788,9.504957
       parent: 2
-  - uid: 10148
-    components:
-    - type: Transform
-      pos: -16.60056,20.490124
-      parent: 2
   - uid: 10149
     components:
     - type: Transform
@@ -65122,7 +64811,7 @@ entities:
       pos: -32.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
 - proto: GasMinerCarbonDioxide
   entities:
   - uid: 10267
@@ -65333,7 +65022,7 @@ entities:
       pos: -48.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10300
     components:
     - type: Transform
@@ -65341,21 +65030,21 @@ entities:
       pos: -53.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10301
     components:
     - type: Transform
       pos: -47.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10302
     components:
     - type: Transform
       pos: -48.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10303
     components:
     - type: Transform
@@ -65363,7 +65052,7 @@ entities:
       pos: -50.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10304
     components:
     - type: Transform
@@ -65371,14 +65060,14 @@ entities:
       pos: -49.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10305
     components:
     - type: Transform
       pos: -33.5,53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10306
     components:
     - type: Transform
@@ -65386,7 +65075,7 @@ entities:
       pos: -31.5,53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10307
     components:
     - type: Transform
@@ -65394,7 +65083,7 @@ entities:
       pos: -29.5,53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10308
     components:
     - type: Transform
@@ -65402,7 +65091,7 @@ entities:
       pos: -35.5,53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10309
     components:
     - type: Transform
@@ -65410,14 +65099,14 @@ entities:
       pos: -35.5,57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10310
     components:
     - type: Transform
       pos: -29.5,57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10311
     components:
     - type: Transform
@@ -65425,7 +65114,7 @@ entities:
       pos: -50.5,57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10312
     components:
     - type: Transform
@@ -65433,14 +65122,14 @@ entities:
       pos: -50.5,67.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10313
     components:
     - type: Transform
       pos: -46.5,67.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10314
     components:
     - type: Transform
@@ -65448,7 +65137,7 @@ entities:
       pos: -47.5,58.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10315
     components:
     - type: Transform
@@ -65456,7 +65145,7 @@ entities:
       pos: -51.5,58.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10316
     components:
     - type: Transform
@@ -65464,21 +65153,21 @@ entities:
       pos: -51.5,64.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10317
     components:
     - type: Transform
       pos: -47.5,64.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10318
     components:
     - type: Transform
       pos: -28.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10319
     components:
     - type: Transform
@@ -65486,7 +65175,7 @@ entities:
       pos: -36.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10320
     components:
     - type: Transform
@@ -65494,14 +65183,14 @@ entities:
       pos: -31.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10321
     components:
     - type: Transform
       pos: -25.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10322
     components:
     - type: Transform
@@ -65509,7 +65198,7 @@ entities:
       pos: -40.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10323
     components:
     - type: Transform
@@ -65517,14 +65206,14 @@ entities:
       pos: -47.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10324
     components:
     - type: Transform
       pos: -44.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10325
     components:
     - type: Transform
@@ -65532,7 +65221,7 @@ entities:
       pos: -49.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10326
     components:
     - type: Transform
@@ -65540,21 +65229,21 @@ entities:
       pos: -51.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10327
     components:
     - type: Transform
       pos: -57.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10328
     components:
     - type: Transform
       pos: -49.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10329
     components:
     - type: Transform
@@ -65562,7 +65251,7 @@ entities:
       pos: -16.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10330
     components:
     - type: Transform
@@ -65570,21 +65259,21 @@ entities:
       pos: -23.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10331
     components:
     - type: Transform
       pos: -24.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10332
     components:
     - type: Transform
       pos: -23.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10333
     components:
     - type: Transform
@@ -65592,7 +65281,7 @@ entities:
       pos: -26.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10334
     components:
     - type: Transform
@@ -65600,7 +65289,7 @@ entities:
       pos: -24.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10335
     components:
     - type: Transform
@@ -65608,14 +65297,14 @@ entities:
       pos: -63.5,-62.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10336
     components:
     - type: Transform
       pos: -24.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10337
     components:
     - type: Transform
@@ -65623,28 +65312,28 @@ entities:
       pos: -14.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10338
     components:
     - type: Transform
       pos: -4.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10339
     components:
     - type: Transform
       pos: -3.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10340
     components:
     - type: Transform
       pos: -7.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10341
     components:
     - type: Transform
@@ -65652,7 +65341,7 @@ entities:
       pos: -11.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10342
     components:
     - type: Transform
@@ -65660,7 +65349,7 @@ entities:
       pos: -11.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10343
     components:
     - type: Transform
@@ -65668,7 +65357,7 @@ entities:
       pos: -15.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10344
     components:
     - type: Transform
@@ -65676,7 +65365,7 @@ entities:
       pos: -18.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10345
     components:
     - type: Transform
@@ -65684,14 +65373,14 @@ entities:
       pos: -18.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10346
     components:
     - type: Transform
       pos: -21.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10347
     components:
     - type: Transform
@@ -65699,14 +65388,14 @@ entities:
       pos: -26.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10348
     components:
     - type: Transform
       pos: -26.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10349
     components:
     - type: Transform
@@ -65718,14 +65407,14 @@ entities:
       pos: -17.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10351
     components:
     - type: Transform
       pos: -18.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10352
     components:
     - type: Transform
@@ -65733,7 +65422,7 @@ entities:
       pos: -18.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10353
     components:
     - type: Transform
@@ -65759,14 +65448,14 @@ entities:
       pos: -30.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10357
     components:
     - type: Transform
       pos: -30.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10358
     components:
     - type: Transform
@@ -65774,7 +65463,7 @@ entities:
       pos: -34.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10359
     components:
     - type: Transform
@@ -65782,14 +65471,14 @@ entities:
       pos: -19.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10360
     components:
     - type: Transform
       pos: -5.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10361
     components:
     - type: Transform
@@ -65797,7 +65486,7 @@ entities:
       pos: -19.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10362
     components:
     - type: Transform
@@ -65811,7 +65500,7 @@ entities:
       pos: -29.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10364
     components:
     - type: Transform
@@ -65825,7 +65514,7 @@ entities:
       pos: -32.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10366
     components:
     - type: Transform
@@ -65833,7 +65522,7 @@ entities:
       pos: -28.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10367
     components:
     - type: Transform
@@ -65841,7 +65530,7 @@ entities:
       pos: -20.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10368
     components:
     - type: Transform
@@ -65849,7 +65538,7 @@ entities:
       pos: -24.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10369
     components:
     - type: Transform
@@ -65857,7 +65546,7 @@ entities:
       pos: -22.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10370
     components:
     - type: Transform
@@ -65913,7 +65602,7 @@ entities:
       pos: 16.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10379
     components:
     - type: Transform
@@ -65921,14 +65610,14 @@ entities:
       pos: 16.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10380
     components:
     - type: Transform
       pos: 7.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10381
     components:
     - type: Transform
@@ -65936,7 +65625,7 @@ entities:
       pos: 7.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10382
     components:
     - type: Transform
@@ -65944,14 +65633,14 @@ entities:
       pos: 11.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10383
     components:
     - type: Transform
       pos: 11.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10384
     components:
     - type: Transform
@@ -65967,21 +65656,21 @@ entities:
       pos: 13.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10386
     components:
     - type: Transform
       pos: 13.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10387
     components:
     - type: Transform
       pos: 9.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10388
     components:
     - type: Transform
@@ -65996,7 +65685,7 @@ entities:
       pos: -13.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10390
     components:
     - type: Transform
@@ -66011,14 +65700,14 @@ entities:
       pos: 21.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10392
     components:
     - type: Transform
       pos: -11.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10393
     components:
     - type: Transform
@@ -66026,7 +65715,7 @@ entities:
       pos: -13.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10394
     components:
     - type: Transform
@@ -66049,7 +65738,7 @@ entities:
       pos: -3.5,-30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10397
     components:
     - type: Transform
@@ -66057,7 +65746,7 @@ entities:
       pos: -3.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10398
     components:
     - type: Transform
@@ -66065,14 +65754,14 @@ entities:
       pos: -1.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10399
     components:
     - type: Transform
       pos: 0.5,-30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10400
     components:
     - type: Transform
@@ -66104,7 +65793,7 @@ entities:
       pos: -24.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10404
     components:
     - type: Transform
@@ -66112,14 +65801,14 @@ entities:
       pos: -22.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10405
     components:
     - type: Transform
       pos: -11.5,-29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10406
     components:
     - type: Transform
@@ -66127,7 +65816,7 @@ entities:
       pos: 7.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10407
     components:
     - type: Transform
@@ -66135,7 +65824,7 @@ entities:
       pos: -1.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10408
     components:
     - type: Transform
@@ -66143,7 +65832,7 @@ entities:
       pos: -12.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10409
     components:
     - type: Transform
@@ -66151,7 +65840,7 @@ entities:
       pos: 0.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10410
     components:
     - type: Transform
@@ -66175,14 +65864,14 @@ entities:
       pos: 11.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10413
     components:
     - type: Transform
       pos: 12.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10414
     components:
     - type: Transform
@@ -66197,7 +65886,7 @@ entities:
       pos: 34.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10416
     components:
     - type: Transform
@@ -66205,14 +65894,14 @@ entities:
       pos: 30.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10417
     components:
     - type: Transform
       pos: 33.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10418
     components:
     - type: Transform
@@ -66220,14 +65909,14 @@ entities:
       pos: 5.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10419
     components:
     - type: Transform
       pos: 21.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10420
     components:
     - type: Transform
@@ -66235,7 +65924,7 @@ entities:
       pos: 33.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10421
     components:
     - type: Transform
@@ -66243,7 +65932,7 @@ entities:
       pos: 9.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10422
     components:
     - type: Transform
@@ -66251,7 +65940,7 @@ entities:
       pos: 21.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10423
     components:
     - type: Transform
@@ -66259,14 +65948,14 @@ entities:
       pos: 23.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10424
     components:
     - type: Transform
       pos: 26.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10425
     components:
     - type: Transform
@@ -66274,7 +65963,7 @@ entities:
       pos: 26.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10426
     components:
     - type: Transform
@@ -66282,7 +65971,7 @@ entities:
       pos: 27.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10427
     components:
     - type: Transform
@@ -66290,7 +65979,7 @@ entities:
       pos: 26.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10428
     components:
     - type: Transform
@@ -66298,14 +65987,14 @@ entities:
       pos: -24.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10429
     components:
     - type: Transform
       pos: -52.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10430
     components:
     - type: Transform
@@ -66325,7 +66014,7 @@ entities:
       pos: -62.5,-62.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10433
     components:
     - type: Transform
@@ -66333,7 +66022,7 @@ entities:
       pos: 21.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10434
     components:
     - type: Transform
@@ -66341,7 +66030,7 @@ entities:
       pos: 43.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10435
     components:
     - type: Transform
@@ -66349,7 +66038,7 @@ entities:
       pos: 42.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10436
     components:
     - type: Transform
@@ -66363,14 +66052,14 @@ entities:
       pos: 23.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10438
     components:
     - type: Transform
       pos: 18.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10439
     components:
     - type: Transform
@@ -66378,7 +66067,7 @@ entities:
       pos: 18.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10440
     components:
     - type: Transform
@@ -66386,7 +66075,7 @@ entities:
       pos: 12.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10441
     components:
     - type: Transform
@@ -66394,7 +66083,7 @@ entities:
       pos: 12.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10442
     components:
     - type: Transform
@@ -66402,7 +66091,7 @@ entities:
       pos: 21.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10443
     components:
     - type: Transform
@@ -66410,14 +66099,14 @@ entities:
       pos: 17.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10444
     components:
     - type: Transform
       pos: 17.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10445
     components:
     - type: Transform
@@ -66425,14 +66114,14 @@ entities:
       pos: 40.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10446
     components:
     - type: Transform
       pos: 31.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10447
     components:
     - type: Transform
@@ -66440,7 +66129,7 @@ entities:
       pos: 31.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10448
     components:
     - type: Transform
@@ -66448,7 +66137,7 @@ entities:
       pos: 29.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10449
     components:
     - type: Transform
@@ -66456,7 +66145,7 @@ entities:
       pos: -25.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10450
     components:
     - type: Transform
@@ -66464,7 +66153,7 @@ entities:
       pos: -25.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10451
     components:
     - type: Transform
@@ -66472,7 +66161,7 @@ entities:
       pos: 16.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10452
     components:
     - type: Transform
@@ -66480,7 +66169,7 @@ entities:
       pos: 52.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10453
     components:
     - type: Transform
@@ -66488,7 +66177,7 @@ entities:
       pos: 42.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10454
     components:
     - type: Transform
@@ -66496,7 +66185,7 @@ entities:
       pos: 32.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10455
     components:
     - type: Transform
@@ -66504,7 +66193,7 @@ entities:
       pos: 42.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10456
     components:
     - type: Transform
@@ -66512,7 +66201,7 @@ entities:
       pos: 32.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10457
     components:
     - type: Transform
@@ -66531,7 +66220,7 @@ entities:
       pos: 16.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10460
     components:
     - type: Transform
@@ -66539,7 +66228,7 @@ entities:
       pos: 16.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10461
     components:
     - type: Transform
@@ -66547,7 +66236,7 @@ entities:
       pos: -45.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10462
     components:
     - type: Transform
@@ -66555,7 +66244,7 @@ entities:
       pos: -62.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10463
     components:
     - type: Transform
@@ -66563,7 +66252,7 @@ entities:
       pos: -44.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10464
     components:
     - type: Transform
@@ -66571,7 +66260,7 @@ entities:
       pos: -63.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10465
     components:
     - type: Transform
@@ -66579,7 +66268,7 @@ entities:
       pos: -62.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10466
     components:
     - type: Transform
@@ -66587,7 +66276,7 @@ entities:
       pos: -61.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10467
     components:
     - type: Transform
@@ -66595,21 +66284,21 @@ entities:
       pos: -65.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10468
     components:
     - type: Transform
       pos: -58.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10469
     components:
     - type: Transform
       pos: -62.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10470
     components:
     - type: Transform
@@ -66617,7 +66306,7 @@ entities:
       pos: -78.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10471
     components:
     - type: Transform
@@ -66625,7 +66314,7 @@ entities:
       pos: -56.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10472
     components:
     - type: Transform
@@ -66633,7 +66322,7 @@ entities:
       pos: -68.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10473
     components:
     - type: Transform
@@ -66641,7 +66330,7 @@ entities:
       pos: -67.5,-49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10474
     components:
     - type: Transform
@@ -66649,7 +66338,7 @@ entities:
       pos: -58.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10475
     components:
     - type: Transform
@@ -66657,7 +66346,7 @@ entities:
       pos: -79.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10476
     components:
     - type: Transform
@@ -66665,7 +66354,7 @@ entities:
       pos: -77.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10477
     components:
     - type: Transform
@@ -66673,7 +66362,7 @@ entities:
       pos: -76.5,-54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10478
     components:
     - type: Transform
@@ -66741,14 +66430,14 @@ entities:
       pos: 21.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10487
     components:
     - type: Transform
       pos: 27.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10488
     components:
     - type: Transform
@@ -66756,7 +66445,7 @@ entities:
       pos: 27.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10489
     components:
     - type: Transform
@@ -66764,7 +66453,7 @@ entities:
       pos: -0.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10490
     components:
     - type: Transform
@@ -66772,14 +66461,14 @@ entities:
       pos: 42.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10491
     components:
     - type: Transform
       pos: 43.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
 - proto: GasPipeFourway
   entities:
   - uid: 10492
@@ -66788,91 +66477,91 @@ entities:
       pos: 32.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10493
     components:
     - type: Transform
       pos: -36.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10494
     components:
     - type: Transform
       pos: -48.5,67.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10495
     components:
     - type: Transform
       pos: -36.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10496
     components:
     - type: Transform
       pos: -10.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10497
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10498
     components:
     - type: Transform
       pos: 8.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10499
     components:
     - type: Transform
       pos: -31.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10500
     components:
     - type: Transform
       pos: -36.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10501
     components:
     - type: Transform
       pos: -34.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10502
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10503
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10504
     components:
     - type: Transform
       pos: 10.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10505
     components:
     - type: Transform
@@ -66884,14 +66573,14 @@ entities:
       pos: -29.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10507
     components:
     - type: Transform
       pos: -34.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10508
     components:
     - type: Transform
@@ -66903,107 +66592,135 @@ entities:
       pos: -28.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10510
     components:
     - type: Transform
       pos: 10.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10511
     components:
     - type: Transform
       pos: 11.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10512
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10513
     components:
     - type: Transform
       pos: 13.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10514
     components:
     - type: Transform
       pos: 11.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10515
     components:
     - type: Transform
       pos: -12.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10516
     components:
     - type: Transform
       pos: -6.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10517
     components:
     - type: Transform
       pos: 21.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10518
     components:
     - type: Transform
       pos: 20.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10519
     components:
     - type: Transform
       pos: 30.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10520
     components:
     - type: Transform
       pos: 21.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10521
     components:
     - type: Transform
       pos: 23.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10522
     components:
     - type: Transform
       pos: 21.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10523
     components:
     - type: Transform
       pos: 21.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
 - proto: GasPipeStraight
   entities:
+  - uid: 7898
+    components:
+    - type: Transform
+      pos: -18.5,26.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 7899
+    components:
+    - type: Transform
+      pos: -18.5,25.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 7904
+    components:
+    - type: Transform
+      pos: -18.5,24.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 7907
+    components:
+    - type: Transform
+      pos: -17.5,24.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 10524
     components:
     - type: Transform
@@ -67011,7 +66728,7 @@ entities:
       pos: -50.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10525
     components:
     - type: Transform
@@ -67019,7 +66736,7 @@ entities:
       pos: -16.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10526
     components:
     - type: Transform
@@ -67027,7 +66744,7 @@ entities:
       pos: -52.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10527
     components:
     - type: Transform
@@ -67035,7 +66752,7 @@ entities:
       pos: -50.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10528
     components:
     - type: Transform
@@ -67043,7 +66760,7 @@ entities:
       pos: -51.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10529
     components:
     - type: Transform
@@ -67051,7 +66768,7 @@ entities:
       pos: -48.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10530
     components:
     - type: Transform
@@ -67059,7 +66776,7 @@ entities:
       pos: -47.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10531
     components:
     - type: Transform
@@ -67067,7 +66784,7 @@ entities:
       pos: -46.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10532
     components:
     - type: Transform
@@ -67075,28 +66792,28 @@ entities:
       pos: -49.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10533
     components:
     - type: Transform
       pos: -48.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10534
     components:
     - type: Transform
       pos: -45.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10535
     components:
     - type: Transform
       pos: -44.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10536
     components:
     - type: Transform
@@ -67104,7 +66821,7 @@ entities:
       pos: -47.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10537
     components:
     - type: Transform
@@ -67112,7 +66829,7 @@ entities:
       pos: -52.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10538
     components:
     - type: Transform
@@ -67120,14 +66837,14 @@ entities:
       pos: -51.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10539
     components:
     - type: Transform
       pos: -47.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10540
     components:
     - type: Transform
@@ -67135,14 +66852,14 @@ entities:
       pos: -31.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10541
     components:
     - type: Transform
       pos: 32.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10542
     components:
     - type: Transform
@@ -67150,7 +66867,7 @@ entities:
       pos: -36.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10543
     components:
     - type: Transform
@@ -67158,7 +66875,7 @@ entities:
       pos: -36.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10544
     components:
     - type: Transform
@@ -67166,7 +66883,7 @@ entities:
       pos: -36.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10545
     components:
     - type: Transform
@@ -67174,7 +66891,7 @@ entities:
       pos: -36.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10546
     components:
     - type: Transform
@@ -67182,7 +66899,7 @@ entities:
       pos: -34.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10547
     components:
     - type: Transform
@@ -67190,7 +66907,7 @@ entities:
       pos: -34.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10548
     components:
     - type: Transform
@@ -67198,7 +66915,7 @@ entities:
       pos: -36.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10549
     components:
     - type: Transform
@@ -67206,7 +66923,7 @@ entities:
       pos: -34.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10550
     components:
     - type: Transform
@@ -67214,7 +66931,7 @@ entities:
       pos: -35.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10551
     components:
     - type: Transform
@@ -67222,7 +66939,7 @@ entities:
       pos: -36.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10552
     components:
     - type: Transform
@@ -67230,7 +66947,7 @@ entities:
       pos: -37.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10553
     components:
     - type: Transform
@@ -67238,7 +66955,7 @@ entities:
       pos: -38.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10554
     components:
     - type: Transform
@@ -67246,7 +66963,7 @@ entities:
       pos: -39.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10555
     components:
     - type: Transform
@@ -67254,7 +66971,7 @@ entities:
       pos: -37.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10556
     components:
     - type: Transform
@@ -67262,7 +66979,7 @@ entities:
       pos: -38.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10557
     components:
     - type: Transform
@@ -67270,7 +66987,7 @@ entities:
       pos: -39.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10558
     components:
     - type: Transform
@@ -67278,7 +66995,7 @@ entities:
       pos: -40.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10559
     components:
     - type: Transform
@@ -67286,7 +67003,7 @@ entities:
       pos: -40.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10560
     components:
     - type: Transform
@@ -67294,7 +67011,7 @@ entities:
       pos: -42.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10561
     components:
     - type: Transform
@@ -67302,7 +67019,7 @@ entities:
       pos: -44.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10562
     components:
     - type: Transform
@@ -67310,7 +67027,7 @@ entities:
       pos: -43.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10563
     components:
     - type: Transform
@@ -67318,7 +67035,7 @@ entities:
       pos: -46.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10564
     components:
     - type: Transform
@@ -67326,7 +67043,7 @@ entities:
       pos: -47.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10565
     components:
     - type: Transform
@@ -67334,7 +67051,7 @@ entities:
       pos: -48.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10566
     components:
     - type: Transform
@@ -67342,7 +67059,7 @@ entities:
       pos: -43.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10567
     components:
     - type: Transform
@@ -67350,7 +67067,7 @@ entities:
       pos: -44.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10568
     components:
     - type: Transform
@@ -67358,7 +67075,7 @@ entities:
       pos: -45.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10569
     components:
     - type: Transform
@@ -67366,7 +67083,7 @@ entities:
       pos: -46.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10570
     components:
     - type: Transform
@@ -67374,7 +67091,7 @@ entities:
       pos: -47.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10571
     components:
     - type: Transform
@@ -67382,7 +67099,7 @@ entities:
       pos: -48.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10572
     components:
     - type: Transform
@@ -67390,105 +67107,105 @@ entities:
       pos: -49.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10573
     components:
     - type: Transform
       pos: -49.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10574
     components:
     - type: Transform
       pos: -49.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10575
     components:
     - type: Transform
       pos: -50.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10576
     components:
     - type: Transform
       pos: -50.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10577
     components:
     - type: Transform
       pos: -50.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10578
     components:
     - type: Transform
       pos: -50.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10579
     components:
     - type: Transform
       pos: -41.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10580
     components:
     - type: Transform
       pos: -41.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10581
     components:
     - type: Transform
       pos: -42.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10582
     components:
     - type: Transform
       pos: -42.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10583
     components:
     - type: Transform
       pos: -42.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10584
     components:
     - type: Transform
       pos: -42.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10585
     components:
     - type: Transform
       pos: -36.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10586
     components:
     - type: Transform
       pos: -36.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10587
     components:
     - type: Transform
@@ -67496,7 +67213,7 @@ entities:
       pos: -34.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10588
     components:
     - type: Transform
@@ -67504,7 +67221,7 @@ entities:
       pos: -34.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10589
     components:
     - type: Transform
@@ -67512,7 +67229,7 @@ entities:
       pos: -34.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10590
     components:
     - type: Transform
@@ -67520,7 +67237,7 @@ entities:
       pos: -34.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10591
     components:
     - type: Transform
@@ -67528,7 +67245,7 @@ entities:
       pos: -36.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10592
     components:
     - type: Transform
@@ -67536,7 +67253,7 @@ entities:
       pos: -36.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10593
     components:
     - type: Transform
@@ -67544,7 +67261,7 @@ entities:
       pos: -36.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10594
     components:
     - type: Transform
@@ -67552,7 +67269,7 @@ entities:
       pos: -34.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10595
     components:
     - type: Transform
@@ -67560,7 +67277,7 @@ entities:
       pos: -32.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10596
     components:
     - type: Transform
@@ -67568,7 +67285,7 @@ entities:
       pos: -31.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10597
     components:
     - type: Transform
@@ -67576,7 +67293,7 @@ entities:
       pos: -31.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10598
     components:
     - type: Transform
@@ -67584,7 +67301,7 @@ entities:
       pos: -31.5,45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10599
     components:
     - type: Transform
@@ -67592,7 +67309,7 @@ entities:
       pos: -33.5,45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10600
     components:
     - type: Transform
@@ -67600,7 +67317,7 @@ entities:
       pos: -31.5,47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10601
     components:
     - type: Transform
@@ -67608,7 +67325,7 @@ entities:
       pos: -34.5,47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10602
     components:
     - type: Transform
@@ -67616,7 +67333,7 @@ entities:
       pos: -35.5,47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10603
     components:
     - type: Transform
@@ -67624,7 +67341,7 @@ entities:
       pos: -36.5,47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10604
     components:
     - type: Transform
@@ -67632,7 +67349,7 @@ entities:
       pos: -37.5,47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10605
     components:
     - type: Transform
@@ -67640,7 +67357,7 @@ entities:
       pos: -39.5,47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10606
     components:
     - type: Transform
@@ -67648,7 +67365,7 @@ entities:
       pos: -32.5,48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10607
     components:
     - type: Transform
@@ -67656,7 +67373,7 @@ entities:
       pos: -33.5,48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10608
     components:
     - type: Transform
@@ -67664,7 +67381,7 @@ entities:
       pos: -34.5,48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10609
     components:
     - type: Transform
@@ -67672,7 +67389,7 @@ entities:
       pos: -35.5,48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10610
     components:
     - type: Transform
@@ -67680,7 +67397,7 @@ entities:
       pos: -36.5,48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10611
     components:
     - type: Transform
@@ -67688,7 +67405,7 @@ entities:
       pos: -37.5,48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10612
     components:
     - type: Transform
@@ -67696,7 +67413,7 @@ entities:
       pos: -38.5,48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10613
     components:
     - type: Transform
@@ -67704,7 +67421,7 @@ entities:
       pos: -39.5,48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10614
     components:
     - type: Transform
@@ -67712,7 +67429,7 @@ entities:
       pos: -40.5,47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10615
     components:
     - type: Transform
@@ -67720,7 +67437,7 @@ entities:
       pos: -38.5,48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10616
     components:
     - type: Transform
@@ -67728,7 +67445,7 @@ entities:
       pos: -40.5,49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10617
     components:
     - type: Transform
@@ -67736,7 +67453,7 @@ entities:
       pos: -38.5,49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10618
     components:
     - type: Transform
@@ -67744,7 +67461,7 @@ entities:
       pos: -38.5,50.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10619
     components:
     - type: Transform
@@ -67752,49 +67469,49 @@ entities:
       pos: -40.5,50.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10620
     components:
     - type: Transform
       pos: -33.5,48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10621
     components:
     - type: Transform
       pos: -33.5,49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10622
     components:
     - type: Transform
       pos: -33.5,50.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10623
     components:
     - type: Transform
       pos: -31.5,50.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10624
     components:
     - type: Transform
       pos: -31.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10625
     components:
     - type: Transform
       pos: -31.5,52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10626
     components:
     - type: Transform
@@ -67802,7 +67519,7 @@ entities:
       pos: -32.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10627
     components:
     - type: Transform
@@ -67810,7 +67527,7 @@ entities:
       pos: -31.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10628
     components:
     - type: Transform
@@ -67818,7 +67535,7 @@ entities:
       pos: -30.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10629
     components:
     - type: Transform
@@ -67826,7 +67543,7 @@ entities:
       pos: -29.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10630
     components:
     - type: Transform
@@ -67834,7 +67551,7 @@ entities:
       pos: -28.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10631
     components:
     - type: Transform
@@ -67842,7 +67559,7 @@ entities:
       pos: -27.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10632
     components:
     - type: Transform
@@ -67850,7 +67567,7 @@ entities:
       pos: -26.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10633
     components:
     - type: Transform
@@ -67858,7 +67575,7 @@ entities:
       pos: -30.5,49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10634
     components:
     - type: Transform
@@ -67866,7 +67583,7 @@ entities:
       pos: -29.5,49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10635
     components:
     - type: Transform
@@ -67874,7 +67591,7 @@ entities:
       pos: -28.5,49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10636
     components:
     - type: Transform
@@ -67882,7 +67599,7 @@ entities:
       pos: -27.5,49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10637
     components:
     - type: Transform
@@ -67890,7 +67607,7 @@ entities:
       pos: -26.5,49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10638
     components:
     - type: Transform
@@ -67898,7 +67615,7 @@ entities:
       pos: -33.5,52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10639
     components:
     - type: Transform
@@ -67906,7 +67623,7 @@ entities:
       pos: -29.5,54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10640
     components:
     - type: Transform
@@ -67914,7 +67631,7 @@ entities:
       pos: -35.5,54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10641
     components:
     - type: Transform
@@ -67922,7 +67639,7 @@ entities:
       pos: -35.5,55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10642
     components:
     - type: Transform
@@ -67930,7 +67647,7 @@ entities:
       pos: -35.5,56.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10643
     components:
     - type: Transform
@@ -67938,7 +67655,7 @@ entities:
       pos: -29.5,56.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10644
     components:
     - type: Transform
@@ -67946,7 +67663,7 @@ entities:
       pos: -29.5,55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10645
     components:
     - type: Transform
@@ -67954,7 +67671,7 @@ entities:
       pos: -30.5,57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10646
     components:
     - type: Transform
@@ -67962,91 +67679,91 @@ entities:
       pos: -34.5,57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10647
     components:
     - type: Transform
       pos: -46.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10648
     components:
     - type: Transform
       pos: -48.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10649
     components:
     - type: Transform
       pos: -48.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10650
     components:
     - type: Transform
       pos: -48.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10651
     components:
     - type: Transform
       pos: -44.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10652
     components:
     - type: Transform
       pos: -44.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10653
     components:
     - type: Transform
       pos: -44.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10654
     components:
     - type: Transform
       pos: -42.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10655
     components:
     - type: Transform
       pos: -40.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10656
     components:
     - type: Transform
       pos: -40.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10657
     components:
     - type: Transform
       pos: -40.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10658
     components:
     - type: Transform
       pos: -38.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10659
     components:
     - type: Transform
@@ -68054,7 +67771,7 @@ entities:
       pos: -35.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10660
     components:
     - type: Transform
@@ -68062,7 +67779,7 @@ entities:
       pos: -36.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10661
     components:
     - type: Transform
@@ -68070,7 +67787,7 @@ entities:
       pos: -37.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10662
     components:
     - type: Transform
@@ -68078,7 +67795,7 @@ entities:
       pos: -39.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10663
     components:
     - type: Transform
@@ -68086,7 +67803,7 @@ entities:
       pos: -40.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10664
     components:
     - type: Transform
@@ -68094,7 +67811,7 @@ entities:
       pos: -43.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10665
     components:
     - type: Transform
@@ -68102,7 +67819,7 @@ entities:
       pos: -44.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10666
     components:
     - type: Transform
@@ -68110,7 +67827,7 @@ entities:
       pos: -45.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10667
     components:
     - type: Transform
@@ -68118,7 +67835,7 @@ entities:
       pos: -37.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10668
     components:
     - type: Transform
@@ -68126,7 +67843,7 @@ entities:
       pos: -38.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10669
     components:
     - type: Transform
@@ -68134,7 +67851,7 @@ entities:
       pos: -39.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10670
     components:
     - type: Transform
@@ -68142,7 +67859,7 @@ entities:
       pos: -41.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10671
     components:
     - type: Transform
@@ -68150,7 +67867,7 @@ entities:
       pos: -42.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10672
     components:
     - type: Transform
@@ -68158,7 +67875,7 @@ entities:
       pos: -45.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10673
     components:
     - type: Transform
@@ -68166,7 +67883,7 @@ entities:
       pos: -46.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10674
     components:
     - type: Transform
@@ -68174,7 +67891,7 @@ entities:
       pos: -47.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10675
     components:
     - type: Transform
@@ -68182,7 +67899,7 @@ entities:
       pos: -46.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10676
     components:
     - type: Transform
@@ -68190,7 +67907,7 @@ entities:
       pos: -46.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10677
     components:
     - type: Transform
@@ -68198,7 +67915,7 @@ entities:
       pos: -46.5,45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10678
     components:
     - type: Transform
@@ -68206,7 +67923,7 @@ entities:
       pos: -46.5,46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10679
     components:
     - type: Transform
@@ -68214,7 +67931,7 @@ entities:
       pos: -48.5,45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10680
     components:
     - type: Transform
@@ -68222,7 +67939,7 @@ entities:
       pos: -48.5,46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10681
     components:
     - type: Transform
@@ -68230,7 +67947,7 @@ entities:
       pos: -48.5,47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10682
     components:
     - type: Transform
@@ -68238,7 +67955,7 @@ entities:
       pos: -48.5,48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10683
     components:
     - type: Transform
@@ -68246,7 +67963,7 @@ entities:
       pos: -46.5,48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10684
     components:
     - type: Transform
@@ -68254,7 +67971,7 @@ entities:
       pos: -46.5,47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10685
     components:
     - type: Transform
@@ -68262,7 +67979,7 @@ entities:
       pos: -48.5,49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10686
     components:
     - type: Transform
@@ -68270,7 +67987,7 @@ entities:
       pos: -46.5,53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10687
     components:
     - type: Transform
@@ -68278,7 +67995,7 @@ entities:
       pos: -46.5,50.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10688
     components:
     - type: Transform
@@ -68286,7 +68003,7 @@ entities:
       pos: -46.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10689
     components:
     - type: Transform
@@ -68294,7 +68011,7 @@ entities:
       pos: -48.5,52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10690
     components:
     - type: Transform
@@ -68302,7 +68019,7 @@ entities:
       pos: -48.5,53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10691
     components:
     - type: Transform
@@ -68310,7 +68027,7 @@ entities:
       pos: -48.5,54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10692
     components:
     - type: Transform
@@ -68318,7 +68035,7 @@ entities:
       pos: -46.5,54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10693
     components:
     - type: Transform
@@ -68326,7 +68043,7 @@ entities:
       pos: -46.5,55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10694
     components:
     - type: Transform
@@ -68334,7 +68051,7 @@ entities:
       pos: -48.5,55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10695
     components:
     - type: Transform
@@ -68342,7 +68059,7 @@ entities:
       pos: -49.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10696
     components:
     - type: Transform
@@ -68350,7 +68067,7 @@ entities:
       pos: -47.5,52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10697
     components:
     - type: Transform
@@ -68358,7 +68075,7 @@ entities:
       pos: -48.5,52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10698
     components:
     - type: Transform
@@ -68366,7 +68083,7 @@ entities:
       pos: -49.5,52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10699
     components:
     - type: Transform
@@ -68374,7 +68091,7 @@ entities:
       pos: -47.5,57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10700
     components:
     - type: Transform
@@ -68382,7 +68099,7 @@ entities:
       pos: -48.5,57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10701
     components:
     - type: Transform
@@ -68390,7 +68107,7 @@ entities:
       pos: -49.5,57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10702
     components:
     - type: Transform
@@ -68398,7 +68115,7 @@ entities:
       pos: -50.5,58.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10703
     components:
     - type: Transform
@@ -68406,7 +68123,7 @@ entities:
       pos: -46.5,58.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10704
     components:
     - type: Transform
@@ -68414,7 +68131,7 @@ entities:
       pos: -46.5,59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10705
     components:
     - type: Transform
@@ -68422,7 +68139,7 @@ entities:
       pos: -46.5,60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10706
     components:
     - type: Transform
@@ -68430,7 +68147,7 @@ entities:
       pos: -50.5,60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10707
     components:
     - type: Transform
@@ -68438,77 +68155,77 @@ entities:
       pos: -50.5,59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10708
     components:
     - type: Transform
       pos: -50.5,62.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10709
     components:
     - type: Transform
       pos: -46.5,62.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10710
     components:
     - type: Transform
       pos: -46.5,63.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10711
     components:
     - type: Transform
       pos: -46.5,64.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10712
     components:
     - type: Transform
       pos: -46.5,65.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10713
     components:
     - type: Transform
       pos: -46.5,66.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10714
     components:
     - type: Transform
       pos: -50.5,63.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10715
     components:
     - type: Transform
       pos: -50.5,64.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10716
     components:
     - type: Transform
       pos: -50.5,65.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10717
     components:
     - type: Transform
       pos: -50.5,66.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10718
     components:
     - type: Transform
@@ -68516,7 +68233,7 @@ entities:
       pos: -49.5,67.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10719
     components:
     - type: Transform
@@ -68524,7 +68241,7 @@ entities:
       pos: -47.5,67.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10720
     components:
     - type: Transform
@@ -68532,7 +68249,7 @@ entities:
       pos: -48.5,57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10721
     components:
     - type: Transform
@@ -68540,7 +68257,7 @@ entities:
       pos: -49.5,58.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10722
     components:
     - type: Transform
@@ -68548,63 +68265,63 @@ entities:
       pos: -50.5,58.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10723
     components:
     - type: Transform
       pos: -47.5,59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10724
     components:
     - type: Transform
       pos: -51.5,59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10725
     components:
     - type: Transform
       pos: -47.5,61.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10726
     components:
     - type: Transform
       pos: -51.5,61.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10727
     components:
     - type: Transform
       pos: -51.5,62.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10728
     components:
     - type: Transform
       pos: -51.5,63.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10729
     components:
     - type: Transform
       pos: -47.5,62.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10730
     components:
     - type: Transform
       pos: -47.5,63.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10731
     components:
     - type: Transform
@@ -68612,7 +68329,7 @@ entities:
       pos: -50.5,64.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10732
     components:
     - type: Transform
@@ -68620,7 +68337,7 @@ entities:
       pos: -49.5,64.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10733
     components:
     - type: Transform
@@ -68628,7 +68345,7 @@ entities:
       pos: -32.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10734
     components:
     - type: Transform
@@ -68636,7 +68353,7 @@ entities:
       pos: -31.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10735
     components:
     - type: Transform
@@ -68644,7 +68361,7 @@ entities:
       pos: -30.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10736
     components:
     - type: Transform
@@ -68652,7 +68369,7 @@ entities:
       pos: -29.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10737
     components:
     - type: Transform
@@ -68660,7 +68377,7 @@ entities:
       pos: -30.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10738
     components:
     - type: Transform
@@ -68668,154 +68385,154 @@ entities:
       pos: -29.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10739
     components:
     - type: Transform
       pos: -36.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10740
     components:
     - type: Transform
       pos: -36.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10741
     components:
     - type: Transform
       pos: -36.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10742
     components:
     - type: Transform
       pos: -36.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10743
     components:
     - type: Transform
       pos: -36.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10744
     components:
     - type: Transform
       pos: -36.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10745
     components:
     - type: Transform
       pos: -36.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10746
     components:
     - type: Transform
       pos: -36.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10747
     components:
     - type: Transform
       pos: -36.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10748
     components:
     - type: Transform
       pos: -36.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10749
     components:
     - type: Transform
       pos: -36.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10750
     components:
     - type: Transform
       pos: -36.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10751
     components:
     - type: Transform
       pos: -36.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10752
     components:
     - type: Transform
       pos: -36.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10753
     components:
     - type: Transform
       pos: -36.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10754
     components:
     - type: Transform
       pos: -36.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10755
     components:
     - type: Transform
       pos: -36.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10756
     components:
     - type: Transform
       pos: -36.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10757
     components:
     - type: Transform
       pos: -36.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10758
     components:
     - type: Transform
       pos: -36.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10759
     components:
     - type: Transform
       pos: -36.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10760
     components:
     - type: Transform
@@ -68823,7 +68540,7 @@ entities:
       pos: -35.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10761
     components:
     - type: Transform
@@ -68831,7 +68548,7 @@ entities:
       pos: -34.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10762
     components:
     - type: Transform
@@ -68839,7 +68556,7 @@ entities:
       pos: -32.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10763
     components:
     - type: Transform
@@ -68847,7 +68564,7 @@ entities:
       pos: -30.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10764
     components:
     - type: Transform
@@ -68855,7 +68572,7 @@ entities:
       pos: -29.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10765
     components:
     - type: Transform
@@ -68863,7 +68580,7 @@ entities:
       pos: -28.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10766
     components:
     - type: Transform
@@ -68871,7 +68588,7 @@ entities:
       pos: -27.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10767
     components:
     - type: Transform
@@ -68879,7 +68596,7 @@ entities:
       pos: -26.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10768
     components:
     - type: Transform
@@ -68887,7 +68604,7 @@ entities:
       pos: -25.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10769
     components:
     - type: Transform
@@ -68895,7 +68612,7 @@ entities:
       pos: -23.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10770
     components:
     - type: Transform
@@ -68903,7 +68620,7 @@ entities:
       pos: -22.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10771
     components:
     - type: Transform
@@ -68911,7 +68628,7 @@ entities:
       pos: -20.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10772
     components:
     - type: Transform
@@ -68919,7 +68636,7 @@ entities:
       pos: -19.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10773
     components:
     - type: Transform
@@ -68927,7 +68644,7 @@ entities:
       pos: -18.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10774
     components:
     - type: Transform
@@ -68935,7 +68652,7 @@ entities:
       pos: -17.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10775
     components:
     - type: Transform
@@ -68943,7 +68660,7 @@ entities:
       pos: -16.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10776
     components:
     - type: Transform
@@ -68951,7 +68668,7 @@ entities:
       pos: -15.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10777
     components:
     - type: Transform
@@ -68959,7 +68676,7 @@ entities:
       pos: -13.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10778
     components:
     - type: Transform
@@ -68967,7 +68684,7 @@ entities:
       pos: -12.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10779
     components:
     - type: Transform
@@ -68975,7 +68692,7 @@ entities:
       pos: -11.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10780
     components:
     - type: Transform
@@ -68983,7 +68700,7 @@ entities:
       pos: -10.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10781
     components:
     - type: Transform
@@ -68991,7 +68708,7 @@ entities:
       pos: -9.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10782
     components:
     - type: Transform
@@ -68999,7 +68716,7 @@ entities:
       pos: -7.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10783
     components:
     - type: Transform
@@ -69007,7 +68724,7 @@ entities:
       pos: -5.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10784
     components:
     - type: Transform
@@ -69015,7 +68732,7 @@ entities:
       pos: -4.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10785
     components:
     - type: Transform
@@ -69023,7 +68740,7 @@ entities:
       pos: -1.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10786
     components:
     - type: Transform
@@ -69031,7 +68748,7 @@ entities:
       pos: -2.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10787
     components:
     - type: Transform
@@ -69039,7 +68756,7 @@ entities:
       pos: -0.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10788
     components:
     - type: Transform
@@ -69047,7 +68764,7 @@ entities:
       pos: 0.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10789
     components:
     - type: Transform
@@ -69055,7 +68772,7 @@ entities:
       pos: 2.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10790
     components:
     - type: Transform
@@ -69063,7 +68780,7 @@ entities:
       pos: 4.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10791
     components:
     - type: Transform
@@ -69071,7 +68788,7 @@ entities:
       pos: 5.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10792
     components:
     - type: Transform
@@ -69079,7 +68796,7 @@ entities:
       pos: 6.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10793
     components:
     - type: Transform
@@ -69087,7 +68804,7 @@ entities:
       pos: 7.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10794
     components:
     - type: Transform
@@ -69095,7 +68812,7 @@ entities:
       pos: 8.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10795
     components:
     - type: Transform
@@ -69103,7 +68820,7 @@ entities:
       pos: 8.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10796
     components:
     - type: Transform
@@ -69111,7 +68828,7 @@ entities:
       pos: 8.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10797
     components:
     - type: Transform
@@ -69119,7 +68836,7 @@ entities:
       pos: 8.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10798
     components:
     - type: Transform
@@ -69127,7 +68844,7 @@ entities:
       pos: 8.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10799
     components:
     - type: Transform
@@ -69135,7 +68852,7 @@ entities:
       pos: 8.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10800
     components:
     - type: Transform
@@ -69143,7 +68860,7 @@ entities:
       pos: 8.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10801
     components:
     - type: Transform
@@ -69151,7 +68868,7 @@ entities:
       pos: 8.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10802
     components:
     - type: Transform
@@ -69159,7 +68876,7 @@ entities:
       pos: 8.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10803
     components:
     - type: Transform
@@ -69167,7 +68884,7 @@ entities:
       pos: 8.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10804
     components:
     - type: Transform
@@ -69175,7 +68892,7 @@ entities:
       pos: 8.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10805
     components:
     - type: Transform
@@ -69183,7 +68900,7 @@ entities:
       pos: 8.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10806
     components:
     - type: Transform
@@ -69191,7 +68908,7 @@ entities:
       pos: 8.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10807
     components:
     - type: Transform
@@ -69199,7 +68916,7 @@ entities:
       pos: 8.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10808
     components:
     - type: Transform
@@ -69207,7 +68924,7 @@ entities:
       pos: 8.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10809
     components:
     - type: Transform
@@ -69215,7 +68932,7 @@ entities:
       pos: 8.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10810
     components:
     - type: Transform
@@ -69223,7 +68940,7 @@ entities:
       pos: 8.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10811
     components:
     - type: Transform
@@ -69231,7 +68948,7 @@ entities:
       pos: 8.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10812
     components:
     - type: Transform
@@ -69239,7 +68956,7 @@ entities:
       pos: 8.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10813
     components:
     - type: Transform
@@ -69247,7 +68964,7 @@ entities:
       pos: 8.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10814
     components:
     - type: Transform
@@ -69255,7 +68972,7 @@ entities:
       pos: 7.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10815
     components:
     - type: Transform
@@ -69263,7 +68980,7 @@ entities:
       pos: 6.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10816
     components:
     - type: Transform
@@ -69271,7 +68988,7 @@ entities:
       pos: 5.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10817
     components:
     - type: Transform
@@ -69279,7 +68996,7 @@ entities:
       pos: 4.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10818
     components:
     - type: Transform
@@ -69287,7 +69004,7 @@ entities:
       pos: 3.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10819
     components:
     - type: Transform
@@ -69295,7 +69012,7 @@ entities:
       pos: 2.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10820
     components:
     - type: Transform
@@ -69303,7 +69020,7 @@ entities:
       pos: 1.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10821
     components:
     - type: Transform
@@ -69311,7 +69028,7 @@ entities:
       pos: -0.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10822
     components:
     - type: Transform
@@ -69319,7 +69036,7 @@ entities:
       pos: -1.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10823
     components:
     - type: Transform
@@ -69327,7 +69044,7 @@ entities:
       pos: -3.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10824
     components:
     - type: Transform
@@ -69335,7 +69052,7 @@ entities:
       pos: -5.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10825
     components:
     - type: Transform
@@ -69343,7 +69060,7 @@ entities:
       pos: -6.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10826
     components:
     - type: Transform
@@ -69351,7 +69068,7 @@ entities:
       pos: -7.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10827
     components:
     - type: Transform
@@ -69359,7 +69076,7 @@ entities:
       pos: -8.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10828
     components:
     - type: Transform
@@ -69367,7 +69084,7 @@ entities:
       pos: -9.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10829
     components:
     - type: Transform
@@ -69375,7 +69092,7 @@ entities:
       pos: -12.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10830
     components:
     - type: Transform
@@ -69383,7 +69100,7 @@ entities:
       pos: -11.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10831
     components:
     - type: Transform
@@ -69391,7 +69108,7 @@ entities:
       pos: -13.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10832
     components:
     - type: Transform
@@ -69399,7 +69116,7 @@ entities:
       pos: -15.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10833
     components:
     - type: Transform
@@ -69407,7 +69124,7 @@ entities:
       pos: -16.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10834
     components:
     - type: Transform
@@ -69415,15 +69132,7 @@ entities:
       pos: -17.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
-  - uid: 10835
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,27.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10836
     components:
     - type: Transform
@@ -69431,7 +69140,7 @@ entities:
       pos: -20.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10837
     components:
     - type: Transform
@@ -69439,7 +69148,7 @@ entities:
       pos: -22.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10838
     components:
     - type: Transform
@@ -69447,7 +69156,7 @@ entities:
       pos: -23.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10839
     components:
     - type: Transform
@@ -69455,7 +69164,7 @@ entities:
       pos: -24.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10840
     components:
     - type: Transform
@@ -69463,7 +69172,7 @@ entities:
       pos: -25.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10841
     components:
     - type: Transform
@@ -69471,7 +69180,7 @@ entities:
       pos: -26.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10842
     components:
     - type: Transform
@@ -69479,7 +69188,7 @@ entities:
       pos: -28.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10843
     components:
     - type: Transform
@@ -69487,7 +69196,7 @@ entities:
       pos: -29.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10844
     components:
     - type: Transform
@@ -69495,7 +69204,7 @@ entities:
       pos: -30.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10845
     components:
     - type: Transform
@@ -69503,7 +69212,7 @@ entities:
       pos: -33.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10846
     components:
     - type: Transform
@@ -69511,7 +69220,7 @@ entities:
       pos: -32.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10847
     components:
     - type: Transform
@@ -69519,7 +69228,7 @@ entities:
       pos: -34.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10848
     components:
     - type: Transform
@@ -69527,161 +69236,161 @@ entities:
       pos: -35.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10849
     components:
     - type: Transform
       pos: -34.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10850
     components:
     - type: Transform
       pos: -34.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10851
     components:
     - type: Transform
       pos: -34.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10852
     components:
     - type: Transform
       pos: -34.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10853
     components:
     - type: Transform
       pos: -34.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10854
     components:
     - type: Transform
       pos: -34.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10855
     components:
     - type: Transform
       pos: -34.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10856
     components:
     - type: Transform
       pos: -34.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10857
     components:
     - type: Transform
       pos: -34.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10858
     components:
     - type: Transform
       pos: -34.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10859
     components:
     - type: Transform
       pos: -34.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10860
     components:
     - type: Transform
       pos: -34.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10861
     components:
     - type: Transform
       pos: -34.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10862
     components:
     - type: Transform
       pos: -34.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10863
     components:
     - type: Transform
       pos: -34.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10864
     components:
     - type: Transform
       pos: -34.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10865
     components:
     - type: Transform
       pos: -34.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10866
     components:
     - type: Transform
       pos: -34.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10867
     components:
     - type: Transform
       pos: -34.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10868
     components:
     - type: Transform
       pos: -34.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10869
     components:
     - type: Transform
       pos: -34.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10870
     components:
     - type: Transform
       pos: -34.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10871
     components:
     - type: Transform
@@ -69689,7 +69398,7 @@ entities:
       pos: -33.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10872
     components:
     - type: Transform
@@ -69697,7 +69406,7 @@ entities:
       pos: -31.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10873
     components:
     - type: Transform
@@ -69705,7 +69414,7 @@ entities:
       pos: -30.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10874
     components:
     - type: Transform
@@ -69713,7 +69422,7 @@ entities:
       pos: -29.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10875
     components:
     - type: Transform
@@ -69721,7 +69430,7 @@ entities:
       pos: -28.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10876
     components:
     - type: Transform
@@ -69729,7 +69438,7 @@ entities:
       pos: -26.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10877
     components:
     - type: Transform
@@ -69737,7 +69446,7 @@ entities:
       pos: -25.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10878
     components:
     - type: Transform
@@ -69745,7 +69454,7 @@ entities:
       pos: -24.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10879
     components:
     - type: Transform
@@ -69753,7 +69462,7 @@ entities:
       pos: -23.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10880
     components:
     - type: Transform
@@ -69761,7 +69470,7 @@ entities:
       pos: -22.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10881
     components:
     - type: Transform
@@ -69769,7 +69478,7 @@ entities:
       pos: -21.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10882
     components:
     - type: Transform
@@ -69777,7 +69486,7 @@ entities:
       pos: -20.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10883
     components:
     - type: Transform
@@ -69785,7 +69494,7 @@ entities:
       pos: -16.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10884
     components:
     - type: Transform
@@ -69793,7 +69502,7 @@ entities:
       pos: -15.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10885
     components:
     - type: Transform
@@ -69801,7 +69510,7 @@ entities:
       pos: -14.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10886
     components:
     - type: Transform
@@ -69809,7 +69518,7 @@ entities:
       pos: -13.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10887
     components:
     - type: Transform
@@ -69817,7 +69526,7 @@ entities:
       pos: -12.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10888
     components:
     - type: Transform
@@ -69825,7 +69534,7 @@ entities:
       pos: -11.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10889
     components:
     - type: Transform
@@ -69833,7 +69542,7 @@ entities:
       pos: -9.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10890
     components:
     - type: Transform
@@ -69841,7 +69550,7 @@ entities:
       pos: -8.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10891
     components:
     - type: Transform
@@ -69849,7 +69558,7 @@ entities:
       pos: -7.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10892
     components:
     - type: Transform
@@ -69857,7 +69566,7 @@ entities:
       pos: -6.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10893
     components:
     - type: Transform
@@ -69865,7 +69574,7 @@ entities:
       pos: -5.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10894
     components:
     - type: Transform
@@ -69873,7 +69582,7 @@ entities:
       pos: -4.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10895
     components:
     - type: Transform
@@ -69881,7 +69590,7 @@ entities:
       pos: -3.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10896
     components:
     - type: Transform
@@ -69889,7 +69598,7 @@ entities:
       pos: -2.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10897
     components:
     - type: Transform
@@ -69897,7 +69606,7 @@ entities:
       pos: -0.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10898
     components:
     - type: Transform
@@ -69905,7 +69614,7 @@ entities:
       pos: 0.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10899
     components:
     - type: Transform
@@ -69913,7 +69622,7 @@ entities:
       pos: 2.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10900
     components:
     - type: Transform
@@ -69921,7 +69630,7 @@ entities:
       pos: 1.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10901
     components:
     - type: Transform
@@ -69929,7 +69638,7 @@ entities:
       pos: 3.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10902
     components:
     - type: Transform
@@ -69937,7 +69646,7 @@ entities:
       pos: 4.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10903
     components:
     - type: Transform
@@ -69945,7 +69654,7 @@ entities:
       pos: 6.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10904
     components:
     - type: Transform
@@ -69953,7 +69662,7 @@ entities:
       pos: 7.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10905
     components:
     - type: Transform
@@ -69961,7 +69670,7 @@ entities:
       pos: 9.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10906
     components:
     - type: Transform
@@ -69969,7 +69678,7 @@ entities:
       pos: 8.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10907
     components:
     - type: Transform
@@ -69977,7 +69686,7 @@ entities:
       pos: 10.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10908
     components:
     - type: Transform
@@ -69985,7 +69694,7 @@ entities:
       pos: 10.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10909
     components:
     - type: Transform
@@ -69993,7 +69702,7 @@ entities:
       pos: 10.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10910
     components:
     - type: Transform
@@ -70001,7 +69710,7 @@ entities:
       pos: 10.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10911
     components:
     - type: Transform
@@ -70009,7 +69718,7 @@ entities:
       pos: 10.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10912
     components:
     - type: Transform
@@ -70017,7 +69726,7 @@ entities:
       pos: 10.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10913
     components:
     - type: Transform
@@ -70025,7 +69734,7 @@ entities:
       pos: 10.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10914
     components:
     - type: Transform
@@ -70033,7 +69742,7 @@ entities:
       pos: 10.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10915
     components:
     - type: Transform
@@ -70041,7 +69750,7 @@ entities:
       pos: 10.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10916
     components:
     - type: Transform
@@ -70049,7 +69758,7 @@ entities:
       pos: 10.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10917
     components:
     - type: Transform
@@ -70057,7 +69766,7 @@ entities:
       pos: 10.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10918
     components:
     - type: Transform
@@ -70065,7 +69774,7 @@ entities:
       pos: 10.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10919
     components:
     - type: Transform
@@ -70073,7 +69782,7 @@ entities:
       pos: 11.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10920
     components:
     - type: Transform
@@ -70081,7 +69790,7 @@ entities:
       pos: 10.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10921
     components:
     - type: Transform
@@ -70089,7 +69798,7 @@ entities:
       pos: 10.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10922
     components:
     - type: Transform
@@ -70097,7 +69806,7 @@ entities:
       pos: 10.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10923
     components:
     - type: Transform
@@ -70105,7 +69814,7 @@ entities:
       pos: 10.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10924
     components:
     - type: Transform
@@ -70113,7 +69822,7 @@ entities:
       pos: 10.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10925
     components:
     - type: Transform
@@ -70121,7 +69830,7 @@ entities:
       pos: 10.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10926
     components:
     - type: Transform
@@ -70129,7 +69838,7 @@ entities:
       pos: 10.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10927
     components:
     - type: Transform
@@ -70137,7 +69846,7 @@ entities:
       pos: 10.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10928
     components:
     - type: Transform
@@ -70145,7 +69854,7 @@ entities:
       pos: 9.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10929
     components:
     - type: Transform
@@ -70153,7 +69862,7 @@ entities:
       pos: 8.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10930
     components:
     - type: Transform
@@ -70161,7 +69870,7 @@ entities:
       pos: 7.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10931
     components:
     - type: Transform
@@ -70169,7 +69878,7 @@ entities:
       pos: 6.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10932
     components:
     - type: Transform
@@ -70177,7 +69886,7 @@ entities:
       pos: 5.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10933
     components:
     - type: Transform
@@ -70185,7 +69894,7 @@ entities:
       pos: 4.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10934
     components:
     - type: Transform
@@ -70193,7 +69902,7 @@ entities:
       pos: 2.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10935
     components:
     - type: Transform
@@ -70201,7 +69910,7 @@ entities:
       pos: 0.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10936
     components:
     - type: Transform
@@ -70209,7 +69918,7 @@ entities:
       pos: 1.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10937
     components:
     - type: Transform
@@ -70217,7 +69926,7 @@ entities:
       pos: -2.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10938
     components:
     - type: Transform
@@ -70225,7 +69934,7 @@ entities:
       pos: -1.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10939
     components:
     - type: Transform
@@ -70233,7 +69942,7 @@ entities:
       pos: -4.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10940
     components:
     - type: Transform
@@ -70241,7 +69950,7 @@ entities:
       pos: -5.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10941
     components:
     - type: Transform
@@ -70249,7 +69958,7 @@ entities:
       pos: -6.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10942
     components:
     - type: Transform
@@ -70257,7 +69966,7 @@ entities:
       pos: -7.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10943
     components:
     - type: Transform
@@ -70265,7 +69974,7 @@ entities:
       pos: -9.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10944
     components:
     - type: Transform
@@ -70273,7 +69982,7 @@ entities:
       pos: -10.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10945
     components:
     - type: Transform
@@ -70281,7 +69990,7 @@ entities:
       pos: -11.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10946
     components:
     - type: Transform
@@ -70289,7 +69998,7 @@ entities:
       pos: -12.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10947
     components:
     - type: Transform
@@ -70297,7 +70006,7 @@ entities:
       pos: -13.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10948
     components:
     - type: Transform
@@ -70305,7 +70014,7 @@ entities:
       pos: -14.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10949
     components:
     - type: Transform
@@ -70313,15 +70022,7 @@ entities:
       pos: -16.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
-  - uid: 10950
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,25.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10951
     components:
     - type: Transform
@@ -70329,7 +70030,7 @@ entities:
       pos: -18.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10952
     components:
     - type: Transform
@@ -70337,7 +70038,7 @@ entities:
       pos: -19.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10953
     components:
     - type: Transform
@@ -70345,7 +70046,7 @@ entities:
       pos: -20.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10954
     components:
     - type: Transform
@@ -70353,7 +70054,7 @@ entities:
       pos: -21.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10955
     components:
     - type: Transform
@@ -70361,7 +70062,7 @@ entities:
       pos: -24.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10956
     components:
     - type: Transform
@@ -70369,7 +70070,7 @@ entities:
       pos: -27.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10957
     components:
     - type: Transform
@@ -70377,7 +70078,7 @@ entities:
       pos: -29.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10958
     components:
     - type: Transform
@@ -70385,7 +70086,7 @@ entities:
       pos: -28.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10959
     components:
     - type: Transform
@@ -70393,7 +70094,7 @@ entities:
       pos: -31.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10960
     components:
     - type: Transform
@@ -70401,7 +70102,7 @@ entities:
       pos: -32.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10961
     components:
     - type: Transform
@@ -70409,7 +70110,7 @@ entities:
       pos: -33.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10962
     components:
     - type: Transform
@@ -70417,7 +70118,7 @@ entities:
       pos: -31.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10963
     components:
     - type: Transform
@@ -70425,7 +70126,7 @@ entities:
       pos: -31.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10964
     components:
     - type: Transform
@@ -70433,7 +70134,7 @@ entities:
       pos: -31.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10965
     components:
     - type: Transform
@@ -70441,7 +70142,7 @@ entities:
       pos: -25.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10966
     components:
     - type: Transform
@@ -70449,7 +70150,7 @@ entities:
       pos: -25.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10967
     components:
     - type: Transform
@@ -70457,7 +70158,7 @@ entities:
       pos: -25.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10968
     components:
     - type: Transform
@@ -70465,7 +70166,7 @@ entities:
       pos: -25.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10969
     components:
     - type: Transform
@@ -70473,112 +70174,112 @@ entities:
       pos: -25.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10970
     components:
     - type: Transform
       pos: -30.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10971
     components:
     - type: Transform
       pos: -30.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10972
     components:
     - type: Transform
       pos: -31.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10973
     components:
     - type: Transform
       pos: -31.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10974
     components:
     - type: Transform
       pos: -31.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10975
     components:
     - type: Transform
       pos: -31.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10976
     components:
     - type: Transform
       pos: -26.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10977
     components:
     - type: Transform
       pos: -27.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10978
     components:
     - type: Transform
       pos: -27.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10979
     components:
     - type: Transform
       pos: -27.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10980
     components:
     - type: Transform
       pos: -22.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10981
     components:
     - type: Transform
       pos: -21.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10982
     components:
     - type: Transform
       pos: -21.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10983
     components:
     - type: Transform
       pos: -21.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10984
     components:
     - type: Transform
       pos: -21.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10985
     components:
     - type: Transform
@@ -70586,7 +70287,7 @@ entities:
       pos: -35.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10986
     components:
     - type: Transform
@@ -70594,7 +70295,7 @@ entities:
       pos: -36.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10987
     components:
     - type: Transform
@@ -70602,7 +70303,7 @@ entities:
       pos: -37.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10988
     components:
     - type: Transform
@@ -70610,7 +70311,7 @@ entities:
       pos: -38.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10989
     components:
     - type: Transform
@@ -70618,7 +70319,7 @@ entities:
       pos: -37.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10990
     components:
     - type: Transform
@@ -70626,7 +70327,7 @@ entities:
       pos: -38.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 10991
     components:
     - type: Transform
@@ -70634,7 +70335,7 @@ entities:
       pos: -39.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10992
     components:
     - type: Transform
@@ -70642,7 +70343,7 @@ entities:
       pos: -35.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10993
     components:
     - type: Transform
@@ -70650,7 +70351,7 @@ entities:
       pos: -36.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10994
     components:
     - type: Transform
@@ -70658,7 +70359,7 @@ entities:
       pos: -37.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10995
     components:
     - type: Transform
@@ -70666,7 +70367,7 @@ entities:
       pos: -38.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10996
     components:
     - type: Transform
@@ -70674,7 +70375,7 @@ entities:
       pos: -40.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10997
     components:
     - type: Transform
@@ -70682,7 +70383,7 @@ entities:
       pos: -41.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10998
     components:
     - type: Transform
@@ -70690,7 +70391,7 @@ entities:
       pos: -43.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 10999
     components:
     - type: Transform
@@ -70698,7 +70399,7 @@ entities:
       pos: -37.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11000
     components:
     - type: Transform
@@ -70706,7 +70407,7 @@ entities:
       pos: -38.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11001
     components:
     - type: Transform
@@ -70714,7 +70415,7 @@ entities:
       pos: -40.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11002
     components:
     - type: Transform
@@ -70722,7 +70423,7 @@ entities:
       pos: -42.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11003
     components:
     - type: Transform
@@ -70730,7 +70431,7 @@ entities:
       pos: -43.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11004
     components:
     - type: Transform
@@ -70738,7 +70439,7 @@ entities:
       pos: -44.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11005
     components:
     - type: Transform
@@ -70746,7 +70447,7 @@ entities:
       pos: -41.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11006
     components:
     - type: Transform
@@ -70754,7 +70455,7 @@ entities:
       pos: -41.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11007
     components:
     - type: Transform
@@ -70762,7 +70463,7 @@ entities:
       pos: -41.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11008
     components:
     - type: Transform
@@ -70770,7 +70471,7 @@ entities:
       pos: -41.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11009
     components:
     - type: Transform
@@ -70778,7 +70479,7 @@ entities:
       pos: -41.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11010
     components:
     - type: Transform
@@ -70786,7 +70487,7 @@ entities:
       pos: -41.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11011
     components:
     - type: Transform
@@ -70794,7 +70495,7 @@ entities:
       pos: -39.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11012
     components:
     - type: Transform
@@ -70802,7 +70503,7 @@ entities:
       pos: -39.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11013
     components:
     - type: Transform
@@ -70810,7 +70511,7 @@ entities:
       pos: -39.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11014
     components:
     - type: Transform
@@ -70818,7 +70519,7 @@ entities:
       pos: -39.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11015
     components:
     - type: Transform
@@ -70826,7 +70527,7 @@ entities:
       pos: -46.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11016
     components:
     - type: Transform
@@ -70834,7 +70535,7 @@ entities:
       pos: -51.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11017
     components:
     - type: Transform
@@ -70842,7 +70543,7 @@ entities:
       pos: -50.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11018
     components:
     - type: Transform
@@ -70850,7 +70551,7 @@ entities:
       pos: -48.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11019
     components:
     - type: Transform
@@ -70858,7 +70559,7 @@ entities:
       pos: -45.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11020
     components:
     - type: Transform
@@ -70866,7 +70567,7 @@ entities:
       pos: -44.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11021
     components:
     - type: Transform
@@ -70874,7 +70575,7 @@ entities:
       pos: -44.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11022
     components:
     - type: Transform
@@ -70882,7 +70583,7 @@ entities:
       pos: -49.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11023
     components:
     - type: Transform
@@ -70890,119 +70591,119 @@ entities:
       pos: -50.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11024
     components:
     - type: Transform
       pos: -45.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11025
     components:
     - type: Transform
       pos: -45.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11026
     components:
     - type: Transform
       pos: -45.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11027
     components:
     - type: Transform
       pos: -45.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11028
     components:
     - type: Transform
       pos: -44.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11029
     components:
     - type: Transform
       pos: -44.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11030
     components:
     - type: Transform
       pos: -44.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11031
     components:
     - type: Transform
       pos: -45.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11032
     components:
     - type: Transform
       pos: -45.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11033
     components:
     - type: Transform
       pos: -45.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11034
     components:
     - type: Transform
       pos: -45.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11035
     components:
     - type: Transform
       pos: -44.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11036
     components:
     - type: Transform
       pos: -44.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11037
     components:
     - type: Transform
       pos: -44.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11038
     components:
     - type: Transform
       pos: -44.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11039
     components:
     - type: Transform
       pos: -44.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11040
     components:
     - type: Transform
@@ -71010,7 +70711,7 @@ entities:
       pos: -45.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11041
     components:
     - type: Transform
@@ -71018,7 +70719,7 @@ entities:
       pos: -45.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11042
     components:
     - type: Transform
@@ -71026,7 +70727,7 @@ entities:
       pos: -49.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11043
     components:
     - type: Transform
@@ -71034,28 +70735,28 @@ entities:
       pos: -48.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11044
     components:
     - type: Transform
       pos: -51.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11045
     components:
     - type: Transform
       pos: -51.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11046
     components:
     - type: Transform
       pos: -52.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11047
     components:
     - type: Transform
@@ -71063,7 +70764,7 @@ entities:
       pos: -45.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11048
     components:
     - type: Transform
@@ -71071,7 +70772,7 @@ entities:
       pos: -45.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11049
     components:
     - type: Transform
@@ -71079,7 +70780,7 @@ entities:
       pos: -45.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11050
     components:
     - type: Transform
@@ -71087,7 +70788,7 @@ entities:
       pos: -45.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11051
     components:
     - type: Transform
@@ -71095,7 +70796,7 @@ entities:
       pos: -45.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11052
     components:
     - type: Transform
@@ -71103,7 +70804,7 @@ entities:
       pos: -44.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11053
     components:
     - type: Transform
@@ -71111,7 +70812,7 @@ entities:
       pos: -44.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11054
     components:
     - type: Transform
@@ -71119,7 +70820,7 @@ entities:
       pos: -44.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11055
     components:
     - type: Transform
@@ -71127,7 +70828,7 @@ entities:
       pos: -44.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11056
     components:
     - type: Transform
@@ -71135,21 +70836,21 @@ entities:
       pos: -44.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11057
     components:
     - type: Transform
       pos: -45.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11058
     components:
     - type: Transform
       pos: -45.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11059
     components:
     - type: Transform
@@ -71157,7 +70858,7 @@ entities:
       pos: -45.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11060
     components:
     - type: Transform
@@ -71165,7 +70866,7 @@ entities:
       pos: -46.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11061
     components:
     - type: Transform
@@ -71173,7 +70874,7 @@ entities:
       pos: -33.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11062
     components:
     - type: Transform
@@ -71181,7 +70882,7 @@ entities:
       pos: -32.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11063
     components:
     - type: Transform
@@ -71189,7 +70890,7 @@ entities:
       pos: -35.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11064
     components:
     - type: Transform
@@ -71197,7 +70898,7 @@ entities:
       pos: -34.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11065
     components:
     - type: Transform
@@ -71205,7 +70906,7 @@ entities:
       pos: -33.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11066
     components:
     - type: Transform
@@ -71213,7 +70914,7 @@ entities:
       pos: -32.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11067
     components:
     - type: Transform
@@ -71221,7 +70922,7 @@ entities:
       pos: -35.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11068
     components:
     - type: Transform
@@ -71229,7 +70930,7 @@ entities:
       pos: -36.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11069
     components:
     - type: Transform
@@ -71237,7 +70938,7 @@ entities:
       pos: -37.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11070
     components:
     - type: Transform
@@ -71245,7 +70946,7 @@ entities:
       pos: -38.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11071
     components:
     - type: Transform
@@ -71253,7 +70954,7 @@ entities:
       pos: -39.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11072
     components:
     - type: Transform
@@ -71261,7 +70962,7 @@ entities:
       pos: -37.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11073
     components:
     - type: Transform
@@ -71269,7 +70970,7 @@ entities:
       pos: -38.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11074
     components:
     - type: Transform
@@ -71277,7 +70978,7 @@ entities:
       pos: -39.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11075
     components:
     - type: Transform
@@ -71285,7 +70986,7 @@ entities:
       pos: -40.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11076
     components:
     - type: Transform
@@ -71293,7 +70994,7 @@ entities:
       pos: -40.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11077
     components:
     - type: Transform
@@ -71301,7 +71002,7 @@ entities:
       pos: -41.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11078
     components:
     - type: Transform
@@ -71309,7 +71010,7 @@ entities:
       pos: -42.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11079
     components:
     - type: Transform
@@ -71317,7 +71018,7 @@ entities:
       pos: -43.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11080
     components:
     - type: Transform
@@ -71325,7 +71026,7 @@ entities:
       pos: -43.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11081
     components:
     - type: Transform
@@ -71333,7 +71034,7 @@ entities:
       pos: -42.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11082
     components:
     - type: Transform
@@ -71341,7 +71042,7 @@ entities:
       pos: -43.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11083
     components:
     - type: Transform
@@ -71349,7 +71050,7 @@ entities:
       pos: -43.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11084
     components:
     - type: Transform
@@ -71357,7 +71058,7 @@ entities:
       pos: -42.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11085
     components:
     - type: Transform
@@ -71365,7 +71066,7 @@ entities:
       pos: -43.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11086
     components:
     - type: Transform
@@ -71373,7 +71074,7 @@ entities:
       pos: -44.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11087
     components:
     - type: Transform
@@ -71381,7 +71082,7 @@ entities:
       pos: -45.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11088
     components:
     - type: Transform
@@ -71389,7 +71090,7 @@ entities:
       pos: -46.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11089
     components:
     - type: Transform
@@ -71397,7 +71098,7 @@ entities:
       pos: -47.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11090
     components:
     - type: Transform
@@ -71405,7 +71106,7 @@ entities:
       pos: -45.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11091
     components:
     - type: Transform
@@ -71413,7 +71114,7 @@ entities:
       pos: -46.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11092
     components:
     - type: Transform
@@ -71421,7 +71122,7 @@ entities:
       pos: -47.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11093
     components:
     - type: Transform
@@ -71429,7 +71130,7 @@ entities:
       pos: -48.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11094
     components:
     - type: Transform
@@ -71437,21 +71138,21 @@ entities:
       pos: -48.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11095
     components:
     - type: Transform
       pos: -49.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11096
     components:
     - type: Transform
       pos: -49.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11097
     components:
     - type: Transform
@@ -71459,7 +71160,7 @@ entities:
       pos: -50.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11098
     components:
     - type: Transform
@@ -71467,7 +71168,7 @@ entities:
       pos: -49.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11099
     components:
     - type: Transform
@@ -71475,14 +71176,14 @@ entities:
       pos: -51.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11100
     components:
     - type: Transform
       pos: -52.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11101
     components:
     - type: Transform
@@ -71490,7 +71191,7 @@ entities:
       pos: -53.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11102
     components:
     - type: Transform
@@ -71498,7 +71199,7 @@ entities:
       pos: -54.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11103
     components:
     - type: Transform
@@ -71506,7 +71207,7 @@ entities:
       pos: -55.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11104
     components:
     - type: Transform
@@ -71514,7 +71215,7 @@ entities:
       pos: -56.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11105
     components:
     - type: Transform
@@ -71522,7 +71223,7 @@ entities:
       pos: -58.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11106
     components:
     - type: Transform
@@ -71530,7 +71231,7 @@ entities:
       pos: -59.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11107
     components:
     - type: Transform
@@ -71538,7 +71239,7 @@ entities:
       pos: -58.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11108
     components:
     - type: Transform
@@ -71546,7 +71247,7 @@ entities:
       pos: -59.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11109
     components:
     - type: Transform
@@ -71554,7 +71255,7 @@ entities:
       pos: -57.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11110
     components:
     - type: Transform
@@ -71562,7 +71263,7 @@ entities:
       pos: -57.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11111
     components:
     - type: Transform
@@ -71570,7 +71271,7 @@ entities:
       pos: -57.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11112
     components:
     - type: Transform
@@ -71578,7 +71279,7 @@ entities:
       pos: -57.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11113
     components:
     - type: Transform
@@ -71586,7 +71287,7 @@ entities:
       pos: -57.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11114
     components:
     - type: Transform
@@ -71594,7 +71295,7 @@ entities:
       pos: -58.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11115
     components:
     - type: Transform
@@ -71602,7 +71303,7 @@ entities:
       pos: -59.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11116
     components:
     - type: Transform
@@ -71610,7 +71311,7 @@ entities:
       pos: -58.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11117
     components:
     - type: Transform
@@ -71618,35 +71319,35 @@ entities:
       pos: -59.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11118
     components:
     - type: Transform
       pos: -57.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11119
     components:
     - type: Transform
       pos: -49.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11120
     components:
     - type: Transform
       pos: -49.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11121
     components:
     - type: Transform
       pos: -49.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11122
     components:
     - type: Transform
@@ -71654,7 +71355,7 @@ entities:
       pos: -50.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11123
     components:
     - type: Transform
@@ -71662,7 +71363,7 @@ entities:
       pos: -51.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11124
     components:
     - type: Transform
@@ -71670,7 +71371,7 @@ entities:
       pos: -52.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11125
     components:
     - type: Transform
@@ -71678,7 +71379,7 @@ entities:
       pos: -50.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11126
     components:
     - type: Transform
@@ -71686,7 +71387,7 @@ entities:
       pos: -51.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11127
     components:
     - type: Transform
@@ -71694,7 +71395,7 @@ entities:
       pos: -52.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11128
     components:
     - type: Transform
@@ -71702,7 +71403,7 @@ entities:
       pos: -50.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11129
     components:
     - type: Transform
@@ -71710,7 +71411,7 @@ entities:
       pos: -50.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11130
     components:
     - type: Transform
@@ -71718,7 +71419,7 @@ entities:
       pos: -50.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11131
     components:
     - type: Transform
@@ -71726,7 +71427,7 @@ entities:
       pos: -50.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11132
     components:
     - type: Transform
@@ -71734,7 +71435,7 @@ entities:
       pos: -19.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11133
     components:
     - type: Transform
@@ -71742,7 +71443,7 @@ entities:
       pos: -19.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11134
     components:
     - type: Transform
@@ -71750,7 +71451,7 @@ entities:
       pos: -19.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11135
     components:
     - type: Transform
@@ -71758,7 +71459,7 @@ entities:
       pos: -19.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11136
     components:
     - type: Transform
@@ -71766,7 +71467,7 @@ entities:
       pos: -18.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11137
     components:
     - type: Transform
@@ -71774,7 +71475,7 @@ entities:
       pos: -17.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11138
     components:
     - type: Transform
@@ -71782,7 +71483,7 @@ entities:
       pos: -20.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11139
     components:
     - type: Transform
@@ -71790,7 +71491,7 @@ entities:
       pos: -21.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11140
     components:
     - type: Transform
@@ -71798,7 +71499,7 @@ entities:
       pos: -22.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11141
     components:
     - type: Transform
@@ -71806,7 +71507,7 @@ entities:
       pos: -23.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11142
     components:
     - type: Transform
@@ -71814,7 +71515,7 @@ entities:
       pos: -21.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11143
     components:
     - type: Transform
@@ -71822,7 +71523,7 @@ entities:
       pos: -21.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11144
     components:
     - type: Transform
@@ -71830,7 +71531,7 @@ entities:
       pos: -21.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11145
     components:
     - type: Transform
@@ -71838,7 +71539,7 @@ entities:
       pos: -22.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11146
     components:
     - type: Transform
@@ -71846,28 +71547,28 @@ entities:
       pos: -23.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11147
     components:
     - type: Transform
       pos: -23.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11148
     components:
     - type: Transform
       pos: -23.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11149
     components:
     - type: Transform
       pos: -23.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11150
     components:
     - type: Transform
@@ -71875,7 +71576,7 @@ entities:
       pos: -62.5,-61.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11151
     components:
     - type: Transform
@@ -71883,7 +71584,7 @@ entities:
       pos: -24.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11152
     components:
     - type: Transform
@@ -71891,7 +71592,7 @@ entities:
       pos: -24.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11153
     components:
     - type: Transform
@@ -71899,7 +71600,7 @@ entities:
       pos: -23.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11154
     components:
     - type: Transform
@@ -71907,7 +71608,7 @@ entities:
       pos: -23.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11155
     components:
     - type: Transform
@@ -71915,7 +71616,7 @@ entities:
       pos: -23.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11156
     components:
     - type: Transform
@@ -71923,7 +71624,7 @@ entities:
       pos: -25.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11157
     components:
     - type: Transform
@@ -71931,7 +71632,7 @@ entities:
       pos: -20.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11158
     components:
     - type: Transform
@@ -71939,7 +71640,7 @@ entities:
       pos: -19.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11159
     components:
     - type: Transform
@@ -71947,7 +71648,7 @@ entities:
       pos: -18.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11160
     components:
     - type: Transform
@@ -71955,7 +71656,7 @@ entities:
       pos: -16.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11161
     components:
     - type: Transform
@@ -71963,7 +71664,7 @@ entities:
       pos: -15.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11162
     components:
     - type: Transform
@@ -71971,84 +71672,84 @@ entities:
       pos: -14.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11163
     components:
     - type: Transform
       pos: -16.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11164
     components:
     - type: Transform
       pos: -16.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11165
     components:
     - type: Transform
       pos: -16.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11166
     components:
     - type: Transform
       pos: -17.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11167
     components:
     - type: Transform
       pos: -17.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11168
     components:
     - type: Transform
       pos: -17.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11169
     components:
     - type: Transform
       pos: -17.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11170
     components:
     - type: Transform
       pos: -16.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11171
     components:
     - type: Transform
       pos: -16.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11172
     components:
     - type: Transform
       pos: -16.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11173
     components:
     - type: Transform
       pos: -17.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11174
     components:
     - type: Transform
@@ -72056,7 +71757,7 @@ entities:
       pos: -14.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11175
     components:
     - type: Transform
@@ -72064,63 +71765,63 @@ entities:
       pos: -15.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11176
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11177
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11178
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11179
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11180
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11181
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11182
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11183
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11184
     components:
     - type: Transform
@@ -72128,7 +71829,7 @@ entities:
       pos: -3.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11185
     components:
     - type: Transform
@@ -72136,7 +71837,7 @@ entities:
       pos: -3.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11186
     components:
     - type: Transform
@@ -72144,7 +71845,7 @@ entities:
       pos: -3.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11187
     components:
     - type: Transform
@@ -72152,7 +71853,7 @@ entities:
       pos: -3.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11188
     components:
     - type: Transform
@@ -72160,7 +71861,7 @@ entities:
       pos: -3.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11189
     components:
     - type: Transform
@@ -72168,7 +71869,7 @@ entities:
       pos: -1.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11190
     components:
     - type: Transform
@@ -72176,7 +71877,7 @@ entities:
       pos: -1.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11191
     components:
     - type: Transform
@@ -72184,7 +71885,7 @@ entities:
       pos: -1.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11192
     components:
     - type: Transform
@@ -72192,7 +71893,7 @@ entities:
       pos: -1.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11193
     components:
     - type: Transform
@@ -72200,7 +71901,7 @@ entities:
       pos: -1.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11194
     components:
     - type: Transform
@@ -72208,7 +71909,7 @@ entities:
       pos: -1.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11195
     components:
     - type: Transform
@@ -72216,7 +71917,7 @@ entities:
       pos: -2.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11196
     components:
     - type: Transform
@@ -72224,7 +71925,7 @@ entities:
       pos: -1.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11197
     components:
     - type: Transform
@@ -72232,7 +71933,7 @@ entities:
       pos: -0.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11198
     components:
     - type: Transform
@@ -72240,7 +71941,7 @@ entities:
       pos: 0.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11199
     components:
     - type: Transform
@@ -72248,7 +71949,7 @@ entities:
       pos: 1.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11200
     components:
     - type: Transform
@@ -72256,7 +71957,7 @@ entities:
       pos: 2.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11201
     components:
     - type: Transform
@@ -72264,7 +71965,7 @@ entities:
       pos: 0.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11202
     components:
     - type: Transform
@@ -72272,7 +71973,7 @@ entities:
       pos: 1.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11203
     components:
     - type: Transform
@@ -72280,7 +71981,7 @@ entities:
       pos: 2.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11204
     components:
     - type: Transform
@@ -72288,7 +71989,7 @@ entities:
       pos: -2.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11205
     components:
     - type: Transform
@@ -72296,7 +71997,7 @@ entities:
       pos: -3.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11206
     components:
     - type: Transform
@@ -72304,7 +72005,7 @@ entities:
       pos: -4.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11207
     components:
     - type: Transform
@@ -72312,7 +72013,7 @@ entities:
       pos: -5.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11208
     components:
     - type: Transform
@@ -72320,7 +72021,7 @@ entities:
       pos: -6.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11209
     components:
     - type: Transform
@@ -72328,7 +72029,7 @@ entities:
       pos: -7.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11210
     components:
     - type: Transform
@@ -72336,7 +72037,7 @@ entities:
       pos: -5.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11211
     components:
     - type: Transform
@@ -72344,7 +72045,7 @@ entities:
       pos: -6.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11212
     components:
     - type: Transform
@@ -72352,7 +72053,7 @@ entities:
       pos: -7.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11213
     components:
     - type: Transform
@@ -72360,7 +72061,7 @@ entities:
       pos: -8.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11214
     components:
     - type: Transform
@@ -72368,7 +72069,7 @@ entities:
       pos: -9.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11215
     components:
     - type: Transform
@@ -72376,7 +72077,7 @@ entities:
       pos: -11.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11216
     components:
     - type: Transform
@@ -72384,7 +72085,7 @@ entities:
       pos: -10.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11217
     components:
     - type: Transform
@@ -72392,7 +72093,7 @@ entities:
       pos: -11.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11218
     components:
     - type: Transform
@@ -72400,7 +72101,7 @@ entities:
       pos: -12.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11219
     components:
     - type: Transform
@@ -72408,7 +72109,7 @@ entities:
       pos: -13.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11220
     components:
     - type: Transform
@@ -72416,7 +72117,7 @@ entities:
       pos: -14.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11221
     components:
     - type: Transform
@@ -72424,7 +72125,7 @@ entities:
       pos: -15.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11222
     components:
     - type: Transform
@@ -72432,7 +72133,7 @@ entities:
       pos: -15.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11223
     components:
     - type: Transform
@@ -72440,7 +72141,7 @@ entities:
       pos: -14.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11224
     components:
     - type: Transform
@@ -72448,133 +72149,133 @@ entities:
       pos: -13.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11225
     components:
     - type: Transform
       pos: -10.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11226
     components:
     - type: Transform
       pos: -10.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11227
     components:
     - type: Transform
       pos: -10.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11228
     components:
     - type: Transform
       pos: -9.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11229
     components:
     - type: Transform
       pos: -9.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11230
     components:
     - type: Transform
       pos: -9.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11231
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11232
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11233
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11234
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11235
     components:
     - type: Transform
       pos: -8.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11236
     components:
     - type: Transform
       pos: -8.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11237
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11238
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11239
     components:
     - type: Transform
       pos: -13.5,-33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11240
     components:
     - type: Transform
       pos: -13.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11241
     components:
     - type: Transform
       pos: -18.5,-47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11242
     components:
     - type: Transform
       pos: -25.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11243
     components:
     - type: Transform
@@ -72582,7 +72283,7 @@ entities:
       pos: -1.5,-42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11244
     components:
     - type: Transform
@@ -72590,21 +72291,21 @@ entities:
       pos: -26.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11245
     components:
     - type: Transform
       pos: -19.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11246
     components:
     - type: Transform
       pos: -19.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11247
     components:
     - type: Transform
@@ -72612,7 +72313,7 @@ entities:
       pos: -47.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11248
     components:
     - type: Transform
@@ -72620,7 +72321,7 @@ entities:
       pos: -53.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11249
     components:
     - type: Transform
@@ -72628,7 +72329,7 @@ entities:
       pos: -46.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11250
     components:
     - type: Transform
@@ -72636,7 +72337,7 @@ entities:
       pos: -53.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11251
     components:
     - type: Transform
@@ -72644,7 +72345,7 @@ entities:
       pos: -27.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11252
     components:
     - type: Transform
@@ -72652,7 +72353,7 @@ entities:
       pos: -30.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11253
     components:
     - type: Transform
@@ -72666,63 +72367,63 @@ entities:
       pos: -2.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11255
     components:
     - type: Transform
       pos: -2.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11256
     components:
     - type: Transform
       pos: -2.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11257
     components:
     - type: Transform
       pos: -2.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11258
     components:
     - type: Transform
       pos: -2.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11259
     components:
     - type: Transform
       pos: -2.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11260
     components:
     - type: Transform
       pos: -0.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11261
     components:
     - type: Transform
       pos: -0.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11262
     components:
     - type: Transform
       pos: -0.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11263
     components:
     - type: Transform
@@ -72730,7 +72431,7 @@ entities:
       pos: -14.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11264
     components:
     - type: Transform
@@ -72738,7 +72439,7 @@ entities:
       pos: -14.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11265
     components:
     - type: Transform
@@ -72746,7 +72447,7 @@ entities:
       pos: -14.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11266
     components:
     - type: Transform
@@ -72754,7 +72455,7 @@ entities:
       pos: -14.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11267
     components:
     - type: Transform
@@ -72762,7 +72463,7 @@ entities:
       pos: -14.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11268
     components:
     - type: Transform
@@ -72770,7 +72471,7 @@ entities:
       pos: -14.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11269
     components:
     - type: Transform
@@ -72778,7 +72479,7 @@ entities:
       pos: -14.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11270
     components:
     - type: Transform
@@ -72786,7 +72487,7 @@ entities:
       pos: -14.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11271
     components:
     - type: Transform
@@ -72794,7 +72495,7 @@ entities:
       pos: -14.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11272
     components:
     - type: Transform
@@ -72802,7 +72503,7 @@ entities:
       pos: -14.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11273
     components:
     - type: Transform
@@ -72810,7 +72511,7 @@ entities:
       pos: -14.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11274
     components:
     - type: Transform
@@ -72818,7 +72519,7 @@ entities:
       pos: -4.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11275
     components:
     - type: Transform
@@ -72826,7 +72527,7 @@ entities:
       pos: -4.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11276
     components:
     - type: Transform
@@ -72834,7 +72535,7 @@ entities:
       pos: -4.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11277
     components:
     - type: Transform
@@ -72842,7 +72543,7 @@ entities:
       pos: -4.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11278
     components:
     - type: Transform
@@ -72850,7 +72551,7 @@ entities:
       pos: -4.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11279
     components:
     - type: Transform
@@ -72858,7 +72559,7 @@ entities:
       pos: -4.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11280
     components:
     - type: Transform
@@ -72866,7 +72567,7 @@ entities:
       pos: -4.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11281
     components:
     - type: Transform
@@ -72874,7 +72575,7 @@ entities:
       pos: -4.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11282
     components:
     - type: Transform
@@ -72882,7 +72583,7 @@ entities:
       pos: -4.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11283
     components:
     - type: Transform
@@ -72890,7 +72591,7 @@ entities:
       pos: -4.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11284
     components:
     - type: Transform
@@ -72898,7 +72599,7 @@ entities:
       pos: -4.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11285
     components:
     - type: Transform
@@ -72906,7 +72607,7 @@ entities:
       pos: -13.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11286
     components:
     - type: Transform
@@ -72914,7 +72615,7 @@ entities:
       pos: -12.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11287
     components:
     - type: Transform
@@ -72922,7 +72623,7 @@ entities:
       pos: -10.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11288
     components:
     - type: Transform
@@ -72930,7 +72631,7 @@ entities:
       pos: -8.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11289
     components:
     - type: Transform
@@ -72938,7 +72639,7 @@ entities:
       pos: -7.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11290
     components:
     - type: Transform
@@ -72946,7 +72647,7 @@ entities:
       pos: -6.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11291
     components:
     - type: Transform
@@ -72954,189 +72655,189 @@ entities:
       pos: -5.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11292
     components:
     - type: Transform
       pos: -15.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11293
     components:
     - type: Transform
       pos: -15.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11294
     components:
     - type: Transform
       pos: -15.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11295
     components:
     - type: Transform
       pos: -15.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11296
     components:
     - type: Transform
       pos: -15.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11297
     components:
     - type: Transform
       pos: -15.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11298
     components:
     - type: Transform
       pos: -15.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11299
     components:
     - type: Transform
       pos: -15.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11300
     components:
     - type: Transform
       pos: -15.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11301
     components:
     - type: Transform
       pos: -15.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11302
     components:
     - type: Transform
       pos: -15.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11303
     components:
     - type: Transform
       pos: -15.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11304
     components:
     - type: Transform
       pos: -15.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11305
     components:
     - type: Transform
       pos: -3.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11306
     components:
     - type: Transform
       pos: -3.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11307
     components:
     - type: Transform
       pos: -3.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11308
     components:
     - type: Transform
       pos: -3.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11309
     components:
     - type: Transform
       pos: -3.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11310
     components:
     - type: Transform
       pos: -3.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11311
     components:
     - type: Transform
       pos: -3.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11312
     components:
     - type: Transform
       pos: -3.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11313
     components:
     - type: Transform
       pos: -3.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11314
     components:
     - type: Transform
       pos: -3.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11315
     components:
     - type: Transform
       pos: -3.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11316
     components:
     - type: Transform
       pos: -3.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11317
     components:
     - type: Transform
       pos: -3.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11318
     components:
     - type: Transform
@@ -73144,7 +72845,7 @@ entities:
       pos: -4.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11319
     components:
     - type: Transform
@@ -73152,7 +72853,7 @@ entities:
       pos: -5.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11320
     components:
     - type: Transform
@@ -73160,7 +72861,7 @@ entities:
       pos: -6.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11321
     components:
     - type: Transform
@@ -73168,7 +72869,7 @@ entities:
       pos: -8.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11322
     components:
     - type: Transform
@@ -73176,7 +72877,7 @@ entities:
       pos: -10.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11323
     components:
     - type: Transform
@@ -73184,7 +72885,7 @@ entities:
       pos: -14.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11324
     components:
     - type: Transform
@@ -73192,7 +72893,7 @@ entities:
       pos: -13.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11325
     components:
     - type: Transform
@@ -73200,56 +72901,56 @@ entities:
       pos: -12.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11326
     components:
     - type: Transform
       pos: -11.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11327
     components:
     - type: Transform
       pos: -11.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11328
     components:
     - type: Transform
       pos: -11.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11329
     components:
     - type: Transform
       pos: -7.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11330
     components:
     - type: Transform
       pos: -7.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11331
     components:
     - type: Transform
       pos: -7.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11332
     components:
     - type: Transform
       pos: -7.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11333
     components:
     - type: Transform
@@ -73257,7 +72958,7 @@ entities:
       pos: -3.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11334
     components:
     - type: Transform
@@ -73265,7 +72966,7 @@ entities:
       pos: -2.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11335
     components:
     - type: Transform
@@ -73273,7 +72974,7 @@ entities:
       pos: -1.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11336
     components:
     - type: Transform
@@ -73281,7 +72982,7 @@ entities:
       pos: -0.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11337
     components:
     - type: Transform
@@ -73289,7 +72990,7 @@ entities:
       pos: -2.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11338
     components:
     - type: Transform
@@ -73297,7 +72998,7 @@ entities:
       pos: -1.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11339
     components:
     - type: Transform
@@ -73305,7 +73006,7 @@ entities:
       pos: -0.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11340
     components:
     - type: Transform
@@ -73313,7 +73014,7 @@ entities:
       pos: -16.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11341
     components:
     - type: Transform
@@ -73321,7 +73022,7 @@ entities:
       pos: -17.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11342
     components:
     - type: Transform
@@ -73329,7 +73030,7 @@ entities:
       pos: -18.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11343
     components:
     - type: Transform
@@ -73337,7 +73038,7 @@ entities:
       pos: -16.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11344
     components:
     - type: Transform
@@ -73345,7 +73046,7 @@ entities:
       pos: -17.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11345
     components:
     - type: Transform
@@ -73353,7 +73054,7 @@ entities:
       pos: -18.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11346
     components:
     - type: Transform
@@ -73361,7 +73062,7 @@ entities:
       pos: -19.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11347
     components:
     - type: Transform
@@ -73369,7 +73070,7 @@ entities:
       pos: -21.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11348
     components:
     - type: Transform
@@ -73377,7 +73078,7 @@ entities:
       pos: -22.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11349
     components:
     - type: Transform
@@ -73385,7 +73086,7 @@ entities:
       pos: -23.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11350
     components:
     - type: Transform
@@ -73393,35 +73094,35 @@ entities:
       pos: -24.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11351
     components:
     - type: Transform
       pos: -20.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11352
     components:
     - type: Transform
       pos: -20.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11353
     components:
     - type: Transform
       pos: -20.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11354
     components:
     - type: Transform
       pos: -20.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11355
     components:
     - type: Transform
@@ -73429,7 +73130,7 @@ entities:
       pos: -15.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11356
     components:
     - type: Transform
@@ -73437,7 +73138,7 @@ entities:
       pos: -16.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11357
     components:
     - type: Transform
@@ -73445,7 +73146,7 @@ entities:
       pos: -17.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11358
     components:
     - type: Transform
@@ -73453,7 +73154,7 @@ entities:
       pos: -20.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11359
     components:
     - type: Transform
@@ -73461,7 +73162,7 @@ entities:
       pos: -22.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11360
     components:
     - type: Transform
@@ -73469,7 +73170,7 @@ entities:
       pos: -23.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11361
     components:
     - type: Transform
@@ -73477,7 +73178,7 @@ entities:
       pos: -24.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11362
     components:
     - type: Transform
@@ -73485,14 +73186,14 @@ entities:
       pos: -25.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11363
     components:
     - type: Transform
       pos: -26.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11364
     components:
     - type: Transform
@@ -73500,14 +73201,14 @@ entities:
       pos: -27.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11365
     components:
     - type: Transform
       pos: -19.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11366
     components:
     - type: Transform
@@ -73515,7 +73216,7 @@ entities:
       pos: -11.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11367
     components:
     - type: Transform
@@ -73523,7 +73224,7 @@ entities:
       pos: -17.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11368
     components:
     - type: Transform
@@ -73531,14 +73232,14 @@ entities:
       pos: -14.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11369
     components:
     - type: Transform
       pos: -12.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11370
     components:
     - type: Transform
@@ -73546,7 +73247,7 @@ entities:
       pos: -15.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11371
     components:
     - type: Transform
@@ -73554,7 +73255,7 @@ entities:
       pos: -16.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11372
     components:
     - type: Transform
@@ -73562,7 +73263,7 @@ entities:
       pos: -17.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11373
     components:
     - type: Transform
@@ -73570,7 +73271,7 @@ entities:
       pos: -17.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11374
     components:
     - type: Transform
@@ -73578,7 +73279,7 @@ entities:
       pos: -30.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11375
     components:
     - type: Transform
@@ -73586,7 +73287,7 @@ entities:
       pos: -14.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11376
     components:
     - type: Transform
@@ -73594,7 +73295,7 @@ entities:
       pos: -15.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11377
     components:
     - type: Transform
@@ -73602,7 +73303,7 @@ entities:
       pos: -16.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11378
     components:
     - type: Transform
@@ -73610,7 +73311,7 @@ entities:
       pos: -17.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11379
     components:
     - type: Transform
@@ -73618,7 +73319,7 @@ entities:
       pos: -17.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11380
     components:
     - type: Transform
@@ -73626,7 +73327,7 @@ entities:
       pos: -33.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11381
     components:
     - type: Transform
@@ -73634,7 +73335,7 @@ entities:
       pos: -18.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11382
     components:
     - type: Transform
@@ -73642,7 +73343,7 @@ entities:
       pos: -32.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11383
     components:
     - type: Transform
@@ -73650,7 +73351,7 @@ entities:
       pos: -29.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11384
     components:
     - type: Transform
@@ -73658,7 +73359,7 @@ entities:
       pos: -31.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11385
     components:
     - type: Transform
@@ -73666,14 +73367,14 @@ entities:
       pos: -30.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11386
     components:
     - type: Transform
       pos: -28.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11387
     components:
     - type: Transform
@@ -73681,7 +73382,7 @@ entities:
       pos: -31.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11388
     components:
     - type: Transform
@@ -73689,7 +73390,7 @@ entities:
       pos: -32.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11389
     components:
     - type: Transform
@@ -73697,42 +73398,42 @@ entities:
       pos: -32.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11390
     components:
     - type: Transform
       pos: -18.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11391
     components:
     - type: Transform
       pos: -18.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11392
     components:
     - type: Transform
       pos: -18.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11393
     components:
     - type: Transform
       pos: -18.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11394
     components:
     - type: Transform
       pos: -18.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11395
     components:
     - type: Transform
@@ -73746,7 +73447,7 @@ entities:
       pos: -22.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11397
     components:
     - type: Transform
@@ -73754,7 +73455,7 @@ entities:
       pos: -28.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11398
     components:
     - type: Transform
@@ -73762,7 +73463,7 @@ entities:
       pos: -26.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11399
     components:
     - type: Transform
@@ -73770,7 +73471,7 @@ entities:
       pos: -25.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11400
     components:
     - type: Transform
@@ -73778,7 +73479,7 @@ entities:
       pos: -27.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11401
     components:
     - type: Transform
@@ -73786,7 +73487,7 @@ entities:
       pos: -24.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11402
     components:
     - type: Transform
@@ -73794,7 +73495,7 @@ entities:
       pos: -12.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11403
     components:
     - type: Transform
@@ -73802,7 +73503,7 @@ entities:
       pos: -15.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11404
     components:
     - type: Transform
@@ -73810,7 +73511,7 @@ entities:
       pos: -26.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11405
     components:
     - type: Transform
@@ -73818,7 +73519,7 @@ entities:
       pos: -27.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11406
     components:
     - type: Transform
@@ -73826,7 +73527,7 @@ entities:
       pos: -31.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11407
     components:
     - type: Transform
@@ -73834,7 +73535,7 @@ entities:
       pos: -30.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11408
     components:
     - type: Transform
@@ -73842,7 +73543,7 @@ entities:
       pos: -33.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11409
     components:
     - type: Transform
@@ -73850,21 +73551,21 @@ entities:
       pos: -27.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11410
     components:
     - type: Transform
       pos: -34.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11411
     components:
     - type: Transform
       pos: -34.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11412
     components:
     - type: Transform
@@ -73872,7 +73573,7 @@ entities:
       pos: -30.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11413
     components:
     - type: Transform
@@ -73880,21 +73581,21 @@ entities:
       pos: -29.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11414
     components:
     - type: Transform
       pos: -11.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11415
     components:
     - type: Transform
       pos: -22.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11416
     components:
     - type: Transform
@@ -73902,7 +73603,7 @@ entities:
       pos: -18.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11417
     components:
     - type: Transform
@@ -73910,35 +73611,35 @@ entities:
       pos: -21.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11418
     components:
     - type: Transform
       pos: -8.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11419
     components:
     - type: Transform
       pos: -8.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11420
     components:
     - type: Transform
       pos: -8.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11421
     components:
     - type: Transform
       pos: -8.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11422
     components:
     - type: Transform
@@ -73946,7 +73647,7 @@ entities:
       pos: -7.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11423
     components:
     - type: Transform
@@ -73954,7 +73655,7 @@ entities:
       pos: -6.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11424
     components:
     - type: Transform
@@ -73962,7 +73663,7 @@ entities:
       pos: -5.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11425
     components:
     - type: Transform
@@ -73970,42 +73671,42 @@ entities:
       pos: -4.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11426
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11427
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11428
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11429
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11430
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11431
     components:
     - type: Transform
@@ -74013,7 +73714,7 @@ entities:
       pos: -3.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11432
     components:
     - type: Transform
@@ -74021,7 +73722,7 @@ entities:
       pos: -4.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11433
     components:
     - type: Transform
@@ -74029,7 +73730,7 @@ entities:
       pos: -5.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11434
     components:
     - type: Transform
@@ -74037,7 +73738,7 @@ entities:
       pos: -6.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11435
     components:
     - type: Transform
@@ -74045,7 +73746,7 @@ entities:
       pos: -7.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11436
     components:
     - type: Transform
@@ -74053,7 +73754,7 @@ entities:
       pos: -8.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11437
     components:
     - type: Transform
@@ -74061,28 +73762,28 @@ entities:
       pos: -9.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11438
     components:
     - type: Transform
       pos: -10.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11439
     components:
     - type: Transform
       pos: -10.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11440
     components:
     - type: Transform
       pos: -10.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11441
     components:
     - type: Transform
@@ -74090,7 +73791,7 @@ entities:
       pos: -11.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11442
     components:
     - type: Transform
@@ -74098,7 +73799,7 @@ entities:
       pos: -9.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11443
     components:
     - type: Transform
@@ -74106,70 +73807,70 @@ entities:
       pos: -10.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11444
     components:
     - type: Transform
       pos: -12.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11445
     components:
     - type: Transform
       pos: -12.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11446
     components:
     - type: Transform
       pos: -12.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11447
     components:
     - type: Transform
       pos: -12.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11448
     components:
     - type: Transform
       pos: -12.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11449
     components:
     - type: Transform
       pos: -11.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11450
     components:
     - type: Transform
       pos: -11.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11451
     components:
     - type: Transform
       pos: -11.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11452
     components:
     - type: Transform
       pos: -11.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11453
     components:
     - type: Transform
@@ -74177,7 +73878,7 @@ entities:
       pos: -10.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11454
     components:
     - type: Transform
@@ -74185,7 +73886,7 @@ entities:
       pos: -9.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11455
     components:
     - type: Transform
@@ -74193,7 +73894,7 @@ entities:
       pos: -8.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11456
     components:
     - type: Transform
@@ -74201,7 +73902,7 @@ entities:
       pos: -10.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11457
     components:
     - type: Transform
@@ -74209,7 +73910,7 @@ entities:
       pos: -8.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11458
     components:
     - type: Transform
@@ -74217,7 +73918,7 @@ entities:
       pos: -9.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11459
     components:
     - type: Transform
@@ -74225,28 +73926,28 @@ entities:
       pos: -6.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11460
     components:
     - type: Transform
       pos: -19.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11461
     components:
     - type: Transform
       pos: -19.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11462
     components:
     - type: Transform
       pos: -17.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11463
     components:
     - type: Transform
@@ -74254,21 +73955,21 @@ entities:
       pos: -24.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11464
     components:
     - type: Transform
       pos: -34.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11465
     components:
     - type: Transform
       pos: -34.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11466
     components:
     - type: Transform
@@ -74282,7 +73983,7 @@ entities:
       pos: -20.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11468
     components:
     - type: Transform
@@ -74290,7 +73991,7 @@ entities:
       pos: -21.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11469
     components:
     - type: Transform
@@ -74298,14 +73999,14 @@ entities:
       pos: -25.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11470
     components:
     - type: Transform
       pos: -34.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11471
     components:
     - type: Transform
@@ -74313,7 +74014,7 @@ entities:
       pos: -16.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11472
     components:
     - type: Transform
@@ -74321,7 +74022,7 @@ entities:
       pos: -26.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11473
     components:
     - type: Transform
@@ -74329,7 +74030,7 @@ entities:
       pos: -19.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11474
     components:
     - type: Transform
@@ -74337,7 +74038,7 @@ entities:
       pos: -21.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11475
     components:
     - type: Transform
@@ -74345,7 +74046,7 @@ entities:
       pos: -20.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11476
     components:
     - type: Transform
@@ -74353,7 +74054,7 @@ entities:
       pos: -22.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11477
     components:
     - type: Transform
@@ -74361,7 +74062,7 @@ entities:
       pos: -22.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11478
     components:
     - type: Transform
@@ -74369,7 +74070,7 @@ entities:
       pos: -27.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11479
     components:
     - type: Transform
@@ -74377,7 +74078,7 @@ entities:
       pos: -19.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11480
     components:
     - type: Transform
@@ -74385,7 +74086,7 @@ entities:
       pos: -30.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11481
     components:
     - type: Transform
@@ -74393,7 +74094,7 @@ entities:
       pos: -30.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11482
     components:
     - type: Transform
@@ -74401,7 +74102,7 @@ entities:
       pos: -28.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11483
     components:
     - type: Transform
@@ -74409,7 +74110,7 @@ entities:
       pos: -30.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11484
     components:
     - type: Transform
@@ -74417,7 +74118,7 @@ entities:
       pos: -29.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11485
     components:
     - type: Transform
@@ -74425,7 +74126,7 @@ entities:
       pos: -29.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11486
     components:
     - type: Transform
@@ -74433,7 +74134,7 @@ entities:
       pos: -26.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11487
     components:
     - type: Transform
@@ -74441,7 +74142,7 @@ entities:
       pos: -29.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11488
     components:
     - type: Transform
@@ -74449,7 +74150,7 @@ entities:
       pos: -28.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11489
     components:
     - type: Transform
@@ -74457,7 +74158,7 @@ entities:
       pos: -29.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11490
     components:
     - type: Transform
@@ -74465,7 +74166,7 @@ entities:
       pos: -26.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11491
     components:
     - type: Transform
@@ -74473,7 +74174,7 @@ entities:
       pos: -27.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11492
     components:
     - type: Transform
@@ -74481,7 +74182,7 @@ entities:
       pos: -32.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11493
     components:
     - type: Transform
@@ -74489,7 +74190,7 @@ entities:
       pos: -17.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11494
     components:
     - type: Transform
@@ -74497,7 +74198,7 @@ entities:
       pos: -31.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11495
     components:
     - type: Transform
@@ -74505,7 +74206,7 @@ entities:
       pos: -18.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11496
     components:
     - type: Transform
@@ -74513,7 +74214,7 @@ entities:
       pos: -19.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11497
     components:
     - type: Transform
@@ -74521,21 +74222,21 @@ entities:
       pos: -13.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11498
     components:
     - type: Transform
       pos: -28.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11499
     components:
     - type: Transform
       pos: -28.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11500
     components:
     - type: Transform
@@ -74543,7 +74244,7 @@ entities:
       pos: -22.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11501
     components:
     - type: Transform
@@ -74551,7 +74252,7 @@ entities:
       pos: -20.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11502
     components:
     - type: Transform
@@ -74559,7 +74260,7 @@ entities:
       pos: -22.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11503
     components:
     - type: Transform
@@ -74567,7 +74268,7 @@ entities:
       pos: -22.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11504
     components:
     - type: Transform
@@ -74575,7 +74276,7 @@ entities:
       pos: -22.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11505
     components:
     - type: Transform
@@ -74583,7 +74284,7 @@ entities:
       pos: -22.5,-14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11506
     components:
     - type: Transform
@@ -74591,7 +74292,7 @@ entities:
       pos: -22.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11507
     components:
     - type: Transform
@@ -74599,7 +74300,7 @@ entities:
       pos: -20.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11508
     components:
     - type: Transform
@@ -74607,7 +74308,7 @@ entities:
       pos: -17.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11509
     components:
     - type: Transform
@@ -74615,7 +74316,7 @@ entities:
       pos: -27.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11510
     components:
     - type: Transform
@@ -74623,7 +74324,7 @@ entities:
       pos: -29.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11511
     components:
     - type: Transform
@@ -74631,28 +74332,28 @@ entities:
       pos: -20.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11512
     components:
     - type: Transform
       pos: -28.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11513
     components:
     - type: Transform
       pos: -11.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11514
     components:
     - type: Transform
       pos: -28.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11515
     components:
     - type: Transform
@@ -74660,7 +74361,7 @@ entities:
       pos: -20.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11516
     components:
     - type: Transform
@@ -74668,7 +74369,7 @@ entities:
       pos: -18.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11517
     components:
     - type: Transform
@@ -74676,7 +74377,7 @@ entities:
       pos: -20.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11518
     components:
     - type: Transform
@@ -74684,14 +74385,14 @@ entities:
       pos: -22.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11519
     components:
     - type: Transform
       pos: -28.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11520
     components:
     - type: Transform
@@ -74699,7 +74400,7 @@ entities:
       pos: -20.5,-14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11521
     components:
     - type: Transform
@@ -74707,14 +74408,14 @@ entities:
       pos: -22.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11522
     components:
     - type: Transform
       pos: -13.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11523
     components:
     - type: Transform
@@ -74722,7 +74423,7 @@ entities:
       pos: -15.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11524
     components:
     - type: Transform
@@ -74730,14 +74431,14 @@ entities:
       pos: -24.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11525
     components:
     - type: Transform
       pos: -13.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11526
     components:
     - type: Transform
@@ -74745,7 +74446,7 @@ entities:
       pos: -21.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11527
     components:
     - type: Transform
@@ -74753,7 +74454,7 @@ entities:
       pos: -23.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11528
     components:
     - type: Transform
@@ -74761,7 +74462,7 @@ entities:
       pos: -20.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11529
     components:
     - type: Transform
@@ -74769,7 +74470,7 @@ entities:
       pos: -20.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11530
     components:
     - type: Transform
@@ -74777,7 +74478,7 @@ entities:
       pos: -20.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11531
     components:
     - type: Transform
@@ -74785,7 +74486,7 @@ entities:
       pos: -26.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11532
     components:
     - type: Transform
@@ -74793,7 +74494,7 @@ entities:
       pos: -25.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11533
     components:
     - type: Transform
@@ -74801,7 +74502,7 @@ entities:
       pos: -20.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11534
     components:
     - type: Transform
@@ -74809,7 +74510,7 @@ entities:
       pos: -21.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11535
     components:
     - type: Transform
@@ -74817,7 +74518,7 @@ entities:
       pos: -24.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11536
     components:
     - type: Transform
@@ -74825,7 +74526,7 @@ entities:
       pos: -22.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11537
     components:
     - type: Transform
@@ -74833,7 +74534,7 @@ entities:
       pos: -17.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11538
     components:
     - type: Transform
@@ -74841,7 +74542,7 @@ entities:
       pos: -14.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11539
     components:
     - type: Transform
@@ -74849,7 +74550,7 @@ entities:
       pos: -18.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11540
     components:
     - type: Transform
@@ -74857,21 +74558,21 @@ entities:
       pos: -12.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11541
     components:
     - type: Transform
       pos: -13.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11542
     components:
     - type: Transform
       pos: -13.5,-42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11543
     components:
     - type: Transform
@@ -74879,7 +74580,7 @@ entities:
       pos: -11.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11544
     components:
     - type: Transform
@@ -74893,7 +74594,7 @@ entities:
       pos: -33.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11546
     components:
     - type: Transform
@@ -75243,7 +74944,7 @@ entities:
       pos: 9.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11604
     components:
     - type: Transform
@@ -75251,7 +74952,7 @@ entities:
       pos: 11.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11605
     components:
     - type: Transform
@@ -75259,7 +74960,7 @@ entities:
       pos: 12.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11606
     components:
     - type: Transform
@@ -75267,7 +74968,7 @@ entities:
       pos: 14.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11607
     components:
     - type: Transform
@@ -75275,7 +74976,7 @@ entities:
       pos: 15.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11608
     components:
     - type: Transform
@@ -75283,7 +74984,7 @@ entities:
       pos: 16.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11609
     components:
     - type: Transform
@@ -75291,7 +74992,7 @@ entities:
       pos: 17.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11610
     components:
     - type: Transform
@@ -75299,7 +75000,7 @@ entities:
       pos: 18.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11611
     components:
     - type: Transform
@@ -75307,7 +75008,7 @@ entities:
       pos: 19.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11612
     components:
     - type: Transform
@@ -75315,7 +75016,7 @@ entities:
       pos: 14.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11613
     components:
     - type: Transform
@@ -75323,7 +75024,7 @@ entities:
       pos: 13.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11614
     components:
     - type: Transform
@@ -75331,7 +75032,7 @@ entities:
       pos: 13.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11615
     components:
     - type: Transform
@@ -75339,7 +75040,7 @@ entities:
       pos: 15.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11616
     components:
     - type: Transform
@@ -75347,7 +75048,7 @@ entities:
       pos: 12.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11617
     components:
     - type: Transform
@@ -75355,7 +75056,7 @@ entities:
       pos: 10.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11618
     components:
     - type: Transform
@@ -75363,7 +75064,7 @@ entities:
       pos: 9.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11619
     components:
     - type: Transform
@@ -75371,7 +75072,7 @@ entities:
       pos: -1.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11620
     components:
     - type: Transform
@@ -75379,7 +75080,7 @@ entities:
       pos: -0.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11621
     components:
     - type: Transform
@@ -75387,7 +75088,7 @@ entities:
       pos: 0.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11622
     components:
     - type: Transform
@@ -75395,7 +75096,7 @@ entities:
       pos: 1.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11623
     components:
     - type: Transform
@@ -75403,7 +75104,7 @@ entities:
       pos: 2.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11624
     components:
     - type: Transform
@@ -75411,7 +75112,7 @@ entities:
       pos: 3.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11625
     components:
     - type: Transform
@@ -75419,7 +75120,7 @@ entities:
       pos: 3.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11626
     components:
     - type: Transform
@@ -75427,7 +75128,7 @@ entities:
       pos: 3.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11627
     components:
     - type: Transform
@@ -75435,7 +75136,7 @@ entities:
       pos: 3.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11628
     components:
     - type: Transform
@@ -75443,7 +75144,7 @@ entities:
       pos: 4.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11629
     components:
     - type: Transform
@@ -75451,21 +75152,21 @@ entities:
       pos: 5.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11630
     components:
     - type: Transform
       pos: 7.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11631
     components:
     - type: Transform
       pos: 7.5,-25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11632
     components:
     - type: Transform
@@ -75473,14 +75174,14 @@ entities:
       pos: 8.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11633
     components:
     - type: Transform
       pos: 7.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11634
     components:
     - type: Transform
@@ -75488,7 +75189,7 @@ entities:
       pos: 5.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11635
     components:
     - type: Transform
@@ -75496,7 +75197,7 @@ entities:
       pos: 8.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11636
     components:
     - type: Transform
@@ -75504,7 +75205,7 @@ entities:
       pos: 9.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11637
     components:
     - type: Transform
@@ -75512,7 +75213,7 @@ entities:
       pos: 10.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11638
     components:
     - type: Transform
@@ -75520,7 +75221,7 @@ entities:
       pos: 11.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11639
     components:
     - type: Transform
@@ -75528,7 +75229,7 @@ entities:
       pos: 11.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11640
     components:
     - type: Transform
@@ -75536,7 +75237,7 @@ entities:
       pos: 11.5,-14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11641
     components:
     - type: Transform
@@ -75544,7 +75245,7 @@ entities:
       pos: 11.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11642
     components:
     - type: Transform
@@ -75552,7 +75253,7 @@ entities:
       pos: 11.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11643
     components:
     - type: Transform
@@ -75560,7 +75261,7 @@ entities:
       pos: 10.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11644
     components:
     - type: Transform
@@ -75568,7 +75269,7 @@ entities:
       pos: 9.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11645
     components:
     - type: Transform
@@ -75576,42 +75277,42 @@ entities:
       pos: 8.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11646
     components:
     - type: Transform
       pos: 7.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11647
     components:
     - type: Transform
       pos: 7.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11648
     components:
     - type: Transform
       pos: 7.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11649
     components:
     - type: Transform
       pos: 7.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11650
     components:
     - type: Transform
       pos: 7.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11651
     components:
     - type: Transform
@@ -75619,7 +75320,7 @@ entities:
       pos: 11.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11652
     components:
     - type: Transform
@@ -75627,7 +75328,7 @@ entities:
       pos: 11.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11653
     components:
     - type: Transform
@@ -75635,7 +75336,7 @@ entities:
       pos: 11.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11654
     components:
     - type: Transform
@@ -75643,7 +75344,7 @@ entities:
       pos: 11.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11655
     components:
     - type: Transform
@@ -75651,7 +75352,7 @@ entities:
       pos: 11.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11656
     components:
     - type: Transform
@@ -75659,7 +75360,7 @@ entities:
       pos: 11.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11657
     components:
     - type: Transform
@@ -75667,7 +75368,7 @@ entities:
       pos: 11.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11658
     components:
     - type: Transform
@@ -75675,7 +75376,7 @@ entities:
       pos: 11.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11659
     components:
     - type: Transform
@@ -75683,7 +75384,7 @@ entities:
       pos: 11.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11660
     components:
     - type: Transform
@@ -75691,7 +75392,7 @@ entities:
       pos: 11.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11661
     components:
     - type: Transform
@@ -75699,7 +75400,7 @@ entities:
       pos: 11.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11662
     components:
     - type: Transform
@@ -75707,7 +75408,7 @@ entities:
       pos: 11.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11663
     components:
     - type: Transform
@@ -75715,7 +75416,7 @@ entities:
       pos: 10.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11664
     components:
     - type: Transform
@@ -75723,7 +75424,7 @@ entities:
       pos: -0.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11665
     components:
     - type: Transform
@@ -75731,7 +75432,7 @@ entities:
       pos: 0.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11666
     components:
     - type: Transform
@@ -75739,7 +75440,7 @@ entities:
       pos: 1.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11667
     components:
     - type: Transform
@@ -75747,7 +75448,7 @@ entities:
       pos: 2.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11668
     components:
     - type: Transform
@@ -75755,7 +75456,7 @@ entities:
       pos: 3.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11669
     components:
     - type: Transform
@@ -75763,7 +75464,7 @@ entities:
       pos: 6.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11670
     components:
     - type: Transform
@@ -75771,7 +75472,7 @@ entities:
       pos: 7.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11671
     components:
     - type: Transform
@@ -75779,7 +75480,7 @@ entities:
       pos: 8.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11672
     components:
     - type: Transform
@@ -75787,7 +75488,7 @@ entities:
       pos: 5.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11673
     components:
     - type: Transform
@@ -75795,7 +75496,7 @@ entities:
       pos: 5.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11674
     components:
     - type: Transform
@@ -75803,7 +75504,7 @@ entities:
       pos: 5.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11675
     components:
     - type: Transform
@@ -75811,7 +75512,7 @@ entities:
       pos: 8.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11676
     components:
     - type: Transform
@@ -75819,7 +75520,7 @@ entities:
       pos: 5.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11677
     components:
     - type: Transform
@@ -75827,14 +75528,14 @@ entities:
       pos: 4.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11678
     components:
     - type: Transform
       pos: 7.5,-26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11679
     components:
     - type: Transform
@@ -75842,7 +75543,7 @@ entities:
       pos: 3.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11680
     components:
     - type: Transform
@@ -75850,14 +75551,14 @@ entities:
       pos: 5.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11681
     components:
     - type: Transform
       pos: 7.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11682
     components:
     - type: Transform
@@ -75865,7 +75566,7 @@ entities:
       pos: 6.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11683
     components:
     - type: Transform
@@ -75873,7 +75574,7 @@ entities:
       pos: 6.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11684
     components:
     - type: Transform
@@ -75881,7 +75582,7 @@ entities:
       pos: 8.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11685
     components:
     - type: Transform
@@ -75889,7 +75590,7 @@ entities:
       pos: 10.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11686
     components:
     - type: Transform
@@ -75897,7 +75598,7 @@ entities:
       pos: 11.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11687
     components:
     - type: Transform
@@ -75905,7 +75606,7 @@ entities:
       pos: 12.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11688
     components:
     - type: Transform
@@ -75913,7 +75614,7 @@ entities:
       pos: 13.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11689
     components:
     - type: Transform
@@ -75921,7 +75622,7 @@ entities:
       pos: 13.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11690
     components:
     - type: Transform
@@ -75929,7 +75630,7 @@ entities:
       pos: 13.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11691
     components:
     - type: Transform
@@ -75937,7 +75638,7 @@ entities:
       pos: 13.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11692
     components:
     - type: Transform
@@ -75945,7 +75646,7 @@ entities:
       pos: 13.5,-14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11693
     components:
     - type: Transform
@@ -75953,7 +75654,7 @@ entities:
       pos: 13.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11694
     components:
     - type: Transform
@@ -75961,7 +75662,7 @@ entities:
       pos: 13.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11695
     components:
     - type: Transform
@@ -75969,7 +75670,7 @@ entities:
       pos: 13.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11696
     components:
     - type: Transform
@@ -75977,7 +75678,7 @@ entities:
       pos: 13.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11697
     components:
     - type: Transform
@@ -75985,7 +75686,7 @@ entities:
       pos: 13.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11698
     components:
     - type: Transform
@@ -75993,7 +75694,7 @@ entities:
       pos: 13.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11699
     components:
     - type: Transform
@@ -76001,7 +75702,7 @@ entities:
       pos: 13.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11700
     components:
     - type: Transform
@@ -76009,7 +75710,7 @@ entities:
       pos: 13.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11701
     components:
     - type: Transform
@@ -76017,7 +75718,7 @@ entities:
       pos: 13.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11702
     components:
     - type: Transform
@@ -76025,7 +75726,7 @@ entities:
       pos: 13.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11703
     components:
     - type: Transform
@@ -76033,7 +75734,7 @@ entities:
       pos: 13.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11704
     components:
     - type: Transform
@@ -76041,7 +75742,7 @@ entities:
       pos: 13.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11705
     components:
     - type: Transform
@@ -76049,7 +75750,7 @@ entities:
       pos: 11.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11706
     components:
     - type: Transform
@@ -76057,7 +75758,7 @@ entities:
       pos: 12.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11707
     components:
     - type: Transform
@@ -76065,7 +75766,7 @@ entities:
       pos: 11.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11708
     components:
     - type: Transform
@@ -76073,7 +75774,7 @@ entities:
       pos: 10.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11709
     components:
     - type: Transform
@@ -76081,7 +75782,7 @@ entities:
       pos: 9.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11710
     components:
     - type: Transform
@@ -76089,7 +75790,7 @@ entities:
       pos: 9.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11711
     components:
     - type: Transform
@@ -76097,7 +75798,7 @@ entities:
       pos: 9.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11712
     components:
     - type: Transform
@@ -76105,7 +75806,7 @@ entities:
       pos: 9.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11713
     components:
     - type: Transform
@@ -76113,7 +75814,7 @@ entities:
       pos: 9.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11714
     components:
     - type: Transform
@@ -76121,7 +75822,7 @@ entities:
       pos: 9.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11715
     components:
     - type: Transform
@@ -76171,7 +75872,7 @@ entities:
       pos: -22.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11722
     components:
     - type: Transform
@@ -76179,7 +75880,7 @@ entities:
       pos: -29.5,-14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11723
     components:
     - type: Transform
@@ -76187,21 +75888,21 @@ entities:
       pos: -29.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11724
     components:
     - type: Transform
       pos: -13.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11725
     components:
     - type: Transform
       pos: -13.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11726
     components:
     - type: Transform
@@ -76209,7 +75910,7 @@ entities:
       pos: -14.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11727
     components:
     - type: Transform
@@ -76231,7 +75932,7 @@ entities:
       pos: 7.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11730
     components:
     - type: Transform
@@ -76255,63 +75956,63 @@ entities:
       pos: -49.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11733
     components:
     - type: Transform
       pos: -24.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11734
     components:
     - type: Transform
       pos: -24.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11735
     components:
     - type: Transform
       pos: -18.5,-49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11736
     components:
     - type: Transform
       pos: -18.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11737
     components:
     - type: Transform
       pos: -18.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11738
     components:
     - type: Transform
       pos: -12.5,-42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11739
     components:
     - type: Transform
       pos: -24.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11740
     components:
     - type: Transform
       pos: -22.5,-42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11741
     components:
     - type: Transform
@@ -76319,7 +76020,7 @@ entities:
       pos: -9.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11742
     components:
     - type: Transform
@@ -76327,35 +76028,35 @@ entities:
       pos: -14.5,-30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11743
     components:
     - type: Transform
       pos: -13.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11744
     components:
     - type: Transform
       pos: -13.5,-37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11745
     components:
     - type: Transform
       pos: -13.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11746
     components:
     - type: Transform
       pos: -22.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11747
     components:
     - type: Transform
@@ -76363,7 +76064,7 @@ entities:
       pos: -19.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11748
     components:
     - type: Transform
@@ -76371,7 +76072,7 @@ entities:
       pos: -20.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11749
     components:
     - type: Transform
@@ -76379,7 +76080,7 @@ entities:
       pos: -6.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11750
     components:
     - type: Transform
@@ -76387,7 +76088,7 @@ entities:
       pos: -7.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11751
     components:
     - type: Transform
@@ -76395,21 +76096,21 @@ entities:
       pos: -8.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11752
     components:
     - type: Transform
       pos: 2.5,-37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11753
     components:
     - type: Transform
       pos: 2.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11754
     components:
     - type: Transform
@@ -76417,7 +76118,7 @@ entities:
       pos: 1.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11755
     components:
     - type: Transform
@@ -76425,7 +76126,7 @@ entities:
       pos: -29.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11756
     components:
     - type: Transform
@@ -76441,7 +76142,7 @@ entities:
       pos: -23.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11758
     components:
     - type: Transform
@@ -76449,7 +76150,7 @@ entities:
       pos: -24.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11759
     components:
     - type: Transform
@@ -76457,7 +76158,7 @@ entities:
       pos: -24.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11760
     components:
     - type: Transform
@@ -76473,7 +76174,7 @@ entities:
       pos: 3.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11762
     components:
     - type: Transform
@@ -76481,7 +76182,7 @@ entities:
       pos: 2.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11763
     components:
     - type: Transform
@@ -76489,7 +76190,7 @@ entities:
       pos: 1.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11764
     components:
     - type: Transform
@@ -76497,7 +76198,7 @@ entities:
       pos: 0.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11765
     components:
     - type: Transform
@@ -76505,7 +76206,7 @@ entities:
       pos: -0.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11766
     components:
     - type: Transform
@@ -76513,7 +76214,7 @@ entities:
       pos: -1.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11767
     components:
     - type: Transform
@@ -76521,70 +76222,70 @@ entities:
       pos: -2.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11768
     components:
     - type: Transform
       pos: -3.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11769
     components:
     - type: Transform
       pos: -3.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11770
     components:
     - type: Transform
       pos: -3.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11771
     components:
     - type: Transform
       pos: -3.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11772
     components:
     - type: Transform
       pos: -3.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11773
     components:
     - type: Transform
       pos: -3.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11774
     components:
     - type: Transform
       pos: -3.5,-25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11775
     components:
     - type: Transform
       pos: -3.5,-26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11776
     components:
     - type: Transform
       pos: -3.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11777
     components:
     - type: Transform
@@ -76592,7 +76293,7 @@ entities:
       pos: -2.5,-30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11778
     components:
     - type: Transform
@@ -76600,7 +76301,7 @@ entities:
       pos: -1.5,-30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11779
     components:
     - type: Transform
@@ -76608,7 +76309,7 @@ entities:
       pos: -0.5,-30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11780
     components:
     - type: Transform
@@ -76616,7 +76317,7 @@ entities:
       pos: -1.5,-25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11781
     components:
     - type: Transform
@@ -76624,7 +76325,7 @@ entities:
       pos: -1.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11782
     components:
     - type: Transform
@@ -76632,7 +76333,7 @@ entities:
       pos: -1.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11783
     components:
     - type: Transform
@@ -76640,7 +76341,7 @@ entities:
       pos: -1.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11784
     components:
     - type: Transform
@@ -76648,7 +76349,7 @@ entities:
       pos: -1.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11785
     components:
     - type: Transform
@@ -76656,7 +76357,7 @@ entities:
       pos: -0.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11786
     components:
     - type: Transform
@@ -76664,7 +76365,7 @@ entities:
       pos: 0.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11787
     components:
     - type: Transform
@@ -76672,7 +76373,7 @@ entities:
       pos: 1.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11788
     components:
     - type: Transform
@@ -76680,7 +76381,7 @@ entities:
       pos: 3.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11789
     components:
     - type: Transform
@@ -76688,7 +76389,7 @@ entities:
       pos: 4.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11790
     components:
     - type: Transform
@@ -76696,7 +76397,7 @@ entities:
       pos: -0.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11791
     components:
     - type: Transform
@@ -76704,7 +76405,7 @@ entities:
       pos: 0.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11792
     components:
     - type: Transform
@@ -76712,98 +76413,98 @@ entities:
       pos: 1.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11793
     components:
     - type: Transform
       pos: 2.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11794
     components:
     - type: Transform
       pos: 2.5,-29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11795
     components:
     - type: Transform
       pos: 2.5,-30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11796
     components:
     - type: Transform
       pos: 2.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11797
     components:
     - type: Transform
       pos: 0.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11798
     components:
     - type: Transform
       pos: 0.5,-32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11799
     components:
     - type: Transform
       pos: 0.5,-33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11800
     components:
     - type: Transform
       pos: 0.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11801
     components:
     - type: Transform
       pos: 0.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11802
     components:
     - type: Transform
       pos: 2.5,-33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11803
     components:
     - type: Transform
       pos: 2.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11804
     components:
     - type: Transform
       pos: 2.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11805
     components:
     - type: Transform
       pos: 2.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11806
     components:
     - type: Transform
@@ -76819,7 +76520,7 @@ entities:
       pos: 2.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11808
     components:
     - type: Transform
@@ -76827,7 +76528,7 @@ entities:
       pos: 2.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11809
     components:
     - type: Transform
@@ -76835,7 +76536,7 @@ entities:
       pos: 2.5,-42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11810
     components:
     - type: Transform
@@ -76843,7 +76544,7 @@ entities:
       pos: -8.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11811
     components:
     - type: Transform
@@ -76851,7 +76552,7 @@ entities:
       pos: -54.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11812
     components:
     - type: Transform
@@ -76866,7 +76567,7 @@ entities:
       pos: -34.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11814
     components:
     - type: Transform
@@ -76874,7 +76575,7 @@ entities:
       pos: -23.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11815
     components:
     - type: Transform
@@ -76882,7 +76583,7 @@ entities:
       pos: -23.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11816
     components:
     - type: Transform
@@ -76890,7 +76591,7 @@ entities:
       pos: -24.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11817
     components:
     - type: Transform
@@ -76898,14 +76599,14 @@ entities:
       pos: -18.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11818
     components:
     - type: Transform
       pos: -22.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11819
     components:
     - type: Transform
@@ -76913,7 +76614,7 @@ entities:
       pos: -0.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11820
     components:
     - type: Transform
@@ -76921,7 +76622,7 @@ entities:
       pos: -15.5,-29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11821
     components:
     - type: Transform
@@ -76929,7 +76630,7 @@ entities:
       pos: -10.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11822
     components:
     - type: Transform
@@ -76937,7 +76638,7 @@ entities:
       pos: -9.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11823
     components:
     - type: Transform
@@ -76945,7 +76646,7 @@ entities:
       pos: -4.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11824
     components:
     - type: Transform
@@ -76953,7 +76654,7 @@ entities:
       pos: -3.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11825
     components:
     - type: Transform
@@ -76961,7 +76662,7 @@ entities:
       pos: -5.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11826
     components:
     - type: Transform
@@ -76969,14 +76670,14 @@ entities:
       pos: -13.5,-29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11827
     components:
     - type: Transform
       pos: -11.5,-30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11828
     components:
     - type: Transform
@@ -76984,28 +76685,28 @@ entities:
       pos: -12.5,-29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11829
     components:
     - type: Transform
       pos: -11.5,-32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11830
     components:
     - type: Transform
       pos: -11.5,-33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11831
     components:
     - type: Transform
       pos: -11.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11832
     components:
     - type: Transform
@@ -77013,7 +76714,7 @@ entities:
       pos: -1.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11833
     components:
     - type: Transform
@@ -77028,63 +76729,63 @@ entities:
       pos: -22.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11835
     components:
     - type: Transform
       pos: 5.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11836
     components:
     - type: Transform
       pos: 5.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11837
     components:
     - type: Transform
       pos: -16.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11838
     components:
     - type: Transform
       pos: -11.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11839
     components:
     - type: Transform
       pos: -11.5,-37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11840
     components:
     - type: Transform
       pos: -11.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11841
     components:
     - type: Transform
       pos: 5.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11842
     components:
     - type: Transform
       pos: -18.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11843
     components:
     - type: Transform
@@ -77107,7 +76808,7 @@ entities:
       pos: 0.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11846
     components:
     - type: Transform
@@ -77115,7 +76816,7 @@ entities:
       pos: -2.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11847
     components:
     - type: Transform
@@ -77123,7 +76824,7 @@ entities:
       pos: -22.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11848
     components:
     - type: Transform
@@ -77131,7 +76832,7 @@ entities:
       pos: -14.5,-29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11849
     components:
     - type: Transform
@@ -77139,42 +76840,42 @@ entities:
       pos: 0.5,-37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11850
     components:
     - type: Transform
       pos: -16.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11851
     components:
     - type: Transform
       pos: -16.5,-47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11852
     components:
     - type: Transform
       pos: -16.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11853
     components:
     - type: Transform
       pos: -16.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11854
     components:
     - type: Transform
       pos: -18.5,-50.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11855
     components:
     - type: Transform
@@ -77196,7 +76897,7 @@ entities:
       pos: -2.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11858
     components:
     - type: Transform
@@ -77204,7 +76905,7 @@ entities:
       pos: -9.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11859
     components:
     - type: Transform
@@ -77212,7 +76913,7 @@ entities:
       pos: -19.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11860
     components:
     - type: Transform
@@ -77220,7 +76921,7 @@ entities:
       pos: -14.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11861
     components:
     - type: Transform
@@ -77228,35 +76929,35 @@ entities:
       pos: -17.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11862
     components:
     - type: Transform
       pos: -12.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11863
     components:
     - type: Transform
       pos: -13.5,-32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11864
     components:
     - type: Transform
       pos: -12.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11865
     components:
     - type: Transform
       pos: -12.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11866
     components:
     - type: Transform
@@ -77264,7 +76965,7 @@ entities:
       pos: -12.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11867
     components:
     - type: Transform
@@ -77272,7 +76973,7 @@ entities:
       pos: -10.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11868
     components:
     - type: Transform
@@ -77280,28 +76981,28 @@ entities:
       pos: -11.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11869
     components:
     - type: Transform
       pos: -18.5,-51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11870
     components:
     - type: Transform
       pos: -16.5,-51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11871
     components:
     - type: Transform
       pos: -16.5,-50.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11872
     components:
     - type: Transform
@@ -77309,7 +77010,7 @@ entities:
       pos: -0.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11873
     components:
     - type: Transform
@@ -77317,7 +77018,7 @@ entities:
       pos: 0.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11874
     components:
     - type: Transform
@@ -77325,7 +77026,7 @@ entities:
       pos: -4.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11875
     components:
     - type: Transform
@@ -77333,7 +77034,7 @@ entities:
       pos: -13.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11876
     components:
     - type: Transform
@@ -77341,7 +77042,7 @@ entities:
       pos: -15.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11877
     components:
     - type: Transform
@@ -77349,35 +77050,35 @@ entities:
       pos: -16.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11878
     components:
     - type: Transform
       pos: -12.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11879
     components:
     - type: Transform
       pos: -13.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11880
     components:
     - type: Transform
       pos: -12.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11881
     components:
     - type: Transform
       pos: -11.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11882
     components:
     - type: Transform
@@ -77385,7 +77086,7 @@ entities:
       pos: -21.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11883
     components:
     - type: Transform
@@ -77393,7 +77094,7 @@ entities:
       pos: -20.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11884
     components:
     - type: Transform
@@ -77409,7 +77110,7 @@ entities:
       pos: -3.5,-29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11886
     components:
     - type: Transform
@@ -77417,7 +77118,7 @@ entities:
       pos: -3.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11887
     components:
     - type: Transform
@@ -77425,7 +77126,7 @@ entities:
       pos: -10.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11888
     components:
     - type: Transform
@@ -77433,14 +77134,14 @@ entities:
       pos: 0.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11889
     components:
     - type: Transform
       pos: -13.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11890
     components:
     - type: Transform
@@ -77448,7 +77149,7 @@ entities:
       pos: -7.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11891
     components:
     - type: Transform
@@ -77456,7 +77157,7 @@ entities:
       pos: -6.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11892
     components:
     - type: Transform
@@ -77464,7 +77165,7 @@ entities:
       pos: -8.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11893
     components:
     - type: Transform
@@ -77487,21 +77188,21 @@ entities:
       pos: 2.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11896
     components:
     - type: Transform
       pos: -16.5,-49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11897
     components:
     - type: Transform
       pos: -8.5,-37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11898
     components:
     - type: Transform
@@ -77509,7 +77210,7 @@ entities:
       pos: -10.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11899
     components:
     - type: Transform
@@ -77517,7 +77218,7 @@ entities:
       pos: -9.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11900
     components:
     - type: Transform
@@ -77533,7 +77234,7 @@ entities:
       pos: -1.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11902
     components:
     - type: Transform
@@ -77541,7 +77242,7 @@ entities:
       pos: 2.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11903
     components:
     - type: Transform
@@ -77549,14 +77250,14 @@ entities:
       pos: -1.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11904
     components:
     - type: Transform
       pos: -6.5,-37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11905
     components:
     - type: Transform
@@ -77580,7 +77281,7 @@ entities:
       pos: 10.5,-25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11908
     components:
     - type: Transform
@@ -77588,7 +77289,7 @@ entities:
       pos: 10.5,-26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11909
     components:
     - type: Transform
@@ -77596,7 +77297,7 @@ entities:
       pos: 10.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11910
     components:
     - type: Transform
@@ -77604,7 +77305,7 @@ entities:
       pos: 11.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11911
     components:
     - type: Transform
@@ -77612,7 +77313,7 @@ entities:
       pos: 11.5,-25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11912
     components:
     - type: Transform
@@ -77620,7 +77321,7 @@ entities:
       pos: 11.5,-26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11913
     components:
     - type: Transform
@@ -77628,7 +77329,7 @@ entities:
       pos: 11.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11914
     components:
     - type: Transform
@@ -77636,7 +77337,7 @@ entities:
       pos: 9.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11915
     components:
     - type: Transform
@@ -77644,7 +77345,7 @@ entities:
       pos: 9.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11916
     components:
     - type: Transform
@@ -77652,7 +77353,7 @@ entities:
       pos: 9.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11917
     components:
     - type: Transform
@@ -77660,7 +77361,7 @@ entities:
       pos: 9.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11918
     components:
     - type: Transform
@@ -77668,7 +77369,7 @@ entities:
       pos: 7.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11919
     components:
     - type: Transform
@@ -77676,7 +77377,7 @@ entities:
       pos: 7.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11920
     components:
     - type: Transform
@@ -77684,7 +77385,7 @@ entities:
       pos: 20.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11921
     components:
     - type: Transform
@@ -77692,7 +77393,7 @@ entities:
       pos: 29.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11922
     components:
     - type: Transform
@@ -77700,7 +77401,7 @@ entities:
       pos: 28.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11923
     components:
     - type: Transform
@@ -77708,7 +77409,7 @@ entities:
       pos: 34.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11924
     components:
     - type: Transform
@@ -77716,7 +77417,7 @@ entities:
       pos: 26.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11925
     components:
     - type: Transform
@@ -77724,7 +77425,7 @@ entities:
       pos: 30.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11926
     components:
     - type: Transform
@@ -77732,7 +77433,7 @@ entities:
       pos: 27.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11927
     components:
     - type: Transform
@@ -77740,28 +77441,28 @@ entities:
       pos: 25.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11928
     components:
     - type: Transform
       pos: -16.5,-42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11929
     components:
     - type: Transform
       pos: 33.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11930
     components:
     - type: Transform
       pos: 29.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11931
     components:
     - type: Transform
@@ -77769,7 +77470,7 @@ entities:
       pos: 27.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11932
     components:
     - type: Transform
@@ -77777,7 +77478,7 @@ entities:
       pos: 28.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11933
     components:
     - type: Transform
@@ -77785,7 +77486,7 @@ entities:
       pos: 29.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11934
     components:
     - type: Transform
@@ -77793,7 +77494,7 @@ entities:
       pos: 30.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11935
     components:
     - type: Transform
@@ -77801,7 +77502,7 @@ entities:
       pos: 35.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11936
     components:
     - type: Transform
@@ -77809,7 +77510,7 @@ entities:
       pos: 28.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11937
     components:
     - type: Transform
@@ -77817,14 +77518,14 @@ entities:
       pos: 34.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11938
     components:
     - type: Transform
       pos: 21.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11939
     components:
     - type: Transform
@@ -77832,14 +77533,14 @@ entities:
       pos: 22.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11940
     components:
     - type: Transform
       pos: 29.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11941
     components:
     - type: Transform
@@ -77847,7 +77548,7 @@ entities:
       pos: 12.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11942
     components:
     - type: Transform
@@ -77855,7 +77556,7 @@ entities:
       pos: 13.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11943
     components:
     - type: Transform
@@ -77863,7 +77564,7 @@ entities:
       pos: 14.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11944
     components:
     - type: Transform
@@ -77871,7 +77572,7 @@ entities:
       pos: 26.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11945
     components:
     - type: Transform
@@ -77879,7 +77580,7 @@ entities:
       pos: 15.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11946
     components:
     - type: Transform
@@ -77887,7 +77588,7 @@ entities:
       pos: 17.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11947
     components:
     - type: Transform
@@ -77895,7 +77596,7 @@ entities:
       pos: 18.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11948
     components:
     - type: Transform
@@ -77903,7 +77604,7 @@ entities:
       pos: 20.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11949
     components:
     - type: Transform
@@ -77911,7 +77612,7 @@ entities:
       pos: 14.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11950
     components:
     - type: Transform
@@ -77919,7 +77620,7 @@ entities:
       pos: 15.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11951
     components:
     - type: Transform
@@ -77927,7 +77628,7 @@ entities:
       pos: 16.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11952
     components:
     - type: Transform
@@ -77935,7 +77636,7 @@ entities:
       pos: 29.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11953
     components:
     - type: Transform
@@ -77943,7 +77644,7 @@ entities:
       pos: 18.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11954
     components:
     - type: Transform
@@ -77951,7 +77652,7 @@ entities:
       pos: 19.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11955
     components:
     - type: Transform
@@ -77959,7 +77660,7 @@ entities:
       pos: 22.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11956
     components:
     - type: Transform
@@ -77967,7 +77668,7 @@ entities:
       pos: 21.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11957
     components:
     - type: Transform
@@ -77975,7 +77676,7 @@ entities:
       pos: 22.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11958
     components:
     - type: Transform
@@ -77983,7 +77684,7 @@ entities:
       pos: 23.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11959
     components:
     - type: Transform
@@ -77991,14 +77692,14 @@ entities:
       pos: 23.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11960
     components:
     - type: Transform
       pos: 29.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11961
     components:
     - type: Transform
@@ -78006,7 +77707,7 @@ entities:
       pos: 26.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11962
     components:
     - type: Transform
@@ -78014,7 +77715,7 @@ entities:
       pos: 35.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11963
     components:
     - type: Transform
@@ -78022,7 +77723,7 @@ entities:
       pos: 27.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11964
     components:
     - type: Transform
@@ -78030,7 +77731,7 @@ entities:
       pos: 22.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11965
     components:
     - type: Transform
@@ -78038,42 +77739,42 @@ entities:
       pos: 23.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11966
     components:
     - type: Transform
       pos: 21.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11967
     components:
     - type: Transform
       pos: 21.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11968
     components:
     - type: Transform
       pos: 21.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11969
     components:
     - type: Transform
       pos: 21.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11970
     components:
     - type: Transform
       pos: 20.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11971
     components:
     - type: Transform
@@ -78081,7 +77782,7 @@ entities:
       pos: 14.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11972
     components:
     - type: Transform
@@ -78089,7 +77790,7 @@ entities:
       pos: 15.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11973
     components:
     - type: Transform
@@ -78097,7 +77798,7 @@ entities:
       pos: 16.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11974
     components:
     - type: Transform
@@ -78105,7 +77806,7 @@ entities:
       pos: 17.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11975
     components:
     - type: Transform
@@ -78113,7 +77814,7 @@ entities:
       pos: 18.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11976
     components:
     - type: Transform
@@ -78121,7 +77822,7 @@ entities:
       pos: 19.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11977
     components:
     - type: Transform
@@ -78129,7 +77830,7 @@ entities:
       pos: 12.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11978
     components:
     - type: Transform
@@ -78137,7 +77838,7 @@ entities:
       pos: 13.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11979
     components:
     - type: Transform
@@ -78145,7 +77846,7 @@ entities:
       pos: 15.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11980
     components:
     - type: Transform
@@ -78153,7 +77854,7 @@ entities:
       pos: 14.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11981
     components:
     - type: Transform
@@ -78161,7 +77862,7 @@ entities:
       pos: 16.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11982
     components:
     - type: Transform
@@ -78169,7 +77870,7 @@ entities:
       pos: 17.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11983
     components:
     - type: Transform
@@ -78177,7 +77878,7 @@ entities:
       pos: 18.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11984
     components:
     - type: Transform
@@ -78185,7 +77886,7 @@ entities:
       pos: 19.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11985
     components:
     - type: Transform
@@ -78193,77 +77894,77 @@ entities:
       pos: 20.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11986
     components:
     - type: Transform
       pos: 21.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11987
     components:
     - type: Transform
       pos: 21.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11988
     components:
     - type: Transform
       pos: 21.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11989
     components:
     - type: Transform
       pos: 21.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11990
     components:
     - type: Transform
       pos: 21.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11991
     components:
     - type: Transform
       pos: 20.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11992
     components:
     - type: Transform
       pos: 20.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11993
     components:
     - type: Transform
       pos: 20.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11994
     components:
     - type: Transform
       pos: 20.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11995
     components:
     - type: Transform
       pos: 20.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11996
     components:
     - type: Transform
@@ -78271,7 +77972,7 @@ entities:
       pos: 20.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11997
     components:
     - type: Transform
@@ -78279,7 +77980,7 @@ entities:
       pos: 19.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 11998
     components:
     - type: Transform
@@ -78287,7 +77988,7 @@ entities:
       pos: 21.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 11999
     components:
     - type: Transform
@@ -78295,7 +77996,7 @@ entities:
       pos: 23.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12000
     components:
     - type: Transform
@@ -78303,7 +78004,7 @@ entities:
       pos: 27.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12001
     components:
     - type: Transform
@@ -78311,7 +78012,7 @@ entities:
       pos: 26.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12002
     components:
     - type: Transform
@@ -78319,7 +78020,7 @@ entities:
       pos: 28.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12003
     components:
     - type: Transform
@@ -78327,7 +78028,7 @@ entities:
       pos: 31.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12004
     components:
     - type: Transform
@@ -78335,7 +78036,7 @@ entities:
       pos: 25.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12005
     components:
     - type: Transform
@@ -78343,7 +78044,7 @@ entities:
       pos: 30.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12006
     components:
     - type: Transform
@@ -78351,7 +78052,7 @@ entities:
       pos: 30.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12007
     components:
     - type: Transform
@@ -78359,7 +78060,7 @@ entities:
       pos: 30.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12008
     components:
     - type: Transform
@@ -78367,7 +78068,7 @@ entities:
       pos: 25.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12009
     components:
     - type: Transform
@@ -78375,7 +78076,7 @@ entities:
       pos: 25.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12010
     components:
     - type: Transform
@@ -78383,14 +78084,14 @@ entities:
       pos: 31.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12011
     components:
     - type: Transform
       pos: 29.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12012
     components:
     - type: Transform
@@ -78398,7 +78099,7 @@ entities:
       pos: 26.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12013
     components:
     - type: Transform
@@ -78406,7 +78107,7 @@ entities:
       pos: 26.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12014
     components:
     - type: Transform
@@ -78414,7 +78115,7 @@ entities:
       pos: 36.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12015
     components:
     - type: Transform
@@ -78422,7 +78123,7 @@ entities:
       pos: 26.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12016
     components:
     - type: Transform
@@ -78430,7 +78131,7 @@ entities:
       pos: 26.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12017
     components:
     - type: Transform
@@ -78438,7 +78139,7 @@ entities:
       pos: 29.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12018
     components:
     - type: Transform
@@ -78446,7 +78147,7 @@ entities:
       pos: 29.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12019
     components:
     - type: Transform
@@ -78454,7 +78155,7 @@ entities:
       pos: 29.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12020
     components:
     - type: Transform
@@ -78462,7 +78163,7 @@ entities:
       pos: 32.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12021
     components:
     - type: Transform
@@ -78470,7 +78171,7 @@ entities:
       pos: 34.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12022
     components:
     - type: Transform
@@ -78478,7 +78179,7 @@ entities:
       pos: 36.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12023
     components:
     - type: Transform
@@ -78486,7 +78187,7 @@ entities:
       pos: 7.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12024
     components:
     - type: Transform
@@ -78494,7 +78195,7 @@ entities:
       pos: 34.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12025
     components:
     - type: Transform
@@ -78502,7 +78203,7 @@ entities:
       pos: 31.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12026
     components:
     - type: Transform
@@ -78510,7 +78211,7 @@ entities:
       pos: 34.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12027
     components:
     - type: Transform
@@ -78518,63 +78219,63 @@ entities:
       pos: 32.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12028
     components:
     - type: Transform
       pos: 10.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12029
     components:
     - type: Transform
       pos: 10.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12030
     components:
     - type: Transform
       pos: 10.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12031
     components:
     - type: Transform
       pos: 10.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12032
     components:
     - type: Transform
       pos: 10.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12033
     components:
     - type: Transform
       pos: 10.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12034
     components:
     - type: Transform
       pos: 8.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12035
     components:
     - type: Transform
       pos: 8.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12036
     components:
     - type: Transform
@@ -78582,7 +78283,7 @@ entities:
       pos: 8.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12037
     components:
     - type: Transform
@@ -78590,7 +78291,7 @@ entities:
       pos: 10.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12038
     components:
     - type: Transform
@@ -78598,7 +78299,7 @@ entities:
       pos: 8.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12039
     components:
     - type: Transform
@@ -78606,7 +78307,7 @@ entities:
       pos: 8.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12040
     components:
     - type: Transform
@@ -78614,7 +78315,7 @@ entities:
       pos: 8.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12041
     components:
     - type: Transform
@@ -78622,7 +78323,7 @@ entities:
       pos: 8.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12042
     components:
     - type: Transform
@@ -78630,7 +78331,7 @@ entities:
       pos: 8.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12043
     components:
     - type: Transform
@@ -78638,7 +78339,7 @@ entities:
       pos: 8.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12044
     components:
     - type: Transform
@@ -78646,7 +78347,7 @@ entities:
       pos: 8.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12045
     components:
     - type: Transform
@@ -78654,7 +78355,7 @@ entities:
       pos: 10.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12046
     components:
     - type: Transform
@@ -78662,7 +78363,7 @@ entities:
       pos: 10.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12047
     components:
     - type: Transform
@@ -78670,7 +78371,7 @@ entities:
       pos: 10.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12048
     components:
     - type: Transform
@@ -78678,7 +78379,7 @@ entities:
       pos: 10.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12049
     components:
     - type: Transform
@@ -78686,7 +78387,7 @@ entities:
       pos: 10.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12050
     components:
     - type: Transform
@@ -78694,7 +78395,7 @@ entities:
       pos: 9.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12051
     components:
     - type: Transform
@@ -78702,7 +78403,7 @@ entities:
       pos: 9.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12052
     components:
     - type: Transform
@@ -78710,7 +78411,7 @@ entities:
       pos: 10.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12053
     components:
     - type: Transform
@@ -78718,7 +78419,7 @@ entities:
       pos: 11.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12054
     components:
     - type: Transform
@@ -78726,7 +78427,7 @@ entities:
       pos: 12.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12055
     components:
     - type: Transform
@@ -78734,7 +78435,7 @@ entities:
       pos: 13.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12056
     components:
     - type: Transform
@@ -78742,7 +78443,7 @@ entities:
       pos: 14.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12057
     components:
     - type: Transform
@@ -78750,7 +78451,7 @@ entities:
       pos: 15.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12058
     components:
     - type: Transform
@@ -78758,7 +78459,7 @@ entities:
       pos: 17.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12059
     components:
     - type: Transform
@@ -78766,7 +78467,7 @@ entities:
       pos: 19.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12060
     components:
     - type: Transform
@@ -78774,7 +78475,7 @@ entities:
       pos: 20.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12061
     components:
     - type: Transform
@@ -78782,7 +78483,7 @@ entities:
       pos: 18.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12062
     components:
     - type: Transform
@@ -78790,7 +78491,7 @@ entities:
       pos: 21.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12063
     components:
     - type: Transform
@@ -78798,7 +78499,7 @@ entities:
       pos: 21.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12064
     components:
     - type: Transform
@@ -78806,7 +78507,7 @@ entities:
       pos: 21.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12065
     components:
     - type: Transform
@@ -78814,7 +78515,7 @@ entities:
       pos: 21.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12066
     components:
     - type: Transform
@@ -78822,7 +78523,7 @@ entities:
       pos: 21.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12067
     components:
     - type: Transform
@@ -78830,7 +78531,7 @@ entities:
       pos: 11.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12068
     components:
     - type: Transform
@@ -78838,7 +78539,7 @@ entities:
       pos: 12.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12069
     components:
     - type: Transform
@@ -78846,7 +78547,7 @@ entities:
       pos: 13.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12070
     components:
     - type: Transform
@@ -78854,7 +78555,7 @@ entities:
       pos: 14.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12071
     components:
     - type: Transform
@@ -78862,7 +78563,7 @@ entities:
       pos: 15.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12072
     components:
     - type: Transform
@@ -78870,7 +78571,7 @@ entities:
       pos: 16.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12073
     components:
     - type: Transform
@@ -78878,7 +78579,7 @@ entities:
       pos: 17.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12074
     components:
     - type: Transform
@@ -78886,7 +78587,7 @@ entities:
       pos: 19.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12075
     components:
     - type: Transform
@@ -78894,7 +78595,7 @@ entities:
       pos: 20.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12076
     components:
     - type: Transform
@@ -78902,7 +78603,7 @@ entities:
       pos: 21.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12077
     components:
     - type: Transform
@@ -78910,7 +78611,7 @@ entities:
       pos: 22.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12078
     components:
     - type: Transform
@@ -78918,7 +78619,7 @@ entities:
       pos: 23.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12079
     components:
     - type: Transform
@@ -78926,7 +78627,7 @@ entities:
       pos: 23.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12080
     components:
     - type: Transform
@@ -78934,7 +78635,7 @@ entities:
       pos: 23.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12081
     components:
     - type: Transform
@@ -78942,7 +78643,7 @@ entities:
       pos: 23.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12082
     components:
     - type: Transform
@@ -78950,7 +78651,7 @@ entities:
       pos: 23.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12083
     components:
     - type: Transform
@@ -78958,7 +78659,7 @@ entities:
       pos: 23.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12084
     components:
     - type: Transform
@@ -78966,7 +78667,7 @@ entities:
       pos: 23.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12085
     components:
     - type: Transform
@@ -78974,7 +78675,7 @@ entities:
       pos: 21.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12086
     components:
     - type: Transform
@@ -78982,7 +78683,7 @@ entities:
       pos: 21.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12087
     components:
     - type: Transform
@@ -78990,7 +78691,7 @@ entities:
       pos: 21.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12088
     components:
     - type: Transform
@@ -78998,7 +78699,7 @@ entities:
       pos: 21.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12089
     components:
     - type: Transform
@@ -79006,7 +78707,7 @@ entities:
       pos: 23.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12090
     components:
     - type: Transform
@@ -79014,7 +78715,7 @@ entities:
       pos: 23.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12091
     components:
     - type: Transform
@@ -79022,7 +78723,7 @@ entities:
       pos: 21.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12092
     components:
     - type: Transform
@@ -79030,7 +78731,7 @@ entities:
       pos: 21.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12093
     components:
     - type: Transform
@@ -79038,7 +78739,7 @@ entities:
       pos: 21.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12094
     components:
     - type: Transform
@@ -79046,7 +78747,7 @@ entities:
       pos: 20.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12095
     components:
     - type: Transform
@@ -79054,7 +78755,7 @@ entities:
       pos: 20.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12096
     components:
     - type: Transform
@@ -79062,7 +78763,7 @@ entities:
       pos: 21.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12097
     components:
     - type: Transform
@@ -79070,14 +78771,14 @@ entities:
       pos: 22.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12098
     components:
     - type: Transform
       pos: 23.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12099
     components:
     - type: Transform
@@ -79085,7 +78786,7 @@ entities:
       pos: 22.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12100
     components:
     - type: Transform
@@ -79093,7 +78794,7 @@ entities:
       pos: 21.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12101
     components:
     - type: Transform
@@ -79101,7 +78802,7 @@ entities:
       pos: 20.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12102
     components:
     - type: Transform
@@ -79109,7 +78810,7 @@ entities:
       pos: 19.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12103
     components:
     - type: Transform
@@ -79117,7 +78818,7 @@ entities:
       pos: 20.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12104
     components:
     - type: Transform
@@ -79125,7 +78826,7 @@ entities:
       pos: 19.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12105
     components:
     - type: Transform
@@ -79133,7 +78834,7 @@ entities:
       pos: 20.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12106
     components:
     - type: Transform
@@ -79141,7 +78842,7 @@ entities:
       pos: 19.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12107
     components:
     - type: Transform
@@ -79149,7 +78850,7 @@ entities:
       pos: 22.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12108
     components:
     - type: Transform
@@ -79157,7 +78858,7 @@ entities:
       pos: 21.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12109
     components:
     - type: Transform
@@ -79165,7 +78866,7 @@ entities:
       pos: 20.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12110
     components:
     - type: Transform
@@ -79173,7 +78874,7 @@ entities:
       pos: 19.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12111
     components:
     - type: Transform
@@ -79181,7 +78882,7 @@ entities:
       pos: 20.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12112
     components:
     - type: Transform
@@ -79189,7 +78890,7 @@ entities:
       pos: 19.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12113
     components:
     - type: Transform
@@ -79197,7 +78898,7 @@ entities:
       pos: 19.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12114
     components:
     - type: Transform
@@ -79205,14 +78906,14 @@ entities:
       pos: 24.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12115
     components:
     - type: Transform
       pos: 25.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12116
     components:
     - type: Transform
@@ -79220,7 +78921,7 @@ entities:
       pos: 26.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12117
     components:
     - type: Transform
@@ -79228,7 +78929,7 @@ entities:
       pos: 26.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12118
     components:
     - type: Transform
@@ -79236,7 +78937,7 @@ entities:
       pos: 27.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12119
     components:
     - type: Transform
@@ -79244,7 +78945,7 @@ entities:
       pos: 28.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12120
     components:
     - type: Transform
@@ -79252,7 +78953,7 @@ entities:
       pos: 29.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12121
     components:
     - type: Transform
@@ -79260,7 +78961,7 @@ entities:
       pos: 30.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12122
     components:
     - type: Transform
@@ -79268,7 +78969,7 @@ entities:
       pos: 22.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12123
     components:
     - type: Transform
@@ -79276,7 +78977,7 @@ entities:
       pos: 23.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12124
     components:
     - type: Transform
@@ -79284,7 +78985,7 @@ entities:
       pos: 25.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12125
     components:
     - type: Transform
@@ -79292,7 +78993,7 @@ entities:
       pos: 27.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12126
     components:
     - type: Transform
@@ -79300,7 +79001,7 @@ entities:
       pos: 28.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12127
     components:
     - type: Transform
@@ -79308,7 +79009,7 @@ entities:
       pos: 29.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12128
     components:
     - type: Transform
@@ -79316,7 +79017,7 @@ entities:
       pos: 30.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12129
     components:
     - type: Transform
@@ -79324,7 +79025,7 @@ entities:
       pos: 24.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12130
     components:
     - type: Transform
@@ -79332,7 +79033,7 @@ entities:
       pos: 25.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12131
     components:
     - type: Transform
@@ -79340,63 +79041,63 @@ entities:
       pos: 26.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12132
     components:
     - type: Transform
       pos: 26.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12133
     components:
     - type: Transform
       pos: 26.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12134
     components:
     - type: Transform
       pos: 26.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12135
     components:
     - type: Transform
       pos: 26.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12136
     components:
     - type: Transform
       pos: 26.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12137
     components:
     - type: Transform
       pos: 26.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12138
     components:
     - type: Transform
       pos: 28.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12139
     components:
     - type: Transform
       pos: 28.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12140
     components:
     - type: Transform
@@ -79404,14 +79105,14 @@ entities:
       pos: 26.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12141
     components:
     - type: Transform
       pos: 16.5,56.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12142
     components:
     - type: Transform
@@ -79431,7 +79132,7 @@ entities:
       pos: 27.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12145
     components:
     - type: Transform
@@ -79439,14 +79140,14 @@ entities:
       pos: 26.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12146
     components:
     - type: Transform
       pos: 28.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12147
     components:
     - type: Transform
@@ -79454,7 +79155,7 @@ entities:
       pos: 23.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12148
     components:
     - type: Transform
@@ -79462,7 +79163,7 @@ entities:
       pos: 24.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12149
     components:
     - type: Transform
@@ -79470,7 +79171,7 @@ entities:
       pos: 22.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12150
     components:
     - type: Transform
@@ -79478,7 +79179,7 @@ entities:
       pos: 21.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12151
     components:
     - type: Transform
@@ -79486,7 +79187,7 @@ entities:
       pos: 24.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12152
     components:
     - type: Transform
@@ -79494,7 +79195,7 @@ entities:
       pos: 25.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12153
     components:
     - type: Transform
@@ -79502,7 +79203,7 @@ entities:
       pos: 27.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12154
     components:
     - type: Transform
@@ -79515,7 +79216,7 @@ entities:
       pos: 26.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12156
     components:
     - type: Transform
@@ -79528,7 +79229,7 @@ entities:
       pos: 12.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12158
     components:
     - type: Transform
@@ -79536,7 +79237,7 @@ entities:
       pos: 13.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12159
     components:
     - type: Transform
@@ -79544,7 +79245,7 @@ entities:
       pos: 15.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12160
     components:
     - type: Transform
@@ -79552,7 +79253,7 @@ entities:
       pos: 16.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12161
     components:
     - type: Transform
@@ -79560,7 +79261,7 @@ entities:
       pos: 19.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12162
     components:
     - type: Transform
@@ -79568,7 +79269,7 @@ entities:
       pos: 20.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12163
     components:
     - type: Transform
@@ -79576,7 +79277,7 @@ entities:
       pos: 21.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12164
     components:
     - type: Transform
@@ -79584,7 +79285,7 @@ entities:
       pos: 22.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12165
     components:
     - type: Transform
@@ -79592,7 +79293,7 @@ entities:
       pos: 23.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12166
     components:
     - type: Transform
@@ -79600,7 +79301,7 @@ entities:
       pos: 23.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12167
     components:
     - type: Transform
@@ -79608,7 +79309,7 @@ entities:
       pos: 23.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12168
     components:
     - type: Transform
@@ -79616,7 +79317,7 @@ entities:
       pos: 23.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12169
     components:
     - type: Transform
@@ -79624,7 +79325,7 @@ entities:
       pos: 25.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12170
     components:
     - type: Transform
@@ -79632,7 +79333,7 @@ entities:
       pos: 24.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12171
     components:
     - type: Transform
@@ -79640,7 +79341,7 @@ entities:
       pos: 27.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12172
     components:
     - type: Transform
@@ -79648,7 +79349,7 @@ entities:
       pos: 29.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12173
     components:
     - type: Transform
@@ -79656,7 +79357,7 @@ entities:
       pos: 30.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12174
     components:
     - type: Transform
@@ -79664,21 +79365,21 @@ entities:
       pos: 31.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12175
     components:
     - type: Transform
       pos: 32.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12176
     components:
     - type: Transform
       pos: 32.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12177
     components:
     - type: Transform
@@ -79686,7 +79387,7 @@ entities:
       pos: 33.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12178
     components:
     - type: Transform
@@ -79694,7 +79395,7 @@ entities:
       pos: 34.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12179
     components:
     - type: Transform
@@ -79702,7 +79403,7 @@ entities:
       pos: 35.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12180
     components:
     - type: Transform
@@ -79710,7 +79411,7 @@ entities:
       pos: 36.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12181
     components:
     - type: Transform
@@ -79718,7 +79419,7 @@ entities:
       pos: 22.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12182
     components:
     - type: Transform
@@ -79726,7 +79427,7 @@ entities:
       pos: 21.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12183
     components:
     - type: Transform
@@ -79734,7 +79435,7 @@ entities:
       pos: 20.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12184
     components:
     - type: Transform
@@ -79742,7 +79443,7 @@ entities:
       pos: 19.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12185
     components:
     - type: Transform
@@ -79750,7 +79451,7 @@ entities:
       pos: 18.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12186
     components:
     - type: Transform
@@ -79758,21 +79459,21 @@ entities:
       pos: 17.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12187
     components:
     - type: Transform
       pos: 23.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12188
     components:
     - type: Transform
       pos: 23.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12189
     components:
     - type: Transform
@@ -79780,7 +79481,7 @@ entities:
       pos: 14.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12190
     components:
     - type: Transform
@@ -79788,7 +79489,7 @@ entities:
       pos: 14.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12191
     components:
     - type: Transform
@@ -79796,7 +79497,7 @@ entities:
       pos: 14.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12192
     components:
     - type: Transform
@@ -79804,7 +79505,7 @@ entities:
       pos: 15.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12193
     components:
     - type: Transform
@@ -79812,7 +79513,7 @@ entities:
       pos: 16.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12194
     components:
     - type: Transform
@@ -79820,7 +79521,7 @@ entities:
       pos: 17.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12195
     components:
     - type: Transform
@@ -79828,7 +79529,7 @@ entities:
       pos: 22.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12196
     components:
     - type: Transform
@@ -79836,7 +79537,7 @@ entities:
       pos: 21.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12197
     components:
     - type: Transform
@@ -79844,7 +79545,7 @@ entities:
       pos: 20.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12198
     components:
     - type: Transform
@@ -79852,7 +79553,7 @@ entities:
       pos: 19.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12199
     components:
     - type: Transform
@@ -79860,7 +79561,7 @@ entities:
       pos: 9.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12200
     components:
     - type: Transform
@@ -79868,7 +79569,7 @@ entities:
       pos: 10.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12201
     components:
     - type: Transform
@@ -79876,7 +79577,7 @@ entities:
       pos: 11.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12202
     components:
     - type: Transform
@@ -79884,7 +79585,7 @@ entities:
       pos: 12.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12203
     components:
     - type: Transform
@@ -79892,7 +79593,7 @@ entities:
       pos: 12.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12204
     components:
     - type: Transform
@@ -79900,7 +79601,7 @@ entities:
       pos: 12.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12205
     components:
     - type: Transform
@@ -79908,7 +79609,7 @@ entities:
       pos: 12.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12206
     components:
     - type: Transform
@@ -79916,7 +79617,7 @@ entities:
       pos: 14.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12207
     components:
     - type: Transform
@@ -79924,7 +79625,7 @@ entities:
       pos: 15.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12208
     components:
     - type: Transform
@@ -79932,14 +79633,14 @@ entities:
       pos: 16.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12209
     components:
     - type: Transform
       pos: 17.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12210
     components:
     - type: Transform
@@ -79947,7 +79648,7 @@ entities:
       pos: 12.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12211
     components:
     - type: Transform
@@ -79955,7 +79656,7 @@ entities:
       pos: 13.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12212
     components:
     - type: Transform
@@ -79963,7 +79664,7 @@ entities:
       pos: 14.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12213
     components:
     - type: Transform
@@ -79971,7 +79672,7 @@ entities:
       pos: 15.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12214
     components:
     - type: Transform
@@ -79979,7 +79680,7 @@ entities:
       pos: 16.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12215
     components:
     - type: Transform
@@ -79987,7 +79688,7 @@ entities:
       pos: 17.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12216
     components:
     - type: Transform
@@ -79995,7 +79696,7 @@ entities:
       pos: 19.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12217
     components:
     - type: Transform
@@ -80003,21 +79704,21 @@ entities:
       pos: 20.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12218
     components:
     - type: Transform
       pos: 17.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12219
     components:
     - type: Transform
       pos: 17.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12220
     components:
     - type: Transform
@@ -80025,7 +79726,7 @@ entities:
       pos: 18.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12221
     components:
     - type: Transform
@@ -80033,7 +79734,7 @@ entities:
       pos: 19.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12222
     components:
     - type: Transform
@@ -80041,7 +79742,7 @@ entities:
       pos: 20.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12223
     components:
     - type: Transform
@@ -80049,7 +79750,7 @@ entities:
       pos: 21.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12224
     components:
     - type: Transform
@@ -80057,7 +79758,7 @@ entities:
       pos: 21.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12225
     components:
     - type: Transform
@@ -80065,7 +79766,7 @@ entities:
       pos: 21.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12226
     components:
     - type: Transform
@@ -80073,7 +79774,7 @@ entities:
       pos: 20.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12227
     components:
     - type: Transform
@@ -80081,7 +79782,7 @@ entities:
       pos: 19.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12228
     components:
     - type: Transform
@@ -80089,7 +79790,7 @@ entities:
       pos: 18.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12229
     components:
     - type: Transform
@@ -80097,28 +79798,28 @@ entities:
       pos: 17.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12230
     components:
     - type: Transform
       pos: 21.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12231
     components:
     - type: Transform
       pos: 21.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12232
     components:
     - type: Transform
       pos: 21.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12233
     components:
     - type: Transform
@@ -80126,7 +79827,7 @@ entities:
       pos: 22.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12234
     components:
     - type: Transform
@@ -80134,7 +79835,7 @@ entities:
       pos: 23.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12235
     components:
     - type: Transform
@@ -80142,7 +79843,7 @@ entities:
       pos: 24.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12236
     components:
     - type: Transform
@@ -80150,7 +79851,7 @@ entities:
       pos: 26.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12237
     components:
     - type: Transform
@@ -80158,7 +79859,7 @@ entities:
       pos: 28.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12238
     components:
     - type: Transform
@@ -80166,7 +79867,7 @@ entities:
       pos: 29.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12239
     components:
     - type: Transform
@@ -80174,7 +79875,7 @@ entities:
       pos: 30.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12240
     components:
     - type: Transform
@@ -80182,7 +79883,7 @@ entities:
       pos: 31.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12241
     components:
     - type: Transform
@@ -80190,7 +79891,7 @@ entities:
       pos: 32.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12242
     components:
     - type: Transform
@@ -80198,7 +79899,7 @@ entities:
       pos: 33.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12243
     components:
     - type: Transform
@@ -80206,7 +79907,7 @@ entities:
       pos: 34.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12244
     components:
     - type: Transform
@@ -80214,7 +79915,7 @@ entities:
       pos: 35.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12245
     components:
     - type: Transform
@@ -80222,7 +79923,7 @@ entities:
       pos: 36.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12246
     components:
     - type: Transform
@@ -80230,7 +79931,7 @@ entities:
       pos: 37.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12247
     components:
     - type: Transform
@@ -80238,7 +79939,7 @@ entities:
       pos: 24.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12248
     components:
     - type: Transform
@@ -80246,14 +79947,14 @@ entities:
       pos: 25.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12249
     components:
     - type: Transform
       pos: 28.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12250
     components:
     - type: Transform
@@ -80261,7 +79962,7 @@ entities:
       pos: 25.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12251
     components:
     - type: Transform
@@ -80269,7 +79970,7 @@ entities:
       pos: 39.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12252
     components:
     - type: Transform
@@ -80277,7 +79978,7 @@ entities:
       pos: 40.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12253
     components:
     - type: Transform
@@ -80285,7 +79986,7 @@ entities:
       pos: 40.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12254
     components:
     - type: Transform
@@ -80293,7 +79994,7 @@ entities:
       pos: 40.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12255
     components:
     - type: Transform
@@ -80301,7 +80002,7 @@ entities:
       pos: 40.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12256
     components:
     - type: Transform
@@ -80309,14 +80010,14 @@ entities:
       pos: 40.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12257
     components:
     - type: Transform
       pos: 16.5,55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12258
     components:
     - type: Transform
@@ -80324,7 +80025,7 @@ entities:
       pos: 51.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12259
     components:
     - type: Transform
@@ -80332,7 +80033,7 @@ entities:
       pos: 49.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12260
     components:
     - type: Transform
@@ -80340,7 +80041,7 @@ entities:
       pos: 47.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12261
     components:
     - type: Transform
@@ -80348,7 +80049,7 @@ entities:
       pos: 45.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12262
     components:
     - type: Transform
@@ -80356,7 +80057,7 @@ entities:
       pos: 43.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12263
     components:
     - type: Transform
@@ -80364,7 +80065,7 @@ entities:
       pos: 34.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12264
     components:
     - type: Transform
@@ -80372,7 +80073,7 @@ entities:
       pos: 36.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12265
     components:
     - type: Transform
@@ -80380,7 +80081,7 @@ entities:
       pos: 32.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12266
     components:
     - type: Transform
@@ -80388,7 +80089,7 @@ entities:
       pos: 33.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12267
     components:
     - type: Transform
@@ -80396,7 +80097,7 @@ entities:
       pos: 34.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12268
     components:
     - type: Transform
@@ -80404,7 +80105,7 @@ entities:
       pos: 36.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12269
     components:
     - type: Transform
@@ -80412,7 +80113,7 @@ entities:
       pos: 37.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12270
     components:
     - type: Transform
@@ -80420,7 +80121,7 @@ entities:
       pos: 38.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12271
     components:
     - type: Transform
@@ -80428,7 +80129,7 @@ entities:
       pos: 39.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12272
     components:
     - type: Transform
@@ -80436,7 +80137,7 @@ entities:
       pos: 40.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12273
     components:
     - type: Transform
@@ -80444,7 +80145,7 @@ entities:
       pos: 41.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12274
     components:
     - type: Transform
@@ -80452,7 +80153,7 @@ entities:
       pos: 42.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12275
     components:
     - type: Transform
@@ -80460,7 +80161,7 @@ entities:
       pos: 44.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12276
     components:
     - type: Transform
@@ -80468,7 +80169,7 @@ entities:
       pos: 32.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12277
     components:
     - type: Transform
@@ -80476,7 +80177,7 @@ entities:
       pos: 33.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12278
     components:
     - type: Transform
@@ -80484,7 +80185,7 @@ entities:
       pos: 34.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12279
     components:
     - type: Transform
@@ -80492,7 +80193,7 @@ entities:
       pos: 36.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12280
     components:
     - type: Transform
@@ -80500,7 +80201,7 @@ entities:
       pos: 37.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12281
     components:
     - type: Transform
@@ -80508,7 +80209,7 @@ entities:
       pos: 38.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12282
     components:
     - type: Transform
@@ -80516,7 +80217,7 @@ entities:
       pos: 40.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12283
     components:
     - type: Transform
@@ -80524,7 +80225,7 @@ entities:
       pos: 41.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12284
     components:
     - type: Transform
@@ -80532,7 +80233,7 @@ entities:
       pos: 42.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12285
     components:
     - type: Transform
@@ -80540,7 +80241,7 @@ entities:
       pos: 43.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12286
     components:
     - type: Transform
@@ -80548,28 +80249,28 @@ entities:
       pos: 44.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12287
     components:
     - type: Transform
       pos: 30.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12288
     components:
     - type: Transform
       pos: 30.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12289
     components:
     - type: Transform
       pos: 30.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12290
     components:
     - type: Transform
@@ -80577,7 +80278,7 @@ entities:
       pos: 29.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12291
     components:
     - type: Transform
@@ -80585,7 +80286,7 @@ entities:
       pos: 29.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12292
     components:
     - type: Transform
@@ -80593,7 +80294,7 @@ entities:
       pos: 29.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12293
     components:
     - type: Transform
@@ -80601,7 +80302,7 @@ entities:
       pos: 29.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12294
     components:
     - type: Transform
@@ -80609,7 +80310,7 @@ entities:
       pos: 29.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12295
     components:
     - type: Transform
@@ -80617,7 +80318,7 @@ entities:
       pos: 29.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12296
     components:
     - type: Transform
@@ -80633,7 +80334,7 @@ entities:
       pos: -1.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12298
     components:
     - type: Transform
@@ -80641,28 +80342,28 @@ entities:
       pos: -53.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12299
     components:
     - type: Transform
       pos: 21.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12300
     components:
     - type: Transform
       pos: -25.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12301
     components:
     - type: Transform
       pos: 21.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12302
     components:
     - type: Transform
@@ -80670,7 +80371,7 @@ entities:
       pos: -61.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12303
     components:
     - type: Transform
@@ -80678,7 +80379,7 @@ entities:
       pos: -61.5,-61.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12304
     components:
     - type: Transform
@@ -80686,14 +80387,14 @@ entities:
       pos: -58.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12305
     components:
     - type: Transform
       pos: -25.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12306
     components:
     - type: Transform
@@ -80701,7 +80402,7 @@ entities:
       pos: 18.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12307
     components:
     - type: Transform
@@ -80709,7 +80410,7 @@ entities:
       pos: -61.5,-62.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12308
     components:
     - type: Transform
@@ -80717,7 +80418,7 @@ entities:
       pos: -64.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12309
     components:
     - type: Transform
@@ -80725,7 +80426,7 @@ entities:
       pos: -59.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12310
     components:
     - type: Transform
@@ -80733,7 +80434,7 @@ entities:
       pos: 15.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12311
     components:
     - type: Transform
@@ -80741,28 +80442,28 @@ entities:
       pos: 16.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12312
     components:
     - type: Transform
       pos: 16.5,45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12313
     components:
     - type: Transform
       pos: 16.5,47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12314
     components:
     - type: Transform
       pos: 16.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12315
     components:
     - type: Transform
@@ -80770,7 +80471,7 @@ entities:
       pos: 19.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12316
     components:
     - type: Transform
@@ -80778,63 +80479,63 @@ entities:
       pos: 18.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12317
     components:
     - type: Transform
       pos: 16.5,52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12318
     components:
     - type: Transform
       pos: 16.5,53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12319
     components:
     - type: Transform
       pos: 16.5,49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12320
     components:
     - type: Transform
       pos: 16.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12321
     components:
     - type: Transform
       pos: 16.5,50.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12322
     components:
     - type: Transform
       pos: 16.5,46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12323
     components:
     - type: Transform
       pos: 16.5,54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12324
     components:
     - type: Transform
       pos: 16.5,48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12325
     components:
     - type: Transform
@@ -80842,7 +80543,7 @@ entities:
       pos: 50.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12326
     components:
     - type: Transform
@@ -80850,7 +80551,7 @@ entities:
       pos: 48.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12327
     components:
     - type: Transform
@@ -80858,7 +80559,7 @@ entities:
       pos: 46.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12328
     components:
     - type: Transform
@@ -80866,7 +80567,7 @@ entities:
       pos: 44.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12329
     components:
     - type: Transform
@@ -80874,7 +80575,7 @@ entities:
       pos: 33.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12330
     components:
     - type: Transform
@@ -80882,7 +80583,7 @@ entities:
       pos: 35.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12331
     components:
     - type: Transform
@@ -80890,7 +80591,7 @@ entities:
       pos: 37.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12332
     components:
     - type: Transform
@@ -80898,7 +80599,7 @@ entities:
       pos: 52.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12333
     components:
     - type: Transform
@@ -80906,21 +80607,21 @@ entities:
       pos: 38.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12334
     components:
     - type: Transform
       pos: 42.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12335
     components:
     - type: Transform
       pos: 42.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12336
     components:
     - type: Transform
@@ -80928,7 +80629,7 @@ entities:
       pos: 39.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12337
     components:
     - type: Transform
@@ -80936,7 +80637,7 @@ entities:
       pos: 40.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12338
     components:
     - type: Transform
@@ -80944,35 +80645,35 @@ entities:
       pos: 41.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12339
     components:
     - type: Transform
       pos: 42.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12340
     components:
     - type: Transform
       pos: 42.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12341
     components:
     - type: Transform
       pos: 42.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12342
     components:
     - type: Transform
       pos: 42.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12343
     components:
     - type: Transform
@@ -80980,14 +80681,14 @@ entities:
       pos: 52.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12344
     components:
     - type: Transform
       pos: 32.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12345
     components:
     - type: Transform
@@ -80995,7 +80696,7 @@ entities:
       pos: 34.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12346
     components:
     - type: Transform
@@ -81003,7 +80704,7 @@ entities:
       pos: 26.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12347
     components:
     - type: Transform
@@ -81011,7 +80712,7 @@ entities:
       pos: 24.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12348
     components:
     - type: Transform
@@ -81019,7 +80720,7 @@ entities:
       pos: 17.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12349
     components:
     - type: Transform
@@ -81027,14 +80728,14 @@ entities:
       pos: -54.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12350
     components:
     - type: Transform
       pos: 16.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12351
     components:
     - type: Transform
@@ -81042,56 +80743,56 @@ entities:
       pos: 15.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12352
     components:
     - type: Transform
       pos: -45.5,-14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12353
     components:
     - type: Transform
       pos: -45.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12354
     components:
     - type: Transform
       pos: -45.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12355
     components:
     - type: Transform
       pos: -45.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12356
     components:
     - type: Transform
       pos: -45.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12357
     components:
     - type: Transform
       pos: -45.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12358
     components:
     - type: Transform
       pos: -45.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12359
     components:
     - type: Transform
@@ -81099,7 +80800,7 @@ entities:
       pos: -60.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12360
     components:
     - type: Transform
@@ -81107,7 +80808,7 @@ entities:
       pos: -59.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12361
     components:
     - type: Transform
@@ -81115,7 +80816,7 @@ entities:
       pos: -58.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12362
     components:
     - type: Transform
@@ -81123,7 +80824,7 @@ entities:
       pos: -56.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12363
     components:
     - type: Transform
@@ -81131,7 +80832,7 @@ entities:
       pos: -55.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12364
     components:
     - type: Transform
@@ -81139,7 +80840,7 @@ entities:
       pos: -54.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12365
     components:
     - type: Transform
@@ -81147,7 +80848,7 @@ entities:
       pos: -53.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12366
     components:
     - type: Transform
@@ -81155,7 +80856,7 @@ entities:
       pos: -52.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12367
     components:
     - type: Transform
@@ -81163,7 +80864,7 @@ entities:
       pos: -50.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12368
     components:
     - type: Transform
@@ -81171,7 +80872,7 @@ entities:
       pos: -51.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12369
     components:
     - type: Transform
@@ -81179,7 +80880,7 @@ entities:
       pos: -48.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12370
     components:
     - type: Transform
@@ -81187,7 +80888,7 @@ entities:
       pos: -47.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12371
     components:
     - type: Transform
@@ -81195,91 +80896,91 @@ entities:
       pos: -46.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12372
     components:
     - type: Transform
       pos: -44.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12373
     components:
     - type: Transform
       pos: -44.5,-14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12374
     components:
     - type: Transform
       pos: -44.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12375
     components:
     - type: Transform
       pos: -44.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12376
     components:
     - type: Transform
       pos: -44.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12377
     components:
     - type: Transform
       pos: -44.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12378
     components:
     - type: Transform
       pos: -44.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12379
     components:
     - type: Transform
       pos: -44.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12380
     components:
     - type: Transform
       pos: -44.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12381
     components:
     - type: Transform
       pos: -44.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12382
     components:
     - type: Transform
       pos: -62.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12383
     components:
     - type: Transform
       pos: -62.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12384
     components:
     - type: Transform
@@ -81287,7 +80988,7 @@ entities:
       pos: -60.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12385
     components:
     - type: Transform
@@ -81295,7 +80996,7 @@ entities:
       pos: -59.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12386
     components:
     - type: Transform
@@ -81303,7 +81004,7 @@ entities:
       pos: -57.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12387
     components:
     - type: Transform
@@ -81311,7 +81012,7 @@ entities:
       pos: -56.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12388
     components:
     - type: Transform
@@ -81319,7 +81020,7 @@ entities:
       pos: -55.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12389
     components:
     - type: Transform
@@ -81327,7 +81028,7 @@ entities:
       pos: -54.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12390
     components:
     - type: Transform
@@ -81335,7 +81036,7 @@ entities:
       pos: -52.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12391
     components:
     - type: Transform
@@ -81343,7 +81044,7 @@ entities:
       pos: -49.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12392
     components:
     - type: Transform
@@ -81351,7 +81052,7 @@ entities:
       pos: -50.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12393
     components:
     - type: Transform
@@ -81359,7 +81060,7 @@ entities:
       pos: -48.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12394
     components:
     - type: Transform
@@ -81367,7 +81068,7 @@ entities:
       pos: -47.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12395
     components:
     - type: Transform
@@ -81375,7 +81076,7 @@ entities:
       pos: -46.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12396
     components:
     - type: Transform
@@ -81383,7 +81084,7 @@ entities:
       pos: -45.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12397
     components:
     - type: Transform
@@ -81391,21 +81092,21 @@ entities:
       pos: -62.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12398
     components:
     - type: Transform
       pos: -63.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12399
     components:
     - type: Transform
       pos: -63.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12400
     components:
     - type: Transform
@@ -81413,189 +81114,189 @@ entities:
       pos: -63.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12401
     components:
     - type: Transform
       pos: -62.5,-25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12402
     components:
     - type: Transform
       pos: -62.5,-26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12403
     components:
     - type: Transform
       pos: -62.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12404
     components:
     - type: Transform
       pos: -62.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12405
     components:
     - type: Transform
       pos: -62.5,-29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12406
     components:
     - type: Transform
       pos: -62.5,-30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12407
     components:
     - type: Transform
       pos: -62.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12408
     components:
     - type: Transform
       pos: -62.5,-32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12409
     components:
     - type: Transform
       pos: -62.5,-33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12410
     components:
     - type: Transform
       pos: -62.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12411
     components:
     - type: Transform
       pos: -62.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12412
     components:
     - type: Transform
       pos: -62.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12413
     components:
     - type: Transform
       pos: -62.5,-37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12414
     components:
     - type: Transform
       pos: -61.5,-37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12415
     components:
     - type: Transform
       pos: -61.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12416
     components:
     - type: Transform
       pos: -61.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12417
     components:
     - type: Transform
       pos: -61.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12418
     components:
     - type: Transform
       pos: -61.5,-33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12419
     components:
     - type: Transform
       pos: -61.5,-32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12420
     components:
     - type: Transform
       pos: -61.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12421
     components:
     - type: Transform
       pos: -61.5,-30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12422
     components:
     - type: Transform
       pos: -61.5,-29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12423
     components:
     - type: Transform
       pos: -61.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12424
     components:
     - type: Transform
       pos: -61.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12425
     components:
     - type: Transform
       pos: -61.5,-26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12426
     components:
     - type: Transform
       pos: -61.5,-25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12427
     components:
     - type: Transform
@@ -81603,7 +81304,7 @@ entities:
       pos: -63.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12428
     components:
     - type: Transform
@@ -81611,7 +81312,7 @@ entities:
       pos: -60.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12429
     components:
     - type: Transform
@@ -81619,7 +81320,7 @@ entities:
       pos: -59.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12430
     components:
     - type: Transform
@@ -81627,49 +81328,49 @@ entities:
       pos: -64.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12431
     components:
     - type: Transform
       pos: -65.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12432
     components:
     - type: Transform
       pos: -65.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12433
     components:
     - type: Transform
       pos: -65.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12434
     components:
     - type: Transform
       pos: -65.5,-42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12435
     components:
     - type: Transform
       pos: -65.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12436
     components:
     - type: Transform
       pos: -65.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12437
     components:
     - type: Transform
@@ -81677,28 +81378,28 @@ entities:
       pos: -63.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12438
     components:
     - type: Transform
       pos: -62.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12439
     components:
     - type: Transform
       pos: -62.5,-47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12440
     components:
     - type: Transform
       pos: -62.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12441
     components:
     - type: Transform
@@ -81706,7 +81407,7 @@ entities:
       pos: -66.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12442
     components:
     - type: Transform
@@ -81714,7 +81415,7 @@ entities:
       pos: -67.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12443
     components:
     - type: Transform
@@ -81722,7 +81423,7 @@ entities:
       pos: -69.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12444
     components:
     - type: Transform
@@ -81730,7 +81431,7 @@ entities:
       pos: -70.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12445
     components:
     - type: Transform
@@ -81738,7 +81439,7 @@ entities:
       pos: -71.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12446
     components:
     - type: Transform
@@ -81746,7 +81447,7 @@ entities:
       pos: -72.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12447
     components:
     - type: Transform
@@ -81754,7 +81455,7 @@ entities:
       pos: -73.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12448
     components:
     - type: Transform
@@ -81762,7 +81463,7 @@ entities:
       pos: -74.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12449
     components:
     - type: Transform
@@ -81770,7 +81471,7 @@ entities:
       pos: -75.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12450
     components:
     - type: Transform
@@ -81778,21 +81479,21 @@ entities:
       pos: -76.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12451
     components:
     - type: Transform
       pos: -77.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12452
     components:
     - type: Transform
       pos: -77.5,-47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12453
     components:
     - type: Transform
@@ -81800,7 +81501,7 @@ entities:
       pos: -78.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12454
     components:
     - type: Transform
@@ -81808,7 +81509,7 @@ entities:
       pos: -78.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12455
     components:
     - type: Transform
@@ -81816,7 +81517,7 @@ entities:
       pos: -78.5,-42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12456
     components:
     - type: Transform
@@ -81824,7 +81525,7 @@ entities:
       pos: -78.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12457
     components:
     - type: Transform
@@ -81832,7 +81533,7 @@ entities:
       pos: -78.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12458
     components:
     - type: Transform
@@ -81840,7 +81541,7 @@ entities:
       pos: -68.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12459
     components:
     - type: Transform
@@ -81848,7 +81549,7 @@ entities:
       pos: -64.5,-49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12460
     components:
     - type: Transform
@@ -81856,7 +81557,7 @@ entities:
       pos: -65.5,-49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12461
     components:
     - type: Transform
@@ -81864,63 +81565,63 @@ entities:
       pos: -66.5,-49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12462
     components:
     - type: Transform
       pos: -67.5,-50.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12463
     components:
     - type: Transform
       pos: -67.5,-51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12464
     components:
     - type: Transform
       pos: -67.5,-52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12465
     components:
     - type: Transform
       pos: -67.5,-53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12466
     components:
     - type: Transform
       pos: -67.5,-55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12467
     components:
     - type: Transform
       pos: -67.5,-56.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12468
     components:
     - type: Transform
       pos: -67.5,-57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12469
     components:
     - type: Transform
       pos: -67.5,-58.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12470
     components:
     - type: Transform
@@ -81928,7 +81629,7 @@ entities:
       pos: -66.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12471
     components:
     - type: Transform
@@ -81936,7 +81637,7 @@ entities:
       pos: -65.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12472
     components:
     - type: Transform
@@ -81944,7 +81645,7 @@ entities:
       pos: -64.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12473
     components:
     - type: Transform
@@ -81952,7 +81653,7 @@ entities:
       pos: -62.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12474
     components:
     - type: Transform
@@ -81960,7 +81661,7 @@ entities:
       pos: -60.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12475
     components:
     - type: Transform
@@ -81968,7 +81669,7 @@ entities:
       pos: -59.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12476
     components:
     - type: Transform
@@ -81976,7 +81677,7 @@ entities:
       pos: -57.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12477
     components:
     - type: Transform
@@ -81984,7 +81685,7 @@ entities:
       pos: -56.5,-58.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12478
     components:
     - type: Transform
@@ -81992,7 +81693,7 @@ entities:
       pos: -56.5,-56.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12479
     components:
     - type: Transform
@@ -82000,7 +81701,7 @@ entities:
       pos: -56.5,-55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12480
     components:
     - type: Transform
@@ -82008,7 +81709,7 @@ entities:
       pos: -56.5,-54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12481
     components:
     - type: Transform
@@ -82016,7 +81717,7 @@ entities:
       pos: -56.5,-51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12482
     components:
     - type: Transform
@@ -82024,7 +81725,7 @@ entities:
       pos: -56.5,-52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12483
     components:
     - type: Transform
@@ -82032,7 +81733,7 @@ entities:
       pos: -56.5,-50.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12484
     components:
     - type: Transform
@@ -82040,7 +81741,7 @@ entities:
       pos: -57.5,-49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12485
     components:
     - type: Transform
@@ -82048,7 +81749,7 @@ entities:
       pos: -58.5,-49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12486
     components:
     - type: Transform
@@ -82056,7 +81757,7 @@ entities:
       pos: -59.5,-49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12487
     components:
     - type: Transform
@@ -82064,7 +81765,7 @@ entities:
       pos: -60.5,-49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12488
     components:
     - type: Transform
@@ -82072,63 +81773,63 @@ entities:
       pos: -61.5,-49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12489
     components:
     - type: Transform
       pos: -55.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12490
     components:
     - type: Transform
       pos: -55.5,-58.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12491
     components:
     - type: Transform
       pos: -55.5,-57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12492
     components:
     - type: Transform
       pos: -55.5,-55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12493
     components:
     - type: Transform
       pos: -55.5,-53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12494
     components:
     - type: Transform
       pos: -55.5,-51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12495
     components:
     - type: Transform
       pos: -55.5,-50.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12496
     components:
     - type: Transform
       pos: -55.5,-49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12497
     components:
     - type: Transform
@@ -82136,7 +81837,7 @@ entities:
       pos: -56.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12498
     components:
     - type: Transform
@@ -82144,7 +81845,7 @@ entities:
       pos: -57.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12499
     components:
     - type: Transform
@@ -82152,7 +81853,7 @@ entities:
       pos: -58.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12500
     components:
     - type: Transform
@@ -82160,7 +81861,7 @@ entities:
       pos: -59.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12501
     components:
     - type: Transform
@@ -82168,7 +81869,7 @@ entities:
       pos: -62.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12502
     components:
     - type: Transform
@@ -82176,7 +81877,7 @@ entities:
       pos: -63.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12503
     components:
     - type: Transform
@@ -82184,7 +81885,7 @@ entities:
       pos: -64.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12504
     components:
     - type: Transform
@@ -82192,7 +81893,7 @@ entities:
       pos: -65.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12505
     components:
     - type: Transform
@@ -82200,7 +81901,7 @@ entities:
       pos: -66.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12506
     components:
     - type: Transform
@@ -82208,7 +81909,7 @@ entities:
       pos: -67.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12507
     components:
     - type: Transform
@@ -82216,7 +81917,7 @@ entities:
       pos: -68.5,-49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12508
     components:
     - type: Transform
@@ -82224,7 +81925,7 @@ entities:
       pos: -68.5,-50.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12509
     components:
     - type: Transform
@@ -82232,7 +81933,7 @@ entities:
       pos: -68.5,-51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12510
     components:
     - type: Transform
@@ -82240,7 +81941,7 @@ entities:
       pos: -68.5,-52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12511
     components:
     - type: Transform
@@ -82248,7 +81949,7 @@ entities:
       pos: -68.5,-53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12512
     components:
     - type: Transform
@@ -82256,7 +81957,7 @@ entities:
       pos: -68.5,-54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12513
     components:
     - type: Transform
@@ -82264,7 +81965,7 @@ entities:
       pos: -68.5,-56.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12514
     components:
     - type: Transform
@@ -82272,7 +81973,7 @@ entities:
       pos: -68.5,-57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12515
     components:
     - type: Transform
@@ -82280,7 +81981,7 @@ entities:
       pos: -68.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12516
     components:
     - type: Transform
@@ -82288,7 +81989,7 @@ entities:
       pos: -68.5,-58.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12517
     components:
     - type: Transform
@@ -82296,7 +81997,7 @@ entities:
       pos: -67.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12518
     components:
     - type: Transform
@@ -82304,7 +82005,7 @@ entities:
       pos: -66.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12519
     components:
     - type: Transform
@@ -82312,7 +82013,7 @@ entities:
       pos: -65.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12520
     components:
     - type: Transform
@@ -82320,7 +82021,7 @@ entities:
       pos: -63.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12521
     components:
     - type: Transform
@@ -82328,7 +82029,7 @@ entities:
       pos: -61.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12522
     components:
     - type: Transform
@@ -82336,7 +82037,7 @@ entities:
       pos: -58.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12523
     components:
     - type: Transform
@@ -82344,7 +82045,7 @@ entities:
       pos: -57.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12524
     components:
     - type: Transform
@@ -82352,7 +82053,7 @@ entities:
       pos: -56.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12525
     components:
     - type: Transform
@@ -82360,7 +82061,7 @@ entities:
       pos: -61.5,-47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12526
     components:
     - type: Transform
@@ -82368,7 +82069,7 @@ entities:
       pos: -60.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12527
     components:
     - type: Transform
@@ -82376,7 +82077,7 @@ entities:
       pos: -59.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12528
     components:
     - type: Transform
@@ -82384,7 +82085,7 @@ entities:
       pos: -58.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12529
     components:
     - type: Transform
@@ -82392,7 +82093,7 @@ entities:
       pos: -58.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12530
     components:
     - type: Transform
@@ -82400,7 +82101,7 @@ entities:
       pos: -58.5,-42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12531
     components:
     - type: Transform
@@ -82408,7 +82109,7 @@ entities:
       pos: -58.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12532
     components:
     - type: Transform
@@ -82416,7 +82117,7 @@ entities:
       pos: -58.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12533
     components:
     - type: Transform
@@ -82424,7 +82125,7 @@ entities:
       pos: -58.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12534
     components:
     - type: Transform
@@ -82432,7 +82133,7 @@ entities:
       pos: -62.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12535
     components:
     - type: Transform
@@ -82440,7 +82141,7 @@ entities:
       pos: -63.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12536
     components:
     - type: Transform
@@ -82448,7 +82149,7 @@ entities:
       pos: -64.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12537
     components:
     - type: Transform
@@ -82456,7 +82157,7 @@ entities:
       pos: -65.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12538
     components:
     - type: Transform
@@ -82464,7 +82165,7 @@ entities:
       pos: -66.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12539
     components:
     - type: Transform
@@ -82472,7 +82173,7 @@ entities:
       pos: -69.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12540
     components:
     - type: Transform
@@ -82480,7 +82181,7 @@ entities:
       pos: -70.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12541
     components:
     - type: Transform
@@ -82488,7 +82189,7 @@ entities:
       pos: -71.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12542
     components:
     - type: Transform
@@ -82496,7 +82197,7 @@ entities:
       pos: -72.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12543
     components:
     - type: Transform
@@ -82504,7 +82205,7 @@ entities:
       pos: -73.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12544
     components:
     - type: Transform
@@ -82512,7 +82213,7 @@ entities:
       pos: -74.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12545
     components:
     - type: Transform
@@ -82520,7 +82221,7 @@ entities:
       pos: -76.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12546
     components:
     - type: Transform
@@ -82528,7 +82229,7 @@ entities:
       pos: -77.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12547
     components:
     - type: Transform
@@ -82536,7 +82237,7 @@ entities:
       pos: -78.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12548
     components:
     - type: Transform
@@ -82544,7 +82245,7 @@ entities:
       pos: -79.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12549
     components:
     - type: Transform
@@ -82552,7 +82253,7 @@ entities:
       pos: -79.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12550
     components:
     - type: Transform
@@ -82560,7 +82261,7 @@ entities:
       pos: -79.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12551
     components:
     - type: Transform
@@ -82568,7 +82269,7 @@ entities:
       pos: -79.5,-42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12552
     components:
     - type: Transform
@@ -82576,7 +82277,7 @@ entities:
       pos: -79.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12553
     components:
     - type: Transform
@@ -82584,28 +82285,28 @@ entities:
       pos: -79.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12554
     components:
     - type: Transform
       pos: -75.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12555
     components:
     - type: Transform
       pos: -75.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12556
     components:
     - type: Transform
       pos: -75.5,-42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12557
     components:
     - type: Transform
@@ -82613,7 +82314,7 @@ entities:
       pos: -76.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12558
     components:
     - type: Transform
@@ -82621,7 +82322,7 @@ entities:
       pos: -67.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12559
     components:
     - type: Transform
@@ -82629,7 +82330,7 @@ entities:
       pos: -67.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12560
     components:
     - type: Transform
@@ -82637,7 +82338,7 @@ entities:
       pos: -67.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12561
     components:
     - type: Transform
@@ -82645,7 +82346,7 @@ entities:
       pos: -56.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12562
     components:
     - type: Transform
@@ -82653,7 +82354,7 @@ entities:
       pos: -56.5,-47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12563
     components:
     - type: Transform
@@ -82661,7 +82362,7 @@ entities:
       pos: -56.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12564
     components:
     - type: Transform
@@ -82669,7 +82370,7 @@ entities:
       pos: -55.5,-47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12565
     components:
     - type: Transform
@@ -82677,7 +82378,7 @@ entities:
       pos: -55.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12566
     components:
     - type: Transform
@@ -82685,7 +82386,7 @@ entities:
       pos: -54.5,-52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12567
     components:
     - type: Transform
@@ -82693,7 +82394,7 @@ entities:
       pos: -53.5,-52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12568
     components:
     - type: Transform
@@ -82701,7 +82402,7 @@ entities:
       pos: -55.5,-53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12569
     components:
     - type: Transform
@@ -82709,7 +82410,7 @@ entities:
       pos: -54.5,-53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12570
     components:
     - type: Transform
@@ -82717,7 +82418,7 @@ entities:
       pos: -53.5,-53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12571
     components:
     - type: Transform
@@ -82725,7 +82426,7 @@ entities:
       pos: -54.5,-56.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12572
     components:
     - type: Transform
@@ -82733,7 +82434,7 @@ entities:
       pos: -53.5,-56.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12573
     components:
     - type: Transform
@@ -82741,7 +82442,7 @@ entities:
       pos: -54.5,-57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12574
     components:
     - type: Transform
@@ -82749,7 +82450,7 @@ entities:
       pos: -53.5,-57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12575
     components:
     - type: Transform
@@ -82757,7 +82458,7 @@ entities:
       pos: -55.5,-57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12576
     components:
     - type: Transform
@@ -82765,7 +82466,7 @@ entities:
       pos: -55.5,-54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12577
     components:
     - type: Transform
@@ -82773,7 +82474,7 @@ entities:
       pos: -69.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12578
     components:
     - type: Transform
@@ -82781,7 +82482,7 @@ entities:
       pos: -70.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12579
     components:
     - type: Transform
@@ -82789,7 +82490,7 @@ entities:
       pos: -71.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12580
     components:
     - type: Transform
@@ -82797,7 +82498,7 @@ entities:
       pos: -68.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12581
     components:
     - type: Transform
@@ -82805,7 +82506,7 @@ entities:
       pos: -69.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12582
     components:
     - type: Transform
@@ -82813,7 +82514,7 @@ entities:
       pos: -70.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12583
     components:
     - type: Transform
@@ -82821,7 +82522,7 @@ entities:
       pos: -71.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12584
     components:
     - type: Transform
@@ -82829,7 +82530,7 @@ entities:
       pos: -72.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12585
     components:
     - type: Transform
@@ -82837,7 +82538,7 @@ entities:
       pos: -73.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12586
     components:
     - type: Transform
@@ -82845,7 +82546,7 @@ entities:
       pos: -75.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12587
     components:
     - type: Transform
@@ -82853,7 +82554,7 @@ entities:
       pos: -76.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12588
     components:
     - type: Transform
@@ -82861,7 +82562,7 @@ entities:
       pos: -77.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12589
     components:
     - type: Transform
@@ -82869,7 +82570,7 @@ entities:
       pos: -78.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12590
     components:
     - type: Transform
@@ -82877,7 +82578,7 @@ entities:
       pos: -79.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12591
     components:
     - type: Transform
@@ -82885,7 +82586,7 @@ entities:
       pos: -81.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12592
     components:
     - type: Transform
@@ -82893,7 +82594,7 @@ entities:
       pos: -82.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12593
     components:
     - type: Transform
@@ -82901,7 +82602,7 @@ entities:
       pos: -76.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12594
     components:
     - type: Transform
@@ -82909,7 +82610,7 @@ entities:
       pos: -74.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12595
     components:
     - type: Transform
@@ -82917,7 +82618,7 @@ entities:
       pos: -73.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12596
     components:
     - type: Transform
@@ -82925,7 +82626,7 @@ entities:
       pos: -72.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12597
     components:
     - type: Transform
@@ -82933,7 +82634,7 @@ entities:
       pos: -77.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12598
     components:
     - type: Transform
@@ -82941,7 +82642,7 @@ entities:
       pos: -78.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12599
     components:
     - type: Transform
@@ -82949,7 +82650,7 @@ entities:
       pos: -79.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12600
     components:
     - type: Transform
@@ -82957,7 +82658,7 @@ entities:
       pos: -75.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12601
     components:
     - type: Transform
@@ -82965,7 +82666,7 @@ entities:
       pos: -68.5,-54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12602
     components:
     - type: Transform
@@ -82973,7 +82674,7 @@ entities:
       pos: -69.5,-54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12603
     components:
     - type: Transform
@@ -82981,7 +82682,7 @@ entities:
       pos: -70.5,-54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12604
     components:
     - type: Transform
@@ -82989,7 +82690,7 @@ entities:
       pos: -71.5,-54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12605
     components:
     - type: Transform
@@ -82997,7 +82698,7 @@ entities:
       pos: -73.5,-54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12606
     components:
     - type: Transform
@@ -83005,7 +82706,7 @@ entities:
       pos: -74.5,-54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12607
     components:
     - type: Transform
@@ -83013,7 +82714,7 @@ entities:
       pos: -75.5,-54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12608
     components:
     - type: Transform
@@ -83021,7 +82722,7 @@ entities:
       pos: -69.5,-55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12609
     components:
     - type: Transform
@@ -83029,7 +82730,7 @@ entities:
       pos: -70.5,-55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12610
     components:
     - type: Transform
@@ -83037,7 +82738,7 @@ entities:
       pos: -72.5,-55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12611
     components:
     - type: Transform
@@ -83045,7 +82746,7 @@ entities:
       pos: -73.5,-55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12612
     components:
     - type: Transform
@@ -83053,7 +82754,7 @@ entities:
       pos: -74.5,-55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12613
     components:
     - type: Transform
@@ -83061,7 +82762,7 @@ entities:
       pos: -75.5,-55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12614
     components:
     - type: Transform
@@ -83069,7 +82770,7 @@ entities:
       pos: -71.5,-54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12615
     components:
     - type: Transform
@@ -83083,35 +82784,35 @@ entities:
       pos: 4.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12617
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12618
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12619
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12620
     components:
     - type: Transform
       pos: 4.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12621
     components:
     - type: Transform
@@ -83216,7 +82917,7 @@ entities:
       pos: 22.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12635
     components:
     - type: Transform
@@ -83224,7 +82925,7 @@ entities:
       pos: 23.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12636
     components:
     - type: Transform
@@ -83232,7 +82933,7 @@ entities:
       pos: 24.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12637
     components:
     - type: Transform
@@ -83240,7 +82941,7 @@ entities:
       pos: 25.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12638
     components:
     - type: Transform
@@ -83248,7 +82949,7 @@ entities:
       pos: 26.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12639
     components:
     - type: Transform
@@ -83256,7 +82957,7 @@ entities:
       pos: 27.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12640
     components:
     - type: Transform
@@ -83264,7 +82965,7 @@ entities:
       pos: 26.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12641
     components:
     - type: Transform
@@ -83272,28 +82973,28 @@ entities:
       pos: 25.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12642
     components:
     - type: Transform
       pos: 39.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12643
     components:
     - type: Transform
       pos: 39.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12644
     components:
     - type: Transform
       pos: 39.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12645
     components:
     - type: Transform
@@ -83301,7 +83002,7 @@ entities:
       pos: 43.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12646
     components:
     - type: Transform
@@ -83309,7 +83010,7 @@ entities:
       pos: 43.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12647
     components:
     - type: Transform
@@ -83317,7 +83018,7 @@ entities:
       pos: 43.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12648
     components:
     - type: Transform
@@ -83325,7 +83026,7 @@ entities:
       pos: -0.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12649
     components:
     - type: Transform
@@ -83333,7 +83034,7 @@ entities:
       pos: -0.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12650
     components:
     - type: Transform
@@ -83341,7 +83042,7 @@ entities:
       pos: -0.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12651
     components:
     - type: Transform
@@ -83349,7 +83050,7 @@ entities:
       pos: -0.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12652
     components:
     - type: Transform
@@ -83357,7 +83058,7 @@ entities:
       pos: -0.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12653
     components:
     - type: Transform
@@ -83365,7 +83066,7 @@ entities:
       pos: -0.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12654
     components:
     - type: Transform
@@ -83373,7 +83074,7 @@ entities:
       pos: -0.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12655
     components:
     - type: Transform
@@ -83381,7 +83082,7 @@ entities:
       pos: -0.5,45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12656
     components:
     - type: Transform
@@ -83389,7 +83090,7 @@ entities:
       pos: -0.5,46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12657
     components:
     - type: Transform
@@ -83397,7 +83098,7 @@ entities:
       pos: -0.5,47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12658
     components:
     - type: Transform
@@ -83405,7 +83106,7 @@ entities:
       pos: -0.5,48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12659
     components:
     - type: Transform
@@ -83413,7 +83114,7 @@ entities:
       pos: -0.5,49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12660
     components:
     - type: Transform
@@ -83421,7 +83122,7 @@ entities:
       pos: -0.5,50.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12661
     components:
     - type: Transform
@@ -83429,7 +83130,7 @@ entities:
       pos: -0.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12662
     components:
     - type: Transform
@@ -83437,7 +83138,7 @@ entities:
       pos: -0.5,52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12663
     components:
     - type: Transform
@@ -83445,7 +83146,7 @@ entities:
       pos: -0.5,53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12664
     components:
     - type: Transform
@@ -83453,7 +83154,7 @@ entities:
       pos: -0.5,54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12665
     components:
     - type: Transform
@@ -83461,7 +83162,7 @@ entities:
       pos: -0.5,55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12666
     components:
     - type: Transform
@@ -83469,7 +83170,7 @@ entities:
       pos: -0.5,56.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12667
     components:
     - type: Transform
@@ -83477,7 +83178,7 @@ entities:
       pos: -0.5,57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12668
     components:
     - type: Transform
@@ -83485,7 +83186,7 @@ entities:
       pos: -0.5,58.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12669
     components:
     - type: Transform
@@ -83493,7 +83194,7 @@ entities:
       pos: -0.5,59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12670
     components:
     - type: Transform
@@ -83501,7 +83202,7 @@ entities:
       pos: -0.5,60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12671
     components:
     - type: Transform
@@ -83509,7 +83210,7 @@ entities:
       pos: -0.5,61.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12672
     components:
     - type: Transform
@@ -83517,7 +83218,7 @@ entities:
       pos: -0.5,62.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12673
     components:
     - type: Transform
@@ -83525,7 +83226,7 @@ entities:
       pos: -0.5,63.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12674
     components:
     - type: Transform
@@ -83533,100 +83234,114 @@ entities:
       pos: -0.5,64.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12675
     components:
     - type: Transform
       pos: -0.5,66.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12676
     components:
     - type: Transform
       pos: -0.5,67.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12677
     components:
     - type: Transform
       pos: -0.5,68.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12678
     components:
     - type: Transform
       pos: -0.5,69.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12679
     components:
     - type: Transform
       pos: -0.5,70.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12680
     components:
     - type: Transform
       pos: -0.5,71.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12681
     components:
     - type: Transform
       pos: -0.5,72.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12682
     components:
     - type: Transform
       pos: -0.5,73.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12683
     components:
     - type: Transform
       pos: 43.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12684
     components:
     - type: Transform
       pos: 43.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12685
     components:
     - type: Transform
       pos: 43.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12686
     components:
     - type: Transform
       pos: 43.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12687
     components:
     - type: Transform
       pos: 43.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
 - proto: GasPipeTJunction
   entities:
+  - uid: 7887
+    components:
+    - type: Transform
+      pos: -18.5,27.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 7888
+    components:
+    - type: Transform
+      pos: -17.5,25.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 12688
     components:
     - type: Transform
@@ -83640,7 +83355,7 @@ entities:
       pos: -45.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12690
     components:
     - type: Transform
@@ -83648,7 +83363,7 @@ entities:
       pos: -45.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12691
     components:
     - type: Transform
@@ -83656,7 +83371,7 @@ entities:
       pos: -34.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12692
     components:
     - type: Transform
@@ -83664,7 +83379,7 @@ entities:
       pos: -34.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12693
     components:
     - type: Transform
@@ -83672,7 +83387,7 @@ entities:
       pos: -36.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12694
     components:
     - type: Transform
@@ -83680,28 +83395,28 @@ entities:
       pos: -34.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12695
     components:
     - type: Transform
       pos: -42.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12696
     components:
     - type: Transform
       pos: -41.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12697
     components:
     - type: Transform
       pos: -41.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12698
     components:
     - type: Transform
@@ -83709,7 +83424,7 @@ entities:
       pos: -45.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12699
     components:
     - type: Transform
@@ -83717,7 +83432,7 @@ entities:
       pos: -36.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12700
     components:
     - type: Transform
@@ -83725,28 +83440,28 @@ entities:
       pos: -34.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12701
     components:
     - type: Transform
       pos: -36.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12702
     components:
     - type: Transform
       pos: -34.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12703
     components:
     - type: Transform
       pos: -35.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12704
     components:
     - type: Transform
@@ -83754,7 +83469,7 @@ entities:
       pos: -33.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12705
     components:
     - type: Transform
@@ -83762,7 +83477,7 @@ entities:
       pos: -33.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12706
     components:
     - type: Transform
@@ -83770,7 +83485,7 @@ entities:
       pos: -31.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12707
     components:
     - type: Transform
@@ -83778,7 +83493,7 @@ entities:
       pos: -33.5,46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12708
     components:
     - type: Transform
@@ -83786,7 +83501,7 @@ entities:
       pos: -31.5,46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12709
     components:
     - type: Transform
@@ -83794,7 +83509,7 @@ entities:
       pos: -31.5,48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12710
     components:
     - type: Transform
@@ -83802,7 +83517,7 @@ entities:
       pos: -33.5,47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12711
     components:
     - type: Transform
@@ -83810,7 +83525,7 @@ entities:
       pos: -38.5,47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12712
     components:
     - type: Transform
@@ -83818,7 +83533,7 @@ entities:
       pos: -40.5,48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12713
     components:
     - type: Transform
@@ -83826,7 +83541,7 @@ entities:
       pos: -31.5,49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12714
     components:
     - type: Transform
@@ -83834,49 +83549,49 @@ entities:
       pos: -33.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12715
     components:
     - type: Transform
       pos: -34.5,53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12716
     components:
     - type: Transform
       pos: -30.5,53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12717
     components:
     - type: Transform
       pos: -38.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12718
     components:
     - type: Transform
       pos: -40.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12719
     components:
     - type: Transform
       pos: -42.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12720
     components:
     - type: Transform
       pos: -44.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12721
     components:
     - type: Transform
@@ -83884,7 +83599,7 @@ entities:
       pos: -46.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12722
     components:
     - type: Transform
@@ -83892,7 +83607,7 @@ entities:
       pos: -48.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12723
     components:
     - type: Transform
@@ -83900,14 +83615,14 @@ entities:
       pos: -41.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12724
     components:
     - type: Transform
       pos: -43.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12725
     components:
     - type: Transform
@@ -83915,7 +83630,7 @@ entities:
       pos: -48.5,50.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12726
     components:
     - type: Transform
@@ -83923,7 +83638,7 @@ entities:
       pos: -48.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12727
     components:
     - type: Transform
@@ -83931,7 +83646,7 @@ entities:
       pos: -46.5,52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12728
     components:
     - type: Transform
@@ -83939,7 +83654,7 @@ entities:
       pos: -46.5,49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12729
     components:
     - type: Transform
@@ -83947,7 +83662,7 @@ entities:
       pos: -48.5,56.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12730
     components:
     - type: Transform
@@ -83955,7 +83670,7 @@ entities:
       pos: -46.5,56.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12731
     components:
     - type: Transform
@@ -83963,7 +83678,7 @@ entities:
       pos: -46.5,57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12732
     components:
     - type: Transform
@@ -83971,7 +83686,7 @@ entities:
       pos: -50.5,61.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12733
     components:
     - type: Transform
@@ -83979,14 +83694,14 @@ entities:
       pos: -46.5,61.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12734
     components:
     - type: Transform
       pos: -48.5,58.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12735
     components:
     - type: Transform
@@ -83994,7 +83709,7 @@ entities:
       pos: -51.5,60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12736
     components:
     - type: Transform
@@ -84002,14 +83717,14 @@ entities:
       pos: -47.5,60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12737
     components:
     - type: Transform
       pos: -48.5,64.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12738
     components:
     - type: Transform
@@ -84017,7 +83732,7 @@ entities:
       pos: -36.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12739
     components:
     - type: Transform
@@ -84025,7 +83740,7 @@ entities:
       pos: -36.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12740
     components:
     - type: Transform
@@ -84033,7 +83748,7 @@ entities:
       pos: -36.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12741
     components:
     - type: Transform
@@ -84041,7 +83756,7 @@ entities:
       pos: -36.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12742
     components:
     - type: Transform
@@ -84049,7 +83764,7 @@ entities:
       pos: -34.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12743
     components:
     - type: Transform
@@ -84057,7 +83772,7 @@ entities:
       pos: -34.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12744
     components:
     - type: Transform
@@ -84065,7 +83780,7 @@ entities:
       pos: -32.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12745
     components:
     - type: Transform
@@ -84073,7 +83788,7 @@ entities:
       pos: -27.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12746
     components:
     - type: Transform
@@ -84081,7 +83796,7 @@ entities:
       pos: -21.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12747
     components:
     - type: Transform
@@ -84089,28 +83804,28 @@ entities:
       pos: -17.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12748
     components:
     - type: Transform
       pos: -8.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12749
     components:
     - type: Transform
       pos: 1.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12750
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12751
     components:
     - type: Transform
@@ -84118,7 +83833,7 @@ entities:
       pos: 8.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12752
     components:
     - type: Transform
@@ -84126,7 +83841,7 @@ entities:
       pos: 10.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12753
     components:
     - type: Transform
@@ -84134,7 +83849,7 @@ entities:
       pos: 10.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12754
     components:
     - type: Transform
@@ -84142,7 +83857,7 @@ entities:
       pos: 8.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12755
     components:
     - type: Transform
@@ -84150,14 +83865,14 @@ entities:
       pos: 3.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12756
     components:
     - type: Transform
       pos: -2.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12757
     components:
     - type: Transform
@@ -84165,7 +83880,7 @@ entities:
       pos: -4.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12758
     components:
     - type: Transform
@@ -84173,7 +83888,7 @@ entities:
       pos: -14.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12759
     components:
     - type: Transform
@@ -84181,21 +83896,21 @@ entities:
       pos: -23.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12760
     components:
     - type: Transform
       pos: -21.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12761
     components:
     - type: Transform
       pos: -27.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12762
     components:
     - type: Transform
@@ -84203,7 +83918,7 @@ entities:
       pos: -34.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12763
     components:
     - type: Transform
@@ -84211,7 +83926,7 @@ entities:
       pos: -34.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12764
     components:
     - type: Transform
@@ -84219,7 +83934,7 @@ entities:
       pos: -34.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12765
     components:
     - type: Transform
@@ -84227,7 +83942,7 @@ entities:
       pos: -34.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12766
     components:
     - type: Transform
@@ -84235,21 +83950,21 @@ entities:
       pos: -34.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12767
     components:
     - type: Transform
       pos: -31.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12768
     components:
     - type: Transform
       pos: -24.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12769
     components:
     - type: Transform
@@ -84257,21 +83972,21 @@ entities:
       pos: -19.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12770
     components:
     - type: Transform
       pos: -14.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12771
     components:
     - type: Transform
       pos: -6.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12772
     components:
     - type: Transform
@@ -84279,7 +83994,7 @@ entities:
       pos: 10.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12773
     components:
     - type: Transform
@@ -84287,7 +84002,7 @@ entities:
       pos: 8.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12774
     components:
     - type: Transform
@@ -84295,21 +84010,21 @@ entities:
       pos: 10.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12775
     components:
     - type: Transform
       pos: 0.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12776
     components:
     - type: Transform
       pos: -0.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12777
     components:
     - type: Transform
@@ -84317,7 +84032,7 @@ entities:
       pos: -3.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12778
     components:
     - type: Transform
@@ -84325,28 +84040,28 @@ entities:
       pos: -15.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12779
     components:
     - type: Transform
       pos: -22.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12780
     components:
     - type: Transform
       pos: -19.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12781
     components:
     - type: Transform
       pos: -26.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12782
     components:
     - type: Transform
@@ -84354,14 +84069,14 @@ entities:
       pos: -25.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12783
     components:
     - type: Transform
       pos: -30.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12784
     components:
     - type: Transform
@@ -84369,28 +84084,28 @@ entities:
       pos: -42.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12785
     components:
     - type: Transform
       pos: -41.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12786
     components:
     - type: Transform
       pos: -39.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12787
     components:
     - type: Transform
       pos: -39.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12788
     components:
     - type: Transform
@@ -84398,14 +84113,14 @@ entities:
       pos: -44.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12789
     components:
     - type: Transform
       pos: -45.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12790
     components:
     - type: Transform
@@ -84413,7 +84128,7 @@ entities:
       pos: -51.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12791
     components:
     - type: Transform
@@ -84421,7 +84136,7 @@ entities:
       pos: -52.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12792
     components:
     - type: Transform
@@ -84429,7 +84144,7 @@ entities:
       pos: -44.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12793
     components:
     - type: Transform
@@ -84437,7 +84152,7 @@ entities:
       pos: -45.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12794
     components:
     - type: Transform
@@ -84445,7 +84160,7 @@ entities:
       pos: -44.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12795
     components:
     - type: Transform
@@ -84453,7 +84168,7 @@ entities:
       pos: -44.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12796
     components:
     - type: Transform
@@ -84461,7 +84176,7 @@ entities:
       pos: -44.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12797
     components:
     - type: Transform
@@ -84469,7 +84184,7 @@ entities:
       pos: -43.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12798
     components:
     - type: Transform
@@ -84477,14 +84192,14 @@ entities:
       pos: -42.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12799
     components:
     - type: Transform
       pos: -41.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12800
     components:
     - type: Transform
@@ -84492,7 +84207,7 @@ entities:
       pos: -49.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12801
     components:
     - type: Transform
@@ -84500,14 +84215,14 @@ entities:
       pos: -50.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12802
     components:
     - type: Transform
       pos: -52.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12803
     components:
     - type: Transform
@@ -84515,7 +84230,7 @@ entities:
       pos: -57.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12804
     components:
     - type: Transform
@@ -84523,7 +84238,7 @@ entities:
       pos: -57.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12805
     components:
     - type: Transform
@@ -84531,7 +84246,7 @@ entities:
       pos: -57.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12806
     components:
     - type: Transform
@@ -84539,7 +84254,7 @@ entities:
       pos: -57.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12807
     components:
     - type: Transform
@@ -84547,14 +84262,14 @@ entities:
       pos: -49.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12808
     components:
     - type: Transform
       pos: -19.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12809
     components:
     - type: Transform
@@ -84562,14 +84277,14 @@ entities:
       pos: -23.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12810
     components:
     - type: Transform
       pos: -21.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12811
     components:
     - type: Transform
@@ -84577,7 +84292,7 @@ entities:
       pos: -17.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12812
     components:
     - type: Transform
@@ -84585,7 +84300,7 @@ entities:
       pos: -16.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12813
     components:
     - type: Transform
@@ -84593,7 +84308,7 @@ entities:
       pos: -17.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12814
     components:
     - type: Transform
@@ -84601,7 +84316,7 @@ entities:
       pos: -16.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12815
     components:
     - type: Transform
@@ -84615,7 +84330,7 @@ entities:
       pos: -3.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12817
     components:
     - type: Transform
@@ -84623,21 +84338,21 @@ entities:
       pos: -1.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12818
     components:
     - type: Transform
       pos: -3.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12819
     components:
     - type: Transform
       pos: -1.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12820
     components:
     - type: Transform
@@ -84645,21 +84360,21 @@ entities:
       pos: -4.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12821
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12822
     components:
     - type: Transform
       pos: -8.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12823
     components:
     - type: Transform
@@ -84667,7 +84382,7 @@ entities:
       pos: -10.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12824
     components:
     - type: Transform
@@ -84675,7 +84390,7 @@ entities:
       pos: -9.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12825
     components:
     - type: Transform
@@ -84683,7 +84398,7 @@ entities:
       pos: -12.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12826
     components:
     - type: Transform
@@ -84703,14 +84418,14 @@ entities:
       pos: -8.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12829
     components:
     - type: Transform
       pos: -10.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12830
     components:
     - type: Transform
@@ -84718,7 +84433,7 @@ entities:
       pos: -14.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12831
     components:
     - type: Transform
@@ -84726,21 +84441,21 @@ entities:
       pos: -4.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12832
     components:
     - type: Transform
       pos: -11.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12833
     components:
     - type: Transform
       pos: -9.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12834
     components:
     - type: Transform
@@ -84748,7 +84463,7 @@ entities:
       pos: -15.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12835
     components:
     - type: Transform
@@ -84756,7 +84471,7 @@ entities:
       pos: -15.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12836
     components:
     - type: Transform
@@ -84764,7 +84479,7 @@ entities:
       pos: -3.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12837
     components:
     - type: Transform
@@ -84772,7 +84487,7 @@ entities:
       pos: -3.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12838
     components:
     - type: Transform
@@ -84780,7 +84495,7 @@ entities:
       pos: -9.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12839
     components:
     - type: Transform
@@ -84788,14 +84503,14 @@ entities:
       pos: -7.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12840
     components:
     - type: Transform
       pos: -20.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12841
     components:
     - type: Transform
@@ -84803,14 +84518,14 @@ entities:
       pos: -20.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12842
     components:
     - type: Transform
       pos: -19.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12843
     components:
     - type: Transform
@@ -84818,7 +84533,7 @@ entities:
       pos: -21.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12844
     components:
     - type: Transform
@@ -84826,14 +84541,14 @@ entities:
       pos: -26.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12845
     components:
     - type: Transform
       pos: -30.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12846
     components:
     - type: Transform
@@ -84841,7 +84556,7 @@ entities:
       pos: -17.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12847
     components:
     - type: Transform
@@ -84849,7 +84564,7 @@ entities:
       pos: -13.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12848
     components:
     - type: Transform
@@ -84857,7 +84572,7 @@ entities:
       pos: -18.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12849
     components:
     - type: Transform
@@ -84865,7 +84580,7 @@ entities:
       pos: -23.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12850
     components:
     - type: Transform
@@ -84873,14 +84588,14 @@ entities:
       pos: -19.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12851
     components:
     - type: Transform
       pos: -22.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12852
     components:
     - type: Transform
@@ -84888,28 +84603,28 @@ entities:
       pos: -30.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12853
     components:
     - type: Transform
       pos: -19.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12854
     components:
     - type: Transform
       pos: -20.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12855
     components:
     - type: Transform
       pos: -28.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12856
     components:
     - type: Transform
@@ -84917,7 +84632,7 @@ entities:
       pos: -8.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12857
     components:
     - type: Transform
@@ -84925,7 +84640,7 @@ entities:
       pos: -3.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12858
     components:
     - type: Transform
@@ -84933,7 +84648,7 @@ entities:
       pos: -1.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12859
     components:
     - type: Transform
@@ -84941,7 +84656,7 @@ entities:
       pos: -10.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12860
     components:
     - type: Transform
@@ -84949,7 +84664,7 @@ entities:
       pos: -2.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12861
     components:
     - type: Transform
@@ -84957,7 +84672,7 @@ entities:
       pos: -11.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12862
     components:
     - type: Transform
@@ -84965,21 +84680,21 @@ entities:
       pos: -12.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12863
     components:
     - type: Transform
       pos: -18.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12864
     components:
     - type: Transform
       pos: -7.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12865
     components:
     - type: Transform
@@ -84987,14 +84702,14 @@ entities:
       pos: -17.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12866
     components:
     - type: Transform
       pos: -23.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12867
     components:
     - type: Transform
@@ -85008,7 +84723,7 @@ entities:
       pos: -29.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12869
     components:
     - type: Transform
@@ -85016,14 +84731,14 @@ entities:
       pos: -28.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12870
     components:
     - type: Transform
       pos: -13.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12871
     components:
     - type: Transform
@@ -85031,7 +84746,7 @@ entities:
       pos: -12.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12872
     components:
     - type: Transform
@@ -85039,7 +84754,7 @@ entities:
       pos: -22.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12873
     components:
     - type: Transform
@@ -85047,7 +84762,7 @@ entities:
       pos: -22.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12874
     components:
     - type: Transform
@@ -85055,14 +84770,14 @@ entities:
       pos: -25.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12875
     components:
     - type: Transform
       pos: -29.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12876
     components:
     - type: Transform
@@ -85070,7 +84785,7 @@ entities:
       pos: -28.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12877
     components:
     - type: Transform
@@ -85078,7 +84793,7 @@ entities:
       pos: -17.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12878
     components:
     - type: Transform
@@ -85086,7 +84801,7 @@ entities:
       pos: -20.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12879
     components:
     - type: Transform
@@ -85094,7 +84809,7 @@ entities:
       pos: -22.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12880
     components:
     - type: Transform
@@ -85102,14 +84817,14 @@ entities:
       pos: -30.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12881
     components:
     - type: Transform
       pos: -21.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12882
     components:
     - type: Transform
@@ -85117,7 +84832,7 @@ entities:
       pos: -20.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12883
     components:
     - type: Transform
@@ -85125,14 +84840,14 @@ entities:
       pos: 20.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12884
     components:
     - type: Transform
       pos: -16.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12885
     components:
     - type: Transform
@@ -85140,7 +84855,7 @@ entities:
       pos: -1.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12886
     components:
     - type: Transform
@@ -85148,7 +84863,7 @@ entities:
       pos: -13.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12887
     components:
     - type: Transform
@@ -85156,7 +84871,7 @@ entities:
       pos: -13.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12888
     components:
     - type: Transform
@@ -85164,21 +84879,21 @@ entities:
       pos: 20.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12889
     components:
     - type: Transform
       pos: -21.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12890
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12891
     components:
     - type: Transform
@@ -85186,7 +84901,7 @@ entities:
       pos: 9.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12892
     components:
     - type: Transform
@@ -85194,14 +84909,14 @@ entities:
       pos: 7.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12893
     components:
     - type: Transform
       pos: 2.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12894
     components:
     - type: Transform
@@ -85209,7 +84924,7 @@ entities:
       pos: 11.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12895
     components:
     - type: Transform
@@ -85217,7 +84932,7 @@ entities:
       pos: 9.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12896
     components:
     - type: Transform
@@ -85225,7 +84940,7 @@ entities:
       pos: 11.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12897
     components:
     - type: Transform
@@ -85233,7 +84948,7 @@ entities:
       pos: 11.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12898
     components:
     - type: Transform
@@ -85241,14 +84956,14 @@ entities:
       pos: 12.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12899
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12900
     components:
     - type: Transform
@@ -85256,21 +84971,21 @@ entities:
       pos: 6.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12901
     components:
     - type: Transform
       pos: 5.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12902
     components:
     - type: Transform
       pos: 7.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12903
     components:
     - type: Transform
@@ -85278,7 +84993,7 @@ entities:
       pos: 7.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12904
     components:
     - type: Transform
@@ -85286,7 +85001,7 @@ entities:
       pos: 13.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12905
     components:
     - type: Transform
@@ -85294,7 +85009,7 @@ entities:
       pos: 20.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12906
     components:
     - type: Transform
@@ -85302,14 +85017,14 @@ entities:
       pos: 13.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12907
     components:
     - type: Transform
       pos: 9.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12908
     components:
     - type: Transform
@@ -85317,7 +85032,7 @@ entities:
       pos: 7.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12909
     components:
     - type: Transform
@@ -85325,7 +85040,7 @@ entities:
       pos: 3.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12910
     components:
     - type: Transform
@@ -85361,7 +85076,7 @@ entities:
       pos: -13.5,-30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12915
     components:
     - type: Transform
@@ -85369,21 +85084,21 @@ entities:
       pos: -13.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12916
     components:
     - type: Transform
       pos: -25.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12917
     components:
     - type: Transform
       pos: -25.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12918
     components:
     - type: Transform
@@ -85391,7 +85106,7 @@ entities:
       pos: -25.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12919
     components:
     - type: Transform
@@ -85399,7 +85114,7 @@ entities:
       pos: 2.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12920
     components:
     - type: Transform
@@ -85407,7 +85122,7 @@ entities:
       pos: -1.5,-26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12921
     components:
     - type: Transform
@@ -85415,14 +85130,14 @@ entities:
       pos: -3.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12922
     components:
     - type: Transform
       pos: 4.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12923
     components:
     - type: Transform
@@ -85430,7 +85145,7 @@ entities:
       pos: 0.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12924
     components:
     - type: Transform
@@ -85438,7 +85153,7 @@ entities:
       pos: 2.5,-32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12925
     components:
     - type: Transform
@@ -85446,7 +85161,7 @@ entities:
       pos: -11.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12926
     components:
     - type: Transform
@@ -85454,7 +85169,7 @@ entities:
       pos: -29.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12927
     components:
     - type: Transform
@@ -85462,7 +85177,7 @@ entities:
       pos: -18.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12928
     components:
     - type: Transform
@@ -85470,7 +85185,7 @@ entities:
       pos: -16.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12929
     components:
     - type: Transform
@@ -85478,14 +85193,14 @@ entities:
       pos: -11.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12930
     components:
     - type: Transform
       pos: 6.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12931
     components:
     - type: Transform
@@ -85493,7 +85208,7 @@ entities:
       pos: -8.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12932
     components:
     - type: Transform
@@ -85501,7 +85216,7 @@ entities:
       pos: -11.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12933
     components:
     - type: Transform
@@ -85509,7 +85224,7 @@ entities:
       pos: -5.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12934
     components:
     - type: Transform
@@ -85517,7 +85232,7 @@ entities:
       pos: 2.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12935
     components:
     - type: Transform
@@ -85525,7 +85240,7 @@ entities:
       pos: -23.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12936
     components:
     - type: Transform
@@ -85533,14 +85248,14 @@ entities:
       pos: -11.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12937
     components:
     - type: Transform
       pos: -1.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12938
     components:
     - type: Transform
@@ -85548,7 +85263,7 @@ entities:
       pos: 21.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12939
     components:
     - type: Transform
@@ -85556,14 +85271,14 @@ entities:
       pos: 21.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12940
     components:
     - type: Transform
       pos: -18.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12941
     components:
     - type: Transform
@@ -85571,14 +85286,14 @@ entities:
       pos: -11.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12942
     components:
     - type: Transform
       pos: 6.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12943
     components:
     - type: Transform
@@ -85586,7 +85301,7 @@ entities:
       pos: 25.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12944
     components:
     - type: Transform
@@ -85594,14 +85309,14 @@ entities:
       pos: 33.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12945
     components:
     - type: Transform
       pos: 24.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12946
     components:
     - type: Transform
@@ -85609,7 +85324,7 @@ entities:
       pos: 6.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12947
     components:
     - type: Transform
@@ -85617,7 +85332,7 @@ entities:
       pos: 24.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12948
     components:
     - type: Transform
@@ -85625,7 +85340,7 @@ entities:
       pos: 26.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12949
     components:
     - type: Transform
@@ -85633,7 +85348,7 @@ entities:
       pos: 25.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12950
     components:
     - type: Transform
@@ -85641,7 +85356,7 @@ entities:
       pos: 21.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12951
     components:
     - type: Transform
@@ -85649,7 +85364,7 @@ entities:
       pos: 20.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12952
     components:
     - type: Transform
@@ -85657,7 +85372,7 @@ entities:
       pos: 19.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12953
     components:
     - type: Transform
@@ -85665,14 +85380,14 @@ entities:
       pos: 16.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12954
     components:
     - type: Transform
       pos: 17.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12955
     components:
     - type: Transform
@@ -85680,7 +85395,7 @@ entities:
       pos: 21.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12956
     components:
     - type: Transform
@@ -85688,7 +85403,7 @@ entities:
       pos: 13.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12957
     components:
     - type: Transform
@@ -85696,7 +85411,7 @@ entities:
       pos: 20.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12958
     components:
     - type: Transform
@@ -85704,21 +85419,21 @@ entities:
       pos: 6.5,-25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12959
     components:
     - type: Transform
       pos: 24.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12960
     components:
     - type: Transform
       pos: 33.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12961
     components:
     - type: Transform
@@ -85726,7 +85441,7 @@ entities:
       pos: 29.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12962
     components:
     - type: Transform
@@ -85734,7 +85449,7 @@ entities:
       pos: 8.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12963
     components:
     - type: Transform
@@ -85742,21 +85457,21 @@ entities:
       pos: 10.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12964
     components:
     - type: Transform
       pos: 10.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12965
     components:
     - type: Transform
       pos: 16.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12966
     components:
     - type: Transform
@@ -85764,7 +85479,7 @@ entities:
       pos: 21.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12967
     components:
     - type: Transform
@@ -85772,7 +85487,7 @@ entities:
       pos: 18.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12968
     components:
     - type: Transform
@@ -85780,7 +85495,7 @@ entities:
       pos: 23.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12969
     components:
     - type: Transform
@@ -85788,7 +85503,7 @@ entities:
       pos: 23.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12970
     components:
     - type: Transform
@@ -85796,7 +85511,7 @@ entities:
       pos: 23.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12971
     components:
     - type: Transform
@@ -85804,14 +85519,14 @@ entities:
       pos: 21.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12972
     components:
     - type: Transform
       pos: 23.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12973
     components:
     - type: Transform
@@ -85819,7 +85534,7 @@ entities:
       pos: 20.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12974
     components:
     - type: Transform
@@ -85827,7 +85542,7 @@ entities:
       pos: 24.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12975
     components:
     - type: Transform
@@ -85835,7 +85550,7 @@ entities:
       pos: 20.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12976
     components:
     - type: Transform
@@ -85843,7 +85558,7 @@ entities:
       pos: 25.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12977
     components:
     - type: Transform
@@ -85851,14 +85566,14 @@ entities:
       pos: 23.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12978
     components:
     - type: Transform
       pos: 26.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12979
     components:
     - type: Transform
@@ -85870,7 +85585,7 @@ entities:
       pos: -61.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12981
     components:
     - type: Transform
@@ -85878,14 +85593,14 @@ entities:
       pos: 23.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12982
     components:
     - type: Transform
       pos: 28.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12983
     components:
     - type: Transform
@@ -85893,7 +85608,7 @@ entities:
       pos: 14.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12984
     components:
     - type: Transform
@@ -85901,7 +85616,7 @@ entities:
       pos: 23.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12985
     components:
     - type: Transform
@@ -85909,14 +85624,14 @@ entities:
       pos: 23.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12986
     components:
     - type: Transform
       pos: 28.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12987
     components:
     - type: Transform
@@ -85924,7 +85639,7 @@ entities:
       pos: 14.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12988
     components:
     - type: Transform
@@ -85932,14 +85647,14 @@ entities:
       pos: 14.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12989
     components:
     - type: Transform
       pos: 23.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12990
     components:
     - type: Transform
@@ -85947,7 +85662,7 @@ entities:
       pos: 8.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12991
     components:
     - type: Transform
@@ -85955,14 +85670,14 @@ entities:
       pos: 12.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12992
     components:
     - type: Transform
       pos: 13.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12993
     components:
     - type: Transform
@@ -85970,7 +85685,7 @@ entities:
       pos: 12.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12994
     components:
     - type: Transform
@@ -85978,7 +85693,7 @@ entities:
       pos: 18.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12995
     components:
     - type: Transform
@@ -85986,7 +85701,7 @@ entities:
       pos: 21.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12996
     components:
     - type: Transform
@@ -85994,7 +85709,7 @@ entities:
       pos: 25.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12997
     components:
     - type: Transform
@@ -86002,7 +85717,7 @@ entities:
       pos: 38.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 12998
     components:
     - type: Transform
@@ -86010,21 +85725,21 @@ entities:
       pos: 52.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 12999
     components:
     - type: Transform
       pos: 31.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13000
     components:
     - type: Transform
       pos: 35.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13001
     components:
     - type: Transform
@@ -86032,7 +85747,7 @@ entities:
       pos: 43.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13002
     components:
     - type: Transform
@@ -86040,7 +85755,7 @@ entities:
       pos: 31.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13003
     components:
     - type: Transform
@@ -86048,14 +85763,14 @@ entities:
       pos: 35.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13004
     components:
     - type: Transform
       pos: 39.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13005
     components:
     - type: Transform
@@ -86063,7 +85778,7 @@ entities:
       pos: 30.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13006
     components:
     - type: Transform
@@ -86071,7 +85786,7 @@ entities:
       pos: 30.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13007
     components:
     - type: Transform
@@ -86079,7 +85794,7 @@ entities:
       pos: -55.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13008
     components:
     - type: Transform
@@ -86087,21 +85802,21 @@ entities:
       pos: -25.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13009
     components:
     - type: Transform
       pos: 17.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13010
     components:
     - type: Transform
       pos: -62.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13011
     components:
     - type: Transform
@@ -86115,7 +85830,7 @@ entities:
       pos: -45.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13013
     components:
     - type: Transform
@@ -86123,14 +85838,14 @@ entities:
       pos: -61.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13014
     components:
     - type: Transform
       pos: -57.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13015
     components:
     - type: Transform
@@ -86138,7 +85853,7 @@ entities:
       pos: -53.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13016
     components:
     - type: Transform
@@ -86146,7 +85861,7 @@ entities:
       pos: -44.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13017
     components:
     - type: Transform
@@ -86154,14 +85869,14 @@ entities:
       pos: -44.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13018
     components:
     - type: Transform
       pos: -61.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13019
     components:
     - type: Transform
@@ -86169,14 +85884,14 @@ entities:
       pos: -58.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13020
     components:
     - type: Transform
       pos: -51.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13021
     components:
     - type: Transform
@@ -86184,7 +85899,7 @@ entities:
       pos: -49.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13022
     components:
     - type: Transform
@@ -86192,7 +85907,7 @@ entities:
       pos: -63.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13023
     components:
     - type: Transform
@@ -86200,7 +85915,7 @@ entities:
       pos: -65.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13024
     components:
     - type: Transform
@@ -86208,7 +85923,7 @@ entities:
       pos: -64.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13025
     components:
     - type: Transform
@@ -86216,14 +85931,14 @@ entities:
       pos: -68.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13026
     components:
     - type: Transform
       pos: -77.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13027
     components:
     - type: Transform
@@ -86231,7 +85946,7 @@ entities:
       pos: -68.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13028
     components:
     - type: Transform
@@ -86239,14 +85954,14 @@ entities:
       pos: -62.5,-49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13029
     components:
     - type: Transform
       pos: -60.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13030
     components:
     - type: Transform
@@ -86254,7 +85969,7 @@ entities:
       pos: -60.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13031
     components:
     - type: Transform
@@ -86262,7 +85977,7 @@ entities:
       pos: -56.5,-53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13032
     components:
     - type: Transform
@@ -86270,7 +85985,7 @@ entities:
       pos: -56.5,-57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13033
     components:
     - type: Transform
@@ -86278,7 +85993,7 @@ entities:
       pos: -55.5,-52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13034
     components:
     - type: Transform
@@ -86286,7 +86001,7 @@ entities:
       pos: -67.5,-54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13035
     components:
     - type: Transform
@@ -86294,7 +86009,7 @@ entities:
       pos: -55.5,-56.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13036
     components:
     - type: Transform
@@ -86302,7 +86017,7 @@ entities:
       pos: -63.5,-49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13037
     components:
     - type: Transform
@@ -86310,14 +86025,14 @@ entities:
       pos: -68.5,-55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13038
     components:
     - type: Transform
       pos: -63.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13039
     components:
     - type: Transform
@@ -86325,7 +86040,7 @@ entities:
       pos: -67.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13040
     components:
     - type: Transform
@@ -86333,7 +86048,7 @@ entities:
       pos: -68.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13041
     components:
     - type: Transform
@@ -86341,7 +86056,7 @@ entities:
       pos: -56.5,-49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13042
     components:
     - type: Transform
@@ -86349,7 +86064,7 @@ entities:
       pos: -55.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13043
     components:
     - type: Transform
@@ -86357,14 +86072,14 @@ entities:
       pos: -61.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13044
     components:
     - type: Transform
       pos: -61.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13045
     components:
     - type: Transform
@@ -86372,7 +86087,7 @@ entities:
       pos: -58.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13046
     components:
     - type: Transform
@@ -86380,7 +86095,7 @@ entities:
       pos: -67.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13047
     components:
     - type: Transform
@@ -86388,7 +86103,7 @@ entities:
       pos: -68.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13048
     components:
     - type: Transform
@@ -86396,7 +86111,7 @@ entities:
       pos: -75.5,-46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13049
     components:
     - type: Transform
@@ -86404,28 +86119,28 @@ entities:
       pos: -75.5,-43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13050
     components:
     - type: Transform
       pos: -74.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13051
     components:
     - type: Transform
       pos: -75.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13052
     components:
     - type: Transform
       pos: -80.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13053
     components:
     - type: Transform
@@ -86433,7 +86148,7 @@ entities:
       pos: -72.5,-54.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13054
     components:
     - type: Transform
@@ -86441,7 +86156,7 @@ entities:
       pos: -71.5,-55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13055
     components:
     - type: Transform
@@ -86457,7 +86172,7 @@ entities:
       pos: -0.5,65.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
 - proto: GasPort
   entities:
   - uid: 13057
@@ -86479,7 +86194,7 @@ entities:
       pos: 20.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13060
     components:
     - type: Transform
@@ -86487,7 +86202,7 @@ entities:
       pos: 20.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13061
     components:
     - type: Transform
@@ -86495,7 +86210,7 @@ entities:
       pos: 5.5,-25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13062
     components:
     - type: Transform
@@ -86503,7 +86218,7 @@ entities:
       pos: 5.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13063
     components:
     - type: Transform
@@ -86583,7 +86298,7 @@ entities:
       pos: -52.5,-61.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13076
     components:
     - type: MetaData
@@ -86612,7 +86327,7 @@ entities:
       pos: -30.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13080
     components:
     - type: Transform
@@ -86620,7 +86335,7 @@ entities:
       pos: 16.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13081
     components:
     - type: Transform
@@ -86796,9 +86511,20 @@ entities:
     - type: GasValve
       open: False
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
 - proto: GasVentPump
   entities:
+  - uid: 7885
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -17.5,23.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 7926
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 13107
     components:
     - type: Transform
@@ -86806,7 +86532,7 @@ entities:
       pos: -35.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13108
     components:
     - type: Transform
@@ -86814,7 +86540,7 @@ entities:
       pos: -35.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13109
     components:
     - type: Transform
@@ -86822,7 +86548,7 @@ entities:
       pos: -49.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13110
     components:
     - type: Transform
@@ -86830,14 +86556,14 @@ entities:
       pos: -41.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13111
     components:
     - type: Transform
       pos: -45.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13112
     components:
     - type: Transform
@@ -86845,14 +86571,14 @@ entities:
       pos: -35.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13113
     components:
     - type: Transform
       pos: -33.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13114
     components:
     - type: Transform
@@ -86860,7 +86586,7 @@ entities:
       pos: -30.5,46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13115
     components:
     - type: Transform
@@ -86868,14 +86594,14 @@ entities:
       pos: -41.5,48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13116
     components:
     - type: Transform
       pos: -40.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13117
     components:
     - type: Transform
@@ -86883,7 +86609,7 @@ entities:
       pos: -25.5,49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13118
     components:
     - type: Transform
@@ -86891,7 +86617,7 @@ entities:
       pos: -31.5,57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13119
     components:
     - type: Transform
@@ -86899,7 +86625,7 @@ entities:
       pos: -30.5,52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13120
     components:
     - type: Transform
@@ -86907,7 +86633,7 @@ entities:
       pos: -38.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13121
     components:
     - type: Transform
@@ -86915,7 +86641,7 @@ entities:
       pos: -42.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13122
     components:
     - type: Transform
@@ -86923,14 +86649,14 @@ entities:
       pos: -46.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13123
     components:
     - type: Transform
       pos: -41.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13124
     components:
     - type: Transform
@@ -86938,7 +86664,7 @@ entities:
       pos: -47.5,49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13125
     components:
     - type: Transform
@@ -86946,14 +86672,14 @@ entities:
       pos: -50.5,52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13126
     components:
     - type: Transform
       pos: -48.5,68.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13127
     components:
     - type: Transform
@@ -86961,7 +86687,7 @@ entities:
       pos: -48.5,66.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13128
     components:
     - type: Transform
@@ -86969,7 +86695,7 @@ entities:
       pos: -49.5,61.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13129
     components:
     - type: Transform
@@ -86977,7 +86703,7 @@ entities:
       pos: -45.5,61.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13130
     components:
     - type: Transform
@@ -86985,7 +86711,7 @@ entities:
       pos: -47.5,56.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13131
     components:
     - type: Transform
@@ -86993,14 +86719,14 @@ entities:
       pos: -28.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13132
     components:
     - type: Transform
       pos: -8.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13133
     components:
     - type: Transform
@@ -87008,7 +86734,7 @@ entities:
       pos: -26.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13134
     components:
     - type: Transform
@@ -87016,7 +86742,7 @@ entities:
       pos: -30.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13135
     components:
     - type: Transform
@@ -87024,7 +86750,7 @@ entities:
       pos: -26.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13136
     components:
     - type: Transform
@@ -87032,7 +86758,7 @@ entities:
       pos: -22.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13137
     components:
     - type: Transform
@@ -87040,7 +86766,7 @@ entities:
       pos: -35.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13138
     components:
     - type: Transform
@@ -87048,7 +86774,7 @@ entities:
       pos: -35.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13139
     components:
     - type: Transform
@@ -87056,21 +86782,21 @@ entities:
       pos: -35.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13140
     components:
     - type: Transform
       pos: -40.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13141
     components:
     - type: Transform
       pos: -42.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13142
     components:
     - type: Transform
@@ -87078,7 +86804,7 @@ entities:
       pos: -39.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13143
     components:
     - type: Transform
@@ -87086,7 +86812,7 @@ entities:
       pos: -53.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13144
     components:
     - type: Transform
@@ -87094,7 +86820,7 @@ entities:
       pos: -45.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13145
     components:
     - type: Transform
@@ -87102,7 +86828,7 @@ entities:
       pos: -45.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13146
     components:
     - type: Transform
@@ -87110,28 +86836,28 @@ entities:
       pos: -31.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13147
     components:
     - type: Transform
       pos: -32.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13148
     components:
     - type: Transform
       pos: -43.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13149
     components:
     - type: Transform
       pos: -44.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13150
     components:
     - type: Transform
@@ -87139,7 +86865,7 @@ entities:
       pos: -60.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13151
     components:
     - type: Transform
@@ -87147,7 +86873,7 @@ entities:
       pos: -60.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13152
     components:
     - type: Transform
@@ -87155,7 +86881,7 @@ entities:
       pos: -60.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13153
     components:
     - type: Transform
@@ -87163,7 +86889,7 @@ entities:
       pos: -60.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13154
     components:
     - type: Transform
@@ -87171,35 +86897,35 @@ entities:
       pos: -56.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13155
     components:
     - type: Transform
       pos: -50.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13156
     components:
     - type: Transform
       pos: -27.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13157
     components:
     - type: Transform
       pos: -17.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13158
     components:
     - type: Transform
       pos: -26.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13159
     components:
     - type: Transform
@@ -87207,21 +86933,21 @@ entities:
       pos: -13.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13160
     components:
     - type: Transform
       pos: -10.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13161
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13162
     components:
     - type: Transform
@@ -87229,14 +86955,14 @@ entities:
       pos: -0.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13163
     components:
     - type: Transform
       pos: -16.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13164
     components:
     - type: Transform
@@ -87244,14 +86970,14 @@ entities:
       pos: -8.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13165
     components:
     - type: Transform
       pos: -9.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13166
     components:
     - type: Transform
@@ -87259,7 +86985,7 @@ entities:
       pos: 3.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13167
     components:
     - type: Transform
@@ -87267,21 +86993,21 @@ entities:
       pos: -0.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13168
     components:
     - type: Transform
       pos: -23.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13169
     components:
     - type: Transform
       pos: 3.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13170
     components:
     - type: Transform
@@ -87289,14 +87015,14 @@ entities:
       pos: -0.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13171
     components:
     - type: Transform
       pos: -9.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13172
     components:
     - type: Transform
@@ -87304,7 +87030,7 @@ entities:
       pos: -7.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13173
     components:
     - type: Transform
@@ -87312,7 +87038,7 @@ entities:
       pos: 0.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13174
     components:
     - type: Transform
@@ -87320,7 +87046,7 @@ entities:
       pos: -19.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13175
     components:
     - type: Transform
@@ -87328,7 +87054,7 @@ entities:
       pos: -25.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13176
     components:
     - type: Transform
@@ -87336,7 +87062,7 @@ entities:
       pos: -20.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13177
     components:
     - type: Transform
@@ -87344,7 +87070,7 @@ entities:
       pos: -19.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13178
     components:
     - type: Transform
@@ -87352,7 +87078,7 @@ entities:
       pos: -25.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13179
     components:
     - type: Transform
@@ -87360,7 +87086,7 @@ entities:
       pos: -28.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13180
     components:
     - type: Transform
@@ -87368,7 +87094,7 @@ entities:
       pos: -33.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13181
     components:
     - type: Transform
@@ -87376,7 +87102,7 @@ entities:
       pos: -18.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13182
     components:
     - type: Transform
@@ -87387,14 +87113,14 @@ entities:
       deviceLists:
       - 14
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13183
     components:
     - type: Transform
       pos: -28.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13184
     components:
     - type: Transform
@@ -87404,7 +87130,7 @@ entities:
       deviceLists:
       - 8
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13185
     components:
     - type: Transform
@@ -87414,14 +87140,14 @@ entities:
       deviceLists:
       - 8
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13186
     components:
     - type: Transform
       pos: -12.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13187
     components:
     - type: Transform
@@ -87429,7 +87155,7 @@ entities:
       pos: -7.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13188
     components:
     - type: Transform
@@ -87437,7 +87163,7 @@ entities:
       pos: -35.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13189
     components:
     - type: Transform
@@ -87448,7 +87174,7 @@ entities:
       deviceLists:
       - 14
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13190
     components:
     - type: Transform
@@ -87459,14 +87185,14 @@ entities:
       deviceLists:
       - 7
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13191
     components:
     - type: Transform
       pos: -13.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13192
     components:
     - type: Transform
@@ -87474,14 +87200,14 @@ entities:
       pos: -13.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13193
     components:
     - type: Transform
       pos: -22.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13194
     components:
     - type: Transform
@@ -87492,7 +87218,7 @@ entities:
       deviceLists:
       - 15
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13195
     components:
     - type: Transform
@@ -87503,7 +87229,7 @@ entities:
       deviceLists:
       - 19
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13196
     components:
     - type: Transform
@@ -87511,7 +87237,7 @@ entities:
       pos: -29.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13197
     components:
     - type: Transform
@@ -87522,7 +87248,7 @@ entities:
       deviceLists:
       - 19
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13198
     components:
     - type: Transform
@@ -87533,14 +87259,14 @@ entities:
       deviceLists:
       - 14
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13199
     components:
     - type: Transform
       pos: -25.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13200
     components:
     - type: Transform
@@ -87551,7 +87277,7 @@ entities:
       deviceLists:
       - 11
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13201
     components:
     - type: Transform
@@ -87559,7 +87285,7 @@ entities:
       pos: -54.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13202
     components:
     - type: Transform
@@ -87569,7 +87295,7 @@ entities:
       deviceLists:
       - 15
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13203
     components:
     - type: Transform
@@ -87580,7 +87306,7 @@ entities:
       deviceLists:
       - 16
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13204
     components:
     - type: Transform
@@ -87591,7 +87317,7 @@ entities:
       deviceLists:
       - 16
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13205
     components:
     - type: Transform
@@ -87602,7 +87328,7 @@ entities:
       deviceLists:
       - 16
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13206
     components:
     - type: Transform
@@ -87610,14 +87336,14 @@ entities:
       pos: -63.5,-63.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13207
     components:
     - type: Transform
       pos: -6.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13208
     components:
     - type: Transform
@@ -87628,7 +87354,7 @@ entities:
       deviceLists:
       - 12
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13209
     components:
     - type: Transform
@@ -87636,7 +87362,7 @@ entities:
       pos: 1.5,-32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13210
     components:
     - type: Transform
@@ -87644,7 +87370,7 @@ entities:
       pos: -2.5,-26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13211
     components:
     - type: Transform
@@ -87654,7 +87380,7 @@ entities:
       deviceLists:
       - 13
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13212
     components:
     - type: Transform
@@ -87665,21 +87391,21 @@ entities:
       deviceLists:
       - 13
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13213
     components:
     - type: Transform
       pos: 2.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13214
     components:
     - type: Transform
       pos: 9.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13215
     components:
     - type: Transform
@@ -87687,14 +87413,14 @@ entities:
       pos: 12.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13216
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13217
     components:
     - type: Transform
@@ -87702,7 +87428,7 @@ entities:
       pos: 5.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13218
     components:
     - type: Transform
@@ -87710,7 +87436,7 @@ entities:
       pos: 8.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13219
     components:
     - type: Transform
@@ -87718,14 +87444,14 @@ entities:
       pos: 14.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13220
     components:
     - type: Transform
       pos: 12.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13221
     components:
     - type: Transform
@@ -87733,7 +87459,7 @@ entities:
       pos: 33.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13222
     components:
     - type: Transform
@@ -87741,7 +87467,7 @@ entities:
       pos: 24.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13223
     components:
     - type: Transform
@@ -87749,7 +87475,7 @@ entities:
       pos: 24.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13224
     components:
     - type: Transform
@@ -87757,7 +87483,7 @@ entities:
       pos: 37.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13225
     components:
     - type: Transform
@@ -87765,7 +87491,7 @@ entities:
       pos: 17.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13226
     components:
     - type: Transform
@@ -87773,14 +87499,14 @@ entities:
       pos: 20.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13227
     components:
     - type: Transform
       pos: 20.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13228
     components:
     - type: Transform
@@ -87788,21 +87514,21 @@ entities:
       pos: 19.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13229
     components:
     - type: Transform
       pos: 30.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13230
     components:
     - type: Transform
       pos: 25.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13231
     components:
     - type: Transform
@@ -87810,7 +87536,7 @@ entities:
       pos: 37.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13232
     components:
     - type: Transform
@@ -87818,7 +87544,7 @@ entities:
       pos: 30.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13233
     components:
     - type: Transform
@@ -87826,7 +87552,7 @@ entities:
       pos: 34.5,-14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13234
     components:
     - type: Transform
@@ -87834,7 +87560,7 @@ entities:
       pos: 9.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13235
     components:
     - type: Transform
@@ -87842,14 +87568,14 @@ entities:
       pos: 11.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13236
     components:
     - type: Transform
       pos: 9.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13237
     components:
     - type: Transform
@@ -87857,14 +87583,14 @@ entities:
       pos: 9.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13238
     components:
     - type: Transform
       pos: 18.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13239
     components:
     - type: Transform
@@ -87872,7 +87598,7 @@ entities:
       pos: 18.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13240
     components:
     - type: Transform
@@ -87880,7 +87606,7 @@ entities:
       pos: 18.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13241
     components:
     - type: Transform
@@ -87888,14 +87614,14 @@ entities:
       pos: 18.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13242
     components:
     - type: Transform
       pos: 25.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13243
     components:
     - type: Transform
@@ -87903,14 +87629,14 @@ entities:
       pos: 24.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13244
     components:
     - type: Transform
       pos: 27.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13245
     components:
     - type: Transform
@@ -87923,7 +87649,7 @@ entities:
       pos: 32.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13247
     components:
     - type: Transform
@@ -87931,7 +87657,7 @@ entities:
       pos: 27.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13248
     components:
     - type: Transform
@@ -87939,7 +87665,7 @@ entities:
       pos: 37.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13249
     components:
     - type: Transform
@@ -87950,7 +87676,7 @@ entities:
       deviceLists:
       - 17
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13250
     components:
     - type: Transform
@@ -87958,7 +87684,7 @@ entities:
       pos: 28.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13251
     components:
     - type: Transform
@@ -87966,14 +87692,14 @@ entities:
       pos: 24.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13252
     components:
     - type: Transform
       pos: 14.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13253
     components:
     - type: Transform
@@ -87981,7 +87707,7 @@ entities:
       pos: 13.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13254
     components:
     - type: Transform
@@ -87992,7 +87718,7 @@ entities:
       deviceLists:
       - 17
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13255
     components:
     - type: Transform
@@ -88000,7 +87726,7 @@ entities:
       pos: 9.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13256
     components:
     - type: Transform
@@ -88008,28 +87734,28 @@ entities:
       pos: 26.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13257
     components:
     - type: Transform
       pos: 16.5,57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13258
     components:
     - type: Transform
       pos: 20.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13259
     components:
     - type: Transform
       pos: 35.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13260
     components:
     - type: Transform
@@ -88037,7 +87763,7 @@ entities:
       pos: 45.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13261
     components:
     - type: Transform
@@ -88045,14 +87771,14 @@ entities:
       pos: 30.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13262
     components:
     - type: Transform
       pos: 30.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13263
     components:
     - type: Transform
@@ -88060,7 +87786,7 @@ entities:
       pos: -26.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13264
     components:
     - type: Transform
@@ -88068,14 +87794,14 @@ entities:
       pos: 51.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13265
     components:
     - type: Transform
       pos: 52.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13266
     components:
     - type: Transform
@@ -88083,7 +87809,7 @@ entities:
       pos: 6.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13267
     components:
     - type: Transform
@@ -88094,7 +87820,7 @@ entities:
       deviceLists:
       - 17
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13268
     components:
     - type: Transform
@@ -88102,7 +87828,7 @@ entities:
       pos: -45.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13269
     components:
     - type: Transform
@@ -88110,35 +87836,35 @@ entities:
       pos: -45.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13270
     components:
     - type: Transform
       pos: -58.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13271
     components:
     - type: Transform
       pos: -49.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13272
     components:
     - type: Transform
       pos: -53.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13273
     components:
     - type: Transform
       pos: -63.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13274
     components:
     - type: Transform
@@ -88146,7 +87872,7 @@ entities:
       pos: -62.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13275
     components:
     - type: Transform
@@ -88154,49 +87880,49 @@ entities:
       pos: -59.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13276
     components:
     - type: Transform
       pos: -79.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13277
     components:
     - type: Transform
       pos: -77.5,-42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13278
     components:
     - type: Transform
       pos: -75.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13279
     components:
     - type: Transform
       pos: -68.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13280
     components:
     - type: Transform
       pos: -67.5,-42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13281
     components:
     - type: Transform
       pos: -55.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13282
     components:
     - type: Transform
@@ -88204,7 +87930,7 @@ entities:
       pos: -52.5,-56.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13283
     components:
     - type: Transform
@@ -88212,7 +87938,7 @@ entities:
       pos: -52.5,-52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13284
     components:
     - type: Transform
@@ -88220,7 +87946,7 @@ entities:
       pos: -83.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13285
     components:
     - type: Transform
@@ -88228,7 +87954,7 @@ entities:
       pos: -80.5,-61.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13286
     components:
     - type: Transform
@@ -88236,7 +87962,7 @@ entities:
       pos: -74.5,-61.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13287
     components:
     - type: Transform
@@ -88244,21 +87970,21 @@ entities:
       pos: -76.5,-55.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13288
     components:
     - type: Transform
       pos: -71.5,-53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13289
     components:
     - type: Transform
       pos: -60.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13290
     components:
     - type: Transform
@@ -88266,7 +87992,7 @@ entities:
       pos: -60.5,-49.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13291
     components:
     - type: Transform
@@ -88274,7 +88000,7 @@ entities:
       pos: 4.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13292
     components:
     - type: Transform
@@ -88282,14 +88008,14 @@ entities:
       pos: 39.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13293
     components:
     - type: Transform
       pos: -0.5,74.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13294
     components:
     - type: Transform
@@ -88297,16 +88023,27 @@ entities:
       pos: 0.5,65.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
   - uid: 13295
     components:
     - type: Transform
       pos: -1.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0000FFFF'
+      color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
+  - uid: 7897
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -18.5,23.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 7926
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 13296
     components:
     - type: Transform
@@ -88319,7 +88056,7 @@ entities:
       pos: -35.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13298
     components:
     - type: Transform
@@ -88327,7 +88064,7 @@ entities:
       pos: -35.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13299
     components:
     - type: Transform
@@ -88335,7 +88072,7 @@ entities:
       pos: -50.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13300
     components:
     - type: Transform
@@ -88343,7 +88080,7 @@ entities:
       pos: -42.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13301
     components:
     - type: Transform
@@ -88351,7 +88088,7 @@ entities:
       pos: -41.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13302
     components:
     - type: Transform
@@ -88359,7 +88096,7 @@ entities:
       pos: -35.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13303
     components:
     - type: Transform
@@ -88367,7 +88104,7 @@ entities:
       pos: -35.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13304
     components:
     - type: Transform
@@ -88375,7 +88112,7 @@ entities:
       pos: -34.5,46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13305
     components:
     - type: Transform
@@ -88383,14 +88120,14 @@ entities:
       pos: -41.5,47.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13306
     components:
     - type: Transform
       pos: -38.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13307
     components:
     - type: Transform
@@ -88398,7 +88135,7 @@ entities:
       pos: -25.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13308
     components:
     - type: Transform
@@ -88406,7 +88143,7 @@ entities:
       pos: -33.5,57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13309
     components:
     - type: Transform
@@ -88414,7 +88151,7 @@ entities:
       pos: -34.5,52.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13310
     components:
     - type: Transform
@@ -88422,7 +88159,7 @@ entities:
       pos: -48.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13311
     components:
     - type: Transform
@@ -88430,7 +88167,7 @@ entities:
       pos: -44.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13312
     components:
     - type: Transform
@@ -88438,7 +88175,7 @@ entities:
       pos: -40.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13313
     components:
     - type: Transform
@@ -88446,7 +88183,7 @@ entities:
       pos: -43.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13314
     components:
     - type: Transform
@@ -88454,7 +88191,7 @@ entities:
       pos: -47.5,50.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13315
     components:
     - type: Transform
@@ -88462,7 +88199,7 @@ entities:
       pos: -50.5,51.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13316
     components:
     - type: Transform
@@ -88470,7 +88207,7 @@ entities:
       pos: -48.5,63.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13317
     components:
     - type: Transform
@@ -88478,7 +88215,7 @@ entities:
       pos: -50.5,60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13318
     components:
     - type: Transform
@@ -88486,7 +88223,7 @@ entities:
       pos: -46.5,60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13319
     components:
     - type: Transform
@@ -88494,7 +88231,7 @@ entities:
       pos: -49.5,56.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13320
     components:
     - type: Transform
@@ -88502,7 +88239,7 @@ entities:
       pos: -28.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13321
     components:
     - type: Transform
@@ -88510,7 +88247,7 @@ entities:
       pos: -10.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13322
     components:
     - type: Transform
@@ -88518,7 +88255,7 @@ entities:
       pos: -30.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13323
     components:
     - type: Transform
@@ -88526,7 +88263,7 @@ entities:
       pos: -31.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13324
     components:
     - type: Transform
@@ -88534,7 +88271,7 @@ entities:
       pos: -27.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13325
     components:
     - type: Transform
@@ -88542,7 +88279,7 @@ entities:
       pos: -21.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13326
     components:
     - type: Transform
@@ -88550,7 +88287,7 @@ entities:
       pos: -35.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13327
     components:
     - type: Transform
@@ -88558,7 +88295,7 @@ entities:
       pos: -35.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13328
     components:
     - type: Transform
@@ -88566,7 +88303,7 @@ entities:
       pos: -35.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13329
     components:
     - type: Transform
@@ -88574,7 +88311,7 @@ entities:
       pos: -39.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13330
     components:
     - type: Transform
@@ -88582,7 +88319,7 @@ entities:
       pos: -39.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13331
     components:
     - type: Transform
@@ -88590,7 +88327,7 @@ entities:
       pos: -41.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13332
     components:
     - type: Transform
@@ -88598,7 +88335,7 @@ entities:
       pos: -52.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13333
     components:
     - type: Transform
@@ -88606,7 +88343,7 @@ entities:
       pos: -44.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13334
     components:
     - type: Transform
@@ -88614,7 +88351,7 @@ entities:
       pos: -44.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13335
     components:
     - type: Transform
@@ -88622,7 +88359,7 @@ entities:
       pos: -31.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13336
     components:
     - type: Transform
@@ -88630,14 +88367,14 @@ entities:
       pos: -31.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13337
     components:
     - type: Transform
       pos: -42.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13338
     components:
     - type: Transform
@@ -88645,7 +88382,7 @@ entities:
       pos: -41.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13339
     components:
     - type: Transform
@@ -88653,7 +88390,7 @@ entities:
       pos: -53.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13340
     components:
     - type: Transform
@@ -88661,7 +88398,7 @@ entities:
       pos: -53.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13341
     components:
     - type: Transform
@@ -88669,7 +88406,7 @@ entities:
       pos: -24.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13342
     components:
     - type: Transform
@@ -88677,7 +88414,7 @@ entities:
       pos: -14.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13343
     components:
     - type: Transform
@@ -88685,7 +88422,7 @@ entities:
       pos: -24.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13344
     components:
     - type: Transform
@@ -88693,14 +88430,14 @@ entities:
       pos: -24.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13345
     components:
     - type: Transform
       pos: -17.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13346
     components:
     - type: Transform
@@ -88708,7 +88445,7 @@ entities:
       pos: -13.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13347
     components:
     - type: Transform
@@ -88716,7 +88453,7 @@ entities:
       pos: -6.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13348
     components:
     - type: Transform
@@ -88724,7 +88461,7 @@ entities:
       pos: 1.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13349
     components:
     - type: Transform
@@ -88732,21 +88469,21 @@ entities:
       pos: -4.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13350
     components:
     - type: Transform
       pos: -12.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13351
     components:
     - type: Transform
       pos: -10.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13352
     components:
     - type: Transform
@@ -88754,14 +88491,14 @@ entities:
       pos: 3.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13353
     components:
     - type: Transform
       pos: -4.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13354
     components:
     - type: Transform
@@ -88769,7 +88506,7 @@ entities:
       pos: -28.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13355
     components:
     - type: Transform
@@ -88777,7 +88514,7 @@ entities:
       pos: -19.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13356
     components:
     - type: Transform
@@ -88785,7 +88522,7 @@ entities:
       pos: 0.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13357
     components:
     - type: Transform
@@ -88793,7 +88530,7 @@ entities:
       pos: -2.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13358
     components:
     - type: Transform
@@ -88801,7 +88538,7 @@ entities:
       pos: -9.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13359
     components:
     - type: Transform
@@ -88809,7 +88546,7 @@ entities:
       pos: -11.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13360
     components:
     - type: Transform
@@ -88817,7 +88554,7 @@ entities:
       pos: 0.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13361
     components:
     - type: Transform
@@ -88825,7 +88562,7 @@ entities:
       pos: -27.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13362
     components:
     - type: Transform
@@ -88833,7 +88570,7 @@ entities:
       pos: -21.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13363
     components:
     - type: Transform
@@ -88841,14 +88578,14 @@ entities:
       pos: -19.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13364
     components:
     - type: Transform
       pos: -28.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13365
     components:
     - type: Transform
@@ -88856,7 +88593,7 @@ entities:
       pos: -33.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13366
     components:
     - type: Transform
@@ -88867,7 +88604,7 @@ entities:
       deviceLists:
       - 14
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13367
     components:
     - type: Transform
@@ -88877,7 +88614,7 @@ entities:
       deviceLists:
       - 14
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13368
     components:
     - type: Transform
@@ -88885,7 +88622,7 @@ entities:
       pos: -28.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13369
     components:
     - type: Transform
@@ -88896,7 +88633,7 @@ entities:
       deviceLists:
       - 8
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13370
     components:
     - type: Transform
@@ -88907,7 +88644,7 @@ entities:
       deviceLists:
       - 8
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13371
     components:
     - type: Transform
@@ -88918,7 +88655,7 @@ entities:
       deviceLists:
       - 19
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13372
     components:
     - type: Transform
@@ -88929,7 +88666,7 @@ entities:
       deviceLists:
       - 19
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13373
     components:
     - type: Transform
@@ -88940,14 +88677,14 @@ entities:
       deviceLists:
       - 15
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13374
     components:
     - type: Transform
       pos: -11.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13375
     components:
     - type: Transform
@@ -88955,7 +88692,7 @@ entities:
       pos: -7.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13376
     components:
     - type: Transform
@@ -88963,7 +88700,7 @@ entities:
       pos: -5.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13377
     components:
     - type: Transform
@@ -88971,7 +88708,7 @@ entities:
       pos: -18.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13378
     components:
     - type: Transform
@@ -88979,7 +88716,7 @@ entities:
       pos: -17.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13379
     components:
     - type: Transform
@@ -88989,7 +88726,7 @@ entities:
       deviceLists:
       - 7
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13380
     components:
     - type: Transform
@@ -88997,14 +88734,14 @@ entities:
       pos: -13.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13381
     components:
     - type: Transform
       pos: -24.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13382
     components:
     - type: Transform
@@ -89015,14 +88752,14 @@ entities:
       deviceLists:
       - 14
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13383
     components:
     - type: Transform
       pos: -25.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13384
     components:
     - type: Transform
@@ -89030,7 +88767,7 @@ entities:
       pos: -25.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13385
     components:
     - type: Transform
@@ -89041,7 +88778,7 @@ entities:
       deviceLists:
       - 12
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13386
     components:
     - type: Transform
@@ -89049,7 +88786,7 @@ entities:
       pos: -29.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13387
     components:
     - type: Transform
@@ -89060,7 +88797,7 @@ entities:
       deviceLists:
       - 11
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13388
     components:
     - type: Transform
@@ -89071,7 +88808,7 @@ entities:
       deviceLists:
       - 15
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13389
     components:
     - type: Transform
@@ -89082,7 +88819,7 @@ entities:
       deviceLists:
       - 16
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13390
     components:
     - type: Transform
@@ -89090,7 +88827,7 @@ entities:
       pos: -55.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13391
     components:
     - type: Transform
@@ -89101,7 +88838,7 @@ entities:
       deviceLists:
       - 16
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13392
     components:
     - type: Transform
@@ -89112,14 +88849,14 @@ entities:
       deviceLists:
       - 16
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13393
     components:
     - type: Transform
       pos: -8.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13394
     components:
     - type: Transform
@@ -89127,7 +88864,7 @@ entities:
       pos: 1.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13395
     components:
     - type: Transform
@@ -89135,7 +88872,7 @@ entities:
       pos: -2.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13396
     components:
     - type: Transform
@@ -89146,7 +88883,7 @@ entities:
       deviceLists:
       - 13
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13397
     components:
     - type: Transform
@@ -89157,7 +88894,7 @@ entities:
       deviceLists:
       - 13
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13398
     components:
     - type: Transform
@@ -89165,14 +88902,14 @@ entities:
       pos: 4.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13399
     components:
     - type: Transform
       pos: 7.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13400
     components:
     - type: Transform
@@ -89180,14 +88917,14 @@ entities:
       pos: 12.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13401
     components:
     - type: Transform
       pos: 20.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13402
     components:
     - type: Transform
@@ -89195,14 +88932,14 @@ entities:
       pos: -2.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13403
     components:
     - type: Transform
       pos: 6.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13404
     components:
     - type: Transform
@@ -89210,7 +88947,7 @@ entities:
       pos: 8.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13405
     components:
     - type: Transform
@@ -89218,7 +88955,7 @@ entities:
       pos: 12.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13406
     components:
     - type: Transform
@@ -89226,14 +88963,14 @@ entities:
       pos: 9.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13407
     components:
     - type: Transform
       pos: 25.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13408
     components:
     - type: Transform
@@ -89241,35 +88978,35 @@ entities:
       pos: 6.5,-26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13409
     components:
     - type: Transform
       pos: 24.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13410
     components:
     - type: Transform
       pos: 32.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13411
     components:
     - type: Transform
       pos: 19.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13412
     components:
     - type: Transform
       pos: 16.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13413
     components:
     - type: Transform
@@ -89277,28 +89014,28 @@ entities:
       pos: 18.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13414
     components:
     - type: Transform
       pos: 29.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13415
     components:
     - type: Transform
       pos: 26.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13416
     components:
     - type: Transform
       pos: 8.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13417
     components:
     - type: Transform
@@ -89306,7 +89043,7 @@ entities:
       pos: 9.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13418
     components:
     - type: Transform
@@ -89314,7 +89051,7 @@ entities:
       pos: 9.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13419
     components:
     - type: Transform
@@ -89322,7 +89059,7 @@ entities:
       pos: 16.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13420
     components:
     - type: Transform
@@ -89330,7 +89067,7 @@ entities:
       pos: 18.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13421
     components:
     - type: Transform
@@ -89338,7 +89075,7 @@ entities:
       pos: 18.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13422
     components:
     - type: Transform
@@ -89346,21 +89083,21 @@ entities:
       pos: 18.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13423
     components:
     - type: Transform
       pos: 21.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13424
     components:
     - type: Transform
       pos: 24.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13425
     components:
     - type: Transform
@@ -89368,7 +89105,7 @@ entities:
       pos: 27.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13426
     components:
     - type: Transform
@@ -89382,7 +89119,7 @@ entities:
       pos: 29.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13428
     components:
     - type: Transform
@@ -89390,7 +89127,7 @@ entities:
       pos: 28.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13429
     components:
     - type: Transform
@@ -89398,7 +89135,7 @@ entities:
       pos: 13.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13430
     components:
     - type: Transform
@@ -89406,7 +89143,7 @@ entities:
       pos: 13.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13431
     components:
     - type: Transform
@@ -89416,7 +89153,7 @@ entities:
       deviceLists:
       - 17
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13432
     components:
     - type: Transform
@@ -89424,14 +89161,14 @@ entities:
       pos: 22.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13433
     components:
     - type: Transform
       pos: 25.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13434
     components:
     - type: Transform
@@ -89439,21 +89176,21 @@ entities:
       pos: 9.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13435
     components:
     - type: Transform
       pos: 40.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13436
     components:
     - type: Transform
       pos: 38.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13437
     components:
     - type: Transform
@@ -89461,21 +89198,21 @@ entities:
       pos: 45.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13438
     components:
     - type: Transform
       pos: 29.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13439
     components:
     - type: Transform
       pos: 30.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13440
     components:
     - type: Transform
@@ -89486,7 +89223,7 @@ entities:
       deviceLists:
       - 17
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13441
     components:
     - type: Transform
@@ -89494,14 +89231,14 @@ entities:
       pos: 20.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13442
     components:
     - type: Transform
       pos: 30.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13443
     components:
     - type: Transform
@@ -89512,7 +89249,7 @@ entities:
       deviceLists:
       - 17
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13444
     components:
     - type: Transform
@@ -89520,7 +89257,7 @@ entities:
       pos: -44.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13445
     components:
     - type: Transform
@@ -89528,7 +89265,7 @@ entities:
       pos: -57.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13446
     components:
     - type: Transform
@@ -89536,14 +89273,14 @@ entities:
       pos: -51.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13447
     components:
     - type: Transform
       pos: -61.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13448
     components:
     - type: Transform
@@ -89551,28 +89288,28 @@ entities:
       pos: -77.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13449
     components:
     - type: Transform
       pos: -78.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13450
     components:
     - type: Transform
       pos: -68.5,-42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13451
     components:
     - type: Transform
       pos: -64.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13452
     components:
     - type: Transform
@@ -89580,7 +89317,7 @@ entities:
       pos: -61.5,-63.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13453
     components:
     - type: Transform
@@ -89588,14 +89325,14 @@ entities:
       pos: -67.5,-44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13454
     components:
     - type: Transform
       pos: -56.5,-45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13455
     components:
     - type: Transform
@@ -89603,7 +89340,7 @@ entities:
       pos: -52.5,-53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13456
     components:
     - type: Transform
@@ -89611,7 +89348,7 @@ entities:
       pos: -52.5,-57.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13457
     components:
     - type: Transform
@@ -89619,7 +89356,7 @@ entities:
       pos: -80.5,-59.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13458
     components:
     - type: Transform
@@ -89627,21 +89364,21 @@ entities:
       pos: -75.5,-61.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13459
     components:
     - type: Transform
       pos: -76.5,-53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13460
     components:
     - type: Transform
       pos: -72.5,-53.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13461
     components:
     - type: Transform
@@ -89649,14 +89386,14 @@ entities:
       pos: -63.5,-60.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13462
     components:
     - type: Transform
       pos: -63.5,-48.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13463
     components:
     - type: Transform
@@ -89664,14 +89401,14 @@ entities:
       pos: 35.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
   - uid: 13464
     components:
     - type: Transform
       pos: 43.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF0000FF'
+      color: '#990000FF'
 - proto: GasVolumePump
   entities:
   - uid: 13465
@@ -89721,11 +89458,6 @@ entities:
     components:
     - type: Transform
       pos: 2.5,18.5
-      parent: 2
-  - uid: 13472
-    components:
-    - type: Transform
-      pos: -18.5,20.5
       parent: 2
   - uid: 13473
     components:
@@ -89799,6 +89531,18 @@ entities:
       parent: 2
 - proto: Grille
   entities:
+  - uid: 7884
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -18.5,24.5
+      parent: 2
+  - uid: 7906
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -19.5,24.5
+      parent: 2
   - uid: 13485
     components:
     - type: Transform
@@ -96361,11 +96105,6 @@ entities:
       parent: 2
 - proto: GrilleBroken
   entities:
-  - uid: 14759
-    components:
-    - type: Transform
-      pos: -17.5,21.5
-      parent: 2
   - uid: 14760
     components:
     - type: Transform
@@ -96863,6 +96602,426 @@ entities:
     components:
     - type: Transform
       pos: 13.829771,-25.622192
+      parent: 2
+- proto: HolopadAiCore
+  entities:
+  - uid: 7944
+    components:
+    - type: Transform
+      pos: -0.5,79.5
+      parent: 2
+- proto: HolopadAiEntrance
+  entities:
+  - uid: 7943
+    components:
+    - type: Transform
+      pos: -1.5,65.5
+      parent: 2
+- proto: HolopadAiUpload
+  entities:
+  - uid: 7945
+    components:
+    - type: Transform
+      pos: -0.5,75.5
+      parent: 2
+- proto: HolopadCargoBay
+  entities:
+  - uid: 7950
+    components:
+    - type: Transform
+      pos: 31.5,-4.5
+      parent: 2
+- proto: HolopadCargoBreakroom
+  entities:
+  - uid: 7953
+    components:
+    - type: Transform
+      pos: 30.5,0.5
+      parent: 2
+- proto: HolopadCargoFront
+  entities:
+  - uid: 7952
+    components:
+    - type: Transform
+      pos: 15.5,-3.5
+      parent: 2
+- proto: HolopadCargoMailroom
+  entities:
+  - uid: 7951
+    components:
+    - type: Transform
+      pos: 17.5,1.5
+      parent: 2
+- proto: HolopadCargoSalvageBay
+  entities:
+  - uid: 21175
+    components:
+    - type: Transform
+      pos: 30.5,-10.5
+      parent: 2
+- proto: HolopadCommandBridge
+  entities:
+  - uid: 7955
+    components:
+    - type: Transform
+      pos: -9.5,44.5
+      parent: 2
+- proto: HolopadCommandBridgeHallway
+  entities:
+  - uid: 7956
+    components:
+    - type: Transform
+      pos: -9.5,26.5
+      parent: 2
+- proto: HolopadCommandBSO
+  entities:
+  - uid: 7937
+    components:
+    - type: Transform
+      pos: -18.5,22.5
+      parent: 2
+- proto: HolopadCommandCaptain
+  entities:
+  - uid: 7939
+    components:
+    - type: Transform
+      pos: -21.5,36.5
+      parent: 2
+- proto: HolopadCommandCe
+  entities:
+  - uid: 7949
+    components:
+    - type: Transform
+      pos: -7.5,-34.5
+      parent: 2
+- proto: HolopadCommandCmo
+  entities:
+  - uid: 7947
+    components:
+    - type: Transform
+      pos: -34.5,-18.5
+      parent: 2
+- proto: HolopadCommandHop
+  entities:
+  - uid: 7963
+    components:
+    - type: Transform
+      pos: 3.5,33.5
+      parent: 2
+- proto: HolopadCommandHos
+  entities:
+  - uid: 7962
+    components:
+    - type: Transform
+      pos: -25.5,50.5
+      parent: 2
+- proto: HolopadCommandMeetingRoom
+  entities:
+  - uid: 7938
+    components:
+    - type: Transform
+      pos: -9.5,34.5
+      parent: 2
+- proto: HolopadCommandQm
+  entities:
+  - uid: 16292
+    components:
+    - type: Transform
+      pos: 24.5,0.5
+      parent: 2
+- proto: HolopadCommandRd
+  entities:
+  - uid: 22571
+    components:
+    - type: Transform
+      pos: 26.5,14.5
+      parent: 2
+- proto: HolopadCommandVault
+  entities:
+  - uid: 22572
+    components:
+    - type: Transform
+      pos: 5.5,44.5
+      parent: 2
+- proto: HolopadEngineeringAME
+  entities:
+  - uid: 7948
+    components:
+    - type: Transform
+      pos: -10.5,-48.5
+      parent: 2
+- proto: HolopadEngineeringAtmosTeg
+  entities:
+  - uid: 21185
+    components:
+    - type: Transform
+      pos: 1.5,-45.5
+      parent: 2
+- proto: HolopadEngineeringFront
+  entities:
+  - uid: 7958
+    components:
+    - type: Transform
+      pos: 1.5,-29.5
+      parent: 2
+- proto: HolopadEngineeringMain
+  entities:
+  - uid: 7959
+    components:
+    - type: Transform
+      pos: -18.5,-41.5
+      parent: 2
+- proto: HolopadEngineeringPower
+  entities:
+  - uid: 15463
+    components:
+    - type: Transform
+      pos: -6.5,-44.5
+      parent: 2
+- proto: HolopadEngineeringStorage
+  entities:
+  - uid: 7960
+    components:
+    - type: Transform
+      pos: -23.5,-48.5
+      parent: 2
+- proto: HolopadEngineeringTelecoms
+  entities:
+  - uid: 21186
+    components:
+    - type: Transform
+      pos: -9.5,-29.5
+      parent: 2
+- proto: HolopadGeneralArrivals
+  entities:
+  - uid: 22575
+    components:
+    - type: Transform
+      pos: -50.5,8.5
+      parent: 2
+- proto: HolopadGeneralCryosleep
+  entities:
+  - uid: 22578
+    components:
+    - type: Transform
+      pos: 31.5,39.5
+      parent: 2
+- proto: HolopadGeneralDisposals
+  entities:
+  - uid: 22580
+    components:
+    - type: Transform
+      pos: 50.5,22.5
+      parent: 2
+- proto: HolopadGeneralEvac
+  entities:
+  - uid: 22107
+    components:
+    - type: Transform
+      pos: -54.5,20.5
+      parent: 2
+- proto: HolopadGeneralEVAStorage
+  entities:
+  - uid: 22106
+    components:
+    - type: Transform
+      pos: -2.5,20.5
+      parent: 2
+- proto: HolopadMedicalBreakroom
+  entities:
+  - uid: 8324
+    components:
+    - type: Transform
+      pos: -15.5,-20.5
+      parent: 2
+- proto: HolopadMedicalClinic
+  entities:
+  - uid: 9866
+    components:
+    - type: Transform
+      pos: -22.5,-10.5
+      parent: 2
+- proto: HolopadMedicalCryopods
+  entities:
+  - uid: 22579
+    components:
+    - type: Transform
+      pos: -30.5,-12.5
+      parent: 2
+- proto: HolopadMedicalFront
+  entities:
+  - uid: 10148
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 2
+- proto: HolopadMedicalMorgue
+  entities:
+  - uid: 10835
+    components:
+    - type: Transform
+      pos: -23.5,-0.5
+      parent: 2
+- proto: HolopadMedicalParamed
+  entities:
+  - uid: 13472
+    components:
+    - type: Transform
+      pos: -13.5,-15.5
+      parent: 2
+- proto: HolopadMedicalSurgery
+  entities:
+  - uid: 21184
+    components:
+    - type: Transform
+      pos: -22.5,-18.5
+      parent: 2
+- proto: HolopadScienceAnomaly
+  entities:
+  - uid: 22577
+    components:
+    - type: Transform
+      pos: 30.5,19.5
+      parent: 2
+- proto: HolopadScienceArtifact
+  entities:
+  - uid: 22576
+    components:
+    - type: Transform
+      pos: 39.5,8.5
+      parent: 2
+- proto: HolopadScienceBreakroom
+  entities:
+  - uid: 21176
+    components:
+    - type: Transform
+      pos: 19.5,12.5
+      parent: 2
+- proto: HolopadScienceFront
+  entities:
+  - uid: 21177
+    components:
+    - type: Transform
+      pos: 14.5,15.5
+      parent: 2
+- proto: HolopadScienceRnd
+  entities:
+  - uid: 16389
+    components:
+    - type: Transform
+      pos: 27.5,8.5
+      parent: 2
+- proto: HolopadScienceRobotics
+  entities:
+  - uid: 16518
+    components:
+    - type: Transform
+      pos: 21.5,21.5
+      parent: 2
+- proto: HolopadSecurityArmory
+  entities:
+  - uid: 22574
+    components:
+    - type: Transform
+      pos: -40.5,54.5
+      parent: 2
+- proto: HolopadSecurityDetective
+  entities:
+  - uid: 7957
+    components:
+    - type: Transform
+      pos: -41.5,30.5
+      parent: 2
+- proto: HolopadSecurityFront
+  entities:
+  - uid: 21178
+    components:
+    - type: Transform
+      pos: -36.5,36.5
+      parent: 2
+- proto: HolopadSecurityInterrogation
+  entities:
+  - uid: 7961
+    components:
+    - type: Transform
+      pos: -27.5,42.5
+      parent: 2
+- proto: HolopadSecurityLawyer
+  entities:
+  - uid: 8284
+    components:
+    - type: Transform
+      pos: -51.5,30.5
+      parent: 2
+- proto: HolopadSecurityLockerRoom
+  entities:
+  - uid: 21179
+    components:
+    - type: Transform
+      pos: -34.5,58.5
+      parent: 2
+- proto: HolopadSecurityPerma
+  entities:
+  - uid: 14759
+    components:
+    - type: Transform
+      pos: -48.5,67.5
+      parent: 2
+- proto: HolopadSecurityWarden
+  entities:
+  - uid: 22573
+    components:
+    - type: Transform
+      pos: -42.5,48.5
+      parent: 2
+- proto: HolopadServiceBar
+  entities:
+  - uid: 22252
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 2
+- proto: HolopadServiceBotany
+  entities:
+  - uid: 7946
+    components:
+    - type: Transform
+      pos: -24.5,10.5
+      parent: 2
+- proto: HolopadServiceChapel
+  entities:
+  - uid: 7954
+    components:
+    - type: Transform
+      pos: -63.5,-45.5
+      parent: 2
+- proto: HolopadServiceClownMime
+  entities:
+  - uid: 22213
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 2
+- proto: HolopadServiceJanitor
+  entities:
+  - uid: 7964
+    components:
+    - type: Transform
+      pos: -32.5,8.5
+      parent: 2
+- proto: HolopadServiceKitchen
+  entities:
+  - uid: 22570
+    components:
+    - type: Transform
+      pos: -17.5,8.5
+      parent: 2
+- proto: HolopadServiceLibrary
+  entities:
+  - uid: 10950
+    components:
+    - type: Transform
+      pos: -40.5,1.5
       parent: 2
 - proto: HospitalCurtainsOpen
   entities:
@@ -101550,11 +101709,6 @@ entities:
       parent: 2
 - proto: NitrogenCanister
   entities:
-  - uid: 15463
-    components:
-    - type: Transform
-      pos: -19.5,23.5
-      parent: 2
   - uid: 15464
     components:
     - type: Transform
@@ -104007,6 +104161,12 @@ entities:
       parent: 2
 - proto: Poweredlight
   entities:
+  - uid: 7924
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,22.5
+      parent: 2
   - uid: 15872
     components:
     - type: Transform
@@ -107006,13 +107166,6 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 16292
-    components:
-    - type: Transform
-      pos: -20.5,20.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 16293
     components:
     - type: Transform
@@ -107718,11 +107871,6 @@ entities:
       parent: 2
 - proto: Rack
   entities:
-  - uid: 16389
-    components:
-    - type: Transform
-      pos: -16.5,20.5
-      parent: 2
   - uid: 16390
     components:
     - type: Transform
@@ -108412,11 +108560,6 @@ entities:
     components:
     - type: Transform
       pos: 4.5,11.5
-      parent: 2
-  - uid: 16518
-    components:
-    - type: Transform
-      pos: -18.5,24.5
       parent: 2
   - uid: 16519
     components:
@@ -109235,6 +109378,18 @@ entities:
       parent: 2
 - proto: ReinforcedWindow
   entities:
+  - uid: 7891
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -19.5,24.5
+      parent: 2
+  - uid: 7905
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -18.5,24.5
+      parent: 2
   - uid: 16673
     components:
     - type: Transform
@@ -117526,6 +117681,11 @@ entities:
     - type: Transform
       pos: -18.5,31.5
       parent: 2
+  - uid: 22581
+    components:
+    - type: Transform
+      pos: -16.5,21.5
+      parent: 2
 - proto: SpawnPointBorg
   entities:
   - uid: 18138
@@ -117764,6 +117924,11 @@ entities:
     components:
     - type: Transform
       pos: -18.5,31.5
+      parent: 2
+  - uid: 22582
+    components:
+    - type: Transform
+      pos: -19.5,21.5
       parent: 2
 - proto: SpawnPointObserver
   entities:
@@ -122218,6 +122383,13 @@ entities:
     - type: Transform
       pos: -23.5,-32.5
       parent: 2
+- proto: TableFancyGreen
+  entities:
+  - uid: 7918
+    components:
+    - type: Transform
+      pos: -19.5,23.5
+      parent: 2
 - proto: TableGlass
   entities:
   - uid: 18814
@@ -124315,6 +124487,20 @@ entities:
     - type: Transform
       pos: -38.069122,-35.61336
       parent: 2
+- proto: UniqueLockerBlueshieldOfficerFilled
+  entities:
+  - uid: 7914
+    components:
+    - type: Transform
+      pos: -17.5,21.5
+      parent: 2
+- proto: UniqueLockerNanorepFilled
+  entities:
+  - uid: 7915
+    components:
+    - type: Transform
+      pos: -18.5,21.5
+      parent: 2
 - proto: UprightPianoInstrument
   entities:
   - uid: 19174
@@ -124996,6 +125182,66 @@ entities:
       parent: 2
 - proto: WallReinforced
   entities:
+  - uid: 1097
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -17.5,24.5
+      parent: 2
+  - uid: 1503
+    components:
+    - type: Transform
+      pos: -15.5,20.5
+      parent: 2
+  - uid: 1509
+    components:
+    - type: Transform
+      pos: -16.5,20.5
+      parent: 2
+  - uid: 1510
+    components:
+    - type: Transform
+      pos: -18.5,20.5
+      parent: 2
+  - uid: 1511
+    components:
+    - type: Transform
+      pos: -17.5,20.5
+      parent: 2
+  - uid: 1512
+    components:
+    - type: Transform
+      pos: -19.5,20.5
+      parent: 2
+  - uid: 7892
+    components:
+    - type: Transform
+      pos: -20.5,20.5
+      parent: 2
+  - uid: 7895
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -15.5,22.5
+      parent: 2
+  - uid: 7896
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -15.5,23.5
+      parent: 2
+  - uid: 7900
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -15.5,21.5
+      parent: 2
+  - uid: 7903
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -15.5,24.5
+      parent: 2
   - uid: 19279
     components:
     - type: Transform
@@ -134742,31 +134988,6 @@ entities:
     - type: Transform
       pos: -13.5,22.5
       parent: 2
-  - uid: 21175
-    components:
-    - type: Transform
-      pos: -16.5,24.5
-      parent: 2
-  - uid: 21176
-    components:
-    - type: Transform
-      pos: -15.5,24.5
-      parent: 2
-  - uid: 21177
-    components:
-    - type: Transform
-      pos: -15.5,22.5
-      parent: 2
-  - uid: 21178
-    components:
-    - type: Transform
-      pos: -15.5,21.5
-      parent: 2
-  - uid: 21179
-    components:
-    - type: Transform
-      pos: -18.5,21.5
-      parent: 2
   - uid: 21180
     components:
     - type: Transform
@@ -134786,21 +135007,6 @@ entities:
     components:
     - type: Transform
       pos: -20.5,24.5
-      parent: 2
-  - uid: 21184
-    components:
-    - type: Transform
-      pos: -17.5,24.5
-      parent: 2
-  - uid: 21185
-    components:
-    - type: Transform
-      pos: -18.5,24.5
-      parent: 2
-  - uid: 21186
-    components:
-    - type: Transform
-      pos: -19.5,24.5
       parent: 2
   - uid: 21187
     components:
@@ -139497,16 +139703,6 @@ entities:
       parent: 2
 - proto: WallSolidRust
   entities:
-  - uid: 22106
-    components:
-    - type: Transform
-      pos: -15.5,23.5
-      parent: 2
-  - uid: 22107
-    components:
-    - type: Transform
-      pos: -19.5,21.5
-      parent: 2
   - uid: 22108
     components:
     - type: Transform
@@ -140453,11 +140649,6 @@ entities:
     - type: Transform
       pos: -42.5,25.5
       parent: 2
-  - uid: 22213
-    components:
-    - type: Transform
-      pos: -19.5,22.5
-      parent: 2
   - uid: 22214
     components:
     - type: Transform
@@ -140698,11 +140889,6 @@ entities:
       parent: 2
 - proto: WeldingFuelTankFull
   entities:
-  - uid: 22252
-    components:
-    - type: Transform
-      pos: -16.5,23.5
-      parent: 2
   - uid: 22253
     components:
     - type: Transform

--- a/Resources/Maps/_Goobstation/omega.yml
+++ b/Resources/Maps/_Goobstation/omega.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 03/13/2025 02:55:53
+  time: 03/13/2025 21:26:04
   entityCount: 13670
 maps:
 - 1
@@ -54222,8 +54222,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -7.5,16.5
       parent: 2
-      deviceLists:
-      - 9631
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 8115
@@ -55194,8 +55192,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -7.5,17.5
       parent: 2
-      deviceLists:
-      - 9631
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 8234

--- a/Resources/Maps/_Goobstation/omega.yml
+++ b/Resources/Maps/_Goobstation/omega.yml
@@ -54211,7 +54211,7 @@ entities:
   - uid: 8114
     components:
     - type: Transform
-      rot: 3.141592653589793 rad\
+      rot: 3.141592653589793 rad
       pos: -54.5,14.5
       parent: 2
 - proto: GasVentPump

--- a/Resources/Maps/_Goobstation/omega.yml
+++ b/Resources/Maps/_Goobstation/omega.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 03/09/2025 12:41:21
-  entityCount: 13682
+  time: 03/13/2025 02:55:53
+  entityCount: 13670
 maps:
 - 1
 grids:
@@ -69,7 +69,7 @@ entities:
       chunks:
         -1,0:
           ind: -1,0
-          tiles: PgAAAAAAPgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADdgAAAAAAdgAAAAACHQAAAAADeQAAAAAADgAAAAADWQAAAAAAWQAAAAACWQAAAAADWQAAAAADWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADdgAAAAACdgAAAAACHQAAAAABeQAAAAAADgAAAAAAWQAAAAAAWQAAAAADWQAAAAADWQAAAAACWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAdgAAAAABeQAAAAAAeQAAAAAADgAAAAAAWQAAAAAAWQAAAAACWQAAAAAAWQAAAAADWQAAAAACaAAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAHQAAAAACdgAAAAABdgAAAAABdgAAAAAAHQAAAAABDgAAAAABWQAAAAAAWQAAAAADWQAAAAACWQAAAAADWQAAAAAAaAAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAHQAAAAABdgAAAAADdgAAAAACdgAAAAAAHQAAAAADDgAAAAABWQAAAAABWQAAAAACWQAAAAADWQAAAAADWQAAAAACaAAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAHQAAAAACdgAAAAABdgAAAAABdgAAAAACHQAAAAACDgAAAAACWQAAAAACWQAAAAAAWQAAAAABWQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAdgAAAAADdgAAAAADdgAAAAAAHQAAAAACDgAAAAAAWQAAAAADWQAAAAAAWQAAAAAAWQAAAAADWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAdgAAAAAAdgAAAAACdgAAAAADHQAAAAACDgAAAAADWQAAAAABWQAAAAABWQAAAAADWQAAAAACWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADdgAAAAADdgAAAAAAdgAAAAADHQAAAAAADgAAAAABWQAAAAADWQAAAAABWQAAAAAAWQAAAAAAWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAdgAAAAADdgAAAAAAdgAAAAADHQAAAAAADgAAAAACDgAAAAABWQAAAAADWQAAAAAAWQAAAAACDgAAAAAAaQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaQAAAAAAeQAAAAAAeQAAAAAAHQAAAAABDgAAAAADWQAAAAACWQAAAAADWQAAAAAADgAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAABDgAAAAACDgAAAAAADgAAAAACDgAAAAACDgAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAADgAAAAABDgAAAAABDgAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaQAAAAAAWQAAAAADWQAAAAAAWQAAAAABWQAAAAACWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAAAWQAAAAADWQAAAAACWQAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACWQAAAAACWQAAAAAAeQAAAAAA
+          tiles: PgAAAAAAPgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADdgAAAAAAdgAAAAACHQAAAAADeQAAAAAADgAAAAADWQAAAAAAWQAAAAACWQAAAAADWQAAAAADWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADdgAAAAACdgAAAAACHQAAAAABeQAAAAAADgAAAAAAWQAAAAAAWQAAAAADWQAAAAADWQAAAAACWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAdgAAAAABeQAAAAAAeQAAAAAADgAAAAAAWQAAAAAAWQAAAAACWQAAAAAAWQAAAAADWQAAAAACaAAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAHQAAAAACdgAAAAABdgAAAAABdgAAAAAAHQAAAAABDgAAAAABWQAAAAAAWQAAAAADWQAAAAACWQAAAAADWQAAAAAAaAAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAHQAAAAABdgAAAAADdgAAAAACdgAAAAAAHQAAAAADDgAAAAABWQAAAAABWQAAAAACWQAAAAADWQAAAAADWQAAAAACaAAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAHQAAAAACdgAAAAABdgAAAAABdgAAAAACHQAAAAACDgAAAAACWQAAAAACWQAAAAAAWQAAAAABWQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAdgAAAAADdgAAAAADdgAAAAAAHQAAAAACDgAAAAAAWQAAAAADWQAAAAAAWQAAAAAAWQAAAAADWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAdgAAAAAAdgAAAAACdgAAAAADHQAAAAACDgAAAAADWQAAAAABWQAAAAABWQAAAAADWQAAAAACWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADdgAAAAADdgAAAAAAdgAAAAADHQAAAAAADgAAAAABWQAAAAADWQAAAAABWQAAAAAAWQAAAAAAWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAdgAAAAADdgAAAAAAdgAAAAADHQAAAAAADgAAAAACDgAAAAABWQAAAAADWQAAAAAAWQAAAAACDgAAAAAAaQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaQAAAAAAeQAAAAAAeQAAAAAAHQAAAAABDgAAAAADWQAAAAACWQAAAAADWQAAAAAADgAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAABDgAAAAACDgAAAAAADgAAAAACDgAAAAACDgAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAADgAAAAABDgAAAAABDgAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaQAAAAAAWQAAAAADWQAAAAAAWQAAAAABWQAAAAACWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAAAWQAAAAADWQAAAAACWQAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACWQAAAAACWQAAAAAAeQAAAAAA
           version: 6
         0,0:
           ind: 0,0
@@ -77,7 +77,7 @@ entities:
           version: 6
         -1,1:
           ind: -1,1
-          tiles: eQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAWQAAAAADWQAAAAABWQAAAAADWQAAAAACWQAAAAACWQAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAWQAAAAADWQAAAAACWQAAAAACWQAAAAAAWQAAAAABWQAAAAAAeQAAAAAAeQAAAAAAAQAAAAAAeQAAAAAAHQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAABWQAAAAABWQAAAAAAWQAAAAACWQAAAAAAWQAAAAABWQAAAAABWQAAAAABWQAAAAAAWQAAAAADWQAAAAABWQAAAAAAWQAAAAACWQAAAAAAWQAAAAAAWQAAAAADWQAAAAABAgAAAAAAAgAAAAAAAgAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAABWQAAAAADWQAAAAADWQAAAAAAWQAAAAADWQAAAAABWQAAAAABWQAAAAACWQAAAAACWQAAAAABWQAAAAABWQAAAAABWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAABHQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAdgAAAAAAdgAAAAAAdgAAAAAAdgAAAAADdgAAAAABeQAAAAAAHQAAAAABHQAAAAACeQAAAAAAHQAAAAADNgAAAAAANgAAAAAAHQAAAAABNgAAAAAANgAAAAAAHQAAAAABdgAAAAABdgAAAAAAdgAAAAADdgAAAAAAdgAAAAABdgAAAAACHQAAAAADHQAAAAADeQAAAAAAHQAAAAACNgAAAAAAHQAAAAACHQAAAAABHQAAAAADNgAAAAAAHQAAAAABdgAAAAACdgAAAAABdgAAAAAAdgAAAAACdgAAAAABeQAAAAAAHQAAAAAAHQAAAAABeQAAAAAAHQAAAAAANgAAAAAANgAAAAAANgAAAAAANgAAAAAANgAAAAAAHQAAAAABeQAAAAAAdgAAAAAAdgAAAAACdgAAAAAAdgAAAAACeQAAAAAAHQAAAAABHQAAAAABeQAAAAAAHQAAAAADNgAAAAAANgAAAAAANgAAAAAANgAAAAAANgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAdgAAAAABeQAAAAAAeQAAAAAAHQAAAAADHQAAAAAAeQAAAAAAHQAAAAAAHQAAAAACHQAAAAADNgAAAAAAHQAAAAADHQAAAAACUAAAAAAAeQAAAAAAdgAAAAAAdgAAAAAAdgAAAAAAdgAAAAADeQAAAAAAHQAAAAACHQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAALAAAAAAALAAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAeQAAAAAAHQAAAAAAHQAAAAABHQAAAAACHQAAAAACPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAALAAAAAAAeQAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAeQAAAAAAHQAAAAADHQAAAAABHQAAAAADHQAAAAABPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADHQAAAAABHQAAAAAAHQAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAABwAAAAAABwAAAAAABwAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAHQAAAAABHQAAAAABeQAAAAAAHQAAAAAAHQAAAAACHQAAAAADHQAAAAAAHQAAAAACHQAAAAAD
+          tiles: eQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAADWQAAAAABWQAAAAADWQAAAAACWQAAAAACWQAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAADWQAAAAACWQAAAAACWQAAAAAAWQAAAAABWQAAAAAAeQAAAAAAeQAAAAAAAQAAAAAAeQAAAAAAHQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAeQAAAAAAWQAAAAADWQAAAAABWQAAAAABWQAAAAAAWQAAAAACWQAAAAAAWQAAAAABWQAAAAABWQAAAAABWQAAAAAAWQAAAAADWQAAAAABWQAAAAAAWQAAAAACWQAAAAAAWQAAAAAAWQAAAAADWQAAAAABAgAAAAAAAgAAAAAAAgAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAABWQAAAAADWQAAAAADWQAAAAAAWQAAAAADWQAAAAABWQAAAAABWQAAAAACWQAAAAACWQAAAAABWQAAAAABWQAAAAABWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAABHQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAdgAAAAAAdgAAAAAAdgAAAAAAdgAAAAADdgAAAAABeQAAAAAAHQAAAAABHQAAAAACeQAAAAAAHQAAAAADNgAAAAAANgAAAAAAHQAAAAABNgAAAAAANgAAAAAAHQAAAAABdgAAAAABdgAAAAAAdgAAAAADdgAAAAAAdgAAAAABdgAAAAACHQAAAAADHQAAAAADeQAAAAAAHQAAAAACNgAAAAAAHQAAAAACHQAAAAABHQAAAAADNgAAAAAAHQAAAAABdgAAAAACdgAAAAABdgAAAAAAdgAAAAACdgAAAAABeQAAAAAAHQAAAAAAHQAAAAABeQAAAAAAHQAAAAAANgAAAAAANgAAAAAANgAAAAAANgAAAAAANgAAAAAAHQAAAAABeQAAAAAAdgAAAAAAdgAAAAACdgAAAAAAdgAAAAACeQAAAAAAHQAAAAABHQAAAAABeQAAAAAAHQAAAAADNgAAAAAANgAAAAAANgAAAAAANgAAAAAANgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAdgAAAAABeQAAAAAAeQAAAAAAHQAAAAADHQAAAAAAeQAAAAAAHQAAAAAAHQAAAAACHQAAAAADNgAAAAAAHQAAAAADHQAAAAACUAAAAAAAeQAAAAAAdgAAAAAAdgAAAAAAdgAAAAAAdgAAAAADeQAAAAAAHQAAAAACHQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAALAAAAAAALAAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAeQAAAAAAHQAAAAAAHQAAAAABHQAAAAACHQAAAAACPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAALAAAAAAAeQAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAeQAAAAAAHQAAAAADHQAAAAABHQAAAAADHQAAAAABPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADHQAAAAABHQAAAAAAHQAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAABwAAAAAABwAAAAAABwAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAHQAAAAABHQAAAAABeQAAAAAAHQAAAAAAHQAAAAACHQAAAAADHQAAAAAAHQAAAAACHQAAAAAD
           version: 6
         0,1:
           ind: 0,1
@@ -970,6 +970,32 @@ entities:
             734: -49,-8
             735: -50,-8
             736: -51,-8
+        - node:
+            color: '#000082FF'
+            id: ConcreteTrimLineE
+          decals:
+            2193: -8,16
+            2194: -8,17
+        - node:
+            color: '#002882FF'
+            id: ConcreteTrimLineE
+          decals:
+            2196: -8,16
+            2197: -8,17
+        - node:
+            color: '#005082FF'
+            id: ConcreteTrimLineE
+          decals:
+            2199: -8,15
+            2200: -8,16
+            2201: -8,17
+        - node:
+            color: '#008200FF'
+            id: ConcreteTrimLineW
+          decals:
+            2190: -8,16
+            2191: -8,17
+            2202: -8,15
         - node:
             color: '#FFFFFFFF'
             id: Delivery
@@ -5608,6 +5634,16 @@ entities:
       - 450
       - 8216
       - 8209
+  - uid: 9631
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,14.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 4912
+      - 4913
 - proto: AirAlarmElectronics
   entities:
   - uid: 89
@@ -5739,6 +5775,18 @@ entities:
     - type: Transform
       pos: 4.5,7.5
       parent: 2
+- proto: AirlockBlueshieldOfficerCommandLocked
+  entities:
+  - uid: 4901
+    components:
+    - type: Transform
+      pos: -7.5,18.5
+      parent: 2
+    - type: AccessReader
+      access:
+      - - BlueshieldOfficer
+      - - Captain
+      - - NanotrasenRepresentative
 - proto: AirlockBrigGlassLocked
   entities:
   - uid: 111
@@ -8205,6 +8253,12 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -55.5,6.5
+      parent: 2
+  - uid: 5871
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,14.5
       parent: 2
 - proto: AppleSeeds
   entities:
@@ -11282,12 +11336,29 @@ entities:
     - type: Transform
       pos: -25.5,-20.5
       parent: 2
+  - uid: 4885
+    components:
+    - type: Transform
+      pos: -8.5,15.5
+      parent: 2
+  - uid: 4896
+    components:
+    - type: Transform
+      pos: -6.5,15.5
+      parent: 2
 - proto: BedsheetCaptain
   entities:
   - uid: 1111
     components:
     - type: Transform
       pos: -11.5,29.5
+      parent: 2
+- proto: BedsheetCentcom
+  entities:
+  - uid: 4903
+    components:
+    - type: Transform
+      pos: -8.5,15.5
       parent: 2
 - proto: BedsheetCMO
   entities:
@@ -11338,6 +11409,13 @@ entities:
     components:
     - type: Transform
       pos: -20.5,-20.5
+      parent: 2
+- proto: BedsheetNT
+  entities:
+  - uid: 4902
+    components:
+    - type: Transform
+      pos: -6.5,15.5
       parent: 2
 - proto: BedsheetOrange
   entities:
@@ -21003,6 +21081,36 @@ entities:
     - type: Transform
       pos: -61.5,0.5
       parent: 2
+  - uid: 8377
+    components:
+    - type: Transform
+      pos: -7.5,14.5
+      parent: 2
+  - uid: 8378
+    components:
+    - type: Transform
+      pos: -7.5,15.5
+      parent: 2
+  - uid: 8380
+    components:
+    - type: Transform
+      pos: -7.5,16.5
+      parent: 2
+  - uid: 8381
+    components:
+    - type: Transform
+      pos: -7.5,17.5
+      parent: 2
+  - uid: 8382
+    components:
+    - type: Transform
+      pos: -6.5,16.5
+      parent: 2
+  - uid: 9564
+    components:
+    - type: Transform
+      pos: -8.5,16.5
+      parent: 2
 - proto: CableApcStack
   entities:
   - uid: 3030
@@ -21023,12 +21131,14 @@ entities:
   - uid: 3033
     components:
     - type: Transform
-      pos: -10.655096,15.8788185
+      rot: -0.050372879952192307 rad
+      pos: -10.606523,15.865751
       parent: 2
   - uid: 3034
     components:
     - type: Transform
-      pos: -10.655096,15.8788185
+      rot: -0.05027538165450096 rad
+      pos: -10.606536,15.865828
       parent: 2
 - proto: CableHV
   entities:
@@ -27651,6 +27761,36 @@ entities:
     - type: Transform
       pos: -32.5,15.5
       parent: 2
+  - uid: 5997
+    components:
+    - type: Transform
+      pos: -11.5,13.5
+      parent: 2
+  - uid: 6029
+    components:
+    - type: Transform
+      pos: -10.5,13.5
+      parent: 2
+  - uid: 6513
+    components:
+    - type: Transform
+      pos: -9.5,13.5
+      parent: 2
+  - uid: 6558
+    components:
+    - type: Transform
+      pos: -8.5,13.5
+      parent: 2
+  - uid: 8375
+    components:
+    - type: Transform
+      pos: -7.5,13.5
+      parent: 2
+  - uid: 8376
+    components:
+    - type: Transform
+      pos: -7.5,14.5
+      parent: 2
 - proto: CableMVStack
   entities:
   - uid: 4358
@@ -28015,6 +28155,21 @@ entities:
     - type: Transform
       pos: -11.5,24.5
       parent: 2
+  - uid: 4908
+    components:
+    - type: Transform
+      pos: -6.5,17.5
+      parent: 2
+  - uid: 4909
+    components:
+    - type: Transform
+      pos: -6.5,16.5
+      parent: 2
+  - uid: 4910
+    components:
+    - type: Transform
+      pos: -6.5,15.5
+      parent: 2
 - proto: CarpetChapel
   entities:
   - uid: 4426
@@ -28170,6 +28325,21 @@ entities:
     components:
     - type: Transform
       pos: -31.5,-36.5
+      parent: 2
+  - uid: 4859
+    components:
+    - type: Transform
+      pos: -8.5,15.5
+      parent: 2
+  - uid: 4895
+    components:
+    - type: Transform
+      pos: -8.5,16.5
+      parent: 2
+  - uid: 4907
+    components:
+    - type: Transform
+      pos: -8.5,17.5
       parent: 2
 - proto: CarpetOrange
   entities:
@@ -30292,11 +30462,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -34.5,-17.5
       parent: 2
-  - uid: 4859
-    components:
-    - type: Transform
-      pos: -8.5,14.5
-      parent: 2
   - uid: 4860
     components:
     - type: Transform
@@ -30373,259 +30538,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -44.5,2.5
-      parent: 2
-- proto: ChairOfficeDark
-  entities:
-  - uid: 4874
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -7.5,-6.5
-      parent: 2
-  - uid: 4875
-    components:
-    - type: Transform
-      pos: 9.5,24.5
-      parent: 2
-  - uid: 4876
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,34.5
-      parent: 2
-  - uid: 4877
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,34.5
-      parent: 2
-  - uid: 4878
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,33.5
-      parent: 2
-  - uid: 4879
-    components:
-    - type: Transform
-      pos: -7.5,33.5
-      parent: 2
-  - uid: 4880
-    components:
-    - type: Transform
-      pos: 15.5,17.5
-      parent: 2
-  - uid: 4881
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,20.5
-      parent: 2
-  - uid: 4882
-    components:
-    - type: Transform
-      pos: 17.5,30.5
-      parent: 2
-  - uid: 4883
-    components:
-    - type: Transform
-      pos: 28.5,2.5
-      parent: 2
-  - uid: 4884
-    components:
-    - type: Transform
-      pos: 19.5,-15.5
-      parent: 2
-  - uid: 4885
-    components:
-    - type: Transform
-      pos: 26.5,-18.5
-      parent: 2
-  - uid: 4886
-    components:
-    - type: Transform
-      pos: 23.5,-26.5
-      parent: 2
-  - uid: 4887
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-27.5
-      parent: 2
-  - uid: 4888
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -23.5,-39.5
-      parent: 2
-  - uid: 4889
-    components:
-    - type: Transform
-      pos: -23.5,-37.5
-      parent: 2
-  - uid: 4890
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -26.5,-15.5
-      parent: 2
-  - uid: 4891
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -26.5,-14.5
-      parent: 2
-  - uid: 4892
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -29.5,-15.5
-      parent: 2
-  - uid: 4893
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -29.5,-14.5
-      parent: 2
-  - uid: 4894
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -31.5,-19.5
-      parent: 2
-  - uid: 4895
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,-14.5
-      parent: 2
-  - uid: 4896
-    components:
-    - type: Transform
-      pos: -17.5,15.5
-      parent: 2
-  - uid: 4897
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -25.5,11.5
-      parent: 2
-  - uid: 4898
-    components:
-    - type: Transform
-      pos: -30.5,1.5
-      parent: 2
-  - uid: 4899
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -33.5,15.5
-      parent: 2
-  - uid: 4900
-    components:
-    - type: Transform
-      pos: -49.5,-7.5
-      parent: 2
-  - uid: 4901
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -49.5,-9.5
-      parent: 2
-  - uid: 4902
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -30.5,-5.5
-      parent: 2
-  - uid: 4903
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,11.5
-      parent: 2
-  - uid: 4904
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,11.5
-      parent: 2
-  - uid: 4905
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -11.5,11.5
-      parent: 2
-  - uid: 4906
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -42.5,-2.5
-      parent: 2
-- proto: ChairOfficeLight
-  entities:
-  - uid: 4907
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 34.5,-26.5
-      parent: 2
-  - uid: 4908
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,-21.5
-      parent: 2
-  - uid: 4909
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-15.5
-      parent: 2
-  - uid: 4910
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-14.5
-      parent: 2
-  - uid: 4911
-    components:
-    - type: Transform
-      pos: 3.5,-23.5
-      parent: 2
-  - uid: 4912
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 34.5,-25.5
-      parent: 2
-  - uid: 4913
-    components:
-    - type: Transform
-      pos: -11.5,-18.5
-      parent: 2
-  - uid: 4914
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,-14.5
-      parent: 2
-  - uid: 4915
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -25.5,-26.5
-      parent: 2
-  - uid: 4916
-    components:
-    - type: Transform
-      pos: 9.5,-43.5
-      parent: 2
-  - uid: 4917
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,-25.5
       parent: 2
 - proto: ChairWood
   entities:
@@ -34690,6 +34602,13 @@ entities:
     - type: Transform
       pos: 16.5,17.5
       parent: 2
+- proto: DefaultStationBeaconCentcommOffice
+  entities:
+  - uid: 4911
+    components:
+    - type: Transform
+      pos: -7.5,15.5
+      parent: 2
 - proto: DefaultStationBeaconCERoom
   entities:
   - uid: 5355
@@ -35099,6 +35018,12 @@ entities:
       parent: 2
 - proto: DisposalBend
   entities:
+  - uid: 4876
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,19.5
+      parent: 2
   - uid: 5415
     components:
     - type: Transform
@@ -35180,12 +35105,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-2.5
-      parent: 2
-  - uid: 5429
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,19.5
       parent: 2
   - uid: 5430
     components:
@@ -35409,6 +35328,11 @@ entities:
       parent: 2
 - proto: DisposalPipe
   entities:
+  - uid: 4874
+    components:
+    - type: Transform
+      pos: -4.5,18.5
+      parent: 2
   - uid: 5468
     components:
     - type: Transform
@@ -36166,18 +36090,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 61.5,-2.5
-      parent: 2
-  - uid: 5604
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,18.5
-      parent: 2
-  - uid: 5605
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,19.5
       parent: 2
   - uid: 5606
     components:
@@ -37437,6 +37349,12 @@ entities:
       parent: 2
 - proto: DisposalTrunk
   entities:
+  - uid: 4875
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,17.5
+      parent: 2
   - uid: 5825
     components:
     - type: Transform
@@ -37510,12 +37428,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 13.5,-1.5
-      parent: 2
-  - uid: 5838
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,17.5
       parent: 2
   - uid: 5839
     components:
@@ -37663,6 +37575,11 @@ entities:
       parent: 2
 - proto: DisposalUnit
   entities:
+  - uid: 4877
+    components:
+    - type: Transform
+      pos: -4.5,17.5
+      parent: 2
   - uid: 5864
     components:
     - type: Transform
@@ -37700,11 +37617,6 @@ entities:
     components:
     - type: Transform
       pos: -7.5,-1.5
-      parent: 2
-  - uid: 5871
-    components:
-    - type: Transform
-      pos: -5.5,17.5
       parent: 2
   - uid: 5872
     components:
@@ -37954,6 +37866,13 @@ entities:
     - type: Transform
       pos: -26.5,-40.5
       parent: 2
+- proto: DresserBlueshieldOfficerFilled
+  entities:
+  - uid: 4890
+    components:
+    - type: Transform
+      pos: -6.5,17.5
+      parent: 2
 - proto: DresserCaptainFilled
   entities:
   - uid: 5915
@@ -37988,6 +37907,13 @@ entities:
     components:
     - type: Transform
       pos: -23.5,28.5
+      parent: 2
+- proto: DresserNanorepFilled
+  entities:
+  - uid: 4884
+    components:
+    - type: Transform
+      pos: -8.5,17.5
       parent: 2
 - proto: DresserQuarterMasterFilled
   entities:
@@ -38478,13 +38404,6 @@ entities:
     - type: Transform
       pos: -57.5,8.5
       parent: 2
-- proto: ExtendedEmergencyOxygenTankFilled
-  entities:
-  - uid: 5997
-    components:
-    - type: Transform
-      pos: -6.4474344,14.517626
-      parent: 2
 - proto: ExtinguisherCabinetFilled
   entities:
   - uid: 5998
@@ -38667,11 +38586,6 @@ entities:
     components:
     - type: Transform
       pos: -16.5,14.5
-      parent: 2
-  - uid: 6029
-    components:
-    - type: Transform
-      pos: -7.5,14.5
       parent: 2
 - proto: filingCabinetDrawer
   entities:
@@ -42091,6 +42005,70 @@ entities:
       color: '#990000FF'
 - proto: GasPipeStraight
   entities:
+  - uid: 4914
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 4915
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 4916
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 4917
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 5429
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 5604
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 5605
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 5838
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 6507
     components:
     - type: Transform
@@ -42134,13 +42112,6 @@ entities:
     components:
     - type: Transform
       pos: -3.5,17.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 6513
-    components:
-    - type: Transform
-      pos: -3.5,16.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -42449,13 +42420,6 @@ entities:
     components:
     - type: Transform
       pos: -1.5,16.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 6558
-    components:
-    - type: Transform
-      pos: -1.5,17.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -52163,6 +52127,22 @@ entities:
       color: '#947507FF'
 - proto: GasPipeTJunction
   entities:
+  - uid: 4881
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 4882
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 7840
     components:
     - type: Transform
@@ -54236,6 +54216,19 @@ entities:
       parent: 2
 - proto: GasVentPump
   entities:
+  - uid: 4912
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,16.5
+      parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 9631
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 8115
     components:
     - type: Transform
@@ -55198,6 +55191,19 @@ entities:
       color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
+  - uid: 4913
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,17.5
+      parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 9631
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 8234
     components:
     - type: Transform
@@ -56248,45 +56254,10 @@ entities:
     - type: Transform
       pos: -0.5,15.5
       parent: 2
-  - uid: 8375
-    components:
-    - type: Transform
-      pos: -7.5,15.5
-      parent: 2
-  - uid: 8376
-    components:
-    - type: Transform
-      pos: -8.5,15.5
-      parent: 2
-  - uid: 8377
-    components:
-    - type: Transform
-      pos: -9.5,16.5
-      parent: 2
-  - uid: 8378
-    components:
-    - type: Transform
-      pos: -9.5,17.5
-      parent: 2
   - uid: 8379
     components:
     - type: Transform
       pos: -8.5,18.5
-      parent: 2
-  - uid: 8380
-    components:
-    - type: Transform
-      pos: -7.5,18.5
-      parent: 2
-  - uid: 8381
-    components:
-    - type: Transform
-      pos: -6.5,17.5
-      parent: 2
-  - uid: 8382
-    components:
-    - type: Transform
-      pos: -6.5,16.5
       parent: 2
   - uid: 8383
     components:
@@ -63573,12 +63544,7 @@ entities:
   - uid: 9563
     components:
     - type: Transform
-      pos: -13.5,15.5
-      parent: 2
-  - uid: 9564
-    components:
-    - type: Transform
-      pos: -12.5,15.5
+      pos: -13.489568,15.403635
       parent: 2
 - proto: PosterContrabandAtmosiaDeclarationIndependence
   entities:
@@ -63935,6 +63901,11 @@ entities:
       parent: 2
 - proto: PottedPlantRandom
   entities:
+  - uid: 4878
+    components:
+    - type: Transform
+      pos: -4.5,18.5
+      parent: 2
   - uid: 9621
     components:
     - type: Transform
@@ -64011,14 +63982,6 @@ entities:
     components:
     - type: Transform
       pos: -7.5,8.5
-      parent: 2
-    - type: ContainerContainer
-      containers:
-        stash: !type:ContainerSlot {}
-  - uid: 9631
-    components:
-    - type: Transform
-      pos: -5.5,18.5
       parent: 2
     - type: ContainerContainer
       containers:
@@ -64330,6 +64293,24 @@ entities:
       parent: 2
 - proto: Poweredlight
   entities:
+  - uid: 4892
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,18.5
+      parent: 2
+  - uid: 4900
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,19.5
+      parent: 2
+  - uid: 4905
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,16.5
+      parent: 2
   - uid: 9673
     components:
     - type: Transform
@@ -64578,14 +64559,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,31.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 9706
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,18.5
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
@@ -66681,11 +66654,6 @@ entities:
     - type: Transform
       pos: 22.5,-32.5
       parent: 2
-  - uid: 10010
-    components:
-    - type: Transform
-      pos: -6.5,14.5
-      parent: 2
   - uid: 10011
     components:
     - type: Transform
@@ -67477,45 +67445,10 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -17.5,0.5
       parent: 2
-  - uid: 10153
-    components:
-    - type: Transform
-      pos: -7.5,15.5
-      parent: 2
-  - uid: 10154
-    components:
-    - type: Transform
-      pos: -8.5,15.5
-      parent: 2
-  - uid: 10155
-    components:
-    - type: Transform
-      pos: -9.5,16.5
-      parent: 2
-  - uid: 10156
-    components:
-    - type: Transform
-      pos: -9.5,17.5
-      parent: 2
   - uid: 10157
     components:
     - type: Transform
       pos: -8.5,18.5
-      parent: 2
-  - uid: 10158
-    components:
-    - type: Transform
-      pos: -7.5,18.5
-      parent: 2
-  - uid: 10159
-    components:
-    - type: Transform
-      pos: -6.5,17.5
-      parent: 2
-  - uid: 10160
-    components:
-    - type: Transform
-      pos: -6.5,16.5
       parent: 2
   - uid: 10161
     components:
@@ -70942,17 +70875,17 @@ entities:
       parent: 2
 - proto: SignDirectionalEng
   entities:
+  - uid: 4887
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.4700418,18.686344
+      parent: 2
   - uid: 10771
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.4997582,-10.299582
-      parent: 2
-  - uid: 10772
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.493349,18.685036
       parent: 2
   - uid: 10773
     components:
@@ -71020,15 +70953,15 @@ entities:
       parent: 2
 - proto: SignDirectionalMed
   entities:
+  - uid: 4904
+    components:
+    - type: Transform
+      pos: -5.4700418,18.287563
+      parent: 2
   - uid: 10783
     components:
     - type: Transform
       pos: -5.504419,-10.705832
-      parent: 2
-  - uid: 10784
-    components:
-    - type: Transform
-      pos: -6.493349,18.29441
       parent: 2
   - uid: 10785
     components:
@@ -71066,17 +70999,17 @@ entities:
       parent: 2
 - proto: SignDirectionalSec
   entities:
+  - uid: 4898
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.4700418,18.475065
+      parent: 2
   - uid: 10791
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-10.5
-      parent: 2
-  - uid: 10792
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,18.5
       parent: 2
   - uid: 10793
     components:
@@ -72578,6 +72511,11 @@ entities:
       parent: 2
 - proto: SpawnPointBlueshieldOfficer
   entities:
+  - uid: 10153
+    components:
+    - type: Transform
+      pos: -6.5,15.5
+      parent: 2
   - uid: 11056
     components:
     - type: Transform
@@ -72802,6 +72740,11 @@ entities:
       parent: 2
 - proto: SpawnPointNanotrasenRepresentative
   entities:
+  - uid: 10010
+    components:
+    - type: Transform
+      pos: -8.5,15.5
+      parent: 2
   - uid: 11092
     components:
     - type: Transform
@@ -73421,6 +73364,17 @@ entities:
       parent: 2
 - proto: SurveillanceCameraCommand
   entities:
+  - uid: 9706
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,15.5
+      parent: 2
+    - type: SurveillanceCamera
+      setupAvailableNetworks:
+      - SurveillanceCameraCommand
+      nameSet: True
+      id: Centcomm Office
   - uid: 11192
     components:
     - type: Transform
@@ -76897,6 +76851,20 @@ entities:
       materialWhiteList:
       - Cloth
       - Durathread
+- proto: UniqueLockerBlueshieldOfficerFilled
+  entities:
+  - uid: 4883
+    components:
+    - type: Transform
+      pos: -6.5,16.5
+      parent: 2
+- proto: UniqueLockerNanorepFilled
+  entities:
+  - uid: 4894
+    components:
+    - type: Transform
+      pos: -8.5,16.5
+      parent: 2
 - proto: UprightPianoInstrument
   entities:
   - uid: 11692
@@ -77099,13 +77067,6 @@ entities:
       name: Hot drinks machine
     - type: Transform
       pos: 0.5,10.5
-      parent: 2
-  - uid: 11722
-    components:
-    - type: MetaData
-      name: Hot drinks machine
-    - type: Transform
-      pos: -5.5,16.5
       parent: 2
   - uid: 11723
     components:
@@ -77382,6 +77343,13 @@ entities:
     - type: Transform
       pos: -28.5,32.5
       parent: 2
+- proto: VendingMachineSweetToof
+  entities:
+  - uid: 4891
+    components:
+    - type: Transform
+      pos: -4.5,16.5
+      parent: 2
 - proto: VendingMachineTankDispenserEVA
   entities:
   - uid: 11764
@@ -77500,10 +77468,51 @@ entities:
       parent: 2
 - proto: WallReinforced
   entities:
-  - uid: 11782
+  - uid: 4879
     components:
     - type: Transform
-      pos: -6.5,15.5
+      rot: 1.5707963267948966 rad
+      pos: -7.5,14.5
+      parent: 2
+  - uid: 4880
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,14.5
+      parent: 2
+  - uid: 4886
+    components:
+    - type: Transform
+      pos: -9.5,17.5
+      parent: 2
+  - uid: 4888
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,16.5
+      parent: 2
+  - uid: 4889
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,18.5
+      parent: 2
+  - uid: 4893
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,14.5
+      parent: 2
+  - uid: 4897
+    components:
+    - type: Transform
+      pos: -9.5,16.5
+      parent: 2
+  - uid: 4899
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,17.5
       parent: 2
   - uid: 11783
     components:
@@ -86390,6 +86399,11 @@ entities:
       parent: 2
 - proto: WaterTankFull
   entities:
+  - uid: 4906
+    components:
+    - type: Transform
+      pos: -12.5,15.5
+      parent: 2
   - uid: 13486
     components:
     - type: Transform
@@ -86399,11 +86413,6 @@ entities:
     components:
     - type: Transform
       pos: 13.5,30.5
-      parent: 2
-  - uid: 13488
-    components:
-    - type: Transform
-      pos: -11.5,15.5
       parent: 2
   - uid: 13489
     components:

--- a/Resources/Maps/_Goobstation/omega.yml
+++ b/Resources/Maps/_Goobstation/omega.yml
@@ -54211,7 +54211,7 @@ entities:
   - uid: 8114
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
+      rot: 3.141592653589793 rad\
       pos: -54.5,14.5
       parent: 2
 - proto: GasVentPump
@@ -54222,9 +54222,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -7.5,16.5
       parent: 2
-    - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 9631
     - type: AtmosPipeColor
@@ -55197,9 +55194,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -7.5,17.5
       parent: 2
-    - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 9631
     - type: AtmosPipeColor

--- a/Resources/Maps/_Goobstation/packed.yml
+++ b/Resources/Maps/_Goobstation/packed.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 03/13/2025 02:25:44
+  time: 03/13/2025 21:25:44
   entityCount: 15098
 maps:
 - 1
@@ -60780,8 +60780,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 16.5,44.5
       parent: 2
-      deviceLists:
-      - 15089
     - type: AtmosPipeColor
       color: '#0055CCFF'
 - proto: GasVentScrubber

--- a/Resources/Maps/_Goobstation/packed.yml
+++ b/Resources/Maps/_Goobstation/packed.yml
@@ -61713,7 +61713,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 15.5,45.5
       parent: 2
-      - 15089
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasVolumePump

--- a/Resources/Maps/_Goobstation/packed.yml
+++ b/Resources/Maps/_Goobstation/packed.yml
@@ -69726,7 +69726,6 @@ entities:
     - type: Transform
       pos: 14.5,43.5
       parent: 2
-      bodyType: Static
 - proto: PottedPlant22
   entities:
   - uid: 10439
@@ -83488,7 +83487,6 @@ entities:
     - type: Transform
       pos: 14.5,44.5
       parent: 2
-      bodyType: Static
 - proto: UniqueLockerNanorepFilled
   entities:
   - uid: 5668
@@ -83496,7 +83494,6 @@ entities:
     - type: Transform
       pos: 16.5,43.5
       parent: 2
-      bodyType: Static
 - proto: Vaccinator
   entities:
   - uid: 12594

--- a/Resources/Maps/_Goobstation/packed.yml
+++ b/Resources/Maps/_Goobstation/packed.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 03/09/2025 18:57:45
-  entityCount: 15078
+  time: 03/13/2025 02:25:44
+  entityCount: 15098
 maps:
 - 1
 grids:
@@ -167,11 +167,11 @@ entities:
           version: 6
         0,2:
           ind: 0,2
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAWwAAAAAAWwAAAAAAWwAAAAAAWwAAAAAAWwAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAWwAAAAAAWwAAAAAAWwAAAAAAWwAAAAAAWwAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAagAAAAAAewAAAAAAHQAAAAAAHQAAAAAAHQAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAWwAAAAAAWwAAAAACWwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAagAAAAAAewAAAAAAewAAAAAAewAAAAAAegAAAAAAewAAAAAAagAAAAAAewAAAAAAWwAAAAADWwAAAAAAWwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAYgAAAAAAYgAAAAAAYgAAAAAAewAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAewAAAAAAWwAAAAAAWwAAAAABWwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAYgAAAAAAYgAAAAAAYgAAAAAAewAAAAAAegAAAAAAegAAAAAAAAAAAAAAAAAAAAAAewAAAAAAHQAAAAACHQAAAAACHQAAAAADAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAYgAAAAAAYgAAAAAAYgAAAAAAewAAAAAAegAAAAAAegAAAAAAAAAAAAAAAAAAAAAAewAAAAAAHQAAAAACHQAAAAADHQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAYgAAAAAAYgAAAAAAYgAAAAAAewAAAAAAAAAAAAAAegAAAAAAAAAAAAAAAAAAAAAAewAAAAAAHQAAAAAAHQAAAAACHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAAAAAAAAAegAAAAAAAAAAAAAAAAAAAAAAewAAAAAAHQAAAAACHQAAAAACHQAAAAADAAAAAAAAegAAAAAAAAAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAAAAAAAAAegAAAAAAegAAAAAAegAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAAAAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAWwAAAAAAWwAAAAAAWwAAAAAAWwAAAAAAWwAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAWwAAAAAAWwAAAAAAWwAAAAAAWwAAAAAAWwAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAagAAAAAAewAAAAAAHQAAAAAAHQAAAAAAHQAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAWwAAAAAAWwAAAAACWwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAagAAAAAAewAAAAAAewAAAAAAewAAAAAAegAAAAAAewAAAAAAagAAAAAAewAAAAAAWwAAAAADWwAAAAAAWwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAYgAAAAAAYgAAAAAAYgAAAAAAewAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAewAAAAAAWwAAAAAAWwAAAAABWwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAYgAAAAAAYgAAAAAAYgAAAAAAewAAAAAAegAAAAAAegAAAAAAAAAAAAAAAAAAAAAAewAAAAAAHQAAAAACHQAAAAACHQAAAAADAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAYgAAAAAAYgAAAAAAYgAAAAAAewAAAAAAegAAAAAAegAAAAAAAAAAAAAAAAAAAAAAewAAAAAAHQAAAAACHQAAAAADHQAAAAABAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAYgAAAAAAYgAAAAAAYgAAAAAAewAAAAAAAAAAAAAAegAAAAAAAAAAAAAAAAAAAAAAewAAAAAAHQAAAAAAHQAAAAACHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAAAAAAAAAegAAAAAAAAAAAAAAAAAAAAAAewAAAAAAHQAAAAACHQAAAAACHQAAAAADAAAAAAAAegAAAAAAAAAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAAAAAAAAAegAAAAAAegAAAAAAegAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAAAAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAHQAAAAAAHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAHQAAAAAAHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAewAAAAAAHQAAAAAAHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAHQAAAAAAHQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAegAAAAAAegAAAAAAegAAAAAAegAAAAAAewAAAAAAewAAAAAAewAAAAAA
           version: 6
         1,2:
           ind: 1,2
-          tiles: ewAAAAAAeAAAAAABeAAAAAADeAAAAAABeAAAAAACeAAAAAACewAAAAAAeAAAAAAAeAAAAAABWwAAAAACWwAAAAACWwAAAAADawAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAeAAAAAAAeAAAAAACeAAAAAACeAAAAAABeAAAAAADewAAAAAAeAAAAAADeAAAAAACWwAAAAADWwAAAAABWwAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAWwAAAAACWwAAAAABWwAAAAABWwAAAAADewAAAAAANgAAAAAANgAAAAAAewAAAAAAWwAAAAADWwAAAAABWwAAAAADWwAAAAACWwAAAAACWwAAAAACWwAAAAACWwAAAAABWwAAAAADWwAAAAADWwAAAAADWwAAAAABewAAAAAANgAAAAAANgAAAAAAWwAAAAACWwAAAAADWwAAAAABWwAAAAACWwAAAAACWwAAAAAAWwAAAAADWwAAAAAAWwAAAAADWwAAAAACWwAAAAADWwAAAAABWwAAAAACHQAAAAACHQAAAAACHQAAAAACewAAAAAAWwAAAAAAWwAAAAADWwAAAAAAWwAAAAACWwAAAAAAWwAAAAADWwAAAAABWwAAAAACWwAAAAAAWwAAAAAAWwAAAAADWwAAAAADewAAAAAAEQAAAAAAEQAAAAAAewAAAAAAewAAAAAAHQAAAAACewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAHQAAAAACewAAAAAAHQAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAALAAAAAAAHQAAAAACHQAAAAACewAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAewAAAAAAHQAAAAAAHQAAAAADHQAAAAAAewAAAAAAHQAAAAABeAAAAAACewAAAAAAHQAAAAABHQAAAAACHQAAAAABewAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAewAAAAAAHQAAAAADHQAAAAAAHQAAAAABewAAAAAAHQAAAAAAeAAAAAAAewAAAAAAHQAAAAACHQAAAAAAHQAAAAAAewAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAHQAAAAADHQAAAAADHQAAAAADHQAAAAADewAAAAAAHQAAAAABeAAAAAACewAAAAAAewAAAAAANgAAAAAAewAAAAAAewAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAewAAAAAAHQAAAAADHQAAAAAAHQAAAAADewAAAAAAHQAAAAADeAAAAAABAAAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAHQAAAAAAHQAAAAABewAAAAAAewAAAAAAHQAAAAABewAAAAAAHQAAAAADHQAAAAABHQAAAAABewAAAAAAAAAAAAAAegAAAAAAewAAAAAAHQAAAAACHQAAAAABHQAAAAACHQAAAAABHQAAAAAAHQAAAAADHQAAAAAAHQAAAAACHQAAAAADHQAAAAAAHQAAAAAAHQAAAAABewAAAAAAegAAAAAAegAAAAAAewAAAAAAHQAAAAACHQAAAAAAHQAAAAADHQAAAAADHQAAAAAAHQAAAAADHQAAAAACHQAAAAACHQAAAAACHQAAAAACHQAAAAACHQAAAAADHQAAAAACAAAAAAAAegAAAAAAewAAAAAAHQAAAAAAHQAAAAABHQAAAAACHQAAAAABHQAAAAAAHQAAAAACHQAAAAACHQAAAAAAHQAAAAAAHQAAAAADHQAAAAADHQAAAAACHQAAAAADegAAAAAAegAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAHQAAAAACHQAAAAABHQAAAAAAHQAAAAABHQAAAAABHQAAAAAAHQAAAAAAHQAAAAAAHQAAAAACHQAAAAAC
+          tiles: ewAAAAAAeAAAAAABeAAAAAADeAAAAAABeAAAAAACeAAAAAACewAAAAAAeAAAAAAAeAAAAAABWwAAAAACWwAAAAACWwAAAAADawAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAeAAAAAAAeAAAAAACeAAAAAACeAAAAAABeAAAAAADewAAAAAAeAAAAAADeAAAAAACWwAAAAADWwAAAAABWwAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAWwAAAAACWwAAAAABWwAAAAABWwAAAAADewAAAAAANgAAAAAANgAAAAAAewAAAAAAWwAAAAADWwAAAAABWwAAAAADWwAAAAACWwAAAAACWwAAAAACWwAAAAACWwAAAAABWwAAAAADWwAAAAADWwAAAAADWwAAAAABewAAAAAANgAAAAAANgAAAAAAWwAAAAACWwAAAAADWwAAAAABWwAAAAACWwAAAAACWwAAAAAAWwAAAAADWwAAAAAAWwAAAAADWwAAAAACWwAAAAADWwAAAAABWwAAAAACHQAAAAACHQAAAAACHQAAAAACewAAAAAAWwAAAAAAWwAAAAADWwAAAAAAWwAAAAACWwAAAAAAWwAAAAADWwAAAAABWwAAAAACWwAAAAAAWwAAAAAAWwAAAAADWwAAAAADewAAAAAAEQAAAAAAEQAAAAAAewAAAAAAewAAAAAAHQAAAAACewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAHQAAAAACewAAAAAAHQAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAALAAAAAAAHQAAAAACHQAAAAACewAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAewAAAAAAHQAAAAAAHQAAAAADHQAAAAAAewAAAAAAHQAAAAABeAAAAAACewAAAAAAHQAAAAABHQAAAAACHQAAAAABewAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAewAAAAAAHQAAAAADHQAAAAAAHQAAAAABewAAAAAAHQAAAAAAeAAAAAAAewAAAAAAHQAAAAACHQAAAAAAHQAAAAAAewAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAHQAAAAADHQAAAAADHQAAAAADHQAAAAADewAAAAAAHQAAAAABeAAAAAACewAAAAAAewAAAAAANgAAAAAAewAAAAAAewAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAewAAAAAAHQAAAAADHQAAAAAAHQAAAAADewAAAAAAHQAAAAADeAAAAAABHQAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAHQAAAAAAHQAAAAABewAAAAAAewAAAAAAHQAAAAABewAAAAAAHQAAAAADHQAAAAABHQAAAAABewAAAAAAHQAAAAAAHQAAAAAAHQAAAAAAHQAAAAACHQAAAAABHQAAAAACHQAAAAABHQAAAAAAHQAAAAADHQAAAAAAHQAAAAACHQAAAAADHQAAAAAAHQAAAAAAHQAAAAABewAAAAAAHQAAAAAAHQAAAAAAewAAAAAAHQAAAAACHQAAAAAAHQAAAAADHQAAAAADHQAAAAAAHQAAAAADHQAAAAACHQAAAAACHQAAAAACHQAAAAACHQAAAAACHQAAAAADHQAAAAACHQAAAAAAHQAAAAAAewAAAAAAHQAAAAAAHQAAAAABHQAAAAACHQAAAAABHQAAAAAAHQAAAAACHQAAAAACHQAAAAAAHQAAAAAAHQAAAAADHQAAAAADHQAAAAACHQAAAAADewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAHQAAAAACHQAAAAABHQAAAAAAHQAAAAABHQAAAAABHQAAAAAAHQAAAAAAHQAAAAAAHQAAAAACHQAAAAAC
           version: 6
         2,1:
           ind: 2,1
@@ -449,7 +449,7 @@ entities:
           4,0:
             0: 62719
           4,2:
-            0: 53246
+            0: 53244
           4,3:
             0: 65021
           0,-5:
@@ -478,7 +478,7 @@ entities:
           3,-2:
             0: 52573
           3,-5:
-            0: 61152
+            0: 65520
           4,-4:
             0: 37332
           4,-3:
@@ -574,7 +574,7 @@ entities:
           4,-6:
             0: 3855
           4,-5:
-            0: 22288
+            0: 22352
           0,6:
             0: 2056
           1,6:
@@ -616,7 +616,7 @@ entities:
           5,1:
             0: 57308
           5,2:
-            0: 3549
+            0: 3548
           5,3:
             0: 65535
           5,-1:
@@ -743,26 +743,26 @@ entities:
             1: 273
             0: 3276
           2,-12:
-            1: 5905
+            1: 8021
           2,-13:
-            1: 4401
+            1: 21877
           2,-11:
             0: 61152
-          3,-12:
-            0: 61047
-            1: 136
           3,-10:
             1: 50
             0: 45192
           3,-9:
             0: 3067
-          3,-13:
-            0: 30583
-            1: 34952
+          3,-12:
+            0: 60966
+            1: 192
           3,-11:
             0: 3682
+          3,-13:
+            0: 9830
+            1: 51200
           4,-12:
-            1: 253
+            1: 252
             0: 16130
           4,-11:
             0: 48056
@@ -779,26 +779,28 @@ entities:
           5,-10:
             0: 62207
           5,-13:
-            1: 8751
+            1: 8749
+            0: 2
           6,-12:
-            1: 253
+            1: 241
             0: 26370
           6,-10:
             0: 61543
           6,-11:
             0: 26208
           6,-13:
-            1: 61165
+            1: 61029
             0: 2
           7,-12:
-            0: 61627
+            1: 16
+            0: 61611
           7,-11:
             0: 65535
           7,-10:
             0: 63743
           7,-13:
-            0: 45875
-            1: 136
+            1: 4232
+            0: 41779
           8,-12:
             0: 56543
           8,-11:
@@ -848,12 +850,10 @@ entities:
             1: 3140
           11,-5:
             0: 51455
-            1: 4096
           11,-9:
             0: 4369
             1: 17484
           11,-4:
-            1: 17
             0: 63692
           12,-8:
             3: 7
@@ -1008,22 +1008,23 @@ entities:
           12,-1:
             0: 65380
           4,-16:
-            1: 4592
+            1: 61680
           3,-16:
-            1: 4336
+            1: 39152
           4,-15:
             0: 4095
             1: 61440
           3,-15:
-            0: 65526
+            0: 12006
+            1: 49152
           4,-14:
-            1: 13117
+            1: 13116
             0: 2
           3,-14:
-            1: 34952
-            0: 30583
+            1: 2240
+            0: 26150
           5,-16:
-            1: 29424
+            1: 63472
           5,-15:
             0: 4088
             1: 61440
@@ -1031,21 +1032,21 @@ entities:
             1: 8749
             0: 2
           6,-16:
-            1: 8944
+            1: 29936
           6,-15:
-            0: 36859
-            1: 28672
+            0: 4091
+            1: 61440
           6,-14:
-            1: 61165
+            1: 28385
             0: 2
           7,-16:
             1: 28272
           7,-15:
-            0: 13105
-            1: 34816
+            0: 9009
+            1: 38912
           7,-14:
-            0: 13107
-            1: 34952
+            1: 34968
+            0: 13091
           8,-16:
             1: 3840
           8,-15:
@@ -1082,15 +1083,15 @@ entities:
           1,-16:
             1: 50368
           1,-15:
-            1: 68
+            1: 17476
           1,-14:
-            1: 17472
+            1: 17476
           2,-16:
-            1: 57280
+            1: 57328
           2,-15:
-            1: 4369
+            1: 56797
           2,-14:
-            1: 4371
+            1: 24023
           -4,-11:
             1: 62448
           -5,-11:
@@ -1182,13 +1183,10 @@ entities:
             1: 65280
           16,-5:
             0: 65295
-          0,8:
-            1: 9728
-          0,9:
-            1: 9826
-            0: 2176
           0,10:
-            1: 59938
+            1: 59904
+          0,9:
+            0: 128
           1,9:
             0: 32754
           1,10:
@@ -1202,18 +1200,18 @@ entities:
           2,11:
             1: 58082
           3,11:
-            1: 61680
+            1: 4112
+            0: 3276
           3,9:
             0: 61166
           3,10:
-            0: 238
+            0: 49390
           4,9:
             0: 57583
-          4,11:
-            1: 12850
-            0: 2184
           4,10:
-            0: 1262
+            0: 5358
+          4,11:
+            0: 3007
           5,9:
             0: 57599
           5,11:
@@ -1281,7 +1279,7 @@ entities:
           12,6:
             0: 28910
           12,7:
-            1: 36608
+            1: 3840
             0: 6
           8,12:
             0: 1
@@ -1388,6 +1386,8 @@ entities:
             0: 32754
           20,-4:
             0: 65359
+          20,-3:
+            1: 3840
           20,-2:
             0: 30583
           20,-1:
@@ -1508,7 +1508,7 @@ entities:
             0: 239
             1: 61440
           13,7:
-            1: 305
+            1: 273
             0: 49152
           13,8:
             0: 65518
@@ -1519,7 +1519,6 @@ entities:
             1: 61440
           14,7:
             0: 28672
-            1: 128
           14,8:
             0: 47935
           15,5:
@@ -1556,7 +1555,7 @@ entities:
             1: 256
           15,11:
             0: 34816
-            1: 773
+            1: 769
           13,10:
             1: 12544
             0: 206
@@ -1657,12 +1656,14 @@ entities:
             0: 2730
           21,-4:
             0: 54479
+          21,-3:
+            1: 4352
+            0: 52428
           21,-2:
+            1: 1
             0: 52672
           21,-5:
             0: 61440
-          21,-3:
-            0: 52428
           22,-4:
             0: 8243
           22,-3:
@@ -1928,8 +1929,8 @@ entities:
         - volume: 2500
           temperature: 235
           moles:
-          - 21.824879
-          - 82.10312
+          - 27.225372
+          - 102.419266
           - 0
           - 0
           - 0
@@ -2855,6 +2856,14 @@ entities:
             780: 37,-11
             781: 37,-12
             782: 37,-13
+        - node:
+            color: '#008200FF'
+            id: ConcreteTrimLineN
+          decals:
+            3924: 14,46
+            3925: 15,46
+            3926: 16,46
+            3929: 17,46
         - node:
             color: '#FFFFFFFF'
             id: Delivery
@@ -7468,6 +7477,16 @@ entities:
       - 7051
       - 8835
       - 8928
+  - uid: 15089
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,43.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 9924
+      - 9923
 - proto: AirCanister
   entities:
   - uid: 75
@@ -9244,6 +9263,19 @@ entities:
     - type: Transform
       pos: 71.5,-6.5
       parent: 2
+- proto: AirlockNanotrasenRepresentativeCommandGlassLocked
+  entities:
+  - uid: 5641
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,44.5
+      parent: 2
+    - type: AccessReader
+      access:
+      - - BlueshieldOfficer
+      - - Captain
+      - - NanotrasenRepresentative
 - proto: AirlockQuartermasterGlassLocked
   entities:
   - uid: 360
@@ -10609,6 +10641,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: 6.5,17.5
       parent: 2
+  - uid: 5658
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,45.5
+      parent: 2
 - proto: APCElectronics
   entities:
   - uid: 539
@@ -11221,6 +11259,16 @@ entities:
     - type: Transform
       pos: 10.5,-40.5
       parent: 2
+  - uid: 5631
+    components:
+    - type: Transform
+      pos: 17.5,46.5
+      parent: 2
+  - uid: 5642
+    components:
+    - type: Transform
+      pos: 14.5,46.5
+      parent: 2
 - proto: BedsheetCaptain
   entities:
   - uid: 646
@@ -11234,6 +11282,14 @@ entities:
     components:
     - type: Transform
       pos: 10.5,-40.5
+      parent: 2
+- proto: BedsheetCentcom
+  entities:
+  - uid: 5665
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 17.5,46.5
       parent: 2
 - proto: BedsheetClown
   entities:
@@ -11327,6 +11383,14 @@ entities:
     components:
     - type: Transform
       pos: 27.5,5.5
+      parent: 2
+- proto: BedsheetNT
+  entities:
+  - uid: 4161
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,46.5
       parent: 2
 - proto: BedsheetOrange
   entities:
@@ -21713,6 +21777,76 @@ entities:
     - type: Transform
       pos: 41.5,-12.5
       parent: 2
+  - uid: 5659
+    components:
+    - type: Transform
+      pos: 13.5,43.5
+      parent: 2
+  - uid: 5660
+    components:
+    - type: Transform
+      pos: 14.5,43.5
+      parent: 2
+  - uid: 5661
+    components:
+    - type: Transform
+      pos: 15.5,43.5
+      parent: 2
+  - uid: 5662
+    components:
+    - type: Transform
+      pos: 15.5,44.5
+      parent: 2
+  - uid: 5663
+    components:
+    - type: Transform
+      pos: 15.5,45.5
+      parent: 2
+  - uid: 5664
+    components:
+    - type: Transform
+      pos: 15.5,43.5
+      parent: 2
+  - uid: 5670
+    components:
+    - type: Transform
+      pos: 13.5,45.5
+      parent: 2
+  - uid: 7248
+    components:
+    - type: Transform
+      pos: 16.5,44.5
+      parent: 2
+  - uid: 7672
+    components:
+    - type: Transform
+      pos: 17.5,44.5
+      parent: 2
+  - uid: 9179
+    components:
+    - type: Transform
+      pos: 18.5,44.5
+      parent: 2
+  - uid: 9180
+    components:
+    - type: Transform
+      pos: 15.5,44.5
+      parent: 2
+  - uid: 15092
+    components:
+    - type: Transform
+      pos: 13.5,44.5
+      parent: 2
+  - uid: 15093
+    components:
+    - type: Transform
+      pos: 13.5,44.5
+      parent: 2
+  - uid: 15094
+    components:
+    - type: Transform
+      pos: 13.5,43.5
+      parent: 2
 - proto: CableApcStack
   entities:
   - uid: 2714
@@ -28959,11 +29093,6 @@ entities:
     - type: Transform
       pos: 18.5,45.5
       parent: 2
-  - uid: 4161
-    components:
-    - type: Transform
-      pos: 18.5,44.5
-      parent: 2
   - uid: 4162
     components:
     - type: Transform
@@ -32423,6 +32552,71 @@ entities:
     components:
     - type: Transform
       pos: 38.5,-12.5
+      parent: 2
+  - uid: 5648
+    components:
+    - type: Transform
+      pos: 17.5,45.5
+      parent: 2
+  - uid: 5649
+    components:
+    - type: Transform
+      pos: 16.5,45.5
+      parent: 2
+  - uid: 5650
+    components:
+    - type: Transform
+      pos: 16.5,46.5
+      parent: 2
+  - uid: 5651
+    components:
+    - type: Transform
+      pos: 16.5,47.5
+      parent: 2
+  - uid: 5652
+    components:
+    - type: Transform
+      pos: 15.5,47.5
+      parent: 2
+  - uid: 5653
+    components:
+    - type: Transform
+      pos: 14.5,47.5
+      parent: 2
+  - uid: 5654
+    components:
+    - type: Transform
+      pos: 16.5,44.5
+      parent: 2
+  - uid: 5655
+    components:
+    - type: Transform
+      pos: 16.5,43.5
+      parent: 2
+  - uid: 5656
+    components:
+    - type: Transform
+      pos: 16.5,42.5
+      parent: 2
+  - uid: 5657
+    components:
+    - type: Transform
+      pos: 13.5,43.5
+      parent: 2
+  - uid: 15095
+    components:
+    - type: Transform
+      pos: 13.5,45.5
+      parent: 2
+  - uid: 15096
+    components:
+    - type: Transform
+      pos: 13.5,44.5
+      parent: 2
+  - uid: 15097
+    components:
+    - type: Transform
+      pos: 13.5,43.5
       parent: 2
 - proto: CableMVStack
   entities:
@@ -36593,275 +36787,6 @@ entities:
     - type: Transform
       pos: 6.5,-12.5
       parent: 2
-- proto: ChairOfficeDark
-  entities:
-  - uid: 5629
-    components:
-    - type: Transform
-      pos: -2.5,-11.5
-      parent: 2
-  - uid: 5630
-    components:
-    - type: Transform
-      pos: 11.5,5.5
-      parent: 2
-  - uid: 5631
-    components:
-    - type: Transform
-      pos: 10.5,5.5
-      parent: 2
-  - uid: 5632
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,3.5
-      parent: 2
-  - uid: 5633
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,-3.5
-      parent: 2
-  - uid: 5634
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-16.5
-      parent: 2
-  - uid: 5635
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,-18.5
-      parent: 2
-  - uid: 5636
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 22.517172,-24.347618
-      parent: 2
-  - uid: 5637
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 20.5,22.5
-      parent: 2
-  - uid: 5638
-    components:
-    - type: Transform
-      pos: 37.5,18.5
-      parent: 2
-  - uid: 5639
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 42.5,19.5
-      parent: 2
-  - uid: 5640
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 35.5,27.5
-      parent: 2
-  - uid: 5641
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,33.5
-      parent: 2
-  - uid: 5642
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,32.5
-      parent: 2
-  - uid: 5643
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,30.5
-      parent: 2
-  - uid: 5644
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 21.5,29.5
-      parent: 2
-  - uid: 5645
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 34.5,45.5
-      parent: 2
-  - uid: 5646
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 31.5,47.5
-      parent: 2
-  - uid: 5647
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 23.5,47.5
-      parent: 2
-  - uid: 5648
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,45.5
-      parent: 2
-  - uid: 5649
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 55.5,-11.5
-      parent: 2
-  - uid: 5650
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 49.5,18.5
-      parent: 2
-  - uid: 5651
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 50.5,10.5
-      parent: 2
-  - uid: 5652
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-10.5
-      parent: 2
-  - uid: 5653
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,-3.5
-      parent: 2
-  - uid: 5654
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 70.5,14.5
-      parent: 2
-  - uid: 5655
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.517927,23.649218
-      parent: 2
-  - uid: 5656
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 30.500034,25.750826
-      parent: 2
-  - uid: 5657
-    components:
-    - type: Transform
-      pos: 50.5,2.5
-      parent: 2
-  - uid: 5658
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,18.5
-      parent: 2
-  - uid: 5659
-    components:
-    - type: Transform
-      pos: 74.5,-1.5
-      parent: 2
-  - uid: 5660
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,25.5
-      parent: 2
-  - uid: 5661
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 30.454672,-24.238243
-      parent: 2
-  - uid: 5662
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 72.5,23.5
-      parent: 2
-  - uid: 5663
-    components:
-    - type: Transform
-      pos: 90.5,29.5
-      parent: 2
-  - uid: 5664
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 89.5,31.5
-      parent: 2
-- proto: ChairOfficeLight
-  entities:
-  - uid: 5665
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 11.5,-34.5
-      parent: 2
-  - uid: 5666
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 50.5,-4.5
-      parent: 2
-  - uid: 5667
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 53.5,-4.5
-      parent: 2
-  - uid: 5668
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 81.5,-6.5
-      parent: 2
-  - uid: 5669
-    components:
-    - type: Transform
-      pos: 44.5,3.5
-      parent: 2
-  - uid: 5670
-    components:
-    - type: Transform
-      pos: 71.5,-19.495005
-      parent: 2
-  - uid: 5671
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 64.5,24.5
-      parent: 2
-  - uid: 5672
-    components:
-    - type: Transform
-      pos: 62.5,9.5
-      parent: 2
-  - uid: 5673
-    components:
-    - type: Transform
-      pos: 79.5,-6.5
-      parent: 2
-  - uid: 5674
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 61.5,-11.5
-      parent: 2
 - proto: ChairPilotSeat
   entities:
   - uid: 5675
@@ -38449,6 +38374,11 @@ entities:
       parent: 2
 - proto: ComfyChair
   entities:
+  - uid: 5673
+    components:
+    - type: Transform
+      pos: 15.5,44.5
+      parent: 2
   - uid: 5912
     components:
     - type: Transform
@@ -39795,6 +39725,13 @@ entities:
     components:
     - type: Transform
       pos: 19.5,22.5
+      parent: 2
+- proto: DefaultStationBeaconCentcommOffice
+  entities:
+  - uid: 5640
+    components:
+    - type: Transform
+      pos: 16.5,45.5
       parent: 2
 - proto: DefaultStationBeaconCERoom
   entities:
@@ -43097,6 +43034,13 @@ entities:
         actions: !type:Container
           ents:
           - 5
+- proto: DresserBlueshieldOfficerFilled
+  entities:
+  - uid: 5667
+    components:
+    - type: Transform
+      pos: 15.5,46.5
+      parent: 2
 - proto: DresserCaptainFilled
   entities:
   - uid: 6673
@@ -43155,6 +43099,13 @@ entities:
     components:
     - type: Transform
       pos: 45.5,22.5
+      parent: 2
+- proto: DresserNanorepFilled
+  entities:
+  - uid: 5669
+    components:
+    - type: Transform
+      pos: 16.5,46.5
       parent: 2
 - proto: DresserQuarterMasterFilled
   entities:
@@ -43457,6 +43408,12 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 53.5,36.5
+      parent: 2
+  - uid: 9723
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,44.5
       parent: 2
 - proto: EmergencyRollerBedSpawnFolded
   entities:
@@ -47040,6 +46997,16 @@ entities:
     - type: Transform
       pos: 11.536887,-11.535692
       parent: 2
+- proto: FoodSnackLollypopWrappedCentComm
+  entities:
+  - uid: 5672
+    components:
+    - type: Transform
+      pos: 15.503757,43.600956
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: FoodTinBeansTrash
   entities:
   - uid: 7114
@@ -47120,7 +47087,7 @@ entities:
       pos: 44.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7126
     components:
     - type: Transform
@@ -47140,7 +47107,7 @@ entities:
       pos: 59.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
 - proto: GasMinerCarbonDioxide
   entities:
   - uid: 7129
@@ -47380,7 +47347,7 @@ entities:
       pos: 11.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7166
     components:
     - type: Transform
@@ -47388,7 +47355,7 @@ entities:
       pos: 61.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7167
     components:
     - type: Transform
@@ -47396,7 +47363,7 @@ entities:
       pos: 27.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7168
     components:
     - type: Transform
@@ -47404,7 +47371,7 @@ entities:
       pos: 26.5,-25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7169
     components:
     - type: Transform
@@ -47412,7 +47379,7 @@ entities:
       pos: 3.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7170
     components:
     - type: Transform
@@ -47426,14 +47393,14 @@ entities:
       pos: 26.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7172
     components:
     - type: Transform
       pos: 27.5,-25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7173
     components:
     - type: Transform
@@ -47457,7 +47424,7 @@ entities:
       pos: 35.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7176
     components:
     - type: Transform
@@ -47488,7 +47455,7 @@ entities:
       pos: 31.5,-32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7180
     components:
     - type: Transform
@@ -47496,7 +47463,7 @@ entities:
       pos: 8.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7181
     components:
     - type: Transform
@@ -47504,7 +47471,7 @@ entities:
       pos: 17.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7182
     components:
     - type: Transform
@@ -47512,7 +47479,7 @@ entities:
       pos: 41.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7183
     components:
     - type: Transform
@@ -47520,7 +47487,7 @@ entities:
       pos: 62.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7184
     components:
     - type: Transform
@@ -47528,7 +47495,7 @@ entities:
       pos: 31.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7185
     components:
     - type: Transform
@@ -47536,7 +47503,7 @@ entities:
       pos: 18.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7186
     components:
     - type: Transform
@@ -47544,7 +47511,7 @@ entities:
       pos: 40.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7187
     components:
     - type: Transform
@@ -47552,7 +47519,7 @@ entities:
       pos: 12.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7188
     components:
     - type: Transform
@@ -47560,7 +47527,7 @@ entities:
       pos: 25.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7189
     components:
     - type: Transform
@@ -47568,7 +47535,7 @@ entities:
       pos: 11.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7190
     components:
     - type: Transform
@@ -47576,7 +47543,7 @@ entities:
       pos: 11.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7191
     components:
     - type: Transform
@@ -47584,7 +47551,7 @@ entities:
       pos: 11.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7192
     components:
     - type: Transform
@@ -47592,7 +47559,7 @@ entities:
       pos: 11.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7193
     components:
     - type: Transform
@@ -47608,7 +47575,7 @@ entities:
       pos: 40.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7195
     components:
     - type: Transform
@@ -47624,7 +47591,7 @@ entities:
       pos: 67.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7197
     components:
     - type: Transform
@@ -47638,7 +47605,7 @@ entities:
       pos: 55.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7199
     components:
     - type: Transform
@@ -47646,7 +47613,7 @@ entities:
       pos: 62.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7200
     components:
     - type: Transform
@@ -47659,7 +47626,7 @@ entities:
       pos: 38.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7202
     components:
     - type: Transform
@@ -47674,7 +47641,7 @@ entities:
       pos: 44.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7204
     components:
     - type: Transform
@@ -47682,7 +47649,7 @@ entities:
       pos: 38.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7205
     components:
     - type: Transform
@@ -47690,7 +47657,7 @@ entities:
       pos: 29.5,-26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7206
     components:
     - type: Transform
@@ -47698,7 +47665,7 @@ entities:
       pos: 32.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7207
     components:
     - type: Transform
@@ -47706,7 +47673,7 @@ entities:
       pos: 32.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7208
     components:
     - type: Transform
@@ -47714,7 +47681,7 @@ entities:
       pos: 30.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7209
     components:
     - type: Transform
@@ -47722,7 +47689,7 @@ entities:
       pos: 30.5,-26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7210
     components:
     - type: Transform
@@ -47730,7 +47697,7 @@ entities:
       pos: 17.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7211
     components:
     - type: Transform
@@ -47738,7 +47705,7 @@ entities:
       pos: 10.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7212
     components:
     - type: Transform
@@ -47766,14 +47733,14 @@ entities:
       pos: 45.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7216
     components:
     - type: Transform
       pos: 41.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7217
     components:
     - type: Transform
@@ -47781,7 +47748,7 @@ entities:
       pos: 56.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7218
     components:
     - type: Transform
@@ -47812,7 +47779,7 @@ entities:
       pos: 32.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7223
     components:
     - type: Transform
@@ -47828,7 +47795,7 @@ entities:
       pos: 47.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7225
     components:
     - type: Transform
@@ -47842,7 +47809,7 @@ entities:
       pos: 46.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7227
     components:
     - type: Transform
@@ -47850,7 +47817,7 @@ entities:
       pos: 46.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7228
     components:
     - type: Transform
@@ -47858,14 +47825,14 @@ entities:
       pos: 7.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7229
     components:
     - type: Transform
       pos: 32.5,46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7230
     components:
     - type: Transform
@@ -47873,7 +47840,7 @@ entities:
       pos: 44.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7231
     components:
     - type: Transform
@@ -47881,7 +47848,7 @@ entities:
       pos: 42.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7232
     components:
     - type: Transform
@@ -47889,7 +47856,7 @@ entities:
       pos: 46.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7233
     components:
     - type: Transform
@@ -47897,7 +47864,7 @@ entities:
       pos: 46.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7234
     components:
     - type: Transform
@@ -47905,7 +47872,7 @@ entities:
       pos: 42.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7235
     components:
     - type: Transform
@@ -47913,14 +47880,14 @@ entities:
       pos: 5.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7236
     components:
     - type: Transform
       pos: 14.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7237
     components:
     - type: Transform
@@ -47928,7 +47895,7 @@ entities:
       pos: 16.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7238
     components:
     - type: Transform
@@ -47936,14 +47903,14 @@ entities:
       pos: 13.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7239
     components:
     - type: Transform
       pos: 13.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7240
     components:
     - type: Transform
@@ -47951,7 +47918,7 @@ entities:
       pos: 26.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7241
     components:
     - type: Transform
@@ -47959,7 +47926,7 @@ entities:
       pos: 40.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7242
     components:
     - type: Transform
@@ -47967,7 +47934,7 @@ entities:
       pos: 35.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7243
     components:
     - type: Transform
@@ -47975,7 +47942,7 @@ entities:
       pos: 33.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7244
     components:
     - type: Transform
@@ -47983,14 +47950,14 @@ entities:
       pos: 38.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7245
     components:
     - type: Transform
       pos: 47.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7246
     components:
     - type: Transform
@@ -47998,7 +47965,7 @@ entities:
       pos: 33.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7247
     components:
     - type: Transform
@@ -48006,22 +47973,14 @@ entities:
       pos: 28.5,45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 7248
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 22.5,45.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7249
     components:
     - type: Transform
       pos: 28.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7250
     components:
     - type: Transform
@@ -48029,7 +47988,7 @@ entities:
       pos: 28.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7251
     components:
     - type: Transform
@@ -48037,7 +47996,7 @@ entities:
       pos: 18.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7252
     components:
     - type: Transform
@@ -48045,7 +48004,7 @@ entities:
       pos: 9.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7253
     components:
     - type: Transform
@@ -48053,7 +48012,7 @@ entities:
       pos: 8.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7254
     components:
     - type: Transform
@@ -48061,7 +48020,7 @@ entities:
       pos: 47.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7255
     components:
     - type: Transform
@@ -48069,7 +48028,7 @@ entities:
       pos: 54.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7256
     components:
     - type: Transform
@@ -48077,7 +48036,7 @@ entities:
       pos: 50.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7257
     components:
     - type: Transform
@@ -48085,7 +48044,7 @@ entities:
       pos: 55.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7258
     components:
     - type: Transform
@@ -48093,7 +48052,7 @@ entities:
       pos: 63.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7259
     components:
     - type: Transform
@@ -48101,14 +48060,14 @@ entities:
       pos: 55.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7260
     components:
     - type: Transform
       pos: 29.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7261
     components:
     - type: Transform
@@ -48116,7 +48075,7 @@ entities:
       pos: 36.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7262
     components:
     - type: Transform
@@ -48124,7 +48083,7 @@ entities:
       pos: 36.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7263
     components:
     - type: Transform
@@ -48137,7 +48096,7 @@ entities:
       pos: 65.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7265
     components:
     - type: Transform
@@ -48160,7 +48119,7 @@ entities:
       pos: 71.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7268
     components:
     - type: Transform
@@ -48168,7 +48127,7 @@ entities:
       pos: 64.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7269
     components:
     - type: Transform
@@ -48176,7 +48135,7 @@ entities:
       pos: 66.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7270
     components:
     - type: Transform
@@ -48184,7 +48143,7 @@ entities:
       pos: 66.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7271
     components:
     - type: Transform
@@ -48192,7 +48151,7 @@ entities:
       pos: 61.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7272
     components:
     - type: Transform
@@ -48222,7 +48181,7 @@ entities:
       pos: 56.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7277
     components:
     - type: Transform
@@ -48230,7 +48189,7 @@ entities:
       pos: 56.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7278
     components:
     - type: Transform
@@ -48238,7 +48197,7 @@ entities:
       pos: 72.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7279
     components:
     - type: Transform
@@ -48246,7 +48205,7 @@ entities:
       pos: 73.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7280
     components:
     - type: Transform
@@ -48325,7 +48284,7 @@ entities:
       pos: 56.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7291
     components:
     - type: Transform
@@ -48333,7 +48292,7 @@ entities:
       pos: 56.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7292
     components:
     - type: Transform
@@ -48341,7 +48300,7 @@ entities:
       pos: 45.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7293
     components:
     - type: Transform
@@ -48349,7 +48308,7 @@ entities:
       pos: 46.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7294
     components:
     - type: Transform
@@ -48357,7 +48316,7 @@ entities:
       pos: -5.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7295
     components:
     - type: Transform
@@ -48365,7 +48324,7 @@ entities:
       pos: -6.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7296
     components:
     - type: Transform
@@ -48373,7 +48332,7 @@ entities:
       pos: -22.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7297
     components:
     - type: Transform
@@ -48381,7 +48340,7 @@ entities:
       pos: -24.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7298
     components:
     - type: Transform
@@ -48389,7 +48348,7 @@ entities:
       pos: -22.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7299
     components:
     - type: Transform
@@ -48397,7 +48356,7 @@ entities:
       pos: -24.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7300
     components:
     - type: Transform
@@ -48451,7 +48410,7 @@ entities:
       pos: 64.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7307
     components:
     - type: Transform
@@ -48459,14 +48418,14 @@ entities:
       pos: 67.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7308
     components:
     - type: Transform
       pos: 69.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7309
     components:
     - type: Transform
@@ -48474,7 +48433,7 @@ entities:
       pos: 69.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7310
     components:
     - type: Transform
@@ -48482,7 +48441,7 @@ entities:
       pos: 72.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7311
     components:
     - type: Transform
@@ -48498,7 +48457,7 @@ entities:
       pos: 5.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7313
     components:
     - type: Transform
@@ -48506,7 +48465,7 @@ entities:
       pos: 5.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
 - proto: GasPipeFourway
   entities:
   - uid: 7314
@@ -48515,21 +48474,21 @@ entities:
       pos: 35.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7315
     components:
     - type: Transform
       pos: 19.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7316
     components:
     - type: Transform
       pos: 18.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7317
     components:
     - type: Transform
@@ -48543,98 +48502,98 @@ entities:
       pos: 55.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7319
     components:
     - type: Transform
       pos: 12.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7320
     components:
     - type: Transform
       pos: 72.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7321
     components:
     - type: Transform
       pos: 25.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7322
     components:
     - type: Transform
       pos: 42.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7323
     components:
     - type: Transform
       pos: 44.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7324
     components:
     - type: Transform
       pos: 46.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7325
     components:
     - type: Transform
       pos: 35.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7326
     components:
     - type: Transform
       pos: 39.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7327
     components:
     - type: Transform
       pos: 40.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7328
     components:
     - type: Transform
       pos: 59.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7329
     components:
     - type: Transform
       pos: 58.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7330
     components:
     - type: Transform
       pos: 60.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7331
     components:
     - type: Transform
       pos: 57.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
 - proto: GasPipeStraight
   entities:
   - uid: 7332
@@ -48644,7 +48603,7 @@ entities:
       pos: 23.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7333
     components:
     - type: Transform
@@ -48652,21 +48611,21 @@ entities:
       pos: 12.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7334
     components:
     - type: Transform
       pos: 19.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7335
     components:
     - type: Transform
       pos: 33.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7336
     components:
     - type: Transform
@@ -48674,7 +48633,7 @@ entities:
       pos: 48.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7337
     components:
     - type: Transform
@@ -48682,7 +48641,7 @@ entities:
       pos: 0.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7338
     components:
     - type: Transform
@@ -48690,14 +48649,14 @@ entities:
       pos: -1.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7339
     components:
     - type: Transform
       pos: 11.5,-37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7340
     components:
     - type: Transform
@@ -48705,7 +48664,7 @@ entities:
       pos: 9.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7341
     components:
     - type: Transform
@@ -48713,7 +48672,7 @@ entities:
       pos: 16.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7342
     components:
     - type: Transform
@@ -48721,7 +48680,7 @@ entities:
       pos: 17.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7343
     components:
     - type: Transform
@@ -48729,7 +48688,7 @@ entities:
       pos: 11.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7344
     components:
     - type: Transform
@@ -48737,7 +48696,7 @@ entities:
       pos: 11.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7345
     components:
     - type: Transform
@@ -48745,7 +48704,7 @@ entities:
       pos: 27.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7346
     components:
     - type: Transform
@@ -48753,7 +48712,7 @@ entities:
       pos: 6.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7347
     components:
     - type: Transform
@@ -48761,7 +48720,7 @@ entities:
       pos: 19.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7348
     components:
     - type: Transform
@@ -48769,7 +48728,7 @@ entities:
       pos: 9.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7349
     components:
     - type: Transform
@@ -48777,7 +48736,7 @@ entities:
       pos: 9.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7350
     components:
     - type: Transform
@@ -48785,28 +48744,28 @@ entities:
       pos: 45.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7351
     components:
     - type: Transform
       pos: 3.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7352
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7353
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7354
     components:
     - type: Transform
@@ -48814,42 +48773,42 @@ entities:
       pos: -10.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7355
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7356
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7357
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7358
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7359
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7360
     components:
     - type: Transform
@@ -48857,14 +48816,14 @@ entities:
       pos: 43.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7361
     components:
     - type: Transform
       pos: 7.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7362
     components:
     - type: Transform
@@ -48872,7 +48831,7 @@ entities:
       pos: 44.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7363
     components:
     - type: Transform
@@ -48880,7 +48839,7 @@ entities:
       pos: 34.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7364
     components:
     - type: Transform
@@ -48888,7 +48847,7 @@ entities:
       pos: 31.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7365
     components:
     - type: Transform
@@ -48896,35 +48855,35 @@ entities:
       pos: 16.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7366
     components:
     - type: Transform
       pos: 25.5,-26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7367
     components:
     - type: Transform
       pos: 25.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7368
     components:
     - type: Transform
       pos: 25.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7369
     components:
     - type: Transform
       pos: 7.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7370
     components:
     - type: Transform
@@ -48932,7 +48891,7 @@ entities:
       pos: 12.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7371
     components:
     - type: Transform
@@ -48940,14 +48899,14 @@ entities:
       pos: 32.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7372
     components:
     - type: Transform
       pos: 10.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7373
     components:
     - type: Transform
@@ -48955,7 +48914,7 @@ entities:
       pos: 11.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7374
     components:
     - type: Transform
@@ -48963,7 +48922,7 @@ entities:
       pos: 28.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7375
     components:
     - type: Transform
@@ -48971,14 +48930,14 @@ entities:
       pos: 25.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7376
     components:
     - type: Transform
       pos: 55.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7377
     components:
     - type: Transform
@@ -48986,14 +48945,14 @@ entities:
       pos: 24.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7378
     components:
     - type: Transform
       pos: 46.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7379
     components:
     - type: Transform
@@ -49014,7 +48973,7 @@ entities:
       pos: -9.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7382
     components:
     - type: Transform
@@ -49033,7 +48992,7 @@ entities:
       pos: 42.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7385
     components:
     - type: Transform
@@ -49055,21 +49014,21 @@ entities:
       pos: 42.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7388
     components:
     - type: Transform
       pos: 42.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7389
     components:
     - type: Transform
       pos: 42.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7390
     components:
     - type: Transform
@@ -49091,7 +49050,7 @@ entities:
       pos: 27.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7393
     components:
     - type: Transform
@@ -49099,7 +49058,7 @@ entities:
       pos: 27.5,-26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7394
     components:
     - type: Transform
@@ -49107,7 +49066,7 @@ entities:
       pos: 27.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7395
     components:
     - type: Transform
@@ -49115,7 +49074,7 @@ entities:
       pos: 27.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7396
     components:
     - type: Transform
@@ -49123,7 +49082,7 @@ entities:
       pos: 27.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7397
     components:
     - type: Transform
@@ -49131,7 +49090,7 @@ entities:
       pos: 21.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7398
     components:
     - type: Transform
@@ -49139,7 +49098,7 @@ entities:
       pos: 20.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7399
     components:
     - type: Transform
@@ -49147,7 +49106,7 @@ entities:
       pos: 27.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7400
     components:
     - type: Transform
@@ -49161,7 +49120,7 @@ entities:
       pos: 49.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7402
     components:
     - type: Transform
@@ -49192,7 +49151,7 @@ entities:
       pos: 25.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7407
     components:
     - type: Transform
@@ -49200,7 +49159,7 @@ entities:
       pos: 27.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7408
     components:
     - type: Transform
@@ -49208,7 +49167,7 @@ entities:
       pos: 28.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7409
     components:
     - type: Transform
@@ -49216,21 +49175,21 @@ entities:
       pos: 29.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7410
     components:
     - type: Transform
       pos: 25.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7411
     components:
     - type: Transform
       pos: 25.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7412
     components:
     - type: Transform
@@ -49249,7 +49208,7 @@ entities:
       pos: 25.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7415
     components:
     - type: Transform
@@ -49269,21 +49228,21 @@ entities:
       pos: -8.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7418
     components:
     - type: Transform
       pos: 25.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7419
     components:
     - type: Transform
       pos: 25.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7420
     components:
     - type: Transform
@@ -49306,7 +49265,7 @@ entities:
       pos: 25.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7423
     components:
     - type: Transform
@@ -49314,7 +49273,7 @@ entities:
       pos: 37.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7424
     components:
     - type: Transform
@@ -49322,7 +49281,7 @@ entities:
       pos: -7.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7425
     components:
     - type: Transform
@@ -49330,7 +49289,7 @@ entities:
       pos: -7.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7426
     components:
     - type: Transform
@@ -49338,7 +49297,7 @@ entities:
       pos: 41.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7427
     components:
     - type: Transform
@@ -49346,7 +49305,7 @@ entities:
       pos: 14.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7428
     components:
     - type: Transform
@@ -49354,7 +49313,7 @@ entities:
       pos: -6.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7429
     components:
     - type: Transform
@@ -49362,7 +49321,7 @@ entities:
       pos: 10.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7430
     components:
     - type: Transform
@@ -49370,7 +49329,7 @@ entities:
       pos: 7.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7431
     components:
     - type: Transform
@@ -49378,7 +49337,7 @@ entities:
       pos: 12.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7432
     components:
     - type: Transform
@@ -49386,7 +49345,7 @@ entities:
       pos: 13.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7433
     components:
     - type: Transform
@@ -49394,14 +49353,14 @@ entities:
       pos: 18.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7434
     components:
     - type: Transform
       pos: 25.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7435
     components:
     - type: Transform
@@ -49409,7 +49368,7 @@ entities:
       pos: 15.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7436
     components:
     - type: Transform
@@ -49417,7 +49376,7 @@ entities:
       pos: 8.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7437
     components:
     - type: Transform
@@ -49425,7 +49384,7 @@ entities:
       pos: 10.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7438
     components:
     - type: Transform
@@ -49448,7 +49407,7 @@ entities:
       pos: 46.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7441
     components:
     - type: Transform
@@ -49514,21 +49473,21 @@ entities:
       pos: 39.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7450
     components:
     - type: Transform
       pos: 7.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7451
     components:
     - type: Transform
       pos: 7.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7452
     components:
     - type: Transform
@@ -49536,7 +49495,7 @@ entities:
       pos: -11.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7453
     components:
     - type: Transform
@@ -49549,7 +49508,7 @@ entities:
       pos: 31.5,-33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7455
     components:
     - type: Transform
@@ -49574,14 +49533,14 @@ entities:
       pos: 31.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7459
     components:
     - type: Transform
       pos: 31.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7460
     components:
     - type: Transform
@@ -49589,7 +49548,7 @@ entities:
       pos: 30.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7461
     components:
     - type: Transform
@@ -49597,7 +49556,7 @@ entities:
       pos: 31.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7462
     components:
     - type: Transform
@@ -49605,14 +49564,14 @@ entities:
       pos: 22.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7463
     components:
     - type: Transform
       pos: 42.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7464
     components:
     - type: Transform
@@ -49620,7 +49579,7 @@ entities:
       pos: 30.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7465
     components:
     - type: Transform
@@ -49628,7 +49587,7 @@ entities:
       pos: 29.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7466
     components:
     - type: Transform
@@ -49647,14 +49606,14 @@ entities:
       pos: 55.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7469
     components:
     - type: Transform
       pos: 55.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7470
     components:
     - type: Transform
@@ -49662,7 +49621,7 @@ entities:
       pos: 58.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7471
     components:
     - type: Transform
@@ -49670,7 +49629,7 @@ entities:
       pos: 27.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7472
     components:
     - type: Transform
@@ -49678,7 +49637,7 @@ entities:
       pos: 26.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7473
     components:
     - type: Transform
@@ -49686,7 +49645,7 @@ entities:
       pos: 25.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7474
     components:
     - type: Transform
@@ -49694,7 +49653,7 @@ entities:
       pos: 24.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7475
     components:
     - type: Transform
@@ -49702,7 +49661,7 @@ entities:
       pos: 23.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7476
     components:
     - type: Transform
@@ -49710,7 +49669,7 @@ entities:
       pos: 21.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7477
     components:
     - type: Transform
@@ -49718,7 +49677,7 @@ entities:
       pos: 20.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7478
     components:
     - type: Transform
@@ -49726,7 +49685,7 @@ entities:
       pos: 19.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7479
     components:
     - type: Transform
@@ -49734,56 +49693,56 @@ entities:
       pos: 18.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7480
     components:
     - type: Transform
       pos: 17.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7481
     components:
     - type: Transform
       pos: 17.5,-33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7482
     components:
     - type: Transform
       pos: 17.5,-32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7483
     components:
     - type: Transform
       pos: 17.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7484
     components:
     - type: Transform
       pos: 17.5,-30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7485
     components:
     - type: Transform
       pos: 17.5,-29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7486
     components:
     - type: Transform
       pos: 17.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7487
     components:
     - type: Transform
@@ -49791,7 +49750,7 @@ entities:
       pos: 18.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7488
     components:
     - type: Transform
@@ -49799,7 +49758,7 @@ entities:
       pos: 25.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7489
     components:
     - type: Transform
@@ -49807,7 +49766,7 @@ entities:
       pos: 24.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7490
     components:
     - type: Transform
@@ -49815,7 +49774,7 @@ entities:
       pos: 19.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7491
     components:
     - type: Transform
@@ -49823,7 +49782,7 @@ entities:
       pos: 21.5,-33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7492
     components:
     - type: Transform
@@ -49831,7 +49790,7 @@ entities:
       pos: 21.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7493
     components:
     - type: Transform
@@ -49839,7 +49798,7 @@ entities:
       pos: 20.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7494
     components:
     - type: Transform
@@ -49847,56 +49806,56 @@ entities:
       pos: 19.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7495
     components:
     - type: Transform
       pos: 33.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7496
     components:
     - type: Transform
       pos: 18.5,-29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7497
     components:
     - type: Transform
       pos: 18.5,-30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7498
     components:
     - type: Transform
       pos: 18.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7499
     components:
     - type: Transform
       pos: 18.5,-32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7500
     components:
     - type: Transform
       pos: 18.5,-33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7501
     components:
     - type: Transform
       pos: 18.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7502
     components:
     - type: Transform
@@ -49904,7 +49863,7 @@ entities:
       pos: 19.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7503
     components:
     - type: Transform
@@ -49912,7 +49871,7 @@ entities:
       pos: 22.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7504
     components:
     - type: Transform
@@ -49920,7 +49879,7 @@ entities:
       pos: 23.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7505
     components:
     - type: Transform
@@ -49928,7 +49887,7 @@ entities:
       pos: 25.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7506
     components:
     - type: Transform
@@ -49936,7 +49895,7 @@ entities:
       pos: 26.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7507
     components:
     - type: Transform
@@ -49944,7 +49903,7 @@ entities:
       pos: 27.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7508
     components:
     - type: Transform
@@ -49952,7 +49911,7 @@ entities:
       pos: 23.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7509
     components:
     - type: Transform
@@ -49960,7 +49919,7 @@ entities:
       pos: 28.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7510
     components:
     - type: Transform
@@ -49968,7 +49927,7 @@ entities:
       pos: 29.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7511
     components:
     - type: Transform
@@ -49976,7 +49935,7 @@ entities:
       pos: 22.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7512
     components:
     - type: Transform
@@ -49984,7 +49943,7 @@ entities:
       pos: 21.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7513
     components:
     - type: Transform
@@ -49992,7 +49951,7 @@ entities:
       pos: 20.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7514
     components:
     - type: Transform
@@ -50000,7 +49959,7 @@ entities:
       pos: 23.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7515
     components:
     - type: Transform
@@ -50008,112 +49967,112 @@ entities:
       pos: 24.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7516
     components:
     - type: Transform
       pos: 25.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7517
     components:
     - type: Transform
       pos: 25.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7518
     components:
     - type: Transform
       pos: 25.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7519
     components:
     - type: Transform
       pos: 25.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7520
     components:
     - type: Transform
       pos: 25.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7521
     components:
     - type: Transform
       pos: 25.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7522
     components:
     - type: Transform
       pos: 25.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7523
     components:
     - type: Transform
       pos: 25.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7524
     components:
     - type: Transform
       pos: 25.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7525
     components:
     - type: Transform
       pos: 25.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7526
     components:
     - type: Transform
       pos: 25.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7527
     components:
     - type: Transform
       pos: 25.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7528
     components:
     - type: Transform
       pos: 25.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7529
     components:
     - type: Transform
       pos: 25.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7530
     components:
     - type: Transform
       pos: 25.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7531
     components:
     - type: Transform
@@ -50121,7 +50080,7 @@ entities:
       pos: 24.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7532
     components:
     - type: Transform
@@ -50129,7 +50088,7 @@ entities:
       pos: 23.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7533
     components:
     - type: Transform
@@ -50137,7 +50096,7 @@ entities:
       pos: 22.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7534
     components:
     - type: Transform
@@ -50145,7 +50104,7 @@ entities:
       pos: 21.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7535
     components:
     - type: Transform
@@ -50153,7 +50112,7 @@ entities:
       pos: 20.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7536
     components:
     - type: Transform
@@ -50161,7 +50120,7 @@ entities:
       pos: 19.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7537
     components:
     - type: Transform
@@ -50169,7 +50128,7 @@ entities:
       pos: 18.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7538
     components:
     - type: Transform
@@ -50177,7 +50136,7 @@ entities:
       pos: 17.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7539
     components:
     - type: Transform
@@ -50185,7 +50144,7 @@ entities:
       pos: 15.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7540
     components:
     - type: Transform
@@ -50193,7 +50152,7 @@ entities:
       pos: 13.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7541
     components:
     - type: Transform
@@ -50201,7 +50160,7 @@ entities:
       pos: 12.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7542
     components:
     - type: Transform
@@ -50209,7 +50168,7 @@ entities:
       pos: 10.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7543
     components:
     - type: Transform
@@ -50217,7 +50176,7 @@ entities:
       pos: 9.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7544
     components:
     - type: Transform
@@ -50225,7 +50184,7 @@ entities:
       pos: 7.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7545
     components:
     - type: Transform
@@ -50233,7 +50192,7 @@ entities:
       pos: 6.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7546
     components:
     - type: Transform
@@ -50241,7 +50200,7 @@ entities:
       pos: 5.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7547
     components:
     - type: Transform
@@ -50249,7 +50208,7 @@ entities:
       pos: -3.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7548
     components:
     - type: Transform
@@ -50257,7 +50216,7 @@ entities:
       pos: -2.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7549
     components:
     - type: Transform
@@ -50265,7 +50224,7 @@ entities:
       pos: -1.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7550
     components:
     - type: Transform
@@ -50273,7 +50232,7 @@ entities:
       pos: 0.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7551
     components:
     - type: Transform
@@ -50281,7 +50240,7 @@ entities:
       pos: 1.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7552
     components:
     - type: Transform
@@ -50289,7 +50248,7 @@ entities:
       pos: 2.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7553
     components:
     - type: Transform
@@ -50297,7 +50256,7 @@ entities:
       pos: 4.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7554
     components:
     - type: Transform
@@ -50305,7 +50264,7 @@ entities:
       pos: 5.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7555
     components:
     - type: Transform
@@ -50313,7 +50272,7 @@ entities:
       pos: 6.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7556
     components:
     - type: Transform
@@ -50321,7 +50280,7 @@ entities:
       pos: 7.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7557
     components:
     - type: Transform
@@ -50329,7 +50288,7 @@ entities:
       pos: 8.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7558
     components:
     - type: Transform
@@ -50337,7 +50296,7 @@ entities:
       pos: 10.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7559
     components:
     - type: Transform
@@ -50345,7 +50304,7 @@ entities:
       pos: 11.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7560
     components:
     - type: Transform
@@ -50353,7 +50312,7 @@ entities:
       pos: 12.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7561
     components:
     - type: Transform
@@ -50361,7 +50320,7 @@ entities:
       pos: 13.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7562
     components:
     - type: Transform
@@ -50369,7 +50328,7 @@ entities:
       pos: 14.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7563
     components:
     - type: Transform
@@ -50377,7 +50336,7 @@ entities:
       pos: 15.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7564
     components:
     - type: Transform
@@ -50385,7 +50344,7 @@ entities:
       pos: 16.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7565
     components:
     - type: Transform
@@ -50393,28 +50352,28 @@ entities:
       pos: 17.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7566
     components:
     - type: Transform
       pos: 18.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7567
     components:
     - type: Transform
       pos: 18.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7568
     components:
     - type: Transform
       pos: 18.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7569
     components:
     - type: Transform
@@ -50422,7 +50381,7 @@ entities:
       pos: 19.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7570
     components:
     - type: Transform
@@ -50430,7 +50389,7 @@ entities:
       pos: 20.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7571
     components:
     - type: Transform
@@ -50438,7 +50397,7 @@ entities:
       pos: 21.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7572
     components:
     - type: Transform
@@ -50446,7 +50405,7 @@ entities:
       pos: 22.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7573
     components:
     - type: Transform
@@ -50454,7 +50413,7 @@ entities:
       pos: 23.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7574
     components:
     - type: Transform
@@ -50462,7 +50421,7 @@ entities:
       pos: 24.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7575
     components:
     - type: Transform
@@ -50470,7 +50429,7 @@ entities:
       pos: 26.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7576
     components:
     - type: Transform
@@ -50478,7 +50437,7 @@ entities:
       pos: 27.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7577
     components:
     - type: Transform
@@ -50486,7 +50445,7 @@ entities:
       pos: 28.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7578
     components:
     - type: Transform
@@ -50494,7 +50453,7 @@ entities:
       pos: 29.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7579
     components:
     - type: Transform
@@ -50502,7 +50461,7 @@ entities:
       pos: 31.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7580
     components:
     - type: Transform
@@ -50510,7 +50469,7 @@ entities:
       pos: 32.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7581
     components:
     - type: Transform
@@ -50518,7 +50477,7 @@ entities:
       pos: 33.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7582
     components:
     - type: Transform
@@ -50526,7 +50485,7 @@ entities:
       pos: 34.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7583
     components:
     - type: Transform
@@ -50534,7 +50493,7 @@ entities:
       pos: 35.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7584
     components:
     - type: Transform
@@ -50542,7 +50501,7 @@ entities:
       pos: 36.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7585
     components:
     - type: Transform
@@ -50550,7 +50509,7 @@ entities:
       pos: 37.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7586
     components:
     - type: Transform
@@ -50558,7 +50517,7 @@ entities:
       pos: 38.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7587
     components:
     - type: Transform
@@ -50566,7 +50525,7 @@ entities:
       pos: 39.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7588
     components:
     - type: Transform
@@ -50574,7 +50533,7 @@ entities:
       pos: 44.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7589
     components:
     - type: Transform
@@ -50582,7 +50541,7 @@ entities:
       pos: 43.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7590
     components:
     - type: Transform
@@ -50590,7 +50549,7 @@ entities:
       pos: 42.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7591
     components:
     - type: Transform
@@ -50598,7 +50557,7 @@ entities:
       pos: 40.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7592
     components:
     - type: Transform
@@ -50606,7 +50565,7 @@ entities:
       pos: 40.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7593
     components:
     - type: Transform
@@ -50614,7 +50573,7 @@ entities:
       pos: 40.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7594
     components:
     - type: Transform
@@ -50622,7 +50581,7 @@ entities:
       pos: 40.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7595
     components:
     - type: Transform
@@ -50630,7 +50589,7 @@ entities:
       pos: 40.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7596
     components:
     - type: Transform
@@ -50638,7 +50597,7 @@ entities:
       pos: 40.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7597
     components:
     - type: Transform
@@ -50646,7 +50605,7 @@ entities:
       pos: 40.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7598
     components:
     - type: Transform
@@ -50654,7 +50613,7 @@ entities:
       pos: 40.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7599
     components:
     - type: Transform
@@ -50662,7 +50621,7 @@ entities:
       pos: 40.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7600
     components:
     - type: Transform
@@ -50670,7 +50629,7 @@ entities:
       pos: 40.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7601
     components:
     - type: Transform
@@ -50678,7 +50637,7 @@ entities:
       pos: 40.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7602
     components:
     - type: Transform
@@ -50686,7 +50645,7 @@ entities:
       pos: 51.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7603
     components:
     - type: Transform
@@ -50694,7 +50653,7 @@ entities:
       pos: 50.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7604
     components:
     - type: Transform
@@ -50702,35 +50661,35 @@ entities:
       pos: 49.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7605
     components:
     - type: Transform
       pos: 42.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7606
     components:
     - type: Transform
       pos: 42.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7607
     components:
     - type: Transform
       pos: 42.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7608
     components:
     - type: Transform
       pos: 42.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7609
     components:
     - type: Transform
@@ -50738,7 +50697,7 @@ entities:
       pos: 5.5,5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7610
     components:
     - type: Transform
@@ -50746,7 +50705,7 @@ entities:
       pos: 22.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7611
     components:
     - type: Transform
@@ -50760,7 +50719,7 @@ entities:
       pos: 27.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7613
     components:
     - type: Transform
@@ -50773,7 +50732,7 @@ entities:
       pos: 44.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7615
     components:
     - type: Transform
@@ -50787,7 +50746,7 @@ entities:
       pos: 5.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7617
     components:
     - type: Transform
@@ -50795,14 +50754,14 @@ entities:
       pos: 5.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7618
     components:
     - type: Transform
       pos: 21.5,-29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7619
     components:
     - type: Transform
@@ -50810,7 +50769,7 @@ entities:
       pos: 24.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7620
     components:
     - type: Transform
@@ -50818,7 +50777,7 @@ entities:
       pos: 27.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7621
     components:
     - type: Transform
@@ -50826,7 +50785,7 @@ entities:
       pos: 29.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7622
     components:
     - type: Transform
@@ -50834,7 +50793,7 @@ entities:
       pos: 27.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7623
     components:
     - type: Transform
@@ -50842,7 +50801,7 @@ entities:
       pos: 27.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7624
     components:
     - type: Transform
@@ -50850,7 +50809,7 @@ entities:
       pos: 43.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7625
     components:
     - type: Transform
@@ -50858,7 +50817,7 @@ entities:
       pos: 33.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7626
     components:
     - type: Transform
@@ -50866,7 +50825,7 @@ entities:
       pos: 27.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7627
     components:
     - type: Transform
@@ -50874,7 +50833,7 @@ entities:
       pos: 8.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7628
     components:
     - type: Transform
@@ -50882,21 +50841,21 @@ entities:
       pos: -6.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7629
     components:
     - type: Transform
       pos: 11.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7630
     components:
     - type: Transform
       pos: 11.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7631
     components:
     - type: Transform
@@ -50904,21 +50863,21 @@ entities:
       pos: 36.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7632
     components:
     - type: Transform
       pos: 10.5,-37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7633
     components:
     - type: Transform
       pos: 25.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7634
     components:
     - type: Transform
@@ -50954,7 +50913,7 @@ entities:
       pos: 7.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7639
     components:
     - type: Transform
@@ -50976,7 +50935,7 @@ entities:
       pos: 8.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7642
     components:
     - type: Transform
@@ -50990,7 +50949,7 @@ entities:
       pos: 50.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7644
     components:
     - type: Transform
@@ -50998,7 +50957,7 @@ entities:
       pos: 40.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7645
     components:
     - type: Transform
@@ -51006,14 +50965,14 @@ entities:
       pos: 43.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7646
     components:
     - type: Transform
       pos: 40.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7647
     components:
     - type: Transform
@@ -51021,35 +50980,35 @@ entities:
       pos: 37.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7648
     components:
     - type: Transform
       pos: 40.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7649
     components:
     - type: Transform
       pos: 25.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7650
     components:
     - type: Transform
       pos: 25.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7651
     components:
     - type: Transform
       pos: 25.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7652
     components:
     - type: Transform
@@ -51057,7 +51016,7 @@ entities:
       pos: 42.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7653
     components:
     - type: Transform
@@ -51065,7 +51024,7 @@ entities:
       pos: 43.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7654
     components:
     - type: Transform
@@ -51073,7 +51032,7 @@ entities:
       pos: 26.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7655
     components:
     - type: Transform
@@ -51081,7 +51040,7 @@ entities:
       pos: 27.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7656
     components:
     - type: Transform
@@ -51089,7 +51048,7 @@ entities:
       pos: 30.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7657
     components:
     - type: Transform
@@ -51097,14 +51056,14 @@ entities:
       pos: 29.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7658
     components:
     - type: Transform
       pos: 25.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7659
     components:
     - type: Transform
@@ -51112,7 +51071,7 @@ entities:
       pos: 31.5,-29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7660
     components:
     - type: Transform
@@ -51120,7 +51079,7 @@ entities:
       pos: 5.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7661
     components:
     - type: Transform
@@ -51128,7 +51087,7 @@ entities:
       pos: 9.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7662
     components:
     - type: Transform
@@ -51136,7 +51095,7 @@ entities:
       pos: 27.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7663
     components:
     - type: Transform
@@ -51144,7 +51103,7 @@ entities:
       pos: 27.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7664
     components:
     - type: Transform
@@ -51157,14 +51116,14 @@ entities:
       pos: 42.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7666
     components:
     - type: Transform
       pos: 42.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7667
     components:
     - type: Transform
@@ -51172,7 +51131,7 @@ entities:
       pos: 51.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7668
     components:
     - type: Transform
@@ -51180,7 +51139,7 @@ entities:
       pos: 27.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7669
     components:
     - type: Transform
@@ -51188,7 +51147,7 @@ entities:
       pos: 13.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7670
     components:
     - type: Transform
@@ -51196,7 +51155,7 @@ entities:
       pos: 46.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7671
     components:
     - type: Transform
@@ -51204,21 +51163,14 @@ entities:
       pos: 47.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 7672
-    components:
-    - type: Transform
-      pos: 27.5,44.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#990000FF'
   - uid: 7673
     components:
     - type: Transform
       pos: 27.5,45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7674
     components:
     - type: Transform
@@ -51226,7 +51178,7 @@ entities:
       pos: 33.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7675
     components:
     - type: Transform
@@ -51234,7 +51186,7 @@ entities:
       pos: 32.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7676
     components:
     - type: Transform
@@ -51242,7 +51194,7 @@ entities:
       pos: 27.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7677
     components:
     - type: Transform
@@ -51250,7 +51202,7 @@ entities:
       pos: 42.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7678
     components:
     - type: Transform
@@ -51258,21 +51210,21 @@ entities:
       pos: 35.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7679
     components:
     - type: Transform
       pos: 25.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7680
     components:
     - type: Transform
       pos: 25.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7681
     components:
     - type: Transform
@@ -51280,7 +51232,7 @@ entities:
       pos: 31.5,46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7682
     components:
     - type: Transform
@@ -51288,21 +51240,21 @@ entities:
       pos: 28.5,46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7683
     components:
     - type: Transform
       pos: 25.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7684
     components:
     - type: Transform
       pos: 25.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7685
     components:
     - type: Transform
@@ -51310,7 +51262,7 @@ entities:
       pos: 17.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7686
     components:
     - type: Transform
@@ -51318,7 +51270,7 @@ entities:
       pos: 7.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7687
     components:
     - type: Transform
@@ -51338,7 +51290,7 @@ entities:
       pos: 27.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7690
     components:
     - type: Transform
@@ -51364,7 +51316,7 @@ entities:
       pos: -11.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7694
     components:
     - type: Transform
@@ -51372,7 +51324,7 @@ entities:
       pos: 40.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7695
     components:
     - type: Transform
@@ -51380,7 +51332,7 @@ entities:
       pos: 41.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7696
     components:
     - type: Transform
@@ -51388,14 +51340,14 @@ entities:
       pos: 44.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7697
     components:
     - type: Transform
       pos: 46.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7698
     components:
     - type: Transform
@@ -51403,7 +51355,7 @@ entities:
       pos: 49.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7699
     components:
     - type: Transform
@@ -51453,7 +51405,7 @@ entities:
       pos: 43.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7707
     components:
     - type: Transform
@@ -51461,7 +51413,7 @@ entities:
       pos: 31.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7708
     components:
     - type: Transform
@@ -51469,7 +51421,7 @@ entities:
       pos: 27.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7709
     components:
     - type: Transform
@@ -51477,7 +51429,7 @@ entities:
       pos: 23.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7710
     components:
     - type: Transform
@@ -51485,7 +51437,7 @@ entities:
       pos: 25.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7711
     components:
     - type: Transform
@@ -51493,7 +51445,7 @@ entities:
       pos: 22.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7712
     components:
     - type: Transform
@@ -51501,14 +51453,14 @@ entities:
       pos: 55.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7713
     components:
     - type: Transform
       pos: 21.5,-30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7714
     components:
     - type: Transform
@@ -51516,7 +51468,7 @@ entities:
       pos: 28.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7715
     components:
     - type: Transform
@@ -51524,7 +51476,7 @@ entities:
       pos: 26.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7716
     components:
     - type: Transform
@@ -51532,7 +51484,7 @@ entities:
       pos: 40.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7717
     components:
     - type: Transform
@@ -51540,7 +51492,7 @@ entities:
       pos: 44.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7718
     components:
     - type: Transform
@@ -51548,7 +51500,7 @@ entities:
       pos: 38.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7719
     components:
     - type: Transform
@@ -51556,7 +51508,7 @@ entities:
       pos: 34.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7720
     components:
     - type: Transform
@@ -51564,7 +51516,7 @@ entities:
       pos: 41.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7721
     components:
     - type: Transform
@@ -51572,7 +51524,7 @@ entities:
       pos: 45.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7722
     components:
     - type: Transform
@@ -51595,7 +51547,7 @@ entities:
       pos: 37.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7725
     components:
     - type: Transform
@@ -51603,7 +51555,7 @@ entities:
       pos: 39.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7726
     components:
     - type: Transform
@@ -51611,7 +51563,7 @@ entities:
       pos: 42.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7727
     components:
     - type: Transform
@@ -51619,7 +51571,7 @@ entities:
       pos: 40.5,-21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7728
     components:
     - type: Transform
@@ -51627,7 +51579,7 @@ entities:
       pos: 5.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7729
     components:
     - type: Transform
@@ -51635,7 +51587,7 @@ entities:
       pos: 27.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7730
     components:
     - type: Transform
@@ -51643,7 +51595,7 @@ entities:
       pos: 5.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7731
     components:
     - type: Transform
@@ -51651,7 +51603,7 @@ entities:
       pos: 5.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7732
     components:
     - type: Transform
@@ -51659,7 +51611,7 @@ entities:
       pos: 5.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7733
     components:
     - type: Transform
@@ -51667,7 +51619,7 @@ entities:
       pos: 5.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7734
     components:
     - type: Transform
@@ -51675,14 +51627,14 @@ entities:
       pos: 36.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7735
     components:
     - type: Transform
       pos: 19.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7736
     components:
     - type: Transform
@@ -51690,14 +51642,14 @@ entities:
       pos: 27.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7737
     components:
     - type: Transform
       pos: 19.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7738
     components:
     - type: Transform
@@ -51705,7 +51657,7 @@ entities:
       pos: 18.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7739
     components:
     - type: Transform
@@ -51713,7 +51665,7 @@ entities:
       pos: 17.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7740
     components:
     - type: Transform
@@ -51721,7 +51673,7 @@ entities:
       pos: 16.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7741
     components:
     - type: Transform
@@ -51729,7 +51681,7 @@ entities:
       pos: 28.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7742
     components:
     - type: Transform
@@ -51737,7 +51689,7 @@ entities:
       pos: 6.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7743
     components:
     - type: Transform
@@ -51745,7 +51697,7 @@ entities:
       pos: -3.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7744
     components:
     - type: Transform
@@ -51753,7 +51705,7 @@ entities:
       pos: 48.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7745
     components:
     - type: Transform
@@ -51761,7 +51713,7 @@ entities:
       pos: 29.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7746
     components:
     - type: Transform
@@ -51769,7 +51721,7 @@ entities:
       pos: 28.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7747
     components:
     - type: Transform
@@ -51777,7 +51729,7 @@ entities:
       pos: 34.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7748
     components:
     - type: Transform
@@ -51785,7 +51737,7 @@ entities:
       pos: 30.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7749
     components:
     - type: Transform
@@ -51793,7 +51745,7 @@ entities:
       pos: 31.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7750
     components:
     - type: Transform
@@ -51801,7 +51753,7 @@ entities:
       pos: 32.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7751
     components:
     - type: Transform
@@ -51809,14 +51761,14 @@ entities:
       pos: 35.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7752
     components:
     - type: Transform
       pos: 25.5,-25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7753
     components:
     - type: Transform
@@ -51824,7 +51776,7 @@ entities:
       pos: 30.5,-24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7754
     components:
     - type: Transform
@@ -51832,7 +51784,7 @@ entities:
       pos: 45.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7755
     components:
     - type: Transform
@@ -51840,7 +51792,7 @@ entities:
       pos: 31.5,-30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7756
     components:
     - type: Transform
@@ -51848,7 +51800,7 @@ entities:
       pos: 8.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7757
     components:
     - type: Transform
@@ -51874,7 +51826,7 @@ entities:
       pos: 30.5,-25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7761
     components:
     - type: Transform
@@ -51882,14 +51834,14 @@ entities:
       pos: 33.5,-22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7762
     components:
     - type: Transform
       pos: 19.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7763
     components:
     - type: Transform
@@ -51921,7 +51873,7 @@ entities:
       pos: 30.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7768
     components:
     - type: Transform
@@ -51929,7 +51881,7 @@ entities:
       pos: 2.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7769
     components:
     - type: Transform
@@ -51937,7 +51889,7 @@ entities:
       pos: 3.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7770
     components:
     - type: Transform
@@ -51945,7 +51897,7 @@ entities:
       pos: 4.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7771
     components:
     - type: Transform
@@ -51953,7 +51905,7 @@ entities:
       pos: 27.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7772
     components:
     - type: Transform
@@ -51961,7 +51913,7 @@ entities:
       pos: 27.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7773
     components:
     - type: Transform
@@ -51969,7 +51921,7 @@ entities:
       pos: -0.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7774
     components:
     - type: Transform
@@ -51977,7 +51929,7 @@ entities:
       pos: 27.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7775
     components:
     - type: Transform
@@ -51985,7 +51937,7 @@ entities:
       pos: 27.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7776
     components:
     - type: Transform
@@ -51993,7 +51945,7 @@ entities:
       pos: 27.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7777
     components:
     - type: Transform
@@ -52001,7 +51953,7 @@ entities:
       pos: 42.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7778
     components:
     - type: Transform
@@ -52009,7 +51961,7 @@ entities:
       pos: 26.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7779
     components:
     - type: Transform
@@ -52017,7 +51969,7 @@ entities:
       pos: 27.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7780
     components:
     - type: Transform
@@ -52033,7 +51985,7 @@ entities:
       pos: 27.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7782
     components:
     - type: Transform
@@ -52041,7 +51993,7 @@ entities:
       pos: 27.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7783
     components:
     - type: Transform
@@ -52049,7 +52001,7 @@ entities:
       pos: 27.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7784
     components:
     - type: Transform
@@ -52057,7 +52009,7 @@ entities:
       pos: 27.5,-14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7785
     components:
     - type: Transform
@@ -52065,7 +52017,7 @@ entities:
       pos: 27.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7786
     components:
     - type: Transform
@@ -52073,14 +52025,14 @@ entities:
       pos: 27.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7787
     components:
     - type: Transform
       pos: 46.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7788
     components:
     - type: Transform
@@ -52088,7 +52040,7 @@ entities:
       pos: -4.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7789
     components:
     - type: Transform
@@ -52096,7 +52048,7 @@ entities:
       pos: 27.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7790
     components:
     - type: Transform
@@ -52104,7 +52056,7 @@ entities:
       pos: 25.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7791
     components:
     - type: Transform
@@ -52112,7 +52064,7 @@ entities:
       pos: 19.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7792
     components:
     - type: Transform
@@ -52120,7 +52072,7 @@ entities:
       pos: 23.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7793
     components:
     - type: Transform
@@ -52128,7 +52080,7 @@ entities:
       pos: 18.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7794
     components:
     - type: Transform
@@ -52136,7 +52088,7 @@ entities:
       pos: 22.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7795
     components:
     - type: Transform
@@ -52144,7 +52096,7 @@ entities:
       pos: 17.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7796
     components:
     - type: Transform
@@ -52152,7 +52104,7 @@ entities:
       pos: 26.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7797
     components:
     - type: Transform
@@ -52160,21 +52112,21 @@ entities:
       pos: 27.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7798
     components:
     - type: Transform
       pos: 42.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7799
     components:
     - type: Transform
       pos: 42.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7800
     components:
     - type: Transform
@@ -52182,7 +52134,7 @@ entities:
       pos: 40.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7801
     components:
     - type: Transform
@@ -52190,7 +52142,7 @@ entities:
       pos: 38.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7802
     components:
     - type: Transform
@@ -52198,7 +52150,7 @@ entities:
       pos: 36.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7803
     components:
     - type: Transform
@@ -52206,7 +52158,7 @@ entities:
       pos: 46.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7804
     components:
     - type: Transform
@@ -52214,7 +52166,7 @@ entities:
       pos: 35.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7805
     components:
     - type: Transform
@@ -52222,7 +52174,7 @@ entities:
       pos: 33.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7806
     components:
     - type: Transform
@@ -52230,7 +52182,7 @@ entities:
       pos: 34.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7807
     components:
     - type: Transform
@@ -52238,7 +52190,7 @@ entities:
       pos: 31.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7808
     components:
     - type: Transform
@@ -52246,7 +52198,7 @@ entities:
       pos: 29.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7809
     components:
     - type: Transform
@@ -52254,7 +52206,7 @@ entities:
       pos: 30.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7810
     components:
     - type: Transform
@@ -52262,7 +52214,7 @@ entities:
       pos: 28.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7811
     components:
     - type: Transform
@@ -52270,7 +52222,7 @@ entities:
       pos: 21.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7812
     components:
     - type: Transform
@@ -52278,7 +52230,7 @@ entities:
       pos: 15.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7813
     components:
     - type: Transform
@@ -52286,7 +52238,7 @@ entities:
       pos: 20.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7814
     components:
     - type: Transform
@@ -52294,7 +52246,7 @@ entities:
       pos: 16.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7815
     components:
     - type: Transform
@@ -52302,7 +52254,7 @@ entities:
       pos: 14.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7816
     components:
     - type: Transform
@@ -52310,7 +52262,7 @@ entities:
       pos: 24.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7817
     components:
     - type: Transform
@@ -52318,7 +52270,7 @@ entities:
       pos: 27.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7818
     components:
     - type: Transform
@@ -52326,7 +52278,7 @@ entities:
       pos: 23.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7819
     components:
     - type: Transform
@@ -52334,7 +52286,7 @@ entities:
       pos: 24.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7820
     components:
     - type: Transform
@@ -52342,7 +52294,7 @@ entities:
       pos: 27.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7821
     components:
     - type: Transform
@@ -52350,7 +52302,7 @@ entities:
       pos: 25.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7822
     components:
     - type: Transform
@@ -52358,7 +52310,7 @@ entities:
       pos: 32.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7823
     components:
     - type: Transform
@@ -52366,7 +52318,7 @@ entities:
       pos: 45.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7824
     components:
     - type: Transform
@@ -52374,7 +52326,7 @@ entities:
       pos: 27.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7825
     components:
     - type: Transform
@@ -52382,7 +52334,7 @@ entities:
       pos: 27.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7826
     components:
     - type: Transform
@@ -52390,7 +52342,7 @@ entities:
       pos: 27.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7827
     components:
     - type: Transform
@@ -52398,7 +52350,7 @@ entities:
       pos: 37.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7828
     components:
     - type: Transform
@@ -52406,7 +52358,7 @@ entities:
       pos: 39.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7829
     components:
     - type: Transform
@@ -52414,7 +52366,7 @@ entities:
       pos: 27.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7830
     components:
     - type: Transform
@@ -52422,14 +52374,14 @@ entities:
       pos: 25.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7831
     components:
     - type: Transform
       pos: 19.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7832
     components:
     - type: Transform
@@ -52437,7 +52389,7 @@ entities:
       pos: 39.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7833
     components:
     - type: Transform
@@ -52445,7 +52397,7 @@ entities:
       pos: 38.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7834
     components:
     - type: Transform
@@ -52453,35 +52405,35 @@ entities:
       pos: 36.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7835
     components:
     - type: Transform
       pos: 25.5,-14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7836
     components:
     - type: Transform
       pos: 25.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7837
     components:
     - type: Transform
       pos: 25.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7838
     components:
     - type: Transform
       pos: 25.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7839
     components:
     - type: Transform
@@ -52525,7 +52477,7 @@ entities:
       pos: 49.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7846
     components:
     - type: Transform
@@ -52574,63 +52526,63 @@ entities:
       pos: 32.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7854
     components:
     - type: Transform
       pos: 32.5,-37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7855
     components:
     - type: Transform
       pos: 31.5,-37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7856
     components:
     - type: Transform
       pos: 31.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7857
     components:
     - type: Transform
       pos: 32.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7858
     components:
     - type: Transform
       pos: 32.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7859
     components:
     - type: Transform
       pos: 22.5,-37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7860
     components:
     - type: Transform
       pos: 20.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7861
     components:
     - type: Transform
       pos: 20.5,-37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7862
     components:
     - type: Transform
@@ -52661,28 +52613,28 @@ entities:
       pos: 7.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7866
     components:
     - type: Transform
       pos: 7.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7867
     components:
     - type: Transform
       pos: 27.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7868
     components:
     - type: Transform
       pos: 55.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7869
     components:
     - type: Transform
@@ -52690,7 +52642,7 @@ entities:
       pos: 60.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7870
     components:
     - type: Transform
@@ -52698,7 +52650,7 @@ entities:
       pos: 59.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7871
     components:
     - type: Transform
@@ -52706,7 +52658,7 @@ entities:
       pos: 58.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7872
     components:
     - type: Transform
@@ -52725,7 +52677,7 @@ entities:
       pos: 60.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7875
     components:
     - type: Transform
@@ -52733,7 +52685,7 @@ entities:
       pos: 58.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7876
     components:
     - type: Transform
@@ -52753,14 +52705,14 @@ entities:
       pos: 57.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7879
     components:
     - type: Transform
       pos: 57.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7880
     components:
     - type: Transform
@@ -52768,35 +52720,35 @@ entities:
       pos: 53.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7881
     components:
     - type: Transform
       pos: 46.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7882
     components:
     - type: Transform
       pos: 57.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7883
     components:
     - type: Transform
       pos: 55.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7884
     components:
     - type: Transform
       pos: 57.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7885
     components:
     - type: Transform
@@ -52826,21 +52778,21 @@ entities:
       pos: 26.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7890
     components:
     - type: Transform
       pos: 7.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7891
     components:
     - type: Transform
       pos: 55.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7892
     components:
     - type: Transform
@@ -52848,21 +52800,21 @@ entities:
       pos: 11.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7893
     components:
     - type: Transform
       pos: 11.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7894
     components:
     - type: Transform
       pos: 8.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7895
     components:
     - type: Transform
@@ -52870,7 +52822,7 @@ entities:
       pos: 17.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7896
     components:
     - type: Transform
@@ -52878,7 +52830,7 @@ entities:
       pos: 16.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7897
     components:
     - type: Transform
@@ -52886,7 +52838,7 @@ entities:
       pos: 15.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7898
     components:
     - type: Transform
@@ -52894,7 +52846,7 @@ entities:
       pos: 14.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7899
     components:
     - type: Transform
@@ -52902,7 +52854,7 @@ entities:
       pos: 16.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7900
     components:
     - type: Transform
@@ -52910,7 +52862,7 @@ entities:
       pos: 15.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7901
     components:
     - type: Transform
@@ -52918,14 +52870,14 @@ entities:
       pos: 14.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7902
     components:
     - type: Transform
       pos: 10.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7903
     components:
     - type: Transform
@@ -52940,7 +52892,7 @@ entities:
       pos: 48.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7905
     components:
     - type: Transform
@@ -52948,7 +52900,7 @@ entities:
       pos: 47.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7906
     components:
     - type: Transform
@@ -52956,7 +52908,7 @@ entities:
       pos: 47.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7907
     components:
     - type: Transform
@@ -52964,7 +52916,7 @@ entities:
       pos: 32.5,45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7908
     components:
     - type: Transform
@@ -52972,7 +52924,7 @@ entities:
       pos: 32.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7909
     components:
     - type: Transform
@@ -52980,28 +52932,28 @@ entities:
       pos: 30.5,46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7910
     components:
     - type: Transform
       pos: 33.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7911
     components:
     - type: Transform
       pos: 33.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7912
     components:
     - type: Transform
       pos: 46.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7913
     components:
     - type: Transform
@@ -53009,21 +52961,21 @@ entities:
       pos: 43.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7914
     components:
     - type: Transform
       pos: 44.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7915
     components:
     - type: Transform
       pos: 27.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7916
     components:
     - type: Transform
@@ -53031,14 +52983,14 @@ entities:
       pos: 35.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7917
     components:
     - type: Transform
       pos: 46.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7918
     components:
     - type: Transform
@@ -53046,119 +52998,119 @@ entities:
       pos: 47.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7919
     components:
     - type: Transform
       pos: 33.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7920
     components:
     - type: Transform
       pos: 33.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7921
     components:
     - type: Transform
       pos: 33.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7922
     components:
     - type: Transform
       pos: 33.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7923
     components:
     - type: Transform
       pos: 35.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7924
     components:
     - type: Transform
       pos: 35.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7925
     components:
     - type: Transform
       pos: 35.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7926
     components:
     - type: Transform
       pos: 35.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7927
     components:
     - type: Transform
       pos: 35.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7928
     components:
     - type: Transform
       pos: 35.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7929
     components:
     - type: Transform
       pos: 35.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7930
     components:
     - type: Transform
       pos: 35.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7931
     components:
     - type: Transform
       pos: 44.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7932
     components:
     - type: Transform
       pos: 46.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7933
     components:
     - type: Transform
       pos: 42.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7934
     components:
     - type: Transform
       pos: 42.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7935
     components:
     - type: Transform
@@ -53166,7 +53118,7 @@ entities:
       pos: 40.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7936
     components:
     - type: Transform
@@ -53174,7 +53126,7 @@ entities:
       pos: 38.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7937
     components:
     - type: Transform
@@ -53182,7 +53134,7 @@ entities:
       pos: 37.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7938
     components:
     - type: Transform
@@ -53190,7 +53142,7 @@ entities:
       pos: 36.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7939
     components:
     - type: Transform
@@ -53198,7 +53150,7 @@ entities:
       pos: 34.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7940
     components:
     - type: Transform
@@ -53206,7 +53158,7 @@ entities:
       pos: 33.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7941
     components:
     - type: Transform
@@ -53214,7 +53166,7 @@ entities:
       pos: 32.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7942
     components:
     - type: Transform
@@ -53227,7 +53179,7 @@ entities:
       pos: 33.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7944
     components:
     - type: Transform
@@ -53235,7 +53187,7 @@ entities:
       pos: 34.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7945
     components:
     - type: Transform
@@ -53243,7 +53195,7 @@ entities:
       pos: 35.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7946
     components:
     - type: Transform
@@ -53251,7 +53203,7 @@ entities:
       pos: 36.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7947
     components:
     - type: Transform
@@ -53259,7 +53211,7 @@ entities:
       pos: 37.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7948
     components:
     - type: Transform
@@ -53267,7 +53219,7 @@ entities:
       pos: 38.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7949
     components:
     - type: Transform
@@ -53275,7 +53227,7 @@ entities:
       pos: 39.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7950
     components:
     - type: Transform
@@ -53283,7 +53235,7 @@ entities:
       pos: 39.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7951
     components:
     - type: Transform
@@ -53291,7 +53243,7 @@ entities:
       pos: 39.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7952
     components:
     - type: Transform
@@ -53299,7 +53251,7 @@ entities:
       pos: 39.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7953
     components:
     - type: Transform
@@ -53307,7 +53259,7 @@ entities:
       pos: 39.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7954
     components:
     - type: Transform
@@ -53315,7 +53267,7 @@ entities:
       pos: 27.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7955
     components:
     - type: Transform
@@ -53323,7 +53275,7 @@ entities:
       pos: 28.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7956
     components:
     - type: Transform
@@ -53331,7 +53283,7 @@ entities:
       pos: 35.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7957
     components:
     - type: Transform
@@ -53339,7 +53291,7 @@ entities:
       pos: 36.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7958
     components:
     - type: Transform
@@ -53347,7 +53299,7 @@ entities:
       pos: 37.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7959
     components:
     - type: Transform
@@ -53355,7 +53307,7 @@ entities:
       pos: 47.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7960
     components:
     - type: Transform
@@ -53363,7 +53315,7 @@ entities:
       pos: -6.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7961
     components:
     - type: Transform
@@ -53371,14 +53323,14 @@ entities:
       pos: -6.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7962
     components:
     - type: Transform
       pos: 7.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7963
     components:
     - type: Transform
@@ -53386,7 +53338,7 @@ entities:
       pos: -5.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7964
     components:
     - type: Transform
@@ -53394,7 +53346,7 @@ entities:
       pos: 43.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7965
     components:
     - type: Transform
@@ -53402,28 +53354,28 @@ entities:
       pos: 6.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7966
     components:
     - type: Transform
       pos: 10.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7967
     components:
     - type: Transform
       pos: 10.5,-39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7968
     components:
     - type: Transform
       pos: 10.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7969
     components:
     - type: Transform
@@ -53431,7 +53383,7 @@ entities:
       pos: 9.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7970
     components:
     - type: Transform
@@ -53439,35 +53391,35 @@ entities:
       pos: -6.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7971
     components:
     - type: Transform
       pos: 18.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7972
     components:
     - type: Transform
       pos: 18.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7973
     components:
     - type: Transform
       pos: 18.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7974
     components:
     - type: Transform
       pos: 27.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7975
     components:
     - type: Transform
@@ -53475,7 +53427,7 @@ entities:
       pos: 17.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7976
     components:
     - type: Transform
@@ -53483,7 +53435,7 @@ entities:
       pos: 14.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7977
     components:
     - type: Transform
@@ -53491,7 +53443,7 @@ entities:
       pos: 14.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7978
     components:
     - type: Transform
@@ -53499,7 +53451,7 @@ entities:
       pos: 13.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7979
     components:
     - type: Transform
@@ -53507,7 +53459,7 @@ entities:
       pos: 16.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7980
     components:
     - type: Transform
@@ -53515,7 +53467,7 @@ entities:
       pos: 15.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7981
     components:
     - type: Transform
@@ -53523,21 +53475,21 @@ entities:
       pos: 14.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7982
     components:
     - type: Transform
       pos: 9.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7983
     components:
     - type: Transform
       pos: 9.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7984
     components:
     - type: Transform
@@ -53545,7 +53497,7 @@ entities:
       pos: -6.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7985
     components:
     - type: Transform
@@ -53553,7 +53505,7 @@ entities:
       pos: -6.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7986
     components:
     - type: Transform
@@ -53561,7 +53513,7 @@ entities:
       pos: -6.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7987
     components:
     - type: Transform
@@ -53569,7 +53521,7 @@ entities:
       pos: -6.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7988
     components:
     - type: Transform
@@ -53577,7 +53529,7 @@ entities:
       pos: -6.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7989
     components:
     - type: Transform
@@ -53585,7 +53537,7 @@ entities:
       pos: -6.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7990
     components:
     - type: Transform
@@ -53593,7 +53545,7 @@ entities:
       pos: -6.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 7991
     components:
     - type: Transform
@@ -53601,7 +53553,7 @@ entities:
       pos: -5.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7992
     components:
     - type: Transform
@@ -53609,7 +53561,7 @@ entities:
       pos: -5.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7993
     components:
     - type: Transform
@@ -53617,7 +53569,7 @@ entities:
       pos: -5.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7994
     components:
     - type: Transform
@@ -53625,7 +53577,7 @@ entities:
       pos: -5.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7995
     components:
     - type: Transform
@@ -53633,7 +53585,7 @@ entities:
       pos: -5.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7996
     components:
     - type: Transform
@@ -53641,7 +53593,7 @@ entities:
       pos: -5.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7997
     components:
     - type: Transform
@@ -53649,7 +53601,7 @@ entities:
       pos: -5.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7998
     components:
     - type: Transform
@@ -53657,7 +53609,7 @@ entities:
       pos: -5.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 7999
     components:
     - type: Transform
@@ -53665,7 +53617,7 @@ entities:
       pos: -5.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8000
     components:
     - type: Transform
@@ -53673,7 +53625,7 @@ entities:
       pos: -5.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8001
     components:
     - type: Transform
@@ -53681,7 +53633,7 @@ entities:
       pos: -5.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8002
     components:
     - type: Transform
@@ -53689,7 +53641,7 @@ entities:
       pos: -13.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8003
     components:
     - type: Transform
@@ -53697,7 +53649,7 @@ entities:
       pos: -12.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8004
     components:
     - type: Transform
@@ -53705,7 +53657,7 @@ entities:
       pos: -14.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8005
     components:
     - type: Transform
@@ -53713,7 +53665,7 @@ entities:
       pos: -14.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8006
     components:
     - type: Transform
@@ -53721,14 +53673,14 @@ entities:
       pos: 62.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8007
     components:
     - type: Transform
       pos: 8.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8008
     components:
     - type: Transform
@@ -53736,7 +53688,7 @@ entities:
       pos: 55.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8009
     components:
     - type: Transform
@@ -53744,7 +53696,7 @@ entities:
       pos: 58.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8010
     components:
     - type: Transform
@@ -53752,14 +53704,14 @@ entities:
       pos: 54.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8011
     components:
     - type: Transform
       pos: 7.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8012
     components:
     - type: Transform
@@ -53767,21 +53719,21 @@ entities:
       pos: 13.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8013
     components:
     - type: Transform
       pos: 12.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8014
     components:
     - type: Transform
       pos: 12.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8015
     components:
     - type: Transform
@@ -53789,42 +53741,42 @@ entities:
       pos: 14.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8016
     components:
     - type: Transform
       pos: 16.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8017
     components:
     - type: Transform
       pos: 16.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8018
     components:
     - type: Transform
       pos: 16.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8019
     components:
     - type: Transform
       pos: 16.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8020
     components:
     - type: Transform
       pos: 16.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8021
     components:
     - type: Transform
@@ -53832,7 +53784,7 @@ entities:
       pos: 8.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8022
     components:
     - type: Transform
@@ -53840,7 +53792,7 @@ entities:
       pos: 25.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8023
     components:
     - type: Transform
@@ -53848,7 +53800,7 @@ entities:
       pos: 24.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8024
     components:
     - type: Transform
@@ -53856,7 +53808,7 @@ entities:
       pos: 23.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8025
     components:
     - type: Transform
@@ -53864,7 +53816,7 @@ entities:
       pos: 21.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8026
     components:
     - type: Transform
@@ -53872,7 +53824,7 @@ entities:
       pos: 20.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8027
     components:
     - type: Transform
@@ -53880,7 +53832,7 @@ entities:
       pos: 18.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8028
     components:
     - type: Transform
@@ -53888,7 +53840,7 @@ entities:
       pos: 17.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8029
     components:
     - type: Transform
@@ -53896,7 +53848,7 @@ entities:
       pos: 16.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8030
     components:
     - type: Transform
@@ -53904,7 +53856,7 @@ entities:
       pos: 14.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8031
     components:
     - type: Transform
@@ -53912,7 +53864,7 @@ entities:
       pos: 24.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8032
     components:
     - type: Transform
@@ -53920,7 +53872,7 @@ entities:
       pos: 22.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8033
     components:
     - type: Transform
@@ -53928,7 +53880,7 @@ entities:
       pos: 21.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8034
     components:
     - type: Transform
@@ -53936,7 +53888,7 @@ entities:
       pos: 20.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8035
     components:
     - type: Transform
@@ -53944,21 +53896,21 @@ entities:
       pos: 19.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8036
     components:
     - type: Transform
       pos: 7.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8037
     components:
     - type: Transform
       pos: 7.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8038
     components:
     - type: Transform
@@ -53966,7 +53918,7 @@ entities:
       pos: 12.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8039
     components:
     - type: Transform
@@ -53974,7 +53926,7 @@ entities:
       pos: 11.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8040
     components:
     - type: Transform
@@ -53982,28 +53934,28 @@ entities:
       pos: 10.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8041
     components:
     - type: Transform
       pos: 8.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8042
     components:
     - type: Transform
       pos: 8.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8043
     components:
     - type: Transform
       pos: 8.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8044
     components:
     - type: Transform
@@ -54011,7 +53963,7 @@ entities:
       pos: 12.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8045
     components:
     - type: Transform
@@ -54019,7 +53971,7 @@ entities:
       pos: 11.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8046
     components:
     - type: Transform
@@ -54027,7 +53979,7 @@ entities:
       pos: 10.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8047
     components:
     - type: Transform
@@ -54035,7 +53987,7 @@ entities:
       pos: 24.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8048
     components:
     - type: Transform
@@ -54043,7 +53995,7 @@ entities:
       pos: 25.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8049
     components:
     - type: Transform
@@ -54051,7 +54003,7 @@ entities:
       pos: 26.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8050
     components:
     - type: Transform
@@ -54059,21 +54011,21 @@ entities:
       pos: 24.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8051
     components:
     - type: Transform
       pos: 27.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8052
     components:
     - type: Transform
       pos: 27.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8053
     components:
     - type: Transform
@@ -54081,21 +54033,21 @@ entities:
       pos: 34.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8054
     components:
     - type: Transform
       pos: 27.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8055
     components:
     - type: Transform
       pos: 27.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8056
     components:
     - type: Transform
@@ -54103,7 +54055,7 @@ entities:
       pos: 29.5,46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8057
     components:
     - type: Transform
@@ -54111,7 +54063,7 @@ entities:
       pos: 47.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8058
     components:
     - type: Transform
@@ -54119,7 +54071,7 @@ entities:
       pos: 47.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8059
     components:
     - type: Transform
@@ -54127,7 +54079,7 @@ entities:
       pos: 47.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8060
     components:
     - type: Transform
@@ -54135,7 +54087,7 @@ entities:
       pos: 50.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8061
     components:
     - type: Transform
@@ -54143,7 +54095,7 @@ entities:
       pos: 45.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8062
     components:
     - type: Transform
@@ -54151,7 +54103,7 @@ entities:
       pos: 47.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8063
     components:
     - type: Transform
@@ -54159,7 +54111,7 @@ entities:
       pos: 42.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8064
     components:
     - type: Transform
@@ -54167,7 +54119,7 @@ entities:
       pos: 44.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8065
     components:
     - type: Transform
@@ -54175,7 +54127,7 @@ entities:
       pos: 51.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8066
     components:
     - type: Transform
@@ -54183,7 +54135,7 @@ entities:
       pos: 51.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8067
     components:
     - type: Transform
@@ -54191,7 +54143,7 @@ entities:
       pos: 52.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8068
     components:
     - type: Transform
@@ -54199,7 +54151,7 @@ entities:
       pos: 27.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8069
     components:
     - type: Transform
@@ -54207,7 +54159,7 @@ entities:
       pos: 28.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8070
     components:
     - type: Transform
@@ -54215,7 +54167,7 @@ entities:
       pos: 29.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8071
     components:
     - type: Transform
@@ -54223,7 +54175,7 @@ entities:
       pos: 30.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8072
     components:
     - type: Transform
@@ -54231,7 +54183,7 @@ entities:
       pos: 31.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8073
     components:
     - type: Transform
@@ -54239,7 +54191,7 @@ entities:
       pos: 32.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8074
     components:
     - type: Transform
@@ -54247,7 +54199,7 @@ entities:
       pos: 28.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8075
     components:
     - type: Transform
@@ -54255,7 +54207,7 @@ entities:
       pos: 29.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8076
     components:
     - type: Transform
@@ -54263,7 +54215,7 @@ entities:
       pos: 30.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8077
     components:
     - type: Transform
@@ -54271,7 +54223,7 @@ entities:
       pos: 31.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8078
     components:
     - type: Transform
@@ -54279,7 +54231,7 @@ entities:
       pos: 32.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8079
     components:
     - type: Transform
@@ -54287,7 +54239,7 @@ entities:
       pos: 35.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8080
     components:
     - type: Transform
@@ -54295,7 +54247,7 @@ entities:
       pos: 36.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8081
     components:
     - type: Transform
@@ -54303,7 +54255,7 @@ entities:
       pos: 37.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8082
     components:
     - type: Transform
@@ -54311,7 +54263,7 @@ entities:
       pos: 38.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8083
     components:
     - type: Transform
@@ -54319,7 +54271,7 @@ entities:
       pos: 39.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8084
     components:
     - type: Transform
@@ -54327,7 +54279,7 @@ entities:
       pos: 41.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8085
     components:
     - type: Transform
@@ -54335,7 +54287,7 @@ entities:
       pos: 42.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8086
     components:
     - type: Transform
@@ -54343,7 +54295,7 @@ entities:
       pos: 42.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8087
     components:
     - type: Transform
@@ -54351,7 +54303,7 @@ entities:
       pos: 41.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8088
     components:
     - type: Transform
@@ -54359,7 +54311,7 @@ entities:
       pos: 40.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8089
     components:
     - type: Transform
@@ -54367,7 +54319,7 @@ entities:
       pos: 38.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8090
     components:
     - type: Transform
@@ -54375,7 +54327,7 @@ entities:
       pos: 37.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8091
     components:
     - type: Transform
@@ -54383,7 +54335,7 @@ entities:
       pos: 36.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8092
     components:
     - type: Transform
@@ -54391,7 +54343,7 @@ entities:
       pos: 40.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8093
     components:
     - type: Transform
@@ -54399,7 +54351,7 @@ entities:
       pos: 40.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8094
     components:
     - type: Transform
@@ -54407,7 +54359,7 @@ entities:
       pos: 39.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8095
     components:
     - type: Transform
@@ -54415,70 +54367,70 @@ entities:
       pos: 39.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8096
     components:
     - type: Transform
       pos: 33.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8097
     components:
     - type: Transform
       pos: 33.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8098
     components:
     - type: Transform
       pos: 33.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8099
     components:
     - type: Transform
       pos: 35.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8100
     components:
     - type: Transform
       pos: 35.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8101
     components:
     - type: Transform
       pos: 35.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8102
     components:
     - type: Transform
       pos: 35.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8103
     components:
     - type: Transform
       pos: 35.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8104
     components:
     - type: Transform
       pos: 35.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8105
     components:
     - type: Transform
@@ -54486,7 +54438,7 @@ entities:
       pos: 34.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8106
     components:
     - type: Transform
@@ -54494,7 +54446,7 @@ entities:
       pos: 35.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8107
     components:
     - type: Transform
@@ -54502,7 +54454,7 @@ entities:
       pos: 36.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8108
     components:
     - type: Transform
@@ -54510,7 +54462,7 @@ entities:
       pos: 37.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8109
     components:
     - type: Transform
@@ -54518,7 +54470,7 @@ entities:
       pos: 36.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8110
     components:
     - type: Transform
@@ -54526,7 +54478,7 @@ entities:
       pos: 37.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8111
     components:
     - type: Transform
@@ -54534,7 +54486,7 @@ entities:
       pos: 33.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8112
     components:
     - type: Transform
@@ -54542,7 +54494,7 @@ entities:
       pos: 33.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8113
     components:
     - type: Transform
@@ -54550,7 +54502,7 @@ entities:
       pos: 33.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8114
     components:
     - type: Transform
@@ -54558,7 +54510,7 @@ entities:
       pos: 33.5,28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8115
     components:
     - type: Transform
@@ -54566,7 +54518,7 @@ entities:
       pos: 34.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8116
     components:
     - type: Transform
@@ -54574,7 +54526,7 @@ entities:
       pos: 35.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8117
     components:
     - type: Transform
@@ -54588,7 +54540,7 @@ entities:
       pos: 36.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8119
     components:
     - type: Transform
@@ -54596,7 +54548,7 @@ entities:
       pos: 37.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8120
     components:
     - type: Transform
@@ -54604,7 +54556,7 @@ entities:
       pos: 38.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8121
     components:
     - type: Transform
@@ -54612,7 +54564,7 @@ entities:
       pos: 47.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8122
     components:
     - type: Transform
@@ -54620,7 +54572,7 @@ entities:
       pos: 53.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8123
     components:
     - type: Transform
@@ -54628,7 +54580,7 @@ entities:
       pos: 42.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8124
     components:
     - type: Transform
@@ -54636,7 +54588,7 @@ entities:
       pos: 42.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8125
     components:
     - type: Transform
@@ -54644,7 +54596,7 @@ entities:
       pos: 41.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8126
     components:
     - type: Transform
@@ -54652,7 +54604,7 @@ entities:
       pos: 41.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8127
     components:
     - type: Transform
@@ -54660,7 +54612,7 @@ entities:
       pos: 54.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8128
     components:
     - type: Transform
@@ -54684,70 +54636,70 @@ entities:
       pos: 67.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8132
     components:
     - type: Transform
       pos: 26.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8133
     components:
     - type: Transform
       pos: 26.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8134
     components:
     - type: Transform
       pos: 26.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8135
     components:
     - type: Transform
       pos: 26.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8136
     components:
     - type: Transform
       pos: 26.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8137
     components:
     - type: Transform
       pos: 26.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8138
     components:
     - type: Transform
       pos: 25.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8139
     components:
     - type: Transform
       pos: 25.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8140
     components:
     - type: Transform
       pos: 25.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8141
     components:
     - type: Transform
@@ -54755,7 +54707,7 @@ entities:
       pos: 27.5,45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8142
     components:
     - type: Transform
@@ -54763,7 +54715,7 @@ entities:
       pos: 25.5,45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8143
     components:
     - type: Transform
@@ -54771,7 +54723,7 @@ entities:
       pos: 24.5,45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8144
     components:
     - type: Transform
@@ -54779,28 +54731,28 @@ entities:
       pos: 23.5,45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8145
     components:
     - type: Transform
       pos: 22.5,44.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8146
     components:
     - type: Transform
       pos: 22.5,43.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8147
     components:
     - type: Transform
       pos: 22.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8148
     components:
     - type: Transform
@@ -54808,7 +54760,7 @@ entities:
       pos: 25.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8149
     components:
     - type: Transform
@@ -54816,7 +54768,7 @@ entities:
       pos: 24.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8150
     components:
     - type: Transform
@@ -54824,7 +54776,7 @@ entities:
       pos: 23.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8151
     components:
     - type: Transform
@@ -54832,7 +54784,7 @@ entities:
       pos: 22.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8152
     components:
     - type: Transform
@@ -54840,7 +54792,7 @@ entities:
       pos: 21.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8153
     components:
     - type: Transform
@@ -54848,7 +54800,7 @@ entities:
       pos: 20.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8154
     components:
     - type: Transform
@@ -54856,7 +54808,7 @@ entities:
       pos: 19.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8155
     components:
     - type: Transform
@@ -54864,7 +54816,7 @@ entities:
       pos: 18.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8156
     components:
     - type: Transform
@@ -54872,7 +54824,7 @@ entities:
       pos: 18.5,38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8157
     components:
     - type: Transform
@@ -54880,7 +54832,7 @@ entities:
       pos: 18.5,39.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8158
     components:
     - type: Transform
@@ -54888,7 +54840,7 @@ entities:
       pos: 17.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8159
     components:
     - type: Transform
@@ -54896,7 +54848,7 @@ entities:
       pos: 16.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8160
     components:
     - type: Transform
@@ -54904,7 +54856,7 @@ entities:
       pos: 15.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8161
     components:
     - type: Transform
@@ -54912,7 +54864,7 @@ entities:
       pos: 44.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8162
     components:
     - type: Transform
@@ -54920,7 +54872,7 @@ entities:
       pos: 44.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8163
     components:
     - type: Transform
@@ -54928,7 +54880,7 @@ entities:
       pos: 47.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8164
     components:
     - type: Transform
@@ -54936,7 +54888,7 @@ entities:
       pos: 47.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8165
     components:
     - type: Transform
@@ -54944,7 +54896,7 @@ entities:
       pos: 47.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8166
     components:
     - type: Transform
@@ -54952,7 +54904,7 @@ entities:
       pos: 47.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8167
     components:
     - type: Transform
@@ -54965,7 +54917,7 @@ entities:
       pos: 52.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8169
     components:
     - type: Transform
@@ -54973,7 +54925,7 @@ entities:
       pos: 53.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8170
     components:
     - type: Transform
@@ -54981,7 +54933,7 @@ entities:
       pos: 59.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8171
     components:
     - type: Transform
@@ -54989,7 +54941,7 @@ entities:
       pos: 59.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8172
     components:
     - type: Transform
@@ -54997,7 +54949,7 @@ entities:
       pos: 59.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8173
     components:
     - type: Transform
@@ -55005,7 +54957,7 @@ entities:
       pos: 59.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8174
     components:
     - type: Transform
@@ -55013,7 +54965,7 @@ entities:
       pos: 59.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8175
     components:
     - type: Transform
@@ -55021,7 +54973,7 @@ entities:
       pos: 59.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8176
     components:
     - type: Transform
@@ -55029,7 +54981,7 @@ entities:
       pos: 59.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8177
     components:
     - type: Transform
@@ -55037,7 +54989,7 @@ entities:
       pos: 58.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8178
     components:
     - type: Transform
@@ -55045,7 +54997,7 @@ entities:
       pos: 57.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8179
     components:
     - type: Transform
@@ -55053,7 +55005,7 @@ entities:
       pos: 56.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8180
     components:
     - type: Transform
@@ -55061,7 +55013,7 @@ entities:
       pos: 55.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8181
     components:
     - type: Transform
@@ -55069,7 +55021,7 @@ entities:
       pos: 53.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8182
     components:
     - type: Transform
@@ -55077,7 +55029,7 @@ entities:
       pos: 52.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8183
     components:
     - type: Transform
@@ -55085,7 +55037,7 @@ entities:
       pos: 51.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8184
     components:
     - type: Transform
@@ -55093,7 +55045,7 @@ entities:
       pos: 50.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8185
     components:
     - type: Transform
@@ -55101,7 +55053,7 @@ entities:
       pos: 49.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8186
     components:
     - type: Transform
@@ -55109,7 +55061,7 @@ entities:
       pos: 48.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8187
     components:
     - type: Transform
@@ -55121,7 +55073,7 @@ entities:
       pos: 57.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8189
     components:
     - type: Transform
@@ -55129,56 +55081,56 @@ entities:
       pos: 57.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8190
     components:
     - type: Transform
       pos: 77.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8191
     components:
     - type: Transform
       pos: 55.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8192
     components:
     - type: Transform
       pos: 57.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8193
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8194
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8195
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8196
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8197
     components:
     - type: Transform
@@ -55186,7 +55138,7 @@ entities:
       pos: 2.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8198
     components:
     - type: Transform
@@ -55194,7 +55146,7 @@ entities:
       pos: 3.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8199
     components:
     - type: Transform
@@ -55202,7 +55154,7 @@ entities:
       pos: 0.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8200
     components:
     - type: Transform
@@ -55210,7 +55162,7 @@ entities:
       pos: -0.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8201
     components:
     - type: Transform
@@ -55218,7 +55170,7 @@ entities:
       pos: 9.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8202
     components:
     - type: Transform
@@ -55226,7 +55178,7 @@ entities:
       pos: 9.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8203
     components:
     - type: Transform
@@ -55234,7 +55186,7 @@ entities:
       pos: 9.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8204
     components:
     - type: Transform
@@ -55242,7 +55194,7 @@ entities:
       pos: 9.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8205
     components:
     - type: Transform
@@ -55250,7 +55202,7 @@ entities:
       pos: 9.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8206
     components:
     - type: Transform
@@ -55258,7 +55210,7 @@ entities:
       pos: 9.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8207
     components:
     - type: Transform
@@ -55266,7 +55218,7 @@ entities:
       pos: 9.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8208
     components:
     - type: Transform
@@ -55274,7 +55226,7 @@ entities:
       pos: 9.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8209
     components:
     - type: Transform
@@ -55282,7 +55234,7 @@ entities:
       pos: 8.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8210
     components:
     - type: Transform
@@ -55290,7 +55242,7 @@ entities:
       pos: 6.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8211
     components:
     - type: Transform
@@ -55298,7 +55250,7 @@ entities:
       pos: 5.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8212
     components:
     - type: Transform
@@ -55306,7 +55258,7 @@ entities:
       pos: 4.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8213
     components:
     - type: Transform
@@ -55314,7 +55266,7 @@ entities:
       pos: 3.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8214
     components:
     - type: Transform
@@ -55322,7 +55274,7 @@ entities:
       pos: 2.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8215
     components:
     - type: Transform
@@ -55330,7 +55282,7 @@ entities:
       pos: 0.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8216
     components:
     - type: Transform
@@ -55338,7 +55290,7 @@ entities:
       pos: -0.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8217
     components:
     - type: Transform
@@ -55346,28 +55298,28 @@ entities:
       pos: -1.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8218
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8219
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8220
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8221
     components:
     - type: Transform
@@ -55375,7 +55327,7 @@ entities:
       pos: -5.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8222
     components:
     - type: Transform
@@ -55383,7 +55335,7 @@ entities:
       pos: -4.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8223
     components:
     - type: Transform
@@ -55391,7 +55343,7 @@ entities:
       pos: -3.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8224
     components:
     - type: Transform
@@ -55399,7 +55351,7 @@ entities:
       pos: -0.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8225
     components:
     - type: Transform
@@ -55407,7 +55359,7 @@ entities:
       pos: -0.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8226
     components:
     - type: Transform
@@ -55415,7 +55367,7 @@ entities:
       pos: -0.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8227
     components:
     - type: Transform
@@ -55423,56 +55375,56 @@ entities:
       pos: 9.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8228
     components:
     - type: Transform
       pos: 8.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8229
     components:
     - type: Transform
       pos: 8.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8230
     components:
     - type: Transform
       pos: 8.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8231
     components:
     - type: Transform
       pos: 8.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8232
     components:
     - type: Transform
       pos: 8.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8233
     components:
     - type: Transform
       pos: 8.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8234
     components:
     - type: Transform
       pos: 8.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8235
     components:
     - type: Transform
@@ -55480,7 +55432,7 @@ entities:
       pos: 26.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8236
     components:
     - type: Transform
@@ -55488,7 +55440,7 @@ entities:
       pos: 25.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8237
     components:
     - type: Transform
@@ -55496,7 +55448,7 @@ entities:
       pos: 24.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8238
     components:
     - type: Transform
@@ -55504,7 +55456,7 @@ entities:
       pos: 24.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8239
     components:
     - type: Transform
@@ -55512,7 +55464,7 @@ entities:
       pos: 23.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8240
     components:
     - type: Transform
@@ -55520,7 +55472,7 @@ entities:
       pos: 26.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8241
     components:
     - type: Transform
@@ -55528,7 +55480,7 @@ entities:
       pos: 26.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8242
     components:
     - type: Transform
@@ -55536,7 +55488,7 @@ entities:
       pos: 26.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8243
     components:
     - type: Transform
@@ -55544,7 +55496,7 @@ entities:
       pos: 26.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8244
     components:
     - type: Transform
@@ -55552,28 +55504,28 @@ entities:
       pos: 26.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8245
     components:
     - type: Transform
       pos: 54.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8246
     components:
     - type: Transform
       pos: 54.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8247
     components:
     - type: Transform
       pos: 54.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8248
     components:
     - type: Transform
@@ -55581,7 +55533,7 @@ entities:
       pos: 53.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8249
     components:
     - type: Transform
@@ -55589,7 +55541,7 @@ entities:
       pos: 52.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8250
     components:
     - type: Transform
@@ -55597,7 +55549,7 @@ entities:
       pos: 51.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8251
     components:
     - type: Transform
@@ -55605,7 +55557,7 @@ entities:
       pos: 50.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8252
     components:
     - type: Transform
@@ -55613,7 +55565,7 @@ entities:
       pos: 49.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8253
     components:
     - type: Transform
@@ -55621,7 +55573,7 @@ entities:
       pos: 47.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8254
     components:
     - type: Transform
@@ -55629,28 +55581,28 @@ entities:
       pos: 47.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8255
     components:
     - type: Transform
       pos: 62.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8256
     components:
     - type: Transform
       pos: 62.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8257
     components:
     - type: Transform
       pos: 62.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8258
     components:
     - type: Transform
@@ -55658,7 +55610,7 @@ entities:
       pos: 61.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8259
     components:
     - type: Transform
@@ -55666,7 +55618,7 @@ entities:
       pos: 60.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8260
     components:
     - type: Transform
@@ -55674,7 +55626,7 @@ entities:
       pos: 63.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8261
     components:
     - type: Transform
@@ -55682,7 +55634,7 @@ entities:
       pos: 65.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8262
     components:
     - type: Transform
@@ -55690,7 +55642,7 @@ entities:
       pos: 66.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8263
     components:
     - type: Transform
@@ -55698,7 +55650,7 @@ entities:
       pos: 58.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8264
     components:
     - type: Transform
@@ -55706,7 +55658,7 @@ entities:
       pos: 57.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8265
     components:
     - type: Transform
@@ -55714,7 +55666,7 @@ entities:
       pos: 56.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8266
     components:
     - type: Transform
@@ -55722,7 +55674,7 @@ entities:
       pos: 60.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8267
     components:
     - type: Transform
@@ -55730,14 +55682,14 @@ entities:
       pos: 61.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8268
     components:
     - type: Transform
       pos: 46.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8269
     components:
     - type: Transform
@@ -55745,7 +55697,7 @@ entities:
       pos: 48.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8270
     components:
     - type: Transform
@@ -55753,7 +55705,7 @@ entities:
       pos: 49.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8271
     components:
     - type: Transform
@@ -55761,7 +55713,7 @@ entities:
       pos: 51.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8272
     components:
     - type: Transform
@@ -55769,7 +55721,7 @@ entities:
       pos: 52.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8273
     components:
     - type: Transform
@@ -55777,7 +55729,7 @@ entities:
       pos: 53.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8274
     components:
     - type: Transform
@@ -55785,7 +55737,7 @@ entities:
       pos: 54.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8275
     components:
     - type: Transform
@@ -55793,7 +55745,7 @@ entities:
       pos: 55.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8276
     components:
     - type: Transform
@@ -55801,7 +55753,7 @@ entities:
       pos: 56.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8277
     components:
     - type: Transform
@@ -55809,7 +55761,7 @@ entities:
       pos: 57.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8278
     components:
     - type: Transform
@@ -55817,7 +55769,7 @@ entities:
       pos: 58.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8279
     components:
     - type: Transform
@@ -55825,7 +55777,7 @@ entities:
       pos: 58.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8280
     components:
     - type: Transform
@@ -55833,7 +55785,7 @@ entities:
       pos: 58.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8281
     components:
     - type: Transform
@@ -55841,28 +55793,28 @@ entities:
       pos: 58.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8282
     components:
     - type: Transform
       pos: 63.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8283
     components:
     - type: Transform
       pos: 63.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8284
     components:
     - type: Transform
       pos: 63.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8285
     components:
     - type: Transform
@@ -55870,7 +55822,7 @@ entities:
       pos: 64.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8286
     components:
     - type: Transform
@@ -55878,7 +55830,7 @@ entities:
       pos: 65.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8287
     components:
     - type: Transform
@@ -55886,7 +55838,7 @@ entities:
       pos: 66.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8288
     components:
     - type: Transform
@@ -55894,7 +55846,7 @@ entities:
       pos: 62.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8289
     components:
     - type: Transform
@@ -55902,7 +55854,7 @@ entities:
       pos: 61.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8290
     components:
     - type: Transform
@@ -55910,7 +55862,7 @@ entities:
       pos: 60.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8291
     components:
     - type: Transform
@@ -55918,7 +55870,7 @@ entities:
       pos: 59.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8292
     components:
     - type: Transform
@@ -55926,7 +55878,7 @@ entities:
       pos: 56.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8293
     components:
     - type: Transform
@@ -55934,7 +55886,7 @@ entities:
       pos: 55.5,12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8294
     components:
     - type: Transform
@@ -55942,7 +55894,7 @@ entities:
       pos: 55.5,11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8295
     components:
     - type: Transform
@@ -55950,28 +55902,28 @@ entities:
       pos: 55.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8296
     components:
     - type: Transform
       pos: 58.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8297
     components:
     - type: Transform
       pos: 58.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8298
     components:
     - type: Transform
       pos: 58.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8299
     components:
     - type: Transform
@@ -55979,7 +55931,7 @@ entities:
       pos: 59.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8300
     components:
     - type: Transform
@@ -55987,7 +55939,7 @@ entities:
       pos: 60.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8301
     components:
     - type: Transform
@@ -55995,7 +55947,7 @@ entities:
       pos: 61.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8302
     components:
     - type: Transform
@@ -56043,7 +55995,7 @@ entities:
       pos: 28.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8311
     components:
     - type: Transform
@@ -56051,7 +56003,7 @@ entities:
       pos: 28.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8312
     components:
     - type: Transform
@@ -56059,7 +56011,7 @@ entities:
       pos: 27.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8313
     components:
     - type: Transform
@@ -56067,7 +56019,7 @@ entities:
       pos: 29.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8314
     components:
     - type: Transform
@@ -56075,7 +56027,7 @@ entities:
       pos: 35.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8315
     components:
     - type: Transform
@@ -56083,7 +56035,7 @@ entities:
       pos: 34.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8316
     components:
     - type: Transform
@@ -56091,7 +56043,7 @@ entities:
       pos: 33.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8317
     components:
     - type: Transform
@@ -56099,7 +56051,7 @@ entities:
       pos: 37.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8318
     components:
     - type: Transform
@@ -56107,7 +56059,7 @@ entities:
       pos: 38.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8319
     components:
     - type: Transform
@@ -56115,7 +56067,7 @@ entities:
       pos: 39.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8320
     components:
     - type: Transform
@@ -56128,7 +56080,7 @@ entities:
       pos: 27.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8322
     components:
     - type: Transform
@@ -56142,7 +56094,7 @@ entities:
       pos: 52.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8324
     components:
     - type: Transform
@@ -56150,7 +56102,7 @@ entities:
       pos: 53.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8325
     components:
     - type: Transform
@@ -56158,7 +56110,7 @@ entities:
       pos: 54.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8326
     components:
     - type: Transform
@@ -56166,21 +56118,21 @@ entities:
       pos: 55.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8327
     components:
     - type: Transform
       pos: 62.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8328
     components:
     - type: Transform
       pos: 62.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8329
     components:
     - type: Transform
@@ -56188,7 +56140,7 @@ entities:
       pos: 54.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8330
     components:
     - type: Transform
@@ -56196,7 +56148,7 @@ entities:
       pos: 53.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8331
     components:
     - type: Transform
@@ -56204,7 +56156,7 @@ entities:
       pos: 52.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8332
     components:
     - type: Transform
@@ -56212,7 +56164,7 @@ entities:
       pos: 64.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8333
     components:
     - type: Transform
@@ -56220,7 +56172,7 @@ entities:
       pos: 66.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8334
     components:
     - type: Transform
@@ -56228,7 +56180,7 @@ entities:
       pos: 67.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8335
     components:
     - type: Transform
@@ -56236,7 +56188,7 @@ entities:
       pos: 68.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8336
     components:
     - type: Transform
@@ -56244,7 +56196,7 @@ entities:
       pos: 69.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8337
     components:
     - type: Transform
@@ -56252,7 +56204,7 @@ entities:
       pos: 70.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8338
     components:
     - type: Transform
@@ -56260,7 +56212,7 @@ entities:
       pos: 72.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8339
     components:
     - type: Transform
@@ -56268,7 +56220,7 @@ entities:
       pos: 73.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8340
     components:
     - type: Transform
@@ -56276,7 +56228,7 @@ entities:
       pos: 74.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8341
     components:
     - type: Transform
@@ -56284,7 +56236,7 @@ entities:
       pos: 75.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8342
     components:
     - type: Transform
@@ -56292,7 +56244,7 @@ entities:
       pos: 76.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8343
     components:
     - type: Transform
@@ -56300,7 +56252,7 @@ entities:
       pos: 62.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8344
     components:
     - type: Transform
@@ -56308,7 +56260,7 @@ entities:
       pos: 63.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8345
     components:
     - type: Transform
@@ -56316,7 +56268,7 @@ entities:
       pos: 64.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8346
     components:
     - type: Transform
@@ -56324,7 +56276,7 @@ entities:
       pos: 65.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8347
     components:
     - type: Transform
@@ -56332,7 +56284,7 @@ entities:
       pos: 66.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8348
     components:
     - type: Transform
@@ -56340,7 +56292,7 @@ entities:
       pos: 67.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8349
     components:
     - type: Transform
@@ -56348,7 +56300,7 @@ entities:
       pos: 68.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8350
     components:
     - type: Transform
@@ -56356,7 +56308,7 @@ entities:
       pos: 69.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8351
     components:
     - type: Transform
@@ -56364,7 +56316,7 @@ entities:
       pos: 70.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8352
     components:
     - type: Transform
@@ -56372,7 +56324,7 @@ entities:
       pos: 71.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8353
     components:
     - type: Transform
@@ -56380,7 +56332,7 @@ entities:
       pos: 73.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8354
     components:
     - type: Transform
@@ -56388,7 +56340,7 @@ entities:
       pos: 74.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8355
     components:
     - type: Transform
@@ -56396,7 +56348,7 @@ entities:
       pos: 75.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8356
     components:
     - type: Transform
@@ -56404,35 +56356,35 @@ entities:
       pos: 76.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8357
     components:
     - type: Transform
       pos: 77.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8358
     components:
     - type: Transform
       pos: 77.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8359
     components:
     - type: Transform
       pos: 77.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8360
     components:
     - type: Transform
       pos: 77.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8361
     components:
     - type: Transform
@@ -56440,7 +56392,7 @@ entities:
       pos: 66.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8362
     components:
     - type: Transform
@@ -56448,7 +56400,7 @@ entities:
       pos: 66.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8363
     components:
     - type: Transform
@@ -56456,7 +56408,7 @@ entities:
       pos: 65.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8364
     components:
     - type: Transform
@@ -56464,7 +56416,7 @@ entities:
       pos: 65.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8365
     components:
     - type: Transform
@@ -56472,7 +56424,7 @@ entities:
       pos: 65.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8366
     components:
     - type: Transform
@@ -56480,7 +56432,7 @@ entities:
       pos: 65.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8367
     components:
     - type: Transform
@@ -56488,7 +56440,7 @@ entities:
       pos: 65.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8368
     components:
     - type: Transform
@@ -56496,7 +56448,7 @@ entities:
       pos: 65.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8369
     components:
     - type: Transform
@@ -56504,7 +56456,7 @@ entities:
       pos: 67.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8370
     components:
     - type: Transform
@@ -56520,7 +56472,7 @@ entities:
       pos: 68.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8372
     components:
     - type: Transform
@@ -56528,7 +56480,7 @@ entities:
       pos: 69.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8373
     components:
     - type: Transform
@@ -56536,42 +56488,42 @@ entities:
       pos: 70.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8374
     components:
     - type: Transform
       pos: 71.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8375
     components:
     - type: Transform
       pos: 71.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8376
     components:
     - type: Transform
       pos: 71.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8377
     components:
     - type: Transform
       pos: 71.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8378
     components:
     - type: Transform
       pos: 71.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8379
     components:
     - type: Transform
@@ -56579,7 +56531,7 @@ entities:
       pos: 56.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8380
     components:
     - type: Transform
@@ -56587,7 +56539,7 @@ entities:
       pos: 57.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8381
     components:
     - type: Transform
@@ -56595,7 +56547,7 @@ entities:
       pos: 58.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8382
     components:
     - type: Transform
@@ -56603,7 +56555,7 @@ entities:
       pos: 59.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8383
     components:
     - type: Transform
@@ -56611,7 +56563,7 @@ entities:
       pos: 61.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8384
     components:
     - type: Transform
@@ -56619,7 +56571,7 @@ entities:
       pos: 62.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8385
     components:
     - type: Transform
@@ -56627,7 +56579,7 @@ entities:
       pos: 63.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8386
     components:
     - type: Transform
@@ -56635,35 +56587,35 @@ entities:
       pos: 65.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8387
     components:
     - type: Transform
       pos: 66.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8388
     components:
     - type: Transform
       pos: 66.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8389
     components:
     - type: Transform
       pos: 72.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8390
     components:
     - type: Transform
       pos: 72.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8391
     components:
     - type: Transform
@@ -56671,7 +56623,7 @@ entities:
       pos: 55.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8392
     components:
     - type: Transform
@@ -56679,7 +56631,7 @@ entities:
       pos: 54.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8393
     components:
     - type: Transform
@@ -56687,7 +56639,7 @@ entities:
       pos: 53.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8394
     components:
     - type: Transform
@@ -56695,7 +56647,7 @@ entities:
       pos: 54.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8395
     components:
     - type: Transform
@@ -56703,7 +56655,7 @@ entities:
       pos: 53.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8396
     components:
     - type: Transform
@@ -56723,7 +56675,7 @@ entities:
       pos: 57.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8399
     components:
     - type: Transform
@@ -56741,77 +56693,77 @@ entities:
       pos: 61.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8402
     components:
     - type: Transform
       pos: 61.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8403
     components:
     - type: Transform
       pos: 61.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8404
     components:
     - type: Transform
       pos: 61.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8405
     components:
     - type: Transform
       pos: 61.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8406
     components:
     - type: Transform
       pos: 61.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8407
     components:
     - type: Transform
       pos: 61.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8408
     components:
     - type: Transform
       pos: 60.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8409
     components:
     - type: Transform
       pos: 60.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8410
     components:
     - type: Transform
       pos: 60.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8411
     components:
     - type: Transform
       pos: 60.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8412
     components:
     - type: Transform
@@ -56819,7 +56771,7 @@ entities:
       pos: 71.5,2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8413
     components:
     - type: Transform
@@ -56827,7 +56779,7 @@ entities:
       pos: 71.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8414
     components:
     - type: Transform
@@ -56835,7 +56787,7 @@ entities:
       pos: 71.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8415
     components:
     - type: Transform
@@ -56843,21 +56795,21 @@ entities:
       pos: 72.5,3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8416
     components:
     - type: Transform
       pos: 8.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8417
     components:
     - type: Transform
       pos: 8.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8418
     components:
     - type: Transform
@@ -56931,7 +56883,7 @@ entities:
       pos: -9.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8428
     components:
     - type: Transform
@@ -56939,7 +56891,7 @@ entities:
       pos: -13.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8429
     components:
     - type: Transform
@@ -56947,7 +56899,7 @@ entities:
       pos: -8.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8430
     components:
     - type: Transform
@@ -56972,7 +56924,7 @@ entities:
       pos: 46.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8434
     components:
     - type: Transform
@@ -56980,7 +56932,7 @@ entities:
       pos: 55.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8435
     components:
     - type: Transform
@@ -56988,7 +56940,7 @@ entities:
       pos: 55.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8436
     components:
     - type: Transform
@@ -56996,7 +56948,7 @@ entities:
       pos: 54.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8437
     components:
     - type: Transform
@@ -57004,7 +56956,7 @@ entities:
       pos: 56.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8438
     components:
     - type: Transform
@@ -57012,7 +56964,7 @@ entities:
       pos: 45.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8439
     components:
     - type: Transform
@@ -57020,7 +56972,7 @@ entities:
       pos: 46.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8440
     components:
     - type: Transform
@@ -57028,7 +56980,7 @@ entities:
       pos: 45.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8441
     components:
     - type: Transform
@@ -57036,7 +56988,7 @@ entities:
       pos: 45.5,32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8442
     components:
     - type: Transform
@@ -57044,7 +56996,7 @@ entities:
       pos: 52.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8443
     components:
     - type: Transform
@@ -57052,14 +57004,14 @@ entities:
       pos: 47.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8444
     components:
     - type: Transform
       pos: 46.5,33.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8445
     components:
     - type: Transform
@@ -57067,7 +57019,7 @@ entities:
       pos: -6.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8446
     components:
     - type: Transform
@@ -57075,7 +57027,7 @@ entities:
       pos: -6.5,-14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8447
     components:
     - type: Transform
@@ -57083,7 +57035,7 @@ entities:
       pos: -6.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8448
     components:
     - type: Transform
@@ -57091,7 +57043,7 @@ entities:
       pos: -5.5,-14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8449
     components:
     - type: Transform
@@ -57099,7 +57051,7 @@ entities:
       pos: -5.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8450
     components:
     - type: Transform
@@ -57107,7 +57059,7 @@ entities:
       pos: -5.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8451
     components:
     - type: Transform
@@ -57115,7 +57067,7 @@ entities:
       pos: -5.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8452
     components:
     - type: Transform
@@ -57123,7 +57075,7 @@ entities:
       pos: -15.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8453
     components:
     - type: Transform
@@ -57131,7 +57083,7 @@ entities:
       pos: -16.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8454
     components:
     - type: Transform
@@ -57139,7 +57091,7 @@ entities:
       pos: -17.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8455
     components:
     - type: Transform
@@ -57147,7 +57099,7 @@ entities:
       pos: -18.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8456
     components:
     - type: Transform
@@ -57155,7 +57107,7 @@ entities:
       pos: -19.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8457
     components:
     - type: Transform
@@ -57163,7 +57115,7 @@ entities:
       pos: -20.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8458
     components:
     - type: Transform
@@ -57171,7 +57123,7 @@ entities:
       pos: -21.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8459
     components:
     - type: Transform
@@ -57179,7 +57131,7 @@ entities:
       pos: -22.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8460
     components:
     - type: Transform
@@ -57187,7 +57139,7 @@ entities:
       pos: -15.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8461
     components:
     - type: Transform
@@ -57195,7 +57147,7 @@ entities:
       pos: -16.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8462
     components:
     - type: Transform
@@ -57203,7 +57155,7 @@ entities:
       pos: -17.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8463
     components:
     - type: Transform
@@ -57211,7 +57163,7 @@ entities:
       pos: -18.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8464
     components:
     - type: Transform
@@ -57219,7 +57171,7 @@ entities:
       pos: -19.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8465
     components:
     - type: Transform
@@ -57227,7 +57179,7 @@ entities:
       pos: -20.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8466
     components:
     - type: Transform
@@ -57235,7 +57187,7 @@ entities:
       pos: -21.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8467
     components:
     - type: Transform
@@ -57243,7 +57195,7 @@ entities:
       pos: -24.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8468
     components:
     - type: Transform
@@ -57251,7 +57203,7 @@ entities:
       pos: -24.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8469
     components:
     - type: Transform
@@ -57259,7 +57211,7 @@ entities:
       pos: -24.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8470
     components:
     - type: Transform
@@ -57267,7 +57219,7 @@ entities:
       pos: -24.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8471
     components:
     - type: Transform
@@ -57275,7 +57227,7 @@ entities:
       pos: -24.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8472
     components:
     - type: Transform
@@ -57283,7 +57235,7 @@ entities:
       pos: -24.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8473
     components:
     - type: Transform
@@ -57291,7 +57243,7 @@ entities:
       pos: -24.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8474
     components:
     - type: Transform
@@ -57299,7 +57251,7 @@ entities:
       pos: -22.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8475
     components:
     - type: Transform
@@ -57307,7 +57259,7 @@ entities:
       pos: -22.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8476
     components:
     - type: Transform
@@ -57315,7 +57267,7 @@ entities:
       pos: -22.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8477
     components:
     - type: Transform
@@ -57323,7 +57275,7 @@ entities:
       pos: -22.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8478
     components:
     - type: Transform
@@ -57331,7 +57283,7 @@ entities:
       pos: -22.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8479
     components:
     - type: Transform
@@ -57339,7 +57291,7 @@ entities:
       pos: -22.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8480
     components:
     - type: Transform
@@ -57347,7 +57299,7 @@ entities:
       pos: -22.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8481
     components:
     - type: Transform
@@ -57355,7 +57307,7 @@ entities:
       pos: -22.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8482
     components:
     - type: Transform
@@ -57363,7 +57315,7 @@ entities:
       pos: -22.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8483
     components:
     - type: Transform
@@ -57371,7 +57323,7 @@ entities:
       pos: -22.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8484
     components:
     - type: Transform
@@ -57379,7 +57331,7 @@ entities:
       pos: -22.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8485
     components:
     - type: Transform
@@ -57387,7 +57339,7 @@ entities:
       pos: -22.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8486
     components:
     - type: Transform
@@ -57395,7 +57347,7 @@ entities:
       pos: -22.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8487
     components:
     - type: Transform
@@ -57403,7 +57355,7 @@ entities:
       pos: -22.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8488
     components:
     - type: Transform
@@ -57411,7 +57363,7 @@ entities:
       pos: -22.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8489
     components:
     - type: Transform
@@ -57419,7 +57371,7 @@ entities:
       pos: -22.5,-20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8490
     components:
     - type: Transform
@@ -57427,7 +57379,7 @@ entities:
       pos: -22.5,-19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8491
     components:
     - type: Transform
@@ -57435,7 +57387,7 @@ entities:
       pos: -24.5,-18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8492
     components:
     - type: Transform
@@ -57443,7 +57395,7 @@ entities:
       pos: -24.5,-16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8493
     components:
     - type: Transform
@@ -57451,7 +57403,7 @@ entities:
       pos: -24.5,-15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8494
     components:
     - type: Transform
@@ -57459,7 +57411,7 @@ entities:
       pos: -24.5,-14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8495
     components:
     - type: Transform
@@ -57467,7 +57419,7 @@ entities:
       pos: -24.5,-13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8496
     components:
     - type: Transform
@@ -57475,7 +57427,7 @@ entities:
       pos: -24.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8497
     components:
     - type: Transform
@@ -57483,7 +57435,7 @@ entities:
       pos: -24.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8498
     components:
     - type: Transform
@@ -57491,7 +57443,7 @@ entities:
       pos: -24.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8499
     components:
     - type: Transform
@@ -57499,7 +57451,7 @@ entities:
       pos: -24.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8500
     components:
     - type: Transform
@@ -57507,7 +57459,7 @@ entities:
       pos: -24.5,-8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8501
     components:
     - type: Transform
@@ -57515,7 +57467,7 @@ entities:
       pos: -24.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8502
     components:
     - type: Transform
@@ -57523,7 +57475,7 @@ entities:
       pos: 64.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8503
     components:
     - type: Transform
@@ -57539,7 +57491,7 @@ entities:
       pos: 65.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8505
     components:
     - type: Transform
@@ -57704,7 +57656,7 @@ entities:
       pos: 66.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8526
     components:
     - type: Transform
@@ -57712,7 +57664,7 @@ entities:
       pos: 67.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8527
     components:
     - type: Transform
@@ -57720,7 +57672,7 @@ entities:
       pos: 64.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8528
     components:
     - type: Transform
@@ -57728,7 +57680,7 @@ entities:
       pos: 64.5,16.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8529
     components:
     - type: Transform
@@ -57736,7 +57688,7 @@ entities:
       pos: 67.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8530
     components:
     - type: Transform
@@ -57744,7 +57696,7 @@ entities:
       pos: 67.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8531
     components:
     - type: Transform
@@ -57752,21 +57704,21 @@ entities:
       pos: 68.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8532
     components:
     - type: Transform
       pos: 69.5,22.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8533
     components:
     - type: Transform
       pos: 69.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8534
     components:
     - type: Transform
@@ -57774,7 +57726,7 @@ entities:
       pos: 70.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8535
     components:
     - type: Transform
@@ -57782,7 +57734,7 @@ entities:
       pos: 71.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8536
     components:
     - type: Transform
@@ -57790,7 +57742,7 @@ entities:
       pos: 72.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8537
     components:
     - type: Transform
@@ -57821,21 +57773,21 @@ entities:
       pos: 8.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8541
     components:
     - type: Transform
       pos: 8.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8542
     components:
     - type: Transform
       pos: 7.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8543
     components:
     - type: Transform
@@ -57843,7 +57795,7 @@ entities:
       pos: 6.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8544
     components:
     - type: Transform
@@ -57851,7 +57803,7 @@ entities:
       pos: 5.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8545
     components:
     - type: Transform
@@ -57864,9 +57816,152 @@ entities:
       pos: 5.5,17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
+  - uid: 9977
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,45.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 9979
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,45.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 9997
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,45.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 10438
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,45.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 11159
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,45.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 11160
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,45.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 15079
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,44.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 15080
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,44.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 15081
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,44.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 15082
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,44.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 15083
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,44.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 15084
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,44.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 15085
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,44.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 15086
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,44.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 15087
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,44.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 15088
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,44.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasPipeTJunction
   entities:
+  - uid: 5629
+    components:
+    - type: Transform
+      pos: 22.5,45.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 5630
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 27.5,44.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 8547
     components:
     - type: Transform
@@ -57874,7 +57969,7 @@ entities:
       pos: 31.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8548
     components:
     - type: Transform
@@ -57882,14 +57977,14 @@ entities:
       pos: 18.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8549
     components:
     - type: Transform
       pos: 18.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8550
     components:
     - type: Transform
@@ -57897,35 +57992,35 @@ entities:
       pos: 13.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8551
     components:
     - type: Transform
       pos: 13.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8552
     components:
     - type: Transform
       pos: 22.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8553
     components:
     - type: Transform
       pos: 9.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8554
     components:
     - type: Transform
       pos: 11.5,9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8555
     components:
     - type: Transform
@@ -57933,14 +58028,14 @@ entities:
       pos: 27.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8556
     components:
     - type: Transform
       pos: 19.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8557
     components:
     - type: Transform
@@ -57948,7 +58043,7 @@ entities:
       pos: 17.5,-34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8558
     components:
     - type: Transform
@@ -57956,7 +58051,7 @@ entities:
       pos: 33.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8559
     components:
     - type: Transform
@@ -57971,7 +58066,7 @@ entities:
       pos: 30.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8561
     components:
     - type: Transform
@@ -58000,7 +58095,7 @@ entities:
       pos: 26.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8565
     components:
     - type: Transform
@@ -58008,14 +58103,14 @@ entities:
       pos: 28.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8566
     components:
     - type: Transform
       pos: 22.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8567
     components:
     - type: Transform
@@ -58023,28 +58118,28 @@ entities:
       pos: 18.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8568
     components:
     - type: Transform
       pos: 20.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8569
     components:
     - type: Transform
       pos: 24.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8570
     components:
     - type: Transform
       pos: 26.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8571
     components:
     - type: Transform
@@ -58052,7 +58147,7 @@ entities:
       pos: 27.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8572
     components:
     - type: Transform
@@ -58060,7 +58155,7 @@ entities:
       pos: 31.5,-36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8573
     components:
     - type: Transform
@@ -58068,14 +58163,14 @@ entities:
       pos: 26.5,-17.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8574
     components:
     - type: Transform
       pos: 33.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8575
     components:
     - type: Transform
@@ -58083,14 +58178,14 @@ entities:
       pos: 21.5,-35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8576
     components:
     - type: Transform
       pos: 21.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8577
     components:
     - type: Transform
@@ -58098,7 +58193,7 @@ entities:
       pos: 21.5,-32.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8578
     components:
     - type: Transform
@@ -58106,7 +58201,7 @@ entities:
       pos: 21.5,-31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8579
     components:
     - type: Transform
@@ -58114,14 +58209,14 @@ entities:
       pos: 40.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8580
     components:
     - type: Transform
       pos: 40.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8581
     components:
     - type: Transform
@@ -58129,7 +58224,7 @@ entities:
       pos: 25.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8582
     components:
     - type: Transform
@@ -58137,28 +58232,28 @@ entities:
       pos: 3.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8583
     components:
     - type: Transform
       pos: 25.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8584
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8585
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8586
     components:
     - type: Transform
@@ -58171,7 +58266,7 @@ entities:
       pos: 5.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8588
     components:
     - type: Transform
@@ -58185,14 +58280,14 @@ entities:
       pos: 32.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8590
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8591
     components:
     - type: Transform
@@ -58200,7 +58295,7 @@ entities:
       pos: -2.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8592
     components:
     - type: Transform
@@ -58208,7 +58303,7 @@ entities:
       pos: 50.5,34.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8593
     components:
     - type: Transform
@@ -58216,7 +58311,7 @@ entities:
       pos: 42.5,8.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8594
     components:
     - type: Transform
@@ -58224,7 +58319,7 @@ entities:
       pos: 57.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8595
     components:
     - type: Transform
@@ -58245,7 +58340,7 @@ entities:
       pos: 3.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8598
     components:
     - type: Transform
@@ -58253,7 +58348,7 @@ entities:
       pos: 25.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8599
     components:
     - type: Transform
@@ -58261,7 +58356,7 @@ entities:
       pos: 26.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8600
     components:
     - type: Transform
@@ -58269,7 +58364,7 @@ entities:
       pos: 26.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8601
     components:
     - type: Transform
@@ -58277,7 +58372,7 @@ entities:
       pos: 27.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8602
     components:
     - type: Transform
@@ -58285,7 +58380,7 @@ entities:
       pos: 25.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8603
     components:
     - type: Transform
@@ -58293,21 +58388,21 @@ entities:
       pos: 27.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8604
     components:
     - type: Transform
       pos: 16.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8605
     components:
     - type: Transform
       pos: 14.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8606
     components:
     - type: Transform
@@ -58315,7 +58410,7 @@ entities:
       pos: 33.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8607
     components:
     - type: Transform
@@ -58323,14 +58418,14 @@ entities:
       pos: 39.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8608
     components:
     - type: Transform
       pos: 27.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8609
     components:
     - type: Transform
@@ -58338,7 +58433,7 @@ entities:
       pos: 42.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8610
     components:
     - type: Transform
@@ -58346,7 +58441,7 @@ entities:
       pos: 47.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8611
     components:
     - type: Transform
@@ -58382,7 +58477,7 @@ entities:
       pos: 5.5,4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8616
     components:
     - type: Transform
@@ -58390,7 +58485,7 @@ entities:
       pos: 27.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8617
     components:
     - type: Transform
@@ -58407,14 +58502,14 @@ entities:
       pos: 59.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8620
     components:
     - type: Transform
       pos: 25.5,37.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8621
     components:
     - type: Transform
@@ -58422,14 +58517,14 @@ entities:
       pos: 56.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8622
     components:
     - type: Transform
       pos: 45.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8623
     components:
     - type: Transform
@@ -58437,7 +58532,7 @@ entities:
       pos: 29.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8624
     components:
     - type: Transform
@@ -58445,14 +58540,14 @@ entities:
       pos: 27.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8625
     components:
     - type: Transform
       pos: 26.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8626
     components:
     - type: Transform
@@ -58460,35 +58555,35 @@ entities:
       pos: 26.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8627
     components:
     - type: Transform
       pos: 9.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8628
     components:
     - type: Transform
       pos: 8.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8629
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8630
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8631
     components:
     - type: Transform
@@ -58496,14 +58591,14 @@ entities:
       pos: 63.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8632
     components:
     - type: Transform
       pos: 30.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8633
     components:
     - type: Transform
@@ -58511,7 +58606,7 @@ entities:
       pos: 65.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8634
     components:
     - type: Transform
@@ -58519,7 +58614,7 @@ entities:
       pos: 71.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8635
     components:
     - type: Transform
@@ -58527,14 +58622,14 @@ entities:
       pos: 55.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8636
     components:
     - type: Transform
       pos: 61.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8637
     components:
     - type: Transform
@@ -58542,14 +58637,14 @@ entities:
       pos: 40.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8638
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8639
     components:
     - type: Transform
@@ -58557,7 +58652,7 @@ entities:
       pos: 41.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8640
     components:
     - type: Transform
@@ -58565,7 +58660,7 @@ entities:
       pos: -6.5,-7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8641
     components:
     - type: Transform
@@ -58573,7 +58668,7 @@ entities:
       pos: 47.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8642
     components:
     - type: Transform
@@ -58581,7 +58676,7 @@ entities:
       pos: 32.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8643
     components:
     - type: Transform
@@ -58589,7 +58684,7 @@ entities:
       pos: 25.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8644
     components:
     - type: Transform
@@ -58597,7 +58692,7 @@ entities:
       pos: 41.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8645
     components:
     - type: Transform
@@ -58605,14 +58700,14 @@ entities:
       pos: 27.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8646
     components:
     - type: Transform
       pos: 26.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8647
     components:
     - type: Transform
@@ -58620,7 +58715,7 @@ entities:
       pos: 25.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8648
     components:
     - type: Transform
@@ -58628,14 +58723,14 @@ entities:
       pos: 64.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8649
     components:
     - type: Transform
       pos: 48.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8650
     components:
     - type: Transform
@@ -58643,7 +58738,7 @@ entities:
       pos: 27.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8651
     components:
     - type: Transform
@@ -58651,7 +58746,7 @@ entities:
       pos: 33.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8652
     components:
     - type: Transform
@@ -58659,14 +58754,14 @@ entities:
       pos: 33.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8653
     components:
     - type: Transform
       pos: 34.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8654
     components:
     - type: Transform
@@ -58674,14 +58769,14 @@ entities:
       pos: 44.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8655
     components:
     - type: Transform
       pos: 39.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8656
     components:
     - type: Transform
@@ -58689,7 +58784,7 @@ entities:
       pos: 35.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8657
     components:
     - type: Transform
@@ -58703,7 +58798,7 @@ entities:
       pos: 39.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8659
     components:
     - type: Transform
@@ -58711,7 +58806,7 @@ entities:
       pos: 26.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8660
     components:
     - type: Transform
@@ -58719,7 +58814,7 @@ entities:
       pos: 47.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8661
     components:
     - type: Transform
@@ -58727,7 +58822,7 @@ entities:
       pos: 15.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8662
     components:
     - type: Transform
@@ -58735,7 +58830,7 @@ entities:
       pos: 14.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8663
     components:
     - type: Transform
@@ -58743,7 +58838,7 @@ entities:
       pos: 9.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8664
     components:
     - type: Transform
@@ -58751,7 +58846,7 @@ entities:
       pos: 9.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8665
     components:
     - type: Transform
@@ -58765,7 +58860,7 @@ entities:
       pos: -6.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8667
     components:
     - type: Transform
@@ -58773,14 +58868,14 @@ entities:
       pos: -5.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8668
     components:
     - type: Transform
       pos: -12.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8669
     components:
     - type: Transform
@@ -58788,7 +58883,7 @@ entities:
       pos: -10.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8670
     components:
     - type: Transform
@@ -58801,7 +58896,7 @@ entities:
       pos: 8.5,19.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8672
     components:
     - type: Transform
@@ -58809,7 +58904,7 @@ entities:
       pos: 7.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8673
     components:
     - type: Transform
@@ -58817,7 +58912,7 @@ entities:
       pos: 23.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8674
     components:
     - type: Transform
@@ -58825,7 +58920,7 @@ entities:
       pos: 19.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8675
     components:
     - type: Transform
@@ -58833,7 +58928,7 @@ entities:
       pos: 22.5,20.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8676
     components:
     - type: Transform
@@ -58841,7 +58936,7 @@ entities:
       pos: 18.5,21.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8677
     components:
     - type: Transform
@@ -58849,14 +58944,14 @@ entities:
       pos: 8.5,25.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8678
     components:
     - type: Transform
       pos: 27.5,46.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8679
     components:
     - type: Transform
@@ -58864,21 +58959,21 @@ entities:
       pos: 33.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8680
     components:
     - type: Transform
       pos: 33.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8681
     components:
     - type: Transform
       pos: 34.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8682
     components:
     - type: Transform
@@ -58886,14 +58981,14 @@ entities:
       pos: 34.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8683
     components:
     - type: Transform
       pos: 35.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8684
     components:
     - type: Transform
@@ -58912,7 +59007,7 @@ entities:
       pos: 26.5,45.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8687
     components:
     - type: Transform
@@ -58920,7 +59015,7 @@ entities:
       pos: 26.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8688
     components:
     - type: Transform
@@ -58928,7 +59023,7 @@ entities:
       pos: 27.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8689
     components:
     - type: Transform
@@ -58936,7 +59031,7 @@ entities:
       pos: 26.5,35.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8690
     components:
     - type: Transform
@@ -58944,7 +59039,7 @@ entities:
       pos: 18.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8691
     components:
     - type: Transform
@@ -58952,14 +59047,14 @@ entities:
       pos: 56.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8692
     components:
     - type: Transform
       pos: 59.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8693
     components:
     - type: Transform
@@ -58967,14 +59062,14 @@ entities:
       pos: 59.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8694
     components:
     - type: Transform
       pos: 54.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8695
     components:
     - type: Transform
@@ -58982,7 +59077,7 @@ entities:
       pos: 59.5,15.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8696
     components:
     - type: Transform
@@ -58990,7 +59085,7 @@ entities:
       pos: 1.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8697
     components:
     - type: Transform
@@ -58998,7 +59093,7 @@ entities:
       pos: 1.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8698
     components:
     - type: Transform
@@ -59006,7 +59101,7 @@ entities:
       pos: 1.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8699
     components:
     - type: Transform
@@ -59014,7 +59109,7 @@ entities:
       pos: 1.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8700
     components:
     - type: Transform
@@ -59022,14 +59117,14 @@ entities:
       pos: 9.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8701
     components:
     - type: Transform
       pos: 7.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8702
     components:
     - type: Transform
@@ -59037,14 +59132,14 @@ entities:
       pos: 26.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8703
     components:
     - type: Transform
       pos: 62.5,14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8704
     components:
     - type: Transform
@@ -59052,7 +59147,7 @@ entities:
       pos: 48.5,10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8705
     components:
     - type: Transform
@@ -59060,7 +59155,7 @@ entities:
       pos: 25.5,29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8706
     components:
     - type: Transform
@@ -59068,7 +59163,7 @@ entities:
       pos: 50.5,18.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8707
     components:
     - type: Transform
@@ -59076,7 +59171,7 @@ entities:
       pos: 58.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8708
     components:
     - type: Transform
@@ -59084,7 +59179,7 @@ entities:
       pos: 57.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8709
     components:
     - type: Transform
@@ -59092,14 +59187,14 @@ entities:
       pos: 63.5,13.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8710
     components:
     - type: Transform
       pos: 58.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8711
     components:
     - type: Transform
@@ -59107,21 +59202,21 @@ entities:
       pos: 40.5,30.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8712
     components:
     - type: Transform
       pos: 77.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8713
     components:
     - type: Transform
       pos: 65.5,1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8714
     components:
     - type: Transform
@@ -59129,7 +59224,7 @@ entities:
       pos: 66.5,-9.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8715
     components:
     - type: Transform
@@ -59137,7 +59232,7 @@ entities:
       pos: 66.5,-6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8716
     components:
     - type: Transform
@@ -59153,14 +59248,14 @@ entities:
       pos: 64.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8718
     components:
     - type: Transform
       pos: 56.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8719
     components:
     - type: Transform
@@ -59168,7 +59263,7 @@ entities:
       pos: 40.5,6.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8720
     components:
     - type: Transform
@@ -59262,14 +59357,14 @@ entities:
       pos: 46.5,31.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8733
     components:
     - type: Transform
       pos: -23.5,0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8734
     components:
     - type: Transform
@@ -59277,7 +59372,7 @@ entities:
       pos: -22.5,-2.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8735
     components:
     - type: Transform
@@ -59285,7 +59380,7 @@ entities:
       pos: -24.5,-11.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8736
     components:
     - type: Transform
@@ -59293,7 +59388,7 @@ entities:
       pos: -22.5,-14.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8737
     components:
     - type: Transform
@@ -59366,7 +59461,7 @@ entities:
       pos: 24.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8747
     components:
     - type: Transform
@@ -59477,7 +59572,7 @@ entities:
       pos: 31.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8766
     components:
     - type: Transform
@@ -59527,7 +59622,7 @@ entities:
       pos: 27.5,-23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8774
     components:
     - type: Transform
@@ -59535,7 +59630,7 @@ entities:
       pos: 57.5,-0.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8775
     components:
     - type: Transform
@@ -59543,7 +59638,7 @@ entities:
       pos: 31.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8776
     components:
     - type: Transform
@@ -59551,7 +59646,7 @@ entities:
       pos: 51.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8777
     components:
     - type: Transform
@@ -59706,7 +59801,7 @@ entities:
       pos: 26.5,-29.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8797
     components:
     - type: Transform
@@ -59716,7 +59811,7 @@ entities:
       deviceLists:
       - 10
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8798
     components:
     - type: Transform
@@ -59724,7 +59819,7 @@ entities:
       pos: 39.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8799
     components:
     - type: Transform
@@ -59734,7 +59829,7 @@ entities:
       deviceLists:
       - 70
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8800
     components:
     - type: Transform
@@ -59745,7 +59840,7 @@ entities:
       deviceLists:
       - 18
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8801
     components:
     - type: Transform
@@ -59756,7 +59851,7 @@ entities:
       deviceLists:
       - 17
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8802
     components:
     - type: Transform
@@ -59767,14 +59862,14 @@ entities:
       deviceLists:
       - 42
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8803
     components:
     - type: Transform
       pos: 30.5,-27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8804
     components:
     - type: Transform
@@ -59784,7 +59879,7 @@ entities:
       deviceLists:
       - 68
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8805
     components:
     - type: Transform
@@ -59795,7 +59890,7 @@ entities:
       deviceLists:
       - 55
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8806
     components:
     - type: Transform
@@ -59806,7 +59901,7 @@ entities:
       deviceLists:
       - 11
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8807
     components:
     - type: Transform
@@ -59817,7 +59912,7 @@ entities:
       deviceLists:
       - 15
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8808
     components:
     - type: Transform
@@ -59828,7 +59923,7 @@ entities:
       deviceLists:
       - 13
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8809
     components:
     - type: Transform
@@ -59836,7 +59931,7 @@ entities:
       pos: 20.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8810
     components:
     - type: Transform
@@ -59847,7 +59942,7 @@ entities:
       deviceLists:
       - 47
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8811
     components:
     - type: Transform
@@ -59857,7 +59952,7 @@ entities:
       deviceLists:
       - 56
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8812
     components:
     - type: Transform
@@ -59868,7 +59963,7 @@ entities:
       deviceLists:
       - 46
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8813
     components:
     - type: Transform
@@ -59876,7 +59971,7 @@ entities:
       pos: 11.5,-40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8814
     components:
     - type: Transform
@@ -59884,7 +59979,7 @@ entities:
       pos: 36.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8815
     components:
     - type: Transform
@@ -59895,7 +59990,7 @@ entities:
       deviceLists:
       - 24
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8816
     components:
     - type: Transform
@@ -59906,7 +60001,7 @@ entities:
       deviceLists:
       - 25
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8817
     components:
     - type: Transform
@@ -59917,7 +60012,7 @@ entities:
       deviceLists:
       - 27
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8818
     components:
     - type: Transform
@@ -59934,7 +60029,7 @@ entities:
       deviceLists:
       - 26
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8820
     components:
     - type: Transform
@@ -59945,7 +60040,7 @@ entities:
       deviceLists:
       - 16
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8821
     components:
     - type: Transform
@@ -59958,7 +60053,7 @@ entities:
       - 6798
       - 22
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8822
     components:
     - type: Transform
@@ -59969,7 +60064,7 @@ entities:
       deviceLists:
       - 16
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8823
     components:
     - type: Transform
@@ -59979,7 +60074,7 @@ entities:
       deviceLists:
       - 44
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8824
     components:
     - type: Transform
@@ -59989,7 +60084,7 @@ entities:
       deviceLists:
       - 42
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8825
     components:
     - type: Transform
@@ -60000,7 +60095,7 @@ entities:
       deviceLists:
       - 29
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8826
     components:
     - type: Transform
@@ -60010,7 +60105,7 @@ entities:
       deviceLists:
       - 30
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8827
     components:
     - type: Transform
@@ -60021,7 +60116,7 @@ entities:
       deviceLists:
       - 28
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8828
     components:
     - type: Transform
@@ -60032,7 +60127,7 @@ entities:
       deviceLists:
       - 52
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8829
     components:
     - type: Transform
@@ -60043,7 +60138,7 @@ entities:
       deviceLists:
       - 51
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8830
     components:
     - type: Transform
@@ -60053,7 +60148,7 @@ entities:
       deviceLists:
       - 70
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8831
     components:
     - type: Transform
@@ -60070,7 +60165,7 @@ entities:
       deviceLists:
       - 20
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8833
     components:
     - type: Transform
@@ -60080,7 +60175,7 @@ entities:
       deviceLists:
       - 29
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8834
     components:
     - type: Transform
@@ -60091,7 +60186,7 @@ entities:
       deviceLists:
       - 36
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8835
     components:
     - type: Transform
@@ -60101,7 +60196,7 @@ entities:
       deviceLists:
       - 74
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8836
     components:
     - type: Transform
@@ -60111,7 +60206,7 @@ entities:
       deviceLists:
       - 43
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8837
     components:
     - type: Transform
@@ -60121,7 +60216,7 @@ entities:
       deviceLists:
       - 43
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8838
     components:
     - type: Transform
@@ -60132,7 +60227,7 @@ entities:
       deviceLists:
       - 64
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8839
     components:
     - type: Transform
@@ -60140,7 +60235,7 @@ entities:
       pos: 23.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8840
     components:
     - type: Transform
@@ -60148,7 +60243,7 @@ entities:
       pos: 31.5,42.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8841
     components:
     - type: Transform
@@ -60159,7 +60254,7 @@ entities:
       deviceLists:
       - 68
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8842
     components:
     - type: Transform
@@ -60169,7 +60264,7 @@ entities:
       deviceLists:
       - 61
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8843
     components:
     - type: Transform
@@ -60177,7 +60272,7 @@ entities:
       pos: 43.5,24.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8844
     components:
     - type: Transform
@@ -60188,14 +60283,14 @@ entities:
       deviceLists:
       - 62
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8845
     components:
     - type: Transform
       pos: 39.5,27.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8846
     components:
     - type: Transform
@@ -60205,7 +60300,7 @@ entities:
       deviceLists:
       - 61
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8847
     components:
     - type: Transform
@@ -60215,7 +60310,7 @@ entities:
       deviceLists:
       - 63
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8848
     components:
     - type: Transform
@@ -60225,7 +60320,7 @@ entities:
       deviceLists:
       - 53
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8849
     components:
     - type: Transform
@@ -60236,7 +60331,7 @@ entities:
       deviceLists:
       - 65
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8850
     components:
     - type: Transform
@@ -60246,14 +60341,14 @@ entities:
       deviceLists:
       - 31
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8851
     components:
     - type: Transform
       pos: 18.5,40.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8852
     components:
     - type: Transform
@@ -60261,7 +60356,7 @@ entities:
       pos: 14.5,36.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8853
     components:
     - type: Transform
@@ -60271,7 +60366,7 @@ entities:
       deviceLists:
       - 32
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8854
     components:
     - type: Transform
@@ -60279,7 +60374,7 @@ entities:
       pos: 7.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8855
     components:
     - type: Transform
@@ -60287,7 +60382,7 @@ entities:
       pos: 1.5,-12.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8856
     components:
     - type: Transform
@@ -60298,7 +60393,7 @@ entities:
       deviceLists:
       - 35
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8857
     components:
     - type: Transform
@@ -60309,7 +60404,7 @@ entities:
       deviceLists:
       - 33
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8858
     components:
     - type: Transform
@@ -60317,7 +60412,7 @@ entities:
       pos: -1.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8859
     components:
     - type: Transform
@@ -60328,7 +60423,7 @@ entities:
       deviceLists:
       - 34
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8860
     components:
     - type: Transform
@@ -60339,7 +60434,7 @@ entities:
       deviceLists:
       - 37
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8861
     components:
     - type: Transform
@@ -60350,7 +60445,7 @@ entities:
       deviceLists:
       - 38
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8862
     components:
     - type: Transform
@@ -60360,7 +60455,7 @@ entities:
       deviceLists:
       - 23
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8863
     components:
     - type: Transform
@@ -60371,7 +60466,7 @@ entities:
       deviceLists:
       - 67
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8864
     components:
     - type: Transform
@@ -60382,7 +60477,7 @@ entities:
       deviceLists:
       - 14
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8865
     components:
     - type: Transform
@@ -60393,7 +60488,7 @@ entities:
       deviceLists:
       - 66
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8866
     components:
     - type: Transform
@@ -60404,7 +60499,7 @@ entities:
       deviceLists:
       - 19
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8867
     components:
     - type: Transform
@@ -60415,7 +60510,7 @@ entities:
       deviceLists:
       - 39
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8868
     components:
     - type: Transform
@@ -60426,7 +60521,7 @@ entities:
       deviceLists:
       - 21
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8869
     components:
     - type: Transform
@@ -60437,7 +60532,7 @@ entities:
       deviceLists:
       - 12
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8870
     components:
     - type: Transform
@@ -60448,7 +60543,7 @@ entities:
       deviceLists:
       - 61
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8871
     components:
     - type: Transform
@@ -60459,7 +60554,7 @@ entities:
       deviceLists:
       - 40
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8872
     components:
     - type: Transform
@@ -60470,7 +60565,7 @@ entities:
       deviceLists:
       - 59
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8873
     components:
     - type: Transform
@@ -60481,7 +60576,7 @@ entities:
       deviceLists:
       - 49
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8874
     components:
     - type: Transform
@@ -60489,7 +60584,7 @@ entities:
       pos: 64.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8875
     components:
     - type: Transform
@@ -60499,7 +60594,7 @@ entities:
       deviceLists:
       - 45
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8876
     components:
     - type: Transform
@@ -60507,7 +60602,7 @@ entities:
       pos: 66.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8877
     components:
     - type: Transform
@@ -60517,7 +60612,7 @@ entities:
       deviceLists:
       - 58
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8878
     components:
     - type: Transform
@@ -60528,7 +60623,7 @@ entities:
       deviceLists:
       - 57
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8879
     components:
     - type: Transform
@@ -60536,7 +60631,7 @@ entities:
       pos: 56.5,-5.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8880
     components:
     - type: Transform
@@ -60544,7 +60639,7 @@ entities:
       pos: 61.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8881
     components:
     - type: Transform
@@ -60554,7 +60649,7 @@ entities:
       deviceLists:
       - 48
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8882
     components:
     - type: Transform
@@ -60564,7 +60659,7 @@ entities:
       deviceLists:
       - 60
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8883
     components:
     - type: Transform
@@ -60575,7 +60670,7 @@ entities:
       deviceLists:
       - 20
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8884
     components:
     - type: Transform
@@ -60586,7 +60681,7 @@ entities:
       deviceLists:
       - 69
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8885
     components:
     - type: Transform
@@ -60597,7 +60692,7 @@ entities:
       deviceLists:
       - 69
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8886
     components:
     - type: Transform
@@ -60608,7 +60703,7 @@ entities:
       deviceLists:
       - 69
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8887
     components:
     - type: Transform
@@ -60661,7 +60756,7 @@ entities:
       deviceLists:
       - 72
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8892
     components:
     - type: Transform
@@ -60671,7 +60766,7 @@ entities:
       deviceLists:
       - 73
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
   - uid: 8893
     components:
     - type: Transform
@@ -60681,7 +60776,20 @@ entities:
       deviceLists:
       - 10
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#0055CCFF'
+  - uid: 9924
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,44.5
+      parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 15089
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
   - uid: 8894
@@ -60694,7 +60802,7 @@ entities:
       deviceLists:
       - 70
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8895
     components:
     - type: Transform
@@ -60705,7 +60813,7 @@ entities:
       deviceLists:
       - 17
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8896
     components:
     - type: Transform
@@ -60713,7 +60821,7 @@ entities:
       pos: 10.5,-41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8897
     components:
     - type: Transform
@@ -60724,7 +60832,7 @@ entities:
       deviceLists:
       - 70
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8898
     components:
     - type: Transform
@@ -60735,7 +60843,7 @@ entities:
       deviceLists:
       - 61
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8899
     components:
     - type: Transform
@@ -60751,7 +60859,7 @@ entities:
       deviceLists:
       - 55
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8901
     components:
     - type: Transform
@@ -60762,7 +60870,7 @@ entities:
       deviceLists:
       - 11
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8902
     components:
     - type: Transform
@@ -60773,7 +60881,7 @@ entities:
       deviceLists:
       - 52
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8903
     components:
     - type: Transform
@@ -60783,7 +60891,7 @@ entities:
       deviceLists:
       - 68
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8904
     components:
     - type: Transform
@@ -60794,7 +60902,7 @@ entities:
       deviceLists:
       - 13
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8905
     components:
     - type: Transform
@@ -60802,7 +60910,7 @@ entities:
       pos: 22.5,-38.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8906
     components:
     - type: Transform
@@ -60812,7 +60920,7 @@ entities:
       deviceLists:
       - 47
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8907
     components:
     - type: Transform
@@ -60820,7 +60928,7 @@ entities:
       pos: 26.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8908
     components:
     - type: Transform
@@ -60830,7 +60938,7 @@ entities:
       deviceLists:
       - 24
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8909
     components:
     - type: Transform
@@ -60841,7 +60949,7 @@ entities:
       deviceLists:
       - 25
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8910
     components:
     - type: Transform
@@ -60852,7 +60960,7 @@ entities:
       deviceLists:
       - 27
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8911
     components:
     - type: Transform
@@ -60863,7 +60971,7 @@ entities:
       deviceLists:
       - 26
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8912
     components:
     - type: Transform
@@ -60874,7 +60982,7 @@ entities:
       deviceLists:
       - 26
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8913
     components:
     - type: Transform
@@ -60882,7 +60990,7 @@ entities:
       pos: 29.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8914
     components:
     - type: Transform
@@ -60895,7 +61003,7 @@ entities:
       - 6798
       - 22
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8915
     components:
     - type: Transform
@@ -60906,7 +61014,7 @@ entities:
       deviceLists:
       - 16
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8916
     components:
     - type: Transform
@@ -60917,7 +61025,7 @@ entities:
       deviceLists:
       - 44
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8917
     components:
     - type: Transform
@@ -60928,7 +61036,7 @@ entities:
       deviceLists:
       - 16
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8918
     components:
     - type: Transform
@@ -60938,7 +61046,7 @@ entities:
       deviceLists:
       - 30
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8919
     components:
     - type: Transform
@@ -60949,7 +61057,7 @@ entities:
       deviceLists:
       - 28
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8920
     components:
     - type: Transform
@@ -60960,7 +61068,7 @@ entities:
       deviceLists:
       - 15
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8921
     components:
     - type: Transform
@@ -60971,7 +61079,7 @@ entities:
       deviceLists:
       - 51
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8922
     components:
     - type: Transform
@@ -60982,7 +61090,7 @@ entities:
       deviceLists:
       - 29
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8923
     components:
     - type: Transform
@@ -60993,7 +61101,7 @@ entities:
       deviceLists:
       - 42
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8924
     components:
     - type: Transform
@@ -61004,7 +61112,7 @@ entities:
       deviceLists:
       - 20
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8925
     components:
     - type: Transform
@@ -61015,7 +61123,7 @@ entities:
       deviceLists:
       - 29
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8926
     components:
     - type: Transform
@@ -61026,7 +61134,7 @@ entities:
       deviceLists:
       - 36
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8927
     components:
     - type: Transform
@@ -61036,7 +61144,7 @@ entities:
       deviceLists:
       - 10
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8928
     components:
     - type: Transform
@@ -61046,7 +61154,7 @@ entities:
       deviceLists:
       - 74
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8929
     components:
     - type: Transform
@@ -61056,7 +61164,7 @@ entities:
       deviceLists:
       - 43
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8930
     components:
     - type: Transform
@@ -61067,7 +61175,7 @@ entities:
       deviceLists:
       - 61
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8931
     components:
     - type: Transform
@@ -61075,7 +61183,7 @@ entities:
       pos: 43.5,23.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8932
     components:
     - type: Transform
@@ -61086,14 +61194,14 @@ entities:
       deviceLists:
       - 62
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8933
     components:
     - type: Transform
       pos: 40.5,26.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8934
     components:
     - type: Transform
@@ -61104,7 +61212,7 @@ entities:
       deviceLists:
       - 61
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8935
     components:
     - type: Transform
@@ -61114,7 +61222,7 @@ entities:
       deviceLists:
       - 63
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8936
     components:
     - type: Transform
@@ -61125,7 +61233,7 @@ entities:
       deviceLists:
       - 43
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8937
     components:
     - type: Transform
@@ -61136,7 +61244,7 @@ entities:
       deviceLists:
       - 53
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8938
     components:
     - type: Transform
@@ -61146,7 +61254,7 @@ entities:
       deviceLists:
       - 64
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8939
     components:
     - type: Transform
@@ -61154,7 +61262,7 @@ entities:
       pos: 22.5,41.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8940
     components:
     - type: Transform
@@ -61165,7 +61273,7 @@ entities:
       deviceLists:
       - 65
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8941
     components:
     - type: Transform
@@ -61176,7 +61284,7 @@ entities:
       deviceLists:
       - 31
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8942
     components:
     - type: Transform
@@ -61186,7 +61294,7 @@ entities:
       deviceLists:
       - 32
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8943
     components:
     - type: Transform
@@ -61197,7 +61305,7 @@ entities:
       deviceLists:
       - 46
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8944
     components:
     - type: Transform
@@ -61205,7 +61313,7 @@ entities:
       pos: -0.5,-3.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8945
     components:
     - type: Transform
@@ -61216,7 +61324,7 @@ entities:
       deviceLists:
       - 33
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8946
     components:
     - type: Transform
@@ -61227,7 +61335,7 @@ entities:
       deviceLists:
       - 34
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8947
     components:
     - type: Transform
@@ -61238,7 +61346,7 @@ entities:
       deviceLists:
       - 35
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8948
     components:
     - type: Transform
@@ -61249,7 +61357,7 @@ entities:
       deviceLists:
       - 37
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8949
     components:
     - type: Transform
@@ -61257,7 +61365,7 @@ entities:
       pos: 29.5,-28.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8950
     components:
     - type: Transform
@@ -61267,7 +61375,7 @@ entities:
       deviceLists:
       - 38
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8951
     components:
     - type: Transform
@@ -61278,7 +61386,7 @@ entities:
       deviceLists:
       - 56
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8952
     components:
     - type: Transform
@@ -61289,7 +61397,7 @@ entities:
       deviceLists:
       - 66
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8953
     components:
     - type: Transform
@@ -61300,7 +61408,7 @@ entities:
       deviceLists:
       - 21
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8954
     components:
     - type: Transform
@@ -61311,7 +61419,7 @@ entities:
       deviceLists:
       - 14
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8955
     components:
     - type: Transform
@@ -61322,7 +61430,7 @@ entities:
       deviceLists:
       - 67
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8956
     components:
     - type: Transform
@@ -61333,7 +61441,7 @@ entities:
       deviceLists:
       - 23
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8957
     components:
     - type: Transform
@@ -61343,7 +61451,7 @@ entities:
       deviceLists:
       - 12
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8958
     components:
     - type: Transform
@@ -61354,7 +61462,7 @@ entities:
       deviceLists:
       - 39
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8959
     components:
     - type: Transform
@@ -61365,7 +61473,7 @@ entities:
       deviceLists:
       - 19
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8960
     components:
     - type: Transform
@@ -61376,7 +61484,7 @@ entities:
       deviceLists:
       - 40
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8961
     components:
     - type: Transform
@@ -61387,7 +61495,7 @@ entities:
       deviceLists:
       - 49
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8962
     components:
     - type: Transform
@@ -61398,7 +61506,7 @@ entities:
       deviceLists:
       - 45
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8963
     components:
     - type: Transform
@@ -61406,7 +61514,7 @@ entities:
       pos: 67.5,-1.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8964
     components:
     - type: Transform
@@ -61417,7 +61525,7 @@ entities:
       deviceLists:
       - 58
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8965
     components:
     - type: Transform
@@ -61428,14 +61536,14 @@ entities:
       deviceLists:
       - 57
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8966
     components:
     - type: Transform
       pos: 60.5,-4.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8967
     components:
     - type: Transform
@@ -61443,7 +61551,7 @@ entities:
       pos: 60.5,-10.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8968
     components:
     - type: Transform
@@ -61453,7 +61561,7 @@ entities:
       deviceLists:
       - 48
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8969
     components:
     - type: Transform
@@ -61463,7 +61571,7 @@ entities:
       deviceLists:
       - 60
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8970
     components:
     - type: Transform
@@ -61474,7 +61582,7 @@ entities:
       deviceLists:
       - 68
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8971
     components:
     - type: Transform
@@ -61485,7 +61593,7 @@ entities:
       deviceLists:
       - 20
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8972
     components:
     - type: Transform
@@ -61496,7 +61604,7 @@ entities:
       deviceLists:
       - 69
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8973
     components:
     - type: Transform
@@ -61507,7 +61615,7 @@ entities:
       deviceLists:
       - 69
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8974
     components:
     - type: Transform
@@ -61518,7 +61626,7 @@ entities:
       deviceLists:
       - 69
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8975
     components:
     - type: Transform
@@ -61582,7 +61690,7 @@ entities:
       deviceLists:
       - 73
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8981
     components:
     - type: Transform
@@ -61593,7 +61701,7 @@ entities:
       deviceLists:
       - 10
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
   - uid: 8982
     components:
     - type: Transform
@@ -61604,7 +61712,20 @@ entities:
       deviceLists:
       - 28
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#990000FF'
+  - uid: 9923
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,45.5
+      parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 15089
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasVolumePump
   entities:
   - uid: 8983
@@ -61698,6 +61819,21 @@ entities:
       parent: 2
 - proto: Grille
   entities:
+  - uid: 5645
+    components:
+    - type: Transform
+      pos: 14.5,47.5
+      parent: 2
+  - uid: 5646
+    components:
+    - type: Transform
+      pos: 15.5,47.5
+      parent: 2
+  - uid: 5647
+    components:
+    - type: Transform
+      pos: 16.5,47.5
+      parent: 2
   - uid: 8997
     components:
     - type: Transform
@@ -62621,16 +62757,6 @@ entities:
     components:
     - type: Transform
       pos: 36.5,46.5
-      parent: 2
-  - uid: 9179
-    components:
-    - type: Transform
-      pos: 18.5,44.5
-      parent: 2
-  - uid: 9180
-    components:
-    - type: Transform
-      pos: 18.5,45.5
       parent: 2
   - uid: 9181
     components:
@@ -65404,21 +65530,6 @@ entities:
     - type: Transform
       pos: 88.5,38.5
       parent: 2
-  - uid: 9723
-    components:
-    - type: Transform
-      pos: 15.5,47.5
-      parent: 2
-  - uid: 9724
-    components:
-    - type: Transform
-      pos: 14.5,47.5
-      parent: 2
-  - uid: 9725
-    components:
-    - type: Transform
-      pos: 13.5,47.5
-      parent: 2
   - uid: 9726
     components:
     - type: Transform
@@ -66470,18 +66581,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 12.5,45.5
       parent: 2
-  - uid: 9923
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 15.5,45.5
-      parent: 2
-  - uid: 9924
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,45.5
-      parent: 2
   - uid: 9925
     components:
     - type: Transform
@@ -66765,12 +66864,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 2.5,43.5
       parent: 2
-  - uid: 9977
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,45.5
-      parent: 2
   - uid: 9978
     components:
     - type: Transform
@@ -66779,11 +66872,6 @@ entities:
       parent: 2
 - proto: GrilleSpawner
   entities:
-  - uid: 9979
-    components:
-    - type: Transform
-      pos: 16.5,47.5
-      parent: 2
   - uid: 9980
     components:
     - type: Transform
@@ -66868,11 +66956,6 @@ entities:
     components:
     - type: Transform
       pos: -23.5,2.5
-      parent: 2
-  - uid: 9997
-    components:
-    - type: Transform
-      pos: 13.5,45.5
       parent: 2
   - uid: 9998
     components:
@@ -69647,13 +69730,20 @@ entities:
     - type: Transform
       pos: 29.477802,5.1889386
       parent: 2
-- proto: PottedPlant22
+- proto: PottedPlant21
   entities:
-  - uid: 10438
+  - uid: 5674
     components:
     - type: Transform
-      pos: 19.5,44.5
+      anchored: True
+      pos: 14.5,43.5
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      bodyType: Static
+- proto: PottedPlant22
+  entities:
   - uid: 10439
     components:
     - type: Transform
@@ -69978,6 +70068,18 @@ entities:
       parent: 2
 - proto: Poweredlight
   entities:
+  - uid: 9724
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,45.5
+      parent: 2
+  - uid: 9725
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,45.5
+      parent: 2
   - uid: 10480
     components:
     - type: Transform
@@ -73169,6 +73271,21 @@ entities:
       parent: 2
 - proto: ReinforcedWindow
   entities:
+  - uid: 5635
+    components:
+    - type: Transform
+      pos: 15.5,47.5
+      parent: 2
+  - uid: 5637
+    components:
+    - type: Transform
+      pos: 14.5,47.5
+      parent: 2
+  - uid: 5644
+    components:
+    - type: Transform
+      pos: 16.5,47.5
+      parent: 2
   - uid: 10840
     components:
     - type: Transform
@@ -74076,16 +74193,6 @@ entities:
     components:
     - type: Transform
       pos: 36.5,45.5
-      parent: 2
-  - uid: 11159
-    components:
-    - type: Transform
-      pos: 18.5,45.5
-      parent: 2
-  - uid: 11160
-    components:
-    - type: Transform
-      pos: 18.5,44.5
       parent: 2
   - uid: 11161
     components:
@@ -78845,6 +78952,11 @@ entities:
     - type: Transform
       pos: 33.5,40.5
       parent: 2
+  - uid: 15091
+    components:
+    - type: Transform
+      pos: 15.5,45.5
+      parent: 2
 - proto: SpawnPointBorg
   entities:
   - uid: 11963
@@ -79067,6 +79179,11 @@ entities:
     components:
     - type: Transform
       pos: 33.5,40.5
+      parent: 2
+  - uid: 15090
+    components:
+    - type: Transform
+      pos: 16.5,45.5
       parent: 2
 - proto: SpawnPointObserver
   entities:
@@ -80028,6 +80145,17 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Gravity Generator
+  - uid: 15098
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,46.5
+      parent: 2
+    - type: SurveillanceCamera
+      setupAvailableNetworks:
+      - SurveillanceCameraCommand
+      nameSet: True
+      id: Centcomm Office
 - proto: SurveillanceCameraEngineering
   entities:
   - uid: 12141
@@ -82090,6 +82218,13 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 19.5,-9.5
       parent: 2
+- proto: TableFancyGreen
+  entities:
+  - uid: 5671
+    components:
+    - type: Transform
+      pos: 15.5,43.5
+      parent: 2
 - proto: TableGlass
   entities:
   - uid: 12425
@@ -83361,6 +83496,34 @@ entities:
     - type: Transform
       pos: 20.5,-4.5
       parent: 2
+- proto: UniqueLockerBlueshieldOfficerFilled
+  entities:
+  - uid: 5666
+    components:
+    - type: Transform
+      anchored: True
+      pos: 14.5,44.5
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      bodyType: Static
+    - type: Pullable
+      prevFixedRotation: True
+- proto: UniqueLockerNanorepFilled
+  entities:
+  - uid: 5668
+    components:
+    - type: Transform
+      anchored: True
+      pos: 16.5,43.5
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      bodyType: Static
+    - type: Pullable
+      prevFixedRotation: True
 - proto: Vaccinator
   entities:
   - uid: 12594
@@ -83841,6 +84004,42 @@ entities:
     components:
     - type: Transform
       pos: 3.5,38.5
+      parent: 2
+  - uid: 5632
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,45.5
+      parent: 2
+  - uid: 5633
+    components:
+    - type: Transform
+      pos: 13.5,47.5
+      parent: 2
+  - uid: 5634
+    components:
+    - type: Transform
+      pos: 17.5,47.5
+      parent: 2
+  - uid: 5636
+    components:
+    - type: Transform
+      pos: 13.5,45.5
+      parent: 2
+  - uid: 5638
+    components:
+    - type: Transform
+      pos: 13.5,44.5
+      parent: 2
+  - uid: 5639
+    components:
+    - type: Transform
+      pos: 13.5,46.5
+      parent: 2
+  - uid: 5643
+    components:
+    - type: Transform
+      pos: 13.5,43.5
       parent: 2
   - uid: 12661
     components:

--- a/Resources/Maps/_Goobstation/packed.yml
+++ b/Resources/Maps/_Goobstation/packed.yml
@@ -47004,9 +47004,6 @@ entities:
     - type: Transform
       pos: 15.503757,43.600956
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: FoodTinBeansTrash
   entities:
   - uid: 7114
@@ -61716,7 +61713,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 15.5,45.5
       parent: 2
-      deviceLists:
       - 15089
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -69729,12 +69725,8 @@ entities:
   - uid: 5674
     components:
     - type: Transform
-      anchored: True
       pos: 14.5,43.5
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
 - proto: PottedPlant22
   entities:
@@ -83495,29 +83487,17 @@ entities:
   - uid: 5666
     components:
     - type: Transform
-      anchored: True
       pos: 14.5,44.5
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
-    - type: Pullable
-      prevFixedRotation: True
 - proto: UniqueLockerNanorepFilled
   entities:
   - uid: 5668
     components:
     - type: Transform
-      anchored: True
       pos: 16.5,43.5
       parent: 2
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
       bodyType: Static
-    - type: Pullable
-      prevFixedRotation: True
 - proto: Vaccinator
   entities:
   - uid: 12594

--- a/Resources/Maps/_Goobstation/packed.yml
+++ b/Resources/Maps/_Goobstation/packed.yml
@@ -60783,9 +60783,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 16.5,44.5
       parent: 2
-    - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 15089
     - type: AtmosPipeColor
@@ -61719,9 +61716,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 15.5,45.5
       parent: 2
-    - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 15089
     - type: AtmosPipeColor

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -18,7 +18,6 @@
         - type: StationJobs
           availableJobs:
             #service
-            # Goobstation - TODO: add bso and ntr, Done by Yours Truly, Sol
             Captain: [ 1, 1 ]
             NanotrasenRepresentative: [ 1, 1 ] # Goobstation
             BlueshieldOfficer: [ 1, 1 ] # Goobstation

--- a/Resources/Prototypes/Maps/marathon.yml
+++ b/Resources/Prototypes/Maps/marathon.yml
@@ -18,8 +18,10 @@
         - type: StationJobs
           availableJobs:
             #service
-            # Goobstation - TODO: add bso and ntr
+            # Goobstation - TODO: add bso and ntr, Done by Yours Truly, Sol
             Captain: [ 1, 1 ]
+            NanotrasenRepresentative: [ 1, 1 ] # Goobstation
+            BlueshieldOfficer: [ 1, 1 ] # Goobstation
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 3 ]

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -18,7 +18,6 @@
         - type: StationJobs
           availableJobs:
             #service
-            # Goobstation - TODO: add bso and ntr, Done by Yours Truly, Sol
             Captain: [ 1, 1 ]
             NanotrasenRepresentative: [ 1, 1 ] # Goobstation
             BlueshieldOfficer: [ 1, 1 ] # Goobstation

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -18,8 +18,10 @@
         - type: StationJobs
           availableJobs:
             #service
-            # Goobstation - TODO: add bso and ntr
+            # Goobstation - TODO: add bso and ntr, Done by Yours Truly, Sol
             Captain: [ 1, 1 ]
+            NanotrasenRepresentative: [ 1, 1 ] # Goobstation
+            BlueshieldOfficer: [ 1, 1 ] # Goobstation
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -20,8 +20,8 @@
             #service
             # Goobstation - TODO: add bso and ntr - Done by yours truly, Sol.
             Captain: [ 1, 1 ]
-            NanotrasenRepresentative: [ 1, 1 ]
-            BlueshieldOfficer: [ 1, 1 ]
+            NanotrasenRepresentative: [ 1, 1 ] # Goobstation
+            BlueshieldOfficer: [ 1, 1 ] # Goobstation
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 1, 2 ]

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -18,7 +18,6 @@
         - type: StationJobs
           availableJobs:
             #service
-            # Goobstation - TODO: add bso and ntr - Done by yours truly, Sol.
             Captain: [ 1, 1 ]
             NanotrasenRepresentative: [ 1, 1 ] # Goobstation
             BlueshieldOfficer: [ 1, 1 ] # Goobstation

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -18,8 +18,10 @@
         - type: StationJobs
           availableJobs:
             #service
-            # Goobstation - TODO: add bso and ntr
+            # Goobstation - TODO: add bso and ntr - Done by yours truly, Sol.
             Captain: [ 1, 1 ]
+            NanotrasenRepresentative: [ 1, 1 ]
+            BlueshieldOfficer: [ 1, 1 ]
             HeadOfPersonnel: [ 1, 1 ]
             Bartender: [ 1, 1 ]
             Botanist: [ 1, 2 ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Mapped BSO & NTR rooms onto packed, marathon, and omega.
I also mapped holopads onto marathon because I felt like it.

## Why / Balance
Twas in the TODO.
I was bored and in a mapping mood.

## Technical details
Map changes!

## Media
Marathon
![image](https://github.com/user-attachments/assets/05e0010e-5124-456d-b106-963eee8c49d7)
Omega
![image](https://github.com/user-attachments/assets/4ab5dba4-bc39-4d35-a8e5-fd87c1ae16ad)
Packed
![image](https://github.com/user-attachments/assets/9283f7b6-2ba3-41f7-a29e-426a06c0c17c)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Mapped BSO & NTR into Marathon, Packed, and Omega.
- add: Marathon now has holopads.
