### PR TITLE
Increase air vent lock pressure threshold

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -64,7 +64,7 @@
             Welded: { state: vent_welded }
             Lockout: { state: vent_lockout }
     - type: GasVentPump
-      underPressureLockoutThreshold: 30 # DeltaV - lower threshold
+      underPressureLockoutThreshold: 60
     - type: Construction
       graph: GasUnary
       node: ventpump


### PR DESCRIPTION
## About the PR
30 kpa -> 60 kpa

## Why / Balance
30 is too small.  We have a lot of shifts that end with bad atmos without big atmos problems. Locked vent can be easily fixed with screwdriver, but air leak cannot.

:cl:
- tweak: Increased air vent lock pressure threshold

