### PR TITLE
Salvage cyborgs can drop ore bags

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -227,9 +227,18 @@
     - MiningDrill
     # - Shovel # Goobstation
     - MineralScannerUnpowered
-    - OreBag
+    # - OreBag # Goobstation
     - Crowbar
     - RadioHandheld
+    # Frontier: droppable borg items
+  - type: DroppableBorgModule
+    moduleId: Mining
+    items:
+    - id: OreBag
+      whitelist:
+        components:
+        - OreBag
+    # End Frontier: droppable borg items
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: mining-module }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Salvage cyborgs can drop the mining module ore bag and replace it with an ore bag of holding.

## Why / Balance
https://github.com/Goob-Station/Goob-Station/pull/2055 made ore bags of holding really easy to get, and I want it when I play salvage borg. (Also https://github.com/Goob-Station/Goob-Station/pull/2038 took away my cyborg PKA shotgun, so I'm buffing salvage cyborg again)

## Technical details
<!-- Summary of code changes for easier review. -->
Credit to [Deltanedas](https://github.com/new-frontiers-14/frontier-station-14/pull/3038) for rewriting borg hands and [pheenty](https://github.com/Goob-Station/Goob-Station/pull/2050) for porting it here. The technical details are I copied the code pheenty used for medical cyborg beakers and used OreBag instead of FitsInDispenser. I was worried Ore Boxes might be bugged with it since they're also OreBag, but I couldn't pick them up.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/25857d30-6953-4656-86d1-29749ab396de



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: RatherUncreativeName, Pheenty, Deltanedas
- add: Added hand for salvage cyborgs to pick up and drop ore bags.
