### PR TITLE
make max-size bingle pit ignore gravity

### DIFF
--- a/Content.Server/_Goobstation/Bingle/BinglePitSystem.cs
+++ b/Content.Server/_Goobstation/Bingle/BinglePitSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Ghost.Roles.Components;
 using Content.Shared.StepTrigger.Systems;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Destructible;
+using Content.Shared.StepTrigger.Systems;
 using Content.Shared.Stunnable;
 using Content.Shared.Humanoid;
 using Content.Shared.Weapons.Melee.Events;
@@ -40,6 +41,7 @@ public sealed class BinglePitSystem : EntitySystem
     [Dependency] private readonly NavMapSystem _navMap = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
+    [Dependency] private readonly StepTriggerSystem _step = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ITileDefinitionManager _tiledef = default!;
     [Dependency] private readonly TileSystem _tile = default!;
@@ -161,6 +163,10 @@ public sealed class BinglePitSystem : EntitySystem
 
         if (component.Level <= component.MaxSize)
             ScaleUpPit(uid, component);
+
+        // make max-size bingle pit ignore gravity
+        if (component.Level == component.MaxSize)
+            _step.SetIgnoreWeightless(uid, true);
 
         _popup.PopupEntity(Loc.GetString("bingle-pit-grow"), uid);
     }

--- a/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
@@ -243,6 +243,19 @@ public sealed class StepTriggerSystem : EntitySystem
         component.Active = active;
         Dirty(uid, component);
     }
+
+    // Goobstation
+    public void SetIgnoreWeightless(EntityUid uid, bool to, StepTriggerComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        if (to == component.IgnoreWeightless)
+            return;
+
+        component.IgnoreWeightless = to;
+        Dirty(uid, component);
+    }
 }
 
 [ByRefEvent]

--- a/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
@@ -245,15 +245,15 @@ public sealed class StepTriggerSystem : EntitySystem
     }
 
     // Goobstation
-    public void SetIgnoreWeightless(EntityUid uid, bool to, StepTriggerComponent? component = null)
+    public void SetIgnoreWeightless(EntityUid uid, bool ignore, StepTriggerComponent? component = null)
     {
         if (!Resolve(uid, ref component))
             return;
 
-        if (to == component.IgnoreWeightless)
+        if (ignore == component.IgnoreWeightless)
             return;
 
-        component.IgnoreWeightless = to;
+        component.IgnoreWeightless = ignore;
         Dirty(uid, component);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
title

## Why / Balance
can't rob bingles of their victory anymore
it's really easy to counter them before that (just turn off grav) so if bingles got to this point they deserve to just win

## Media
tested, works

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Max-size bingle pit now ignores gravity. 
