### PR TITLE
purchasable lavaland gateway

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -20,8 +20,6 @@
     - id: SalvageShuttleConsoleCircuitboard
     - id: AstroNavCartridge
     - id: CargoTechFabCircuitboard # Goobstation - Cargo Techfab
-    - id: GatewayFlatpackLavaland # Goobstation
-      prob: 0.4
 
 - type: entity
   id: LockerQuarterMasterFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -20,6 +20,8 @@
     - id: SalvageShuttleConsoleCircuitboard
     - id: AstroNavCartridge
     - id: CargoTechFabCircuitboard # Goobstation - Cargo Techfab
+    - id: GatewayFlatpackLavaland # Goobstation
+      prob: 0.4
 
 - type: entity
   id: LockerQuarterMasterFilled

--- a/Resources/Prototypes/_Lavaland/Catalog/Cargo/cargo_cargo.yml
+++ b/Resources/Prototypes/_Lavaland/Catalog/Cargo/cargo_cargo.yml
@@ -4,6 +4,6 @@
     sprite:  /Textures/Structures/Machines/gateway.rsi
     state: frame
   product: GatewayFlatpackLavaland
-  cost: 30000
+  cost: 20000
   category: cargoproduct-category-name-cargo
   group: market

--- a/Resources/Prototypes/_Lavaland/Catalog/Cargo/cargo_cargo.yml
+++ b/Resources/Prototypes/_Lavaland/Catalog/Cargo/cargo_cargo.yml
@@ -1,0 +1,9 @@
+- type: cargoProduct
+  id: CargoGatewayLavaland
+  icon:
+    sprite:  /Textures/Structures/Machines/gateway.rsi
+    state: frame
+  product: GatewayFlatpackLavaland
+  cost: 30000
+  category: cargoproduct-category-name-cargo
+  group: market

--- a/Resources/Prototypes/_Lavaland/Catalog/Fills/Crates/cargo.yml
+++ b/Resources/Prototypes/_Lavaland/Catalog/Fills/Crates/cargo.yml
@@ -1,0 +1,9 @@
+- type: entity
+  id: CrateCargoGatewayLavaland
+  parent: CrateGenericSteel
+  name: lavaland gateway crate
+  description: Allows you to teleport straight to Lavaland.
+  components:
+  - type: StorageFill
+    contents:
+    - id: GatewayFlatpackLavaland

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Devices/flatpack.yml
@@ -5,4 +5,4 @@
   description: A flatpack used to bluespace in a gateway for travel to Lavaland.
   components:
   - type: Flatpack
-    entity: GatewayLavaland
+    entity: GatewayLavalandStation

--- a/Resources/Prototypes/_Lavaland/Entities/Structures/Machines/gateway.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Structures/Machines/gateway.yml
@@ -12,8 +12,30 @@
         type: GatewayBoundUserInterface
   - type: Gateway
     enabled: true
-    tagRestriction: LavalandGateway
+    tagRestriction: LavalandStationGateway
   - type: Tag
     tags:
     - Structure
     - LavalandGateway
+
+- type: entity
+  parent: BaseGateway
+  id: GatewayLavalandStation
+  name: Lavaland gateway
+  description: To hell you go.
+  suffix: Station
+  components:
+  - type: ActivatableUI
+    key: enum.GatewayUiKey.Key
+  - type: UserInterface
+    interfaces:
+      enum.GatewayUiKey.Key:
+        type: GatewayBoundUserInterface
+  - type: Gateway
+    enabled: true
+    tagRestriction: LavalandGateway
+  - type: Tag
+    tags:
+    - Structure
+    - LavalandStationGateway
+  - type: Anchorable

--- a/Resources/Prototypes/_Lavaland/tags.yml
+++ b/Resources/Prototypes/_Lavaland/tags.yml
@@ -17,6 +17,9 @@
   id: LavalandGateway
 
 - type: Tag
+  id: LavalandStationGateway
+
+- type: Tag
   id: LavalandInterior5x5
 
 - type: Tag


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
allows cargo to buy lavaland gateway flatpack for 20k
can't interlink them

## Why / Balance
incentivises salv to get money
also rewards it more
it's basically qol

## Media
tested, works

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: You can now buy lavaland gateways at cargo for a high price.
