### PR TITLE
smallen laser rifle

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -246,6 +246,9 @@
   - type: StaticPrice
     price: 300
   - type: PacifismAllowedGun
+  # Goobstation
+  - type: Item
+    size: Large
 
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
laser rifle 4x4 -> 4x2

## Why / Balance
why was it 4x4
mocho said could maybe make it 3x2 even

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Laser rifles huge (4x4) -> large (4x2).
