### PR TITLE
Removing fin-ops cache

### DIFF
--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -694,6 +694,19 @@ namespace Content.Server.Database
             await db.DbContext.SaveChangesAsync();
         }
 
+        public async Task<int> ModifyServerCurrency(NetUserId userId, int currencyDelta) // Goobstation
+        {
+            await using var db = await GetDb();
+
+            var dbPlayer = await db.DbContext.Player.Where(dbPlayer => dbPlayer.UserId == userId).SingleOrDefaultAsync();
+            if (dbPlayer == null)
+                return currencyDelta;
+
+            dbPlayer.ServerCurrency += currencyDelta;
+            await db.DbContext.SaveChangesAsync();
+            return dbPlayer.ServerCurrency;
+        }
+
         #endregion
 
         #region Connection Logs

--- a/Content.Server/Database/ServerDbManager.cs
+++ b/Content.Server/Database/ServerDbManager.cs
@@ -191,6 +191,7 @@ namespace Content.Server.Database
         Task<PlayerRecord?> GetPlayerRecordByUserId(NetUserId userId, CancellationToken cancel = default);
         Task<int> GetServerCurrency(NetUserId userId); // Goobstation
         Task SetServerCurrency(NetUserId userId, int currency); // Goobstation
+        Task<int> ModifyServerCurrency(NetUserId userId, int currencyDelta); // Goobstation
         #endregion
 
         #region Connection Logs
@@ -674,6 +675,11 @@ namespace Content.Server.Database
             return RunDbCommand(() => _db.SetServerCurrency(userId, currency));
         }
 
+        public Task<int> ModifyServerCurrency(NetUserId userId, int currencyDelta) // Goobstation
+        {
+            DbReadOpsMetric.Inc();
+            return RunDbCommand(() => _db.ModifyServerCurrency(userId, currencyDelta));
+        }
 
         public Task<int> AddConnectionLogAsync(
             NetUserId userId,

--- a/Content.Server/Entry/EntryPoint.cs
+++ b/Content.Server/Entry/EntryPoint.cs
@@ -119,7 +119,6 @@ namespace Content.Server.Entry
                 IoCManager.Resolve<JobWhitelistManager>().Initialize();
                 IoCManager.Resolve<PlayerRateLimitManager>().Initialize();
                 _currencyManager = IoCManager.Resolve<ServerCurrencyManager>(); // Goobstation
-                _currencyManager.Initialize(); // Goobstation
             }
         }
 
@@ -178,7 +177,6 @@ namespace Content.Server.Entry
                     _playTimeTracking?.Update();
                     _watchlistWebhookManager.Update();
                     _connectionManager?.Update();
-                    _currencyManager?.Update(); // Goobstation
                     break;
             }
         }

--- a/Content.Server/Entry/EntryPoint.cs
+++ b/Content.Server/Entry/EntryPoint.cs
@@ -119,6 +119,7 @@ namespace Content.Server.Entry
                 IoCManager.Resolve<JobWhitelistManager>().Initialize();
                 IoCManager.Resolve<PlayerRateLimitManager>().Initialize();
                 _currencyManager = IoCManager.Resolve<ServerCurrencyManager>(); // Goobstation
+                _currencyManager.Initialize(); // Goobstation
             }
         }
 

--- a/Content.Server/_Goobstation/ServerCurrency/Commands/ServerCurrencyCommands.cs
+++ b/Content.Server/_Goobstation/ServerCurrency/Commands/ServerCurrencyCommands.cs
@@ -87,8 +87,7 @@ namespace Content.Server._Goobstation.ServerCurrency.Commands
                 return;
             }
 
-            _currencyMan.RemoveCurrency(shell.Player.UserId, amount);
-            _currencyMan.AddCurrency(targetPlayer, amount);
+            _currencyMan.TransferCurrency(shell.Player.UserId, targetPlayer, amount);
 
             var giver = Loc.GetString("server-currency-gift-command-giver", ("player", args[0]), ("amount", _currencyMan.Stringify(amount)));
             var reciever = Loc.GetString("server-currency-gift-command-reciever", ("player", shell.Player.Name), ("amount", _currencyMan.Stringify(amount)));

--- a/Content.Server/_Goobstation/ServerCurrency/Commands/ServerCurrencyCommands.cs
+++ b/Content.Server/_Goobstation/ServerCurrency/Commands/ServerCurrencyCommands.cs
@@ -231,7 +231,8 @@ namespace Content.Server._Goobstation.ServerCurrency.Commands
                 return;
             }
 
-            var newCurrency = _currencyMan.Stringify(_currencyMan.SetBalance(targetPlayer, currency));
+            _currencyMan.SetBalance(targetPlayer, currency);
+            var newCurrency = _currencyMan.Stringify(currency);
             shell.WriteLine(Loc.GetString("server-currency-command-return", ("player", args[0]), ("balance", newCurrency)));
         }
 

--- a/Content.Server/_Goobstation/ServerCurrency/ServerCurrencyManager.cs
+++ b/Content.Server/_Goobstation/ServerCurrency/ServerCurrencyManager.cs
@@ -57,7 +57,7 @@ namespace Content.Server._Goobstation.ServerCurrency
             // To decrease the calls to DB, we're running internal version instead
             var oldAmount = GetBalance(userId);
             var newAmount = oldAmount + amount;
-            Task.Run(() => GetBalanceAsync(userId)).GetAwaiter().GetResult();
+            Task.Run(() => SetBalanceAsync(userId, amount)).GetAwaiter().GetResult();
             return newAmount;
         }
 

--- a/Content.Server/_Goobstation/ServerCurrency/ServerCurrencyManager.cs
+++ b/Content.Server/_Goobstation/ServerCurrency/ServerCurrencyManager.cs
@@ -57,7 +57,7 @@ namespace Content.Server._Goobstation.ServerCurrency
             // To decrease the calls to DB, we're running internal version instead
             var oldAmount = GetBalance(userId);
             var newAmount = oldAmount + amount;
-            Task.Run(() => SetBalanceAsync(userId, amount)).GetAwaiter().GetResult();
+            Task.Run(() => SetBalanceAsyncInternal(userId, newAmount, oldAmount)).GetAwaiter().GetResult();
             return newAmount;
         }
 

--- a/Content.Server/_Goobstation/ServerCurrency/ServerCurrencyManager.cs
+++ b/Content.Server/_Goobstation/ServerCurrency/ServerCurrencyManager.cs
@@ -147,7 +147,6 @@ namespace Content.Server._Goobstation.ServerCurrency
         {
             var task = Task.Run(() => _db.ModifyServerCurrency(userId, amountDelta));
             TrackPending(task);
-            await task; // why we need more awaits after the first one? idk
             if (_player.TryGetSessionById(userId, out var userSession))
                 BalanceChange?.Invoke(new PlayerBalanceChangeEvent(userSession, userId, await task, await task - amountDelta));
             return await task;

--- a/Content.Server/_Goobstation/ServerCurrency/ServerCurrencySystem.cs
+++ b/Content.Server/_Goobstation/ServerCurrency/ServerCurrencySystem.cs
@@ -34,7 +34,6 @@ namespace Content.Server._Goobstation.ServerCurrency
         {
             base.Initialize();
             _currencyMan.BalanceChange += OnBalanceChange;
-            SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundEndCleanup);
             SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEndText);
             SubscribeNetworkEvent<PlayerBalanceRequestEvent>(OnBalanceRequest);
             Subs.CVar(_cfg, GoobCVars.GoobcoinsPerPlayer, value => _goobcoinsPerPlayer = value, true);
@@ -47,11 +46,6 @@ namespace Content.Server._Goobstation.ServerCurrency
         {
             base.Shutdown();
             _currencyMan.BalanceChange -= OnBalanceChange;
-        }
-
-        private void OnRoundEndCleanup(RoundRestartCleanupEvent ev)
-        {
-            _currencyMan.Save();
         }
 
         private void OnRoundEndText(RoundEndTextAppendEvent ev)


### PR DESCRIPTION
## About the PR
Got rid of currency cache

## Why / Balance
We have spare DB op bandwidth, this should improve UX and allow for dynamic in-round GC changes (for smites and the like)

## Technical details
Added delta operation to DB interface. Added proper sawmill. Removed syncs.

## Media
Works. Can't test more than local

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

Nothing user facing, no CL