### PR TITLE
move bso weapon box to the locker

### DIFF
--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
@@ -29,7 +29,7 @@
     children:
     - id: DefibrillatorCompact
     - id: MedkitBSOFilled
-    - id: MedkitBSOIPCFilled # Still don't know how I feel about this.
+    - id: MedkitBSOIPCFilled
     - id: FlippoLighterBlueshield
     - id: CigPackBlueshield
     - id: BoxZiptie
@@ -37,8 +37,9 @@
     - id: NitrogenTankFilled
     - id: ClothingHeadHelmetSwat
     - id: BlueshieldUndeterminedHardsuit
-    - id: ClothingBackpackDuffelSurgeryFilled # Or this.
-    - id: BoxTracker # ehhh maybe?
+    - id: ClothingBackpackDuffelSurgeryFilled
+    - id: BoxTracker
+    - id: BlueshieldUndeterminedWeapon
 
 - type: entity
   id: LockerBlueshieldOfficerFilled

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -56,6 +56,5 @@
   storage:
     back:
     - Flash
-    - ClothingMaskGasSecurity
     - SecHypo
-    - BlueshieldUndeterminedWeapon
+    - ClothingMaskGasSecurity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
bso no longer spawn with their weapon box, it is found in their locker instead
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bso goes to cryo - another latejoins - picks new weapons. while getting a choice is good, this results in more bso weaponry on the station than intended.
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!---->
:cl: pheenty
- tweak: BSO weaponry box is now in the BSO's locker instead of being given at spawn.

