### PR TITLE
PKA shotty & fire-rate upgrade nerf & range upgrade buff

### DIFF
--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Basic/pka.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Basic/pka.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: proto-kinetic shotgun
   id: WeaponProtoKineticShotgun
-  parent: [WeaponProtoKineticAcceleratorBase, BaseCargoContraband]
+  parent: [WeaponProtoKineticAcceleratorBase, BaseGunWieldable, BaseCargoContraband]
   description: Fires a spread of low-damage kinetic bolts.
   components:
   - type: Sprite
@@ -34,6 +34,10 @@
     whitelist:
       tags:
       - PKAUpgrade
+  - type: GunWieldBonus
+    minAngle: 0
+    maxAngle: 0
+  - type: GunRequiresWield
   - type: Item
     shape:
     - 0,0,4,0

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -44,5 +44,5 @@
   components:
   - type: ProjectileSpread
     proto: PelletKinetic
-    count: 4
+    count: 3
     spread: 40

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/pka_upgrade.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/pka_upgrade.yml
@@ -55,6 +55,7 @@
       color: "#1373eb"
   - type: GunUpgrade
     tags: [ GunUpgradeRange ]
+    capacityCost: 20
     examineText: gun-upgrade-examine-text-range
   - type: GunUpgradeSpeed
     coefficient: 1.5
@@ -75,7 +76,7 @@
       color: "#9bf134"
   - type: GunUpgrade
     tags: [ GunUpgradeReloadSpeed ]
-    capacityCost: 20
+    capacityCost: 40
     examineText: gun-upgrade-examine-text-reload
   - type: GunUpgradeFireRate
     coefficient: 1.5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
PKA shotty fires 3 shots instead of 4
PKA shotty requires wielding to fire
Fire-rate upgrade costs 40 space instead of 20
Range upgrade takes 20 storage instead of 30

## Why / Balance
i got bribed with 500 goob bucks (it was also like objectively the best PKA in the game)

## Technical details
yaml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: the_biggestbruh
- tweak: Proto-kinetic shotgun fires 3 shots (instead of 4)
- tweak: Proto-kinetic shotgun now requires wielding to fire
- tweak: PKA fire-rate upgrades now require 40 storage instead of 20
- tweak: PKA range upgrades now take up 20 space instead of 30