### PR TITLE
partially revert disabler/batong buffs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -502,12 +502,12 @@
     price: 100
   - type: Gun
     fireRate: 2
-    projectileSpeed: 35 # any higher and this causes issues in lag
+    #projectileSpeed: 35 # Goobstation - nuh uh
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisablerPractice
-    fireCost: 50
+    fireCost: 25 # Goobstation - billions must troll with practice disabler
   - type: Tag
     tags:
     - Taser

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -14,7 +14,6 @@
       map: [ "enum.ToggleVisuals.Layer" ]
   - type: Stunbaton
     energyPerUse: 50
-    lightAttackEnergyMultiplier: 2 # Goob edit
   - type: ItemToggle
     predictable: false
     soundActivate:
@@ -45,26 +44,16 @@
   - type: StaminaDamageOnHit # goob edited
     damage: 15
     overtime: 40
-    lightAttackDamageMultiplier: 4
-    lightAttackOvertimeDamageMultiplier: 0
     sound: /Audio/Weapons/egloves.ogg
   - type: StaminaDamageOnCollide # goob edited
     damage: 15
     overtime: 40
     sound: /Audio/Weapons/egloves.ogg
-  - type: DelayedKnockdownOnHit # Goobstation
-    useDelay: stunbaton
-  - type: UseDelayBlockMelee # Goobstation
-    delays:
-    - stunbaton
   - type: LandAtCursor # it deals stamina damage when thrown
   - type: Battery
     maxCharge: 1000
     startingCharge: 1000
   - type: UseDelay
-    delays: # Goobstation
-      stunbaton:
-        length: 2.5
   - type: Item
     heldPrefix: off
     size: Normal

--- a/Resources/ServerInfo/Guidebook/Security/Security.xml
+++ b/Resources/ServerInfo/Guidebook/Security/Security.xml
@@ -17,7 +17,6 @@ They face [textlink="Syndicate Agents" link="Traitors"], [textlink="Nuclear Oper
 ## Gear
 First we have non-lethals a step above simply telling someone to cooperate with instructions. Both the stunbaton and disabler are capable of limiting the movement of an assailant, whereas handcuffs can be applied to deny a criminal free movement and access to their hands.
 
-Stunbaton operates differently depending on attack type. On light attack ([color=yellow]Left click[/color]) it deals 60 immediate stamina damage and knocks target down for 4 seconds after 2 second delay, these values are can be modified or cancelled entirely by armor and stimulants. Light attacks are delayed by 2.5 seconds and consume twice as much battery power. Heavy attacks ([color=yellow]Right click[/color]) deal 15 immediate stamina damage and 40 overtime stamina damage, which soft-crits the target after 2 hits when overtime stamina damage reaches stamcrit threshold (100 stamina damage for most species). Soft stamina crit still allows the target to crawl, but any immediate stamina damage will stamcrit them, allowing them to be cuffed. To stun your target using heavy stunbaton attack, you need to either hit them twice, then wait a while until they are knocked down and hit them once more to fully stamcrit them, or hit them four times in quick succession.
   <Box>
     <GuideEntityEmbed Entity="Stunbaton"/>
     <GuideEntityEmbed Entity="Handcuffs"/>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- remove baton delayed knockdown, make click behavior same as wideswing
- revert disabler projectile speed buff, keep other buffs
- halve practice disabler fire cost

## Why / Balance
nonlethals are way too overtuned, sec main PR makers can't fathom having to pick up a gun and actually shoot the antag as opposed to click with baton once
no more clicking people once to down them

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Stun baton delayed knockdown.
- tweak: Disabler projectile speed buff reverted.
