### PR TITLE
make bluespace crystals cheaper

### DIFF
--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/sheet.yml
@@ -3,5 +3,5 @@
   result: MaterialBSCrystal1
   completetime: 2
   materials:
-    Diamond: 100
-    Plasma: 50
+    Diamond: 20
+    Plasma: 100


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
now 0.2 diamond and 1 plasma, down from 1 and 0.5

## Why / Balance
diamonds are very rare, a whole diamond for a bsc is a scam

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Bluespace crystal recipe is now 0.2 diamond and 1 plasma.
