### PR TITLE
Make Jaunter Not Useless

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -435,9 +435,6 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
         if (!_entMan.TryGetComponent(actionId, out SwapSpellComponent? swap))
             return false;
 
-        if (!swap.AllowSecondaryTarget)
-            return false;
-
         if (_actionsSystem == null || _spells == null)
             return false;
 

--- a/Content.Shared/_Goobstation/Wizard/Components/SwapSpellComponent.cs
+++ b/Content.Shared/_Goobstation/Wizard/Components/SwapSpellComponent.cs
@@ -5,8 +5,6 @@ namespace Content.Shared._Goobstation.Wizard.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class SwapSpellComponent : Component
 {
-    [DataField]
-    public bool AllowSecondaryTarget = true;
 
     [DataField, AutoNetworkedField]
     public EntityUid? SecondaryTarget;

--- a/Content.Shared/_Goobstation/Wizard/SharedSpellsSystem.cs
+++ b/Content.Shared/_Goobstation/Wizard/SharedSpellsSystem.cs
@@ -176,9 +176,6 @@ public abstract class SharedSpellsSystem : EntitySystem
         if (!TryComp(action, out SwapSpellComponent? swap))
             return;
 
-        if (!swap.AllowSecondaryTarget)
-            return;
-
         swap.SecondaryTarget = target;
         Dirty(action, swap);
     }

--- a/Content.Shared/_Goobstation/Wizard/SharedSpellsSystem.cs
+++ b/Content.Shared/_Goobstation/Wizard/SharedSpellsSystem.cs
@@ -989,9 +989,6 @@ public abstract class SharedSpellsSystem : EntitySystem
         if (!TryComp(ev.Action, out SwapSpellComponent? swap))
             return;
 
-        if (!ev.ThroughWalls && !_examine.InRangeUnOccluded(ev.Performer, ev.Target, ev.Range))
-            return;
-
         var userXform = Transform(ev.Performer);
         var targetXform = Transform(ev.Target);
 

--- a/Content.Shared/_Goobstation/Wizard/SpellEvents.cs
+++ b/Content.Shared/_Goobstation/Wizard/SpellEvents.cs
@@ -487,8 +487,6 @@ public sealed partial class SwapSpellEvent : EntityTargetActionEvent, ISpeakSpel
     [DataField]
     public EntProtoId Effect = "SwapSpellEffect";
 
-    [DataField]
-    public bool ThroughWalls = true;
 }
 
 public sealed partial class SoulTapEvent : InstantActionEvent, ISpeakSpell

--- a/Resources/Prototypes/_Goobstation/Actions/implants.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/implants.yml
@@ -7,14 +7,15 @@
     checkCanAccess: false
     raiseOnUser: true
     checkCanInteract: false
-    useDelay: 60
+    useDelay: 25
     itemIconStyle: BigAction
     whitelist:
       requireAll: true
       components:
       - Transform
       - MobState
-    canTargetSelf: false
+    canTargetSelf: true
+    interactOnMiss: false
     range: 15
     icon:
       sprite: /Textures/_Goobstation/Actions/syndicateswap.rsi
@@ -22,6 +23,4 @@
     event: !type:SwapSpellEvent
       sound:
         path: /Audio/Effects/Lightning/lightningbolt.ogg
-      throughWalls: false
   - type: SwapSpell
-    allowSecondaryTarget: false

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -481,7 +481,7 @@
   icon: { sprite: /Textures/_Goobstation/Actions/syndicateswap.rsi, state: icon }
   productEntity: JaunterImplanter
   cost:
-    Telecrystal: 30
+    Telecrystal: 40
   categories:
   - UplinkImplants
   conditions:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reverted https://github.com/Goob-Station/Goob-Station/pull/2160 instead tuned numbers, increasing cooldown and lowering cost

## Why / Balance
No one is going to use jaunter implant if it cant go through wall and swap with people.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Jaunter now cost 40 TC, 25 seconds cooldown, can swap with people through walls