### PR TITLE
Give fullmins fullmin commands (again)

### DIFF
--- a/Resources/toolshedEngineCommandPerms.yml
+++ b/Resources/toolshedEngineCommandPerms.yml
@@ -1,4 +1,4 @@
-﻿- Flags: QUERY
+- Flags: QUERY
   Commands:
     - entities
     - nearby
@@ -181,3 +181,9 @@
     - realtime
     - servertime
     - more
+
+- Flags: FULLADMIN # Goobstation
+  Commands:
+  - self
+  - entities
+  - nearby


### PR DESCRIPTION
## About the PR
fixes stuff RT changed

## Why / Balance
asked to, also fix

## Technical details
fullmins had access to RT commands, but since 247 the RT commands used another perms system on top of regular perms system, this adds them to that. can't do it in seperate file since this garbo is hardcoded in RT

## Media
user with admin and fullmin perms (cvar loginlocal is false)
![image](https://github.com/user-attachments/assets/c0822adf-a25c-49fd-a11e-59349b3b40b3)
![{BE6C1B12-41D1-46E2-B717-AA935BCBB0FE}](https://github.com/user-attachments/assets/5f8a0eac-e02f-4ff8-bca9-a0dc8e607bf4)

Can execute `entities`, `self`, 'ent', and `nearby` commands now
![{D75C9A87-A3C7-47C5-B9F4-EC6531238784}](https://github.com/user-attachments/assets/fbfbd911-0a85-44e5-b3a9-017df22f059d)
![{11FC5F98-C393-4D65-A746-8B6D3EBF085C}](https://github.com/user-attachments/assets/eda3c309-fe2a-4cd6-b9e6-fa4426805caf)
![{DEA10FEC-F9A6-4631-9FFB-7AB20EE9ADBF}](https://github.com/user-attachments/assets/6d5178de-149a-49b4-8e29-728756ee3d01)
![{D848373F-98B2-4A47-8519-B1B7179D0E58}](https://github.com/user-attachments/assets/f0d9c2cb-053e-41e1-b99a-ef7e1bf4912f)

Deadminned users and regular users can't use these
![{5D4D95DE-30CE-4888-A1DE-A39FD1C459DD}](https://github.com/user-attachments/assets/44c331a9-43dd-4bc6-8554-f819fb611ea9)
![{4B15F8A4-EC8D-4115-910A-87B687A54BAF}](https://github.com/user-attachments/assets/6d8fddfc-20ba-4c42-829e-7ec933813ba7)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

This is a non-player facing fix, no cl