### PR TITLE
undestructiblify spears

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -77,32 +77,33 @@
     damage:
       types:
         Piercing: 4
-  - type: Damageable
-    damageContainer: Inorganic
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 40 # Goob edit, excess damage avoids cost of spawning entities.
-      behaviors:
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-    - trigger:
-        !type:DamageTrigger
-        damage: 20
-      behaviors:
-      - !type:PlaySoundBehavior
-        sound:
-          collection: GlassBreak
-          params:
-            volume: -4
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          PartRodMetal1:
-            min: 1
-            max: 1
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
+  # Goobstation - nuh uh
+  #- type: Damageable
+  #  damageContainer: Inorganic
+  #- type: Destructible
+  #  thresholds:
+  #  - trigger:
+  #      !type:DamageTrigger
+  #      damage: 40 # Goob edit, excess damage avoids cost of spawning entities.
+  #    behaviors:
+  #    - !type:DoActsBehavior
+  #      acts: [ "Destruction" ]
+  #  - trigger:
+  #      !type:DamageTrigger
+  #      damage: 20
+  #    behaviors:
+  #    - !type:PlaySoundBehavior
+  #      sound:
+  #        collection: GlassBreak
+  #        params:
+  #          volume: -4
+  #    - !type:SpawnEntitiesBehavior
+  #      spawn:
+  #        PartRodMetal1:
+  #          min: 1
+  #          max: 1
+  #    - !type:DoActsBehavior
+  #      acts: [ "Destruction" ]
   - type: DamageOnLand
     damage:
       types:
@@ -116,11 +117,11 @@
     inHandsMaxFillLevels: 1
     equippedFillBaseName: -fill-
     equippedMaxFillLevels: 1
-  - type: ThrowableBlocked # Goobstation
-    behavior: Damage
-    damage:
-      types:
-        Blunt: 20
+  #- type: ThrowableBlocked # Goobstation
+  #  behavior: Damage
+  #  damage:
+  #    types:
+  #      Blunt: 20
   - type: UndetectableContraband #Goobstation-Contraband detector
 
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -60,8 +60,9 @@
   - type: SolutionContainerManager
     solutions:
       melee:
-        maxVol: 2
+        maxVol: 5 # Goobstation
   - type: MeleeChemicalInjector
+    transferAmount: 1 # Goobstation
     solution: melee
   - type: RefillableSolution
     solution: melee
@@ -104,10 +105,10 @@
   #          max: 1
   #    - !type:DoActsBehavior
   #      acts: [ "Destruction" ]
-  - type: DamageOnLand
-    damage:
-      types:
-        Blunt: 5
+  #- type: DamageOnLand
+  #  damage:
+  #    types:
+  #      Blunt: 5
   - type: UseDelay
   - type: Appearance
   - type: SolutionContainerVisuals
@@ -117,11 +118,7 @@
     inHandsMaxFillLevels: 1
     equippedFillBaseName: -fill-
     equippedMaxFillLevels: 1
-  #- type: ThrowableBlocked # Goobstation
-  #  behavior: Damage
-  #  damage:
-  #    types:
-  #      Blunt: 20
+  - type: ThrowableBlocked # Goobstation
   - type: UndetectableContraband #Goobstation-Contraband detector
 
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
title/see diff
requested by aviu: also gives them 5u chem storage instead of 2u

## Why / Balance
good
also prevents small explosions from erasing spears in your bag/etc

## Media
tested

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Spears are no longer destructible.
- tweak: Spears can now contain up to 5u of chemicals, but inject 1u on melee and 2u on throw.
