### PR TITLE
make air alarms not angry at oxygen

### DIFF
--- a/Resources/Prototypes/Atmospherics/thresholds.yml
+++ b/Resources/Prototypes/Atmospherics/thresholds.yml
@@ -35,12 +35,12 @@
   id: stationOxygen
   lowerBound: !type:AlarmThresholdSetting
     threshold: 0.10
-  #upperBound: !type:AlarmThresholdSetting # Goobstation
-  #  threshold: 0.3
+  upperBound: !type:AlarmThresholdSetting
+    threshold: 1.0 # Goobstation
   lowerWarnAround: !type:AlarmThresholdSetting
     threshold: 1.5
-  #upperWarnAround: !type:AlarmThresholdSetting # Goobstation
-  #  threshold: 0.8
+  upperWarnAround: !type:AlarmThresholdSetting
+    threshold: 0.8 # Goobstation
 
 - type: alarmThreshold
   id: stationNitrogen

--- a/Resources/Prototypes/Atmospherics/thresholds.yml
+++ b/Resources/Prototypes/Atmospherics/thresholds.yml
@@ -35,12 +35,12 @@
   id: stationOxygen
   lowerBound: !type:AlarmThresholdSetting
     threshold: 0.10
-  upperBound: !type:AlarmThresholdSetting
-    threshold: 0.3
+  #upperBound: !type:AlarmThresholdSetting # Goobstation
+  #  threshold: 0.3
   lowerWarnAround: !type:AlarmThresholdSetting
     threshold: 1.5
-  upperWarnAround: !type:AlarmThresholdSetting
-    threshold: 0.8
+  #upperWarnAround: !type:AlarmThresholdSetting # Goobstation
+  #  threshold: 0.8
 
 - type: alarmThreshold
   id: stationNitrogen


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
makes air alarms not angry at high oxygen

## Why / Balance
why did they have an upper bound for oxygen and why was it so low
"but high oxygen means worse fires" no it doesn't, as an experienced atmos i can say that you either are in a fire or you aren't, there's no "worse"
and we don't have oxygen poisoning so high oxygen is just safe

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Air alarms no longer go into danger state due to high oxygen amount.
