### PR TITLE
station record ipc bug

### DIFF
--- a/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
+++ b/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
@@ -386,6 +386,11 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
         if (filter.Value.Length == 0)
             return false;
 
+        if (filter.Type == StationRecordFilterType.Prints && someRecord.Fingerprint == null) // Goobstation - IPC
+            return true;
+        if (filter.Type == StationRecordFilterType.DNA && someRecord.DNA == null) // Goobstation - IPC
+            return true;
+
         var filterLowerCaseValue = filter.Value.ToLower();
 
         return filter.Type switch
@@ -416,10 +421,6 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
         foreach (var pair in records)
         {
             if (IsSkipped(filter, pair.Item2))
-                continue;
-            if (filter != null && filter.Type == StationRecordFilterType.DNA && pair.Item2.DNA == null) // Goobstation - IPC
-                continue;
-            if (filter != null && filter.Type == StationRecordFilterType.Prints && pair.Item2.Fingerprint == null) // Goobstation - IPC
                 continue;
 
             listing.Add(pair.Item1, pair.Item2.Name);

--- a/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
+++ b/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
@@ -417,6 +417,10 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
         {
             if (IsSkipped(filter, pair.Item2))
                 continue;
+            if (filter != null && filter.Type == StationRecordFilterType.DNA && pair.Item2.DNA == null) // Goobstation - IPC
+                continue;
+            if (filter != null && filter.Type == StationRecordFilterType.Prints && pair.Item2.Fingerprint == null) // Goobstation - IPC
+                continue;
 
             listing.Add(pair.Item1, pair.Item2.Name);
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
becuse ipc dont have fingerprint or dna
they showup in hte station records for all when scanning,
this adds a check for when dna is null and lookiing for dna  if dna is null it no longer shows up in the list.
same for fingerprints. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Fishbait
- fix: ipc no longer shows up in station and criminal records when filtering for dna and fingerprints.