### PR TITLE
Make Jaunter Not Useless - Take Two

### DIFF
--- a/Resources/Prototypes/_Goobstation/Actions/implants.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/implants.yml
@@ -7,14 +7,14 @@
     checkCanAccess: false
     raiseOnUser: true
     checkCanInteract: false
-    useDelay: 25
+    useDelay: 30
     itemIconStyle: BigAction
     whitelist:
       requireAll: true
       components:
       - Transform
       - MobState
-    canTargetSelf: true
+    canTargetSelf: false
     interactOnMiss: false
     range: 15
     icon:

--- a/Resources/Prototypes/_Goobstation/Actions/implants.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/implants.yml
@@ -7,14 +7,15 @@
     checkCanAccess: false
     raiseOnUser: true
     checkCanInteract: false
-    useDelay: 60
+    useDelay: 25
     itemIconStyle: BigAction
     whitelist:
       requireAll: true
       components:
       - Transform
       - MobState
-    canTargetSelf: false
+    canTargetSelf: true
+    interactOnMiss: false
     range: 15
     icon:
       sprite: /Textures/_Goobstation/Actions/syndicateswap.rsi
@@ -22,6 +23,6 @@
     event: !type:SwapSpellEvent
       sound:
         path: /Audio/Effects/Lightning/lightningbolt.ogg
-      throughWalls: false
+      throughWalls: true
   - type: SwapSpell
     allowSecondaryTarget: false

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -461,7 +461,7 @@
   icon: { sprite: /Textures/_Goobstation/Actions/syndicateswap.rsi, state: icon }
   productEntity: JaunterImplanter
   cost:
-    Telecrystal: 30
+    Telecrystal: 40
   categories:
   - UplinkImplants
   conditions:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reverted https://github.com/Goob-Station/Goob-Station/pull/2160 instead tuned numbers, increasing cooldown and lowering cost, https://github.com/Goob-Station/Goob-Station/pull/2164 but without the c# code modification, only yaml changes

## Why / Balance
No one is going to use jaunter implant if it cant go through wall and swap with people.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Jaunter now cost 40 TC, 30 seconds cooldown, can swap with people through walls