### PR TITLE
Blob chances rework [CLOSED]

### DIFF
--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -176,18 +176,6 @@
   categories:
   - SpellbookEquipment
 
-- type: listing
-  id: SpellbookHammerMjollnir
-  name: spellbook-hammer-mjollnir-name
-  description: spellbook-hammer-mjollnir-description
-  productEntity: Mjollnir
-  cost:
-    WizCoin: 2
-  categories:
-  - SpellbookEquipment
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
 
 - type: listing
   id: SpellbookHammerSingularity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
@@ -24,48 +24,7 @@
   - type: Item
     size: Large
 
-- type: entity
-  id: Mjollnir
-  parent: BaseItem
-  name: Mjollnir
-  description: A weapon worthy of a god, able to strike with the force of a lightning bolt. It crackles with barely contained energy.
-  components:
-  - type: Wieldable
-    useDelayOnWield: false # GoobStation Edit
-  - type: LandAtCursor
-  - type: Sprite
-    sprite: _Goobstation/Objects/Weapons/Melee/mjollnir.rsi # GoobStation Edit
-    layers:
-    - state: icon
-  - type: UseDelay
-    delay: 5 # Goobstation
-  - type: UseDelayOnMeleeHit
-  - type: MeleeThrowOnHit
-    stunTime: 3
-    activateOnThrown: true
-  - type: MeleeWeapon
-    wideAnimationRotation: -135
-    damage:
-      types:
-        Blunt: 10 # GoobStation Edit
-        Structural: 10 # GoobStation Edit
-    soundHit:
-      path: /Audio/Effects/tesla_consume.ogg
-      params:
-        variation: 0.10
-  - type: IncreaseDamageOnWield
-    damage:
-      types:
-        Blunt: 10 # GoobStation Edit
-        Structural: 15 # GoobStation Edit
-  - type: DamageOtherOnHit
-    damage:
-      types:
-        Blunt: 15
-        Structural: 15
-  - type: Item
-    size: Ginormous
-  - type: Boomerang # Goobstation
+
 
 - type: entity
   id: SingularityHammer

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -167,7 +167,7 @@
   components:
   - type: StationEvent
     weight: 2
-    earliestStart: 75
+    earliestStart: 60
     minimumPlayers: 30 # how is that 20 people when rat king is 30??? changed.
     duration: null
     maxOccurrences: 2
@@ -179,7 +179,7 @@
     carrierBlobProtos:
     - SpawnPointGhostBlobRat
     playersPerCarrierBlob: 30
-    maxCarrierBlob: 1
+    maxCarrierBlob: 3
   - type: Tag
     tags:
       - MidroundAntag

--- a/Resources/Prototypes/_Goobstation/Wizard/actions_upgrades.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/actions_upgrades.yml
@@ -371,7 +371,7 @@
   name: Lesser Summon Guns III
   components:
   - type: ActionUseDelayModifier
-    useDelay: 20
+    useDelay: 25
 
 # Curse of the Barnyard
 - type: entity
@@ -488,7 +488,7 @@
   name: Lesser Summon Bees III
   components:
   - type: ActionUseDelayModifier
-    useDelay: 20
+    useDelay: 25
 
 # Sanguine Strike
 - type: entity
@@ -548,7 +548,7 @@
   name: Force Wall II
   components:
   - type: ActionUseDelayModifier
-    useDelay: 8.75
+    useDelay: 25
 
 - type: entity
   parent: ActionForceWall
@@ -556,7 +556,7 @@
   name: Force Wall III
   components:
   - type: ActionUseDelayModifier
-    useDelay: 7.5
+    useDelay: 25
 
 - type: entity
   parent: ActionForceWall
@@ -564,7 +564,7 @@
   name: Force Wall IV
   components:
   - type: ActionUseDelayModifier
-    useDelay: 6.25
+    useDelay: 25
 
 - type: entity
   parent: ActionForceWall
@@ -572,7 +572,7 @@
   name: Force Wall V
   components:
   - type: ActionUseDelayModifier
-    useDelay: 5
+    useDelay: 25
 
 # Charge
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Blob chances is small and i havent seen it for 1 week, so blob chances is now reworked a little

## Why / Balance
It will increase chances of spawning blob + max amount of blobs per round is now 3

## Technical details
Just changed numbers in midround antags events


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Now max amount of blob is 3
- tweak: Now blob can spawn from 60 minutes of round.

