### PR TITLE
salvaging

### DIFF
--- a/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
@@ -39,6 +39,8 @@
     cost: 750
   - id: WeaponProtoKineticAccelerator
     cost: 750
+  - id: SpaceCash5000
+    cost: 750
   - id: SurvivalMedipen
     cost: 800
   - id: Fulton
@@ -74,9 +76,9 @@
     cost: 1600
   - id: WeaponPlasmaCutter
     cost: 1700
-  - id: SpaceCash1000
-    cost: 2000
   - id: ShelterCapsule
+    cost: 2000
+  - id: OreBagOfHolding
     cost: 2000
   # TODO: super resonator for 2500
   # TODO: jump boots for 2500


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
added ore bag of holding to salvage for 2000 points, also reduced point cost for spesos and increased the spesos amount to 5000 for 750 points

## Why / Balance
i havent seen a single person buy spesos with mining points, this tries to convince people to use this more

ore bag of holding is shrimple quality of life, no more carrying multiple ore bags or tedious moving ores from ore crate to refiner 

## Technical details
simple yaml, untested but should work :clueless:


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have not read and i am not following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added not media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Vlax
- add: added ore bag of holding to salvage vendor for 2000 points
- tweak: increased spesos from 2k to 5k in salvage vendor while reducing the point cost to 750
