### PR TITLE
Carp scroll learning tweak

### DIFF
--- a/Content.Shared/_Goobstation/MartialArts/Components/GrantMartialArtKnowledgeComponent.cs
+++ b/Content.Shared/_Goobstation/MartialArts/Components/GrantMartialArtKnowledgeComponent.cs
@@ -31,7 +31,7 @@ public sealed partial class GrantSleepingCarpComponent : GrantMartialArtKnowledg
     [DataField]
     public override MartialArtsForms MartialArtsForm { get; set; } = MartialArtsForms.SleepingCarp;
     [DataField]
-    public int MaximumUses = 3;
+    public int MaximumUses = 1;
     public int CurrentUses = 0;
 }
 

--- a/Content.Shared/_Goobstation/MartialArts/Components/GrantMartialArtKnowledgeComponent.cs
+++ b/Content.Shared/_Goobstation/MartialArts/Components/GrantMartialArtKnowledgeComponent.cs
@@ -30,6 +30,9 @@ public sealed partial class GrantSleepingCarpComponent : GrantMartialArtKnowledg
 {
     [DataField]
     public override MartialArtsForms MartialArtsForm { get; set; } = MartialArtsForms.SleepingCarp;
+    [DataField]
+    public int MaximumUses = 3;
+    public int CurrentUses = 0;
 }
 
 [RegisterComponent]

--- a/Content.Shared/_Goobstation/MartialArts/SharedMartialArtsSystem.SleepingCarp.cs
+++ b/Content.Shared/_Goobstation/MartialArts/SharedMartialArtsSystem.SleepingCarp.cs
@@ -4,6 +4,7 @@ using Content.Shared._Goobstation.MartialArts.Events;
 using Content.Shared._Shitmed.Targeting;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Popups;
@@ -29,6 +30,14 @@ public partial class SharedMartialArtsSystem
     {
         if (!_netManager.IsServer)
             return;
+
+        if (ent.Comp.MaximumUses == ent.Comp.CurrentUses)
+        {
+            _popupSystem.PopupEntity(Loc.GetString("cqc-fail-used", ("manual", Identity.Entity(ent, EntityManager))),
+            args.User,
+            args.User);
+            return;
+        }
 
         var studentComp = EnsureComp<SleepingCarpStudentComponent>(args.User);
 
@@ -65,8 +74,12 @@ public partial class SharedMartialArtsSystem
                     ent,
                     args.User,
                     PopupType.LargeCaution);
-                return;
+                ent.Comp.MaximumUses++;
+                break;
         }
+
+        if (ent.Comp.MaximumUses == ent.Comp.CurrentUses)
+            return;
     }
 
     private void CarpScrollDelay(Entity<SleepingCarpStudentComponent> ent)

--- a/Content.Shared/_Goobstation/MartialArts/SharedMartialArtsSystem.SleepingCarp.cs
+++ b/Content.Shared/_Goobstation/MartialArts/SharedMartialArtsSystem.SleepingCarp.cs
@@ -74,7 +74,7 @@ public partial class SharedMartialArtsSystem
                     ent,
                     args.User,
                     PopupType.LargeCaution);
-                ent.Comp.MaximumUses++;
+                ent.Comp.CurrentUses++;
                 break;
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Carp scroll is now only learnable by 3 people.

## Why / Balance
Some nukie shifts, one syndicate buys a carp scroll for the entire crew. You can imagine how that goes.
And just general balance tbh.

## Technical details
see commit

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Carp scroll can now only be learned by a single person.