### PR TITLE
Strengthen IPC racism

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Damage/modifier_sets.yml
@@ -6,3 +6,4 @@
     Heat: 2
     Shock: 2.5
     Radiation: 0.5 # Goobstation - Make IPCs take radiation
+    Ion: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Make IPCs take double Ion damage

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This strengthen some of the discrimination against the species where sec will shoot at jailed IPC to death with disabler and it is fine cause it is "non-lethal"

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Double Ion damage for IPCs
