### PR TITLE
make ptk800 and mech pka respect lavaland changes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -473,12 +473,12 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 30
-        Structural: 35
+        Blunt: 80 # Goobstation edit
+        # Structural: 35 # Goobstation edit
   - type: Ammo
     muzzleFlash: HitscanEffect
   - type: TimedDespawn
-    lifetime: 1.5
+    lifetime: 0.3 # Goobstation edit
   - type: PointLight
     radius: 2.5
     color: white

--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -327,8 +327,8 @@
         - !type:DoActsBehavior
           acts: ["Destruction"]
   - type: Gun
-    projectileSpeed: 20
-    fireRate: 2
+    # projectileSpeed: 20 # Goobstation edit
+    fireRate: 1
     selectedMode: SemiAuto
     angleDecay: 45
     minAngle: 5
@@ -352,3 +352,9 @@
     count: 5
   - type: Machine
     board: ShuttleGunKineticCircuitboard
+  - type: PressureDamageChange # Goobstation
+  - type: UpgradeableGun # Goobstation
+    maxUpgradeCapacity: 40
+    whitelist:
+      tags:
+      - PKAUpgrade

--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -328,7 +328,7 @@
           acts: ["Destruction"]
   - type: Gun
     # projectileSpeed: 20 # Goobstation edit
-    fireRate: 1
+    fireRate: 1 # Goobstation edit
     selectedMode: SemiAuto
     angleDecay: 45
     minAngle: 5

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Gun/industrial.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Gun/industrial.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: WeaponMechIndustrialKineticAccelerator
-  name: exosuit proto-kinetic accelerator
-  description: Fires normal-damage kinetic bolts at a short range.
+  name: proto-kinetic launcher
+  description: Fires huge damage kinetic bolts at a medium range.
   suffix: Mech Weapon, Gun, Industrial, Kinetic Accelerator
   parent: [ BaseMechWeaponRange, IndustrialMechEquipment ]
   components:
@@ -9,7 +9,7 @@
     sprite: Objects/Specific/Mech/mecha_equipment.rsi
     state: mecha_kineticgun
   - type: Gun
-    fireRate: 1
+    fireRate: 0.5
     selectedMode: SemiAuto
     availableModes:
       - SemiAuto
@@ -20,4 +20,10 @@
     fireCost: 0.1
   - type: Appearance
   - type: AmmoCounter
+  - type: PressureDamageChange
+  - type: UpgradeableGun
+    maxUpgradeCapacity: 40
+    whitelist:
+      tags:
+      - PKAUpgrade
 # TODO: Plasma Cutter


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
ptk800 and exosuit pka (now called proto-kinetic launcher) now respect lavaland changes being pressure damage reduction and upgrading.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
makes sense
## Technical details
<!-- Summary of code changes for easier review. -->
tested works
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!---->
:cl:
- tweak: PTK-800 and mech proto-kinetic launcher now deal more damage in low pressure and less damage in a normal athosphere, and are upgradeable with modkits.