### PR TITLE
Fix an oversight when recipes were moved over to techfabs.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -357,7 +357,7 @@
     - Cybernetics
     - PowerCells
     - MechBoards
-    - type: EmagLatheRecipes
+  - type: EmagLatheRecipes
     emagStaticPacks:
     - MechWeaponsStatic
     emagDynamicPacks:
@@ -371,7 +371,6 @@
   - type: GuideHelp
     guides:
     - Robotics
-
 
 - type: entity
   id: Biofabricator

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -291,7 +291,7 @@
     - MechElectronicsGoob
   - type: EmagLatheRecipes
     emagDynamicPacks:
-    SecurityMechElectronicsGoob
+    - SecurityMechElectronicsGoob
     #- SecurityBoards - Goobstation -  Moved to Secfab
   - type: MaterialStorage
     whitelist:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -372,6 +372,7 @@
     guides:
     - Robotics
 
+
 - type: entity
   id: Biofabricator
   parent: BaseLatheLube

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -290,7 +290,8 @@
     #- MedicalBoardsGoob - Goobstation - Moved to Scifab and Medfab
     - MechElectronicsGoob
   - type: EmagLatheRecipes
-    #emagDynamicPacks:
+    emagDynamicPacks:
+    SecurityMechElectronicsGoob
     #- SecurityBoards - Goobstation -  Moved to Secfab
   - type: MaterialStorage
     whitelist:
@@ -356,7 +357,11 @@
     - Cybernetics
     - PowerCells
     - MechBoards
-    - MechElectronicsGoob
+    - type: EmagLatheRecipes
+    emagStaticPacks:
+    - MechWeaponsStatic
+    emagDynamicPacks:
+    - MechWeapons
   - type: MaterialStorage
     whitelist:
       tags:


### PR DESCRIPTION

## About the PR
Emagged exofab can make mech weapons and emagged circut printer can make mech circuts.

## Why / Balance
Intended but forgotten
