### PR TITLE
collective mind fixes

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/blob/blob.ftl
+++ b/Resources/Locale/en-US/_Goobstation/blob/blob.ftl
@@ -26,7 +26,7 @@ objective-issuer-blob = Blob
 
 
 ghost-role-information-blobbernaut-name = Blobbernaut
-ghost-role-information-blobbernaut-description = You are a Blobbernaut. You must defend the blob core.
+ghost-role-information-blobbernaut-description = You are a Blobbernaut. You must defend the blob core. Use + or +e in chat to talk in the Blobmind.
 
 ghost-role-information-blob-name = Blob
 ghost-role-information-blob-description = You are the Blob Infection. Consume the station.
@@ -143,11 +143,12 @@ blob-health-alert-desc = Your core's health. You will die if it reaches zero.
 blob-role-greeting =
     You are blob - a parasitic space creature capable of destroying entire stations.
         Your goal is to survive and grow as large as possible.
-    	You are almost invulnerable to physical damage, but heat can still hurt you.
+        You are almost invulnerable to physical damage, but heat can still hurt you.
         Use Alt+LMB to upgrade normal blob tiles to strong blob and strong blob to reflective blob.
-    	Make sure to place resource blobs to generate resources.
+        Make sure to place resource blobs to generate resources.
         Keep in mind that resource blobs and factories will only work when next to node blobs or cores.
-blob-zombie-greeting = You were infected and raised by a blob spore. Now you must help the blob take over the station.
+        You may use + or +e in chat to use the Blobmind to talk to your minions.
+blob-zombie-greeting = You were infected and raised by a blob spore. Now you must help the blob take over the station. Use +e in chat to talk in the Blobmind.
 
 # End round
 blob-round-end-result =

--- a/Resources/Locale/en-US/_Shitmed/abductor/abductor-ui.ftl
+++ b/Resources/Locale/en-US/_Shitmed/abductor/abductor-ui.ftl
@@ -42,7 +42,8 @@ objective-issuer-abductors = [color=#FD0098]Mothership[/color]
 objective-condition-abduct-title = Abduct {$count} person.
 objective-condition-abduct-description = (use the Gizmo on a subdued victim, then use the Gizmo on the abductor console and select the attract action), then replace their heart with one of the glands, put them in the experimenter, and press complete experiment.
 
-abductor-role-greeting = I am a professional combat scientist of a high-tech race. My task is to abduct humans, conduct experiments on them, and return them alive for the purity of the experiment. It is not in my interest to destroy the station, kill, or assist the crew.
+abductor-role-greeting = You are a professional combat scientist of a high-tech race. Your task is to abduct humans, conduct experiments on them, and return them alive for the purity of the experiment. It is not in your interest to destroy the station, kill, or assist the crew.
+Use + or +a in chat to talk in the Glorpmind.
 
 roles-antag-abductor-objective = Kidnap station crew and perform your experiments on them!
 

--- a/Resources/Locale/en-US/_Shitmed/abductor/abductor-ui.ftl
+++ b/Resources/Locale/en-US/_Shitmed/abductor/abductor-ui.ftl
@@ -43,7 +43,7 @@ objective-condition-abduct-title = Abduct {$count} person.
 objective-condition-abduct-description = (use the Gizmo on a subdued victim, then use the Gizmo on the abductor console and select the attract action), then replace their heart with one of the glands, put them in the experimenter, and press complete experiment.
 
 abductor-role-greeting = You are a professional combat scientist of a high-tech race. Your task is to abduct humans, conduct experiments on them, and return them alive for the purity of the experiment. It is not in your interest to destroy the station, kill, or assist the crew.
-Use + or +a in chat to talk in the Glorpmind.
+                        Use + or +a in chat to talk in the Glorpmind.
 
 roles-antag-abductor-objective = Kidnap station crew and perform your experiments on them!
 

--- a/Resources/Prototypes/_Goobstation/CollectiveMind/collective_minds.yml
+++ b/Resources/Prototypes/_Goobstation/CollectiveMind/collective_minds.yml
@@ -10,7 +10,7 @@
   id: Lingmind
   name: collective-mind-lingmind
   keycode: 'h'
-  color: "#787878"
+  color: "#FFA000"
   showNames: false
   requiredTags:
   - LingMind

--- a/Resources/Prototypes/_Shitmed/GameRules/events.yml
+++ b/Resources/Prototypes/_Shitmed/GameRules/events.yml
@@ -65,6 +65,7 @@
           - CanPilot
           - FootstepSound
           - DoorBumpOpener
+          - AbductorMind
       - type: AbductorScientist
       - type: SurgeryIgnoreClothing
       - type: Sanitized
@@ -156,6 +157,7 @@
           - CanPilot
           - FootstepSound
           - DoorBumpOpener
+          - AbductorMind
       - type: AbductorScientist
       - type: SurgeryIgnoreClothing
       - type: Sanitized

--- a/Resources/ServerInfo/_Goobstation/Guidebook/Antagonist/Blob.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/Antagonist/Blob.xml
@@ -50,9 +50,11 @@ When a node is destroyed, all bound special tiles are destroyed with the return 
 	<GuideEntityEmbed Entity="MobBlobPod" Caption="Blob Pod"/>
   </Box>
 
-Blob factories can produce Blob pods and Blobburnouts.
+Blob factories can produce Blob pods and Blobbernauts.
 - Blob pods have the ability to turn dead humanoids into zombie blobs, which will force them to fight on your side against the rest of the crew.
-- Blobburnouts have a lot of damage, which will come in handy for attacking.
+- Blobbernauts have a lot of damage, which will come in handy for attacking.
+
+You and your minions may use + or +e in chat (just like radio, but with + instead of :) to talk in the Blobbermind.
 
 ## Management
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
see diff
fixes abductors not actually getting glorpmind

## Why / Balance
collective mind existing is currently not communicated at all for blobmind and glorpmind is just broken

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Briefings now communicate how to use your collective mind channel when appropriate (+e for blobmind, +a for glorpmind).
- tweak: Changeling hivemind channel color changed.
- fix: Fixed abductors not having glorpmind.
