### PR TITLE
maintenance drone improvements

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/collective-mind/collective-mind.ftl
+++ b/Resources/Locale/en-US/_Goobstation/collective-mind/collective-mind.ftl
@@ -5,3 +5,4 @@ collective-mind-blobmind = Blobmind
 collective-mind-mansus-link = Mansus Link
 collective-mind-abductormind = Glorpmind
 collective-mind-binary = Binary
+collective-mind-dronemind = Dronemind

--- a/Resources/Locale/en-US/_Imp/Drone/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_Imp/Drone/ghost-role-component.ftl
@@ -2,7 +2,8 @@ ghost-role-information-onestar-mecha-name = OneStar Mecha
 ghost-role-information-onestar-mecha-description = You are this station's end.
 
 ghost-role-information-drone-name = Maintenance Drone
-ghost-role-information-drone-description = Maintain the station. Ignore other beings except drones.
+# Goobstation
+ghost-role-information-drone-description = Maintain the station. Ignore other beings except drones. Use +/+d to talk in the Dronemind.
 ghost-role-information-drone-rules = You are bound by these laws both in-game and out-of-character:
 
      1. You may not interfere with the affairs of any being except another drone, regardless of intent or circumstance.

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -489,7 +489,7 @@
   - type: Prying
     enabled: false
   - type: UseDelay # Goobstation - For insta prying
-    delay: 1
+    delay: 0 # Goobstation - no switch CD
   - type: Tool
     qualities:
       - Screwing

--- a/Resources/Prototypes/_Goobstation/CollectiveMind/collective_minds.yml
+++ b/Resources/Prototypes/_Goobstation/CollectiveMind/collective_minds.yml
@@ -55,3 +55,11 @@
   color: "#5ed7aa"
   requiredTags:
   - BinaryMind
+
+- type: collectiveMind
+  id: Dronemind
+  name: collective-mind-dronemind
+  keycode: 'd'
+  color: "#6e979a" # like binary but more gray
+  requiredTags:
+  - DroneMind

--- a/Resources/Prototypes/_Goobstation/tags.yml
+++ b/Resources/Prototypes/_Goobstation/tags.yml
@@ -63,6 +63,9 @@
   id: CursedAnimalMask
 
 - type: Tag
+  id: DroneMind
+
+- type: Tag
   id: Durand
 
 - type: Tag

--- a/Resources/Prototypes/_Imp/_Drone/Mobs_Player_silicon.yml
+++ b/Resources/Prototypes/_Imp/_Drone/Mobs_Player_silicon.yml
@@ -81,6 +81,7 @@
   - type: Alerts
   - type: ProtectedFromStepTriggers
   - type: Targeting # Shitmed Change
+  - type: CollectiveMind # Goobstation
 
 - type: entity
   name: drone
@@ -233,6 +234,9 @@
     - EmagImmune
     - CanPilot
     - VimPilot
+    - DroneMind # Goobstation
+  - type: CollectiveMind # Goobstation
+    defaultChannel: Dronemind
   - type: Access
     tags:
     - Engineering

--- a/Resources/Prototypes/_Imp/_Drone/drone.yml
+++ b/Resources/Prototypes/_Imp/_Drone/drone.yml
@@ -8,6 +8,7 @@
       connections:
       - right arm
       - right arm 2
+      - right arm 3 # Goobstation
       - left arm
       - left arm 2
     right arm:
@@ -18,6 +19,10 @@
       part: RightArmBorg
       connections:
       - right hand 2
+    right arm 3: # Goobstation
+      part: RightArmBorg
+      connections:
+      - right hand 3
     left arm:
       part: LeftArmBorg
       connections:
@@ -29,6 +34,8 @@
     right hand:
       part: RightHandHuman # shitmed moment
     right hand 2:
+      part: RightHandHuman
+    right hand 3: # Goobstation
       part: RightHandHuman
     left hand:
       part: LeftHandHuman

--- a/Resources/Prototypes/_Imp/_Drone/drone_tools.yml
+++ b/Resources/Prototypes/_Imp/_Drone/drone_tools.yml
@@ -9,6 +9,13 @@
   - type: Unremoveable
   - type: Sprite
     sprite: _Imp/Drone/dronesatchel.rsi
+  - type: StorageFill
+    contents:
+      - id: ClothingOuterHardsuitSyndie
+      - id: ClothingMaskGasSyndicate
+      - id: ClothingHandsGlovesCombat
+      - id: DoubleEmergencyOxygenTankFilled
+      - id: DoubleEmergencyNitrogenTankFilled
 
 - type: entity
   parent: trayScanner
@@ -28,6 +35,14 @@
   parent: WelderExperimental
   id: WelderExperimentalUnremoveable
   suffix: Unremoveable
+  components:
+  - type: Unremoveable
+
+# Goobstation
+- type: entity
+  parent: RCDRecharging
+  id: RCDRechargingUnremoveable
+  suffix: Unremovable
   components:
   - type: Unremoveable
 
@@ -79,3 +94,4 @@
   inhand:
   - OmnitoolUnremoveable
   - WelderExperimentalUnremoveable
+  - RCDRechargingUnremoveable

--- a/Resources/Prototypes/_Imp/_Drone/drone_tools.yml
+++ b/Resources/Prototypes/_Imp/_Drone/drone_tools.yml
@@ -9,13 +9,6 @@
   - type: Unremoveable
   - type: Sprite
     sprite: _Imp/Drone/dronesatchel.rsi
-  - type: StorageFill
-    contents:
-      - id: ClothingOuterHardsuitSyndie
-      - id: ClothingMaskGasSyndicate
-      - id: ClothingHandsGlovesCombat
-      - id: DoubleEmergencyOxygenTankFilled
-      - id: DoubleEmergencyNitrogenTankFilled
 
 - type: entity
   parent: trayScanner


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- the omnitool no longer has an 1-second cooldown between tool changes
- now gets an experimental RCD
- now has its own dronemind collective mind channel

## Why / Balance
good
makes them way more worth it and more interesting to play
basically engiborg lite with this

## Media
tested, works

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Maintenance drones now have an experimental RCD.
- add: Maintenance drones now have their own collective mind channel on +d.
- tweak: The maintenance drone omnitool no longer has a cooldown between tool changes.