### PR TITLE
add game director weights to a bunch of events

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -398,8 +398,7 @@
     weight: 5
     duration: 30 # DeltaV: was 60, used as a delay now
     chaos: # Goobstation
-      Hostile: 10
-      Friend: 10
+      Hostile: 20
       Medical: 50
   - type: VentCrittersRule
     entries:
@@ -422,6 +421,9 @@
     minimumPlayers: 15
     weight: 5
     duration: 30 # DeltaV: was 60, used as a delay now
+    chaos: # Goobstation
+      Hostile: 20
+      Medical: 50
   - type: VentCrittersRule
     entries:
     - id: MobPurpleSnake
@@ -443,6 +445,9 @@
     minimumPlayers: 15
     weight: 5
     duration: 30 # DeltaV: was 60, used as a delay now
+    chaos: # Goobstation
+      Hostile: 20
+      Medical: 50
   - type: VentCrittersRule
     entries:
     - id: MobGiantSpiderAngry
@@ -460,6 +465,9 @@
     minimumPlayers: 30 # DeltaV - was 20
     weight: 1 # DeltaV - was 1.5
     duration: 30 # DeltaV: was 60, used as a delay now
+    chaos: # Goobstation
+      Hostile: 20
+      Medical: 50
   - type: VentCrittersRule
     playerRatio: 35 # DeltaV: Clown spiders are very robust
     entries:
@@ -476,8 +484,7 @@
     weight: 1 # Zombies was happening basically every single survival round, so now it's super rare
     duration: 1
     chaos: # Goobstation
-      Hostile: 40
-      Friend: 60
+      Hostile: 100
       Medical: 200
       Death: 200
   - type: ZombieRule
@@ -514,9 +521,8 @@
     minimumPlayers: 20
     duration: 1
     chaos: # Goobstation
-      Hostile: 20
-      Friend: 40
-      Medical: 200
+      Hostile: 60
+      Medical: 75
       Death: 100
   - type: RuleGrids
   - type: LoadMapRule
@@ -585,6 +591,8 @@
     duration: 150
     maxDuration: 300
     reoccurrenceDelay: 30
+    chaos: # Goobstation
+      Friend: 20
   - type: MassHallucinationsRule
     minTimeBetweenIncidents: 0.1
     maxTimeBetweenIncidents: 300
@@ -600,6 +608,10 @@
     weight: 8
     reoccurrenceDelay: 20
     duration: 1
+    chaos: # Goobstation
+      Hostile: 10
+      Friend: 20
+      Mess: 30
   - type: IonStormRule
 
 - type: entity
@@ -611,6 +623,10 @@
     minimumPlayers: 20
     maxOccurrences: 1 # this event has diminishing returns on interesting-ness, so we cap it
     weight: 5
+    chaos: # Goobstation
+      Hostile: 20 # for when they're actually properly hostile
+      Hunger: 10
+      Thirst: 10
   - type: MobReplacementRule
 
 - type: entity
@@ -623,6 +639,9 @@
     weight: 5
     minimumPlayers: 25
     reoccurrenceDelay: 20
+    chaos: # Goobstation
+      Atmos: 15
+      Mess: 30
   - type: GreytideVirusRule
     accessGroups:
     - Cargo
@@ -644,6 +663,10 @@
     reoccurrenceDelay: 20
     minimumPlayers: 4
     duration: null
+    chaos: # Goobstation
+      # can be both hostile and friendly
+      Hostile: 10
+      Friend: -10
   - type: SpaceSpawnRule
     spawnDistance: 0
   - type: AntagSpawner

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -28,6 +28,8 @@
     earliestStart: 15
     weight: 6
     duration: 30 # DeltaV: was 50, used as a delay now
+    chaos: # Goobstation
+      Mess: 10 # there's 15 morbillion mice usually and they're easy to kill
   - type: VentCrittersRule
     entries:
     - id: MobMouse
@@ -52,6 +54,9 @@
     weight: 6
     duration: 30 # DeltaV: was 50, used as a delay now
     minimumPlayers: 30 # Hopefully this is enough for the Rat King's potential Army (it was not, raised from 15 -> 30)
+    chaos: # Goobstation
+      Mess: 10
+      Hostile: 1 # low chance to spawn rat king
   - type: VentCrittersRule
     entries:
     - id: MobMouse
@@ -78,6 +83,9 @@
       path: /Audio/Announcements/attention.ogg
     weight: 6
     duration: 30 # DeltaV: was 50, used as a delay now
+    chaos: # Goobstation
+      Mess: 15
+      Hostile: 2
   - type: VentCrittersRule
     entries:
     - id: MobCockroach
@@ -97,6 +105,9 @@
       path: /Audio/Announcements/attention.ogg
     weight: 6
     duration: 30 # DeltaV: was 50, used as a delay now
+    chaos: # Goobstation
+      Friend: -5
+      Mess: 5
   - type: VentCrittersRule
     entries:
     - id: MobSnail
@@ -118,6 +129,9 @@
     weight: 6
     duration: 30 # DeltaV: was 50, used as a delay now
     minimumPlayers: 30
+    chaos: # Goobstation
+      Mess: 5
+      Hostile: 1 # the very low gib snail prob
   - type: VentCrittersRule
     entries:
     - id: MobSnail

--- a/Resources/Prototypes/GameRules/random_sentience.yml
+++ b/Resources/Prototypes/GameRules/random_sentience.yml
@@ -8,6 +8,9 @@
     maxOccurrences: 1 # this event has diminishing returns on interesting-ness, so we cap it
     startAudio:
       path: /Audio/Announcements/attention.ogg
+    chaos: # Goobstation
+      Mess: 5
+      Friend: -5
   - type: RandomSentienceRule
     minSentiences: 2
     maxSentiences: 5

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -51,6 +51,9 @@
     reoccurrenceDelay: 30
     duration: 1
     maxOccurrences: 1 # should be the same as [copies] in shuttle_incoming_event.yml
+    chaos: # Goobstation
+      Friend: -20
+      Power: -10 # can be salvaged for power
   - type: RuleGrids
   - type: LoadMapRule
 
@@ -91,6 +94,9 @@
   - type: StationEvent
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
     weight: 2
+    chaos: # Goobstation
+      Friend: -10
+      Mess: 20
   - type: LoadMapRule
     preloadedGrid: Honki
 
@@ -124,6 +130,8 @@
   - type: StationEvent
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
     weight: 2 # Its just a big ship, so it needs to be rarer to be interesting.
+    chaos: # Goobstation
+      Friend: -60
   - type: LoadMapRule
     preloadedGrid: Cruiser
 
@@ -151,6 +159,9 @@
   components:
   - type: StationEvent
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
+    chaos: # Goobstation
+      Friend: -20
+      Medical: -20
   - type: LoadMapRule
     preloadedGrid: Flatline
 
@@ -172,6 +183,8 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
     weight: 2 # Its just a big ship, so it needs to be rarer to be interesting.
     earliestStart: 45 # late to hopefully have enough ghosts to fill all roles quickly. (5-6)
+    chaos: # Goobstation
+      Friend: -50
   - type: LoadMapRule
     preloadedGrid: NTIncorporation
 
@@ -183,6 +196,11 @@
     startAnnouncement: null #dont nark on antags
     weight: 1 #  lower because antags.
     earliestStart: 50 # late to hopefully have enough ghosts to fill all roles quickly (3) and because antags
+    chaos: # Goobstation
+      # holy mini-nukies
+      Hostile: 80
+      Death: 100
+      Medical: 100
   - type: LoadMapRule
     preloadedGrid: Instigator
 
@@ -212,6 +230,11 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #Leaving this one because theyre like primitives and its funnier
     weight: 1 # lower because antags
     earliestStart: 50 # late to hopefully have enough ghosts to fill all roles quickly. (4) & antags
+    chaos: # Goobstation
+      # it's 4 free agent barely-equipped dudes
+      Hostile: 60
+      Medical: 20
+      Death: 20
   - type: LoadMapRule
     preloadedGrid: ManOWar
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
title
notably, makes ion storms/etc actually happen, also fixes midround shuttle events

## Why / Balance
fix

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed many events not happening.
