### PR TITLE
Nukie-Surplus

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -938,10 +938,6 @@
   categories:
   - UplinkDisruption
   conditions:
-  - !type:StoreWhitelistCondition
-    blacklist:
-      tags:
-      - NukeOpsUplink
   - !type:BuyerWhitelistCondition
     blacklist:
       components:
@@ -957,10 +953,6 @@
   categories:
   - UplinkDisruption
   conditions:
-  - !type:StoreWhitelistCondition
-    blacklist:
-      tags:
-      - NukeOpsUplink
   - !type:BuyerWhitelistCondition
     blacklist:
       components:


### PR DESCRIPTION

## About the PR
Added surplus bundles (Super Surplus and Surplus) to nukies uplink

## Why / Balance
I think it would funny, nukies with random stuff


## Technical details
Changed blacklist to whitelist in uplink catalog

## Media


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**

:cl:
- add: Nukies now can buy surplus and super surplus bundles!
