### PR TITLE
Bingle pit spawn on action

### DIFF
--- a/Content.Server/_Goobstation/Bingle/BingleSystem.cs
+++ b/Content.Server/_Goobstation/Bingle/BingleSystem.cs
@@ -7,8 +7,11 @@ using Content.Shared._White.Overlays;
 using Content.Server.Flash.Components;
 using Content.Server.Polymorph.Components;
 using Content.Server.Polymorph.Systems;
+using Content.Shared.Actions;
 using Content.Shared.CombatMode;
+using Content.Shared.Gravity;
 using Robust.Server.GameObjects;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server._Goobstation.Bingle;
 
@@ -17,32 +20,14 @@ public sealed class BingleSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly PolymorphSystem _polymorph = default!;
     [Dependency] private readonly AppearanceSystem _appearance = default!;
+    [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<BingleComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<BingleComponent, AttackAttemptEvent>(OnAttackAttempt);
         SubscribeLocalEvent<BingleComponent, ToggleNightVisionEvent>(OnNightvision);
         SubscribeLocalEvent<BingleComponent, ToggleCombatActionEvent>(OnCombatToggle);
-    }
-
-    private void OnMapInit(EntityUid uid, BingleComponent component, MapInitEvent args)
-    {
-        var cords = Transform(uid).Coordinates;
-        if (!cords.IsValid(EntityManager) || cords.Position == Vector2.Zero)
-            return;
-        if (MapId.Nullspace == Transform(uid).MapID)
-            return;
-
-        if (component.Prime)
-            component.MyPit = Spawn("BinglePit", cords);
-        else
-        {
-            var query = EntityQueryEnumerator<BinglePitComponent>();
-            while (query.MoveNext(out var queryUid, out var _))
-                if (cords == Transform(queryUid).Coordinates)
-                    component.MyPit = queryUid;
-        }
+        SubscribeLocalEvent<BingleComponent, SpawnBinglePitActionEvent>(OnSpawnBinglePitAction);
     }
 
     //ran by the pit to upgrade bingle damage
@@ -78,6 +63,51 @@ public sealed class BingleSystem : EntitySystem
         if (!TryComp<CombatModeComponent>(uid, out var combat))
             return;
         _appearance.SetData(uid, BingleVisual.Combat, combat.IsInCombatMode);
+    }
+
+    public void OnSpawnBinglePitAction(EntityUid uid, BingleComponent component, SpawnBinglePitActionEvent args)
+    {
+        var cords = Transform(uid).Coordinates;
+        var grid = Transform(uid).GridUid;
+
+        //check if tile is valid
+        if (!cords.IsValid(EntityManager) || grid == null)
+        {       _popup.PopupEntity(Loc.GetString("bingle-cant-spawn-pit-here"), uid, uid);
+                return; //you are in space and not on a grid.
+        }
+
+        if (TryComp<GravityComponent>(grid, out var gravityComp) && !gravityComp.Enabled)
+        {
+            _popup.PopupEntity(Loc.GetString("bingle-cant-spawn-no-gravity"), uid, uid);
+            return; //Gravity is off
+        }
+
+
+        // check there is no bingle pit on tile
+        var query = EntityQueryEnumerator<BinglePitComponent>();
+        while (query.MoveNext(out var queryUid, out var pitcomp))
+        {
+            if (Transform(queryUid).Coordinates.Position == cords.Position)
+            {
+                _popup.PopupEntity(Loc.GetString("bingle-cant-spawn-to-close"), uid, uid);
+                return; // some pit has the same cord as this so cancel the action
+            }
+        }
+
+        // Spawn pit
+        // add pit as this bingles pit
+        var pit = Spawn("BinglePit", cords);
+        component.MyPit = pit;
+        _popup.PopupEntity(Loc.GetString("bingle-spawn-pit"), uid, uid);
+
+        // remove action
+        foreach (var ( actionId, comp ) in _actionsSystem.GetActions(uid))
+        {
+            if (!TryComp(actionId, out MetaDataComponent? metaData))
+                continue;
+            if (metaData.EntityPrototype != null && metaData.EntityPrototype == (EntProtoId)"ActionSpawnBinglePit")
+                _actionsSystem.RemoveAction(actionId);
+        }
     }
 }
 

--- a/Content.Shared/_Goobstation/Bingle/BingleComponent.cs
+++ b/Content.Shared/_Goobstation/Bingle/BingleComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Actions;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 using Content.Shared.Damage;
@@ -21,4 +22,9 @@ public enum BingleVisual : byte
 {
     Upgraded,
     Combat
+}
+
+public sealed partial class SpawnBinglePitActionEvent : InstantActionEvent
+{
+
 }

--- a/Resources/Locale/en-US/_Goobstation/bingle/bingle.ftl
+++ b/Resources/Locale/en-US/_Goobstation/bingle/bingle.ftl
@@ -19,4 +19,9 @@ ghost-role-information-bingle-description = The Pit is love. The Pit is life. Th
 bingle-upgrade-success = You feel stronger
 bingle-pit-grow =  The pit grows larger
 
-bingle-pit-end-of-round = The Binglepit near {$location} grew to level {$level} and collected {$points} Bingle points
+bingle-pit-end-of-round = The Binglepit near {$location} grew to level [color=teal]{$level}[/color] and collected [color=teal]{$points}[/color] Bingle points
+
+bingle-cant-spawn-pit-here = Not on a grid this is not a good spot for a pit
+bingle-cant-spawn-no-gravity = No gravity need to find a better spot
+bingle-cant-spawn-to-close = to close to another pit
+bingle-spawn-pit = The pit must grow!

--- a/Resources/Prototypes/_Goobstation/Actions/bingle.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/bingle.yml
@@ -1,0 +1,10 @@
+- type: entity
+  id: ActionSpawnBinglePit
+  name: spawn bingle pit
+  description: spawn a pit on your location
+  components:
+  - type: InstantAction
+    icon:
+      sprite: _Goobstation/Mobs/Bingle/bingle.rsi
+      state: pit
+    event: !type:SpawnBinglePitActionEvent

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
@@ -100,6 +100,9 @@
   components:
   - type: Bingle
     prime: true
+  - type: ActionGrant
+    actions:
+    - ActionSpawnBinglePit
 
 - type: entity
   id: MobBingleUpgraded


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
change the bingle pit to spawn on action.
the bingle prime gets an action that spawns a pit, giving the bingle a choise on where to spawn the pit.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Fishbait
- tweak:  The bingle pit now gets spawed by an action insted of where the bingle prime spawns