### PR TITLE
port surgery code for manipulating organ slots

### DIFF
--- a/Content.Shared/_Shitmed/Surgery/Conditions/SurgeryBodyConditionComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Conditions/SurgeryBodyConditionComponent.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Content.Shared.Body.Prototypes;
+
+namespace Content.Shared._Shitmed.Medical.Surgery.Conditions;
+
+/// <summary>
+///     Requires that this surgery is (not) done on one of the provided body prototypes
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SurgeryBodyConditionComponent : Component
+{
+    [DataField(required: true)]
+    public HashSet<ProtoId<BodyPrototype>> Accepted = default!;
+
+    [DataField]
+    public bool Inverse;
+}

--- a/Content.Shared/_Shitmed/Surgery/Conditions/SurgeryOrganSlotConditionComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Conditions/SurgeryOrganSlotConditionComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Shitmed.Medical.Surgery.Conditions;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SurgeryOrganSlotConditionComponent : Component
+{
+    [DataField(required: true)]
+    public string OrganSlot = default!;
+
+    [DataField]
+    public bool Inverse;
+}

--- a/Content.Shared/_Shitmed/Surgery/Conditions/SurgeryOrganSlotConditionComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Conditions/SurgeryOrganSlotConditionComponent.cs
@@ -2,6 +2,9 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared._Shitmed.Medical.Surgery.Conditions;
 
+/// <summary>
+/// Requires that an organ slot does (not) exist on the target part for a surgery to be possible.
+/// </summary>
 [RegisterComponent, NetworkedComponent]
 public sealed partial class SurgeryOrganSlotConditionComponent : Component
 {

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -52,6 +52,7 @@ public abstract partial class SharedSurgerySystem
         SubSurgery<SurgeryAffixOrganStepComponent>(OnAffixOrganStep, OnAffixOrganCheck);
         SubSurgery<SurgeryAddMarkingStepComponent>(OnAddMarkingStep, OnAddMarkingCheck);
         SubSurgery<SurgeryRemoveMarkingStepComponent>(OnRemoveMarkingStep, OnRemoveMarkingCheck);
+        SubSurgery<SurgeryAddOrganSlotStepComponent>(OnAddOrganSlotStep, OnAddOrganSlotCheck);
         Subs.BuiEvents<SurgeryTargetComponent>(SurgeryUIKey.Key, subs =>
         {
             subs.Event<SurgeryStepChosenBuiMsg>(OnSurgeryTargetStepChosen);
@@ -441,6 +442,22 @@ public abstract partial class SharedSurgerySystem
                 RaiseLocalEvent(args.Body, ref ev);
             }
         }
+    }
+
+    private void OnAddOrganSlotStep(Entity<SurgeryAddOrganSlotStepComponent> ent, ref SurgeryStepEvent args)
+    {
+        if (!TryComp(args.Surgery, out SurgeryOrganSlotConditionComponent? condition))
+            return;
+
+        _body.TryCreateOrganSlot(args.Part, condition.OrganSlot, out _);
+    }
+
+    private void OnAddOrganSlotCheck(Entity<SurgeryAddOrganSlotStepComponent> ent, ref SurgeryStepCompleteCheckEvent args)
+    {
+        if (!TryComp(args.Surgery, out SurgeryOrganSlotConditionComponent? condition))
+            return;
+
+        args.Cancelled = !_body.CanInsertOrgan(args.Part, condition.OrganSlot);
     }
 
     private void OnAffixPartStep(Entity<SurgeryAffixPartStepComponent> ent, ref SurgeryStepEvent args)

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
@@ -77,6 +77,8 @@ public abstract partial class SharedSurgerySystem : EntitySystem
         SubscribeLocalEvent<SurgeryOrganConditionComponent, SurgeryValidEvent>(OnOrganConditionValid);
         SubscribeLocalEvent<SurgeryWoundedConditionComponent, SurgeryValidEvent>(OnWoundedValid);
         SubscribeLocalEvent<SurgeryPartRemovedConditionComponent, SurgeryValidEvent>(OnPartRemovedConditionValid);
+        SubscribeLocalEvent<SurgeryBodyConditionComponent, SurgeryValidEvent>(OnBodyConditionValid);
+        SubscribeLocalEvent<SurgeryOrganSlotConditionComponent, SurgeryValidEvent>(OnOrganSlotConditionValid);
         SubscribeLocalEvent<SurgeryPartPresentConditionComponent, SurgeryValidEvent>(OnPartPresentConditionValid);
         SubscribeLocalEvent<SurgeryMarkingConditionComponent, SurgeryValidEvent>(OnMarkingPresentValid);
         SubscribeLocalEvent<SurgeryBodyComponentConditionComponent, SurgeryValidEvent>(OnBodyComponentConditionValid);
@@ -275,6 +277,17 @@ public abstract partial class SharedSurgerySystem : EntitySystem
             else if (!ent.Comp.Inverse)
                 args.Cancelled = true;
         }
+    }
+
+    private void OnBodyConditionValid(Entity<SurgeryBodyConditionComponent> ent, ref SurgeryValidEvent args)
+    {
+        if (TryComp<BodyComponent>(args.Body, out var body) && body.Prototype is {} bodyId)
+            args.Cancelled = ent.Comp.Accepted.Contains(bodyId) ^ !ent.Comp.Inverse;
+    }
+
+    private void OnOrganSlotConditionValid(Entity<SurgeryOrganSlotConditionComponent> ent, ref SurgeryValidEvent args)
+    {
+        args.Cancelled = _body.CanInsertOrgan(args.Part, ent.Comp.OrganSlot) ^ !ent.Comp.Inverse;
     }
 
     private void OnPartRemovedConditionValid(Entity<SurgeryPartRemovedConditionComponent> ent, ref SurgeryValidEvent args)

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
@@ -282,12 +282,12 @@ public abstract partial class SharedSurgerySystem : EntitySystem
     private void OnBodyConditionValid(Entity<SurgeryBodyConditionComponent> ent, ref SurgeryValidEvent args)
     {
         if (TryComp<BodyComponent>(args.Body, out var body) && body.Prototype is {} bodyId)
-            args.Cancelled = ent.Comp.Accepted.Contains(bodyId) ^ !ent.Comp.Inverse;
+            args.Cancelled |= ent.Comp.Accepted.Contains(bodyId) ^ !ent.Comp.Inverse;
     }
 
     private void OnOrganSlotConditionValid(Entity<SurgeryOrganSlotConditionComponent> ent, ref SurgeryValidEvent args)
     {
-        args.Cancelled = _body.CanInsertOrgan(args.Part, ent.Comp.OrganSlot) ^ !ent.Comp.Inverse;
+        args.Cancelled |= _body.CanInsertOrgan(args.Part, ent.Comp.OrganSlot) ^ !ent.Comp.Inverse;
     }
 
     private void OnPartRemovedConditionValid(Entity<SurgeryPartRemovedConditionComponent> ent, ref SurgeryValidEvent args)

--- a/Content.Shared/_Shitmed/Surgery/Steps/SurgeryAddOrganSlotStepComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Steps/SurgeryAddOrganSlotStepComponent.cs
@@ -1,6 +1,12 @@
+using Content.Shared._Shitmed.Medical.Surgery.Conditions;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._Shitmed.Medical.Surgery.Steps;
 
+/// <summary>
+/// Adds an organ slot the body part when the step is complete.
+/// Requires <see cref="SurgeryOrganSlotConditionComponent"/> on
+/// the surgery entity in order to specify the organ slot.
+/// </summary>
 [RegisterComponent, NetworkedComponent]
 public sealed partial class SurgeryAddOrganSlotStepComponent : Component;

--- a/Content.Shared/_Shitmed/Surgery/Steps/SurgeryAddOrganSlotStepComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Steps/SurgeryAddOrganSlotStepComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Shitmed.Medical.Surgery.Steps;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SurgeryAddOrganSlotStepComponent : Component;

--- a/Resources/Locale/en-US/_Shitmed/surgery/surgery-popup.ftl
+++ b/Resources/Locale/en-US/_Shitmed/surgery/surgery-popup.ftl
@@ -35,6 +35,8 @@ surgery-popup-step-SurgeryStepRemoveItem = {$user} is removing something from {$
 surgery-popup-step-SurgeryStepRemoveOrgan = {$user} is removing an organ from {$target}'s {$part}!
 surgery-popup-step-SurgeryStepInsertOrgan = {$user} is inserting an organ into {$target}'s {$part}!
 
+surgery-popup-step-SurgeryStepOpenOrganSlot = {$user} is opening a cavity in {$target}'s {$part}!
+
 surgery-popup-procedure-SurgeryRemoveBrain-step-SurgeryStepRemoveOrgan = {$user} is removing the brain from {$target}'s {$part}!
 surgery-popup-procedure-SurgeryRemoveHeart-step-SurgeryStepRemoveOrgan = {$user} is removing the heart from {$target}'s {$part}!
 surgery-popup-procedure-SurgeryRemoveLiver-step-SurgeryStepRemoveOrgan = {$user} is removing the liver from {$target}'s {$part}!

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
@@ -443,6 +443,30 @@
   - type: SurgeryStepEmoteEffect
 
 - type: entity
+  parent: SurgeryStepBase
+  id: SurgeryStepOpenOrganSlot
+  name: Carve out a cavity
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SurgeryStep
+    tool:
+    - type: Scalpel
+    duration: 6
+  - type: Sprite
+    sprite: _Shitmed/Objects/Specific/Medical/Surgery/manipulation.rsi
+    state: insertion
+  - type: SurgeryAddOrganSlotStep
+  - type: SurgeryStepEmoteEffect
+  - type: SurgeryDamageChangeEffect # DeltaV
+    sleepModifier: 0.5
+    damage:
+      types:
+        Blunt: 5
+  - type: SurgeryStepDirtiness # DeltaV - surgery cross contamination
+    toolDirtiness: 7.5
+    gloveDirtiness: 7.5
+
+- type: entity
   parent: SurgeryStepInsertOrgan
   id: SurgeryStepInsertLungs
   name: Add lungs

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
@@ -457,14 +457,6 @@
     state: insertion
   - type: SurgeryAddOrganSlotStep
   - type: SurgeryStepEmoteEffect
-  - type: SurgeryDamageChangeEffect # DeltaV
-    sleepModifier: 0.5
-    damage:
-      types:
-        Blunt: 5
-  - type: SurgeryStepDirtiness # DeltaV - surgery cross contamination
-    toolDirtiness: 7.5
-    gloveDirtiness: 7.5
 
 - type: entity
   parent: SurgeryStepInsertOrgan


### PR DESCRIPTION
## About the PR
ported from https://github.com/DeltaV-Station/Delta-v/pull/3059

@gluesniffler 

## Why / Balance
can be used for adding evil organs like unique abductor organs but not supercode, CBMs cdda, etc

## Technical details
- `SurgeryOrganSlotCondition` added to a surgery makes it require a body part to have/not have an organ slot. this can let stuff like not showing brain transplants for ipc head
- `SurgeryAddOrganSlotStep` makes a step of above surgery create an empty slot with the specified id in that component.
- `SurgeryBodyCondition` also lets you white/blacklist certain body prototypes for surgeries very epic, lets ipc-specific surgeries be made

## Media
:trollface:
