### PR TITLE
[FATAL ERROR, CLOSED] Carp for nukies

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -2012,4 +2012,4 @@
   - !type:StoreWhitelistCondition
     whitelist:
       tags:
-      - NukeOpsUplink
+      - NukeOpsCommanderUplink

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1998,3 +1998,18 @@
   - !type:BuyerDepartmentCondition
     whitelist:
     - Medical
+
+- type: listing
+  id: 
+  name: uplink-sleeping-carp-name
+  description: uplink-sleeping-carp-desc
+  productEntity: SleepingCarpScroll
+  cost:
+    Telecrystal: 250 # Nukie carp for all team cost
+  categories:
+  - UplinkWeaponry
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -2005,11 +2005,11 @@
   description: uplink-sleeping-carp-desc
   productEntity: SleepingCarpScroll
   cost:
-    Telecrystal: 120 # Nukie carp for all team cost
+    Telecrystal: 70 # Version for LoneOps
   categories:
   - UplinkWeaponry
   conditions:
   - !type:StoreWhitelistCondition
     whitelist:
       tags:
-      - NukeOpsCommanderUplink
+      - LoneOpsUplink

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -2005,7 +2005,7 @@
   description: uplink-sleeping-carp-desc
   productEntity: SleepingCarpScroll
   cost:
-    Telecrystal: 250 # Nukie carp for all team cost
+    Telecrystal: 120 # Nukie carp for all team cost
   categories:
   - UplinkWeaponry
   conditions:

--- a/Resources/Prototypes/Entities/Objects/Misc/briefcases.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/briefcases.yml
@@ -15,7 +15,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 8
+        Blunt: 20
 
 - type: entity
   parent: BriefcaseBase

--- a/Resources/Prototypes/Entities/Objects/Misc/briefcases.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/briefcases.yml
@@ -15,7 +15,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 20
+        Blunt: 8
 
 - type: entity
   parent: BriefcaseBase

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -154,3 +154,17 @@
     balance:
       # Goobstation - Telecrystal rework
       Telecrystal: 999999
+
+- type: entity
+  parent: BaseUplinkRadio
+  # Goobstation - Telecrystal rework
+  id: LoneOpsUplinkRadio350TC
+  suffix: 350 TC, LoneOps
+  components:
+  - type: Store
+    balance:
+      Telecrystal: 350
+  - type: Tag
+    tags:
+    - NukeOpsUplink
+    - LoneOpsUplink

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -106,4 +106,4 @@
   parent: SyndicateOperativeGearFull
   equipment:
     # Goobstation - Telecrystal rework
-    pocket2: BaseUplinkRadio350TC
+    pocket2: LoneOpsUplink

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -689,3 +689,18 @@
     Telecrystal: 40
   categories:
   - UplinkDeception
+
+- type: listing
+  id: NukieUplinkMysteriousScroll
+  name: uplink-sleeping-carp-name
+  description: uplink-sleeping-carp-desc
+  productEntity: SleepingCarpScroll
+  cost:
+    Telecrystal: 250 #nukie can use it by all team
+  categories:
+  - UplinkWeaponry
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink


### PR DESCRIPTION


## About the PR
 Added sleeping carp to a nukies uplink by a bounty 

## Why / Balance
 Nukies can buy one scroll of sleeping carp and use it by all team, so it costs 250 TC. 

## Technical details
 Uplink catalog, ID is NukieUplinkMysteriousScroll 

## Media


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- add: Sleeping carp for nukies
