### PR TITLE
mouse 1984

### DIFF
--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -81,7 +81,7 @@ public enum CollisionGroup
     HalfWallLayer = MidImpassable | LowImpassable,
 
     // Statue, monument, airlock, window
-    FullTileMask = Impassable | HighImpassable | MidImpassable | LowImpassable | InteractImpassable,
+    FullTileMask = Impassable | HighImpassable | MidImpassable | LowImpassable | InteractImpassable | BulletImpassable, // GoobStation - ventcrawling replaces mice going under doors
     // FlyingMob can go past
     FullTileLayer = Opaque | HighImpassable | MidImpassable | LowImpassable | BulletImpassable | InteractImpassable,
 


### PR DESCRIPTION
## About the PR
mice and other SmallMobLayer entities can no longer fit under airlocks

## Why / Balance
ventcrawling exists, airlock actually locks air now

## Technical details
add BulletImpassable to FullTileMask so mice cant go under them

## Media
vents real
![07:49:05](https://github.com/user-attachments/assets/6e9c97f9-2347-4902-810e-90f1c0217d9c)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed airlocks letting objects much larger than air through them.