### PR TITLE
lower wizard and up nukie weights

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
@@ -3,10 +3,10 @@
   weights:
     Traitor: 0.25
     Changeling: 0.10
-    Nukeops: 0.02
+    Nukeops: 0.05
     Revolutionary: 0.04
     Zombie: 0.03
     Heretic: 0.10
     BlobGameMode: 0.04
-    Wizard: 0.08
+    Wizard: 0.05
     HonkOps: 0.01


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
title
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
people complain on discord about wizard being too common
lowering nukies to 0.02 (from 0.09) was a test to see if "the other gamemodes in gamedir are failing so it falls back to nukeops". and well it doesn't. nukies basically do not exist now, so it's safe to up it to 0.05 now
## Technical details
<!-- Summary of code changes for easier review. -->
TWO LINES OMG
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!---->
:cl:
- tweak: Nukies should now once again appear in the game, and wizard should appear somewhat rarer.

