### PR TITLE
[BUGFIX] judo belt abuse

### DIFF
--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.cs
@@ -120,6 +120,9 @@ public abstract partial class SharedMartialArtsSystem : EntitySystem
     {
         if(TryComp<CanPerformComboComponent>(ent, out var comboComponent))
             comboComponent.AllowedCombos.Clear();
+
+        EnsureComp<PullerComponent>(ent).StageChangeCooldown *= 2;
+        //returning time of grab to avoid abuse of judo belt and etc.
     }
 
     private void CheckGrabStageOverride<T>(EntityUid uid, T component, CheckGrabOverridesEvent args)


### PR DESCRIPTION
people have found a way to use the judo belt bug to reduce StageChangeCooldown to zero

![image](https://github.com/user-attachments/assets/92a66970-f306-4bbd-baf3-a64192eb334a)

when removed, just returns value back
does not interfere with cqc manual, etc