### PR TITLE
Martial arts tweak

### DIFF
--- a/Content.Shared/_Goobstation/MartialArts/SharedMartialArtsSystem.KravMaga.cs
+++ b/Content.Shared/_Goobstation/MartialArts/SharedMartialArtsSystem.KravMaga.cs
@@ -47,7 +47,7 @@ public abstract partial class SharedMartialArtsSystem
             case KravMagaMoves.LegSweep:
                 if(_netManager.IsClient)
                     return;
-                _stun.TryParalyze(hitEntity, TimeSpan.FromSeconds(4), true);
+                _stun.TryKnockdown(hitEntity, TimeSpan.FromSeconds(4), true);
                 break;
             case KravMagaMoves.NeckChop:
                 var comp = EnsureComp<KravMagaSilencedComponent>(hitEntity);

--- a/Resources/Prototypes/_Goobstation/MartialArts/judo.yml
+++ b/Resources/Prototypes/_Goobstation/MartialArts/judo.yml
@@ -18,9 +18,10 @@
   attacks:
   - Grab
   - Disarm
+  - Disarm
   event: !type:JudoThrowPerformedEvent
-  staminaDamage: 80
-  paralyzeTime: 7
+  staminaDamage: 30
+  paralyzeTime: 3
 
 - type: combo
   id: JudoArmbar
@@ -30,9 +31,10 @@
   - Disarm
   - Disarm
   - Grab
+  - Grab
   event: !type:JudoArmbarPerformedEvent
-  staminaDamage: 50
-  paralyzeTime: 5
+  staminaDamage: 70
+  paralyzeTime: 7
 
 - type: combo
   id: JudoEyepoke
@@ -43,3 +45,4 @@
   - Harm
   event: !type:JudoEyePokePerformedEvent
   extraDamage: 5
+


### PR DESCRIPTION

## About the PR
Kravmaga no longer stunlocks
Judo slightly weaker

## Why / Balance
Both were incredibly unfun to be on the receiving end


:cl: Armok
- tweak: Krav Maga legsweep no longer stunlocks
- tweak: Judo Combos longer, throw is G>D>D, Armbar is D>D>G>G
- tweak: Judo moves stam damage changed, throw now does 30, and armbar 70.

