### PR TITLE
StageChangeCooldown bugfix

### DIFF
--- a/Content.Shared/_Goobstation/MartialArts/SharedMartialArtsSystem.cs
+++ b/Content.Shared/_Goobstation/MartialArts/SharedMartialArtsSystem.cs
@@ -116,8 +116,12 @@ public abstract partial class SharedMartialArtsSystem : EntitySystem
 
     private void OnShutdown(Entity<MartialArtsKnowledgeComponent> ent, ref ComponentShutdown args)
     {
-        if(TryComp<CanPerformComboComponent>(ent, out var comboComponent))
+        if (TryComp<CanPerformComboComponent>(ent, out var comboComponent))
             comboComponent.AllowedCombos.Clear();
+
+        var pullerComponent = EnsureComp<PullerComponent>(ent); 
+        pullerComponent.StageChangeCooldown *= 2;
+        //returning time of grab to avoid abuse of judo belt and etc.
     }
 
     private void CheckGrabStageOverride<T>(EntityUid uid, T component, CheckGrabOverridesEvent args)

--- a/Content.Shared/_Goobstation/MartialArts/SharedMartialArtsSystem.cs
+++ b/Content.Shared/_Goobstation/MartialArts/SharedMartialArtsSystem.cs
@@ -119,8 +119,7 @@ public abstract partial class SharedMartialArtsSystem : EntitySystem
         if (TryComp<CanPerformComboComponent>(ent, out var comboComponent))
             comboComponent.AllowedCombos.Clear();
 
-        var pullerComponent = EnsureComp<PullerComponent>(ent); 
-        pullerComponent.StageChangeCooldown *= 2;
+        EnsureComp<PullerComponent>(ent).StageChangeCooldown *= 2;
         //returning time of grab to avoid abuse of judo belt and etc.
     }
 


### PR DESCRIPTION
people have found a way to use the judo belt bug to reduce StageChangeCooldown to zero

![image](https://github.com/user-attachments/assets/ccfa0821-d6d0-4d80-a578-bfa67c029a89)

 when removed, just returns value back
does not interfere with cqc, etc