### PR TITLE
Incompatible roundstart game director gamemodes

### DIFF
--- a/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
+++ b/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
@@ -249,6 +249,9 @@ public sealed partial class GoobCVars
     public static readonly CVarDef<float> MinimumTimeUntilFirstEvent =
         CVarDef.Create("gamedirector.minimumtimeuntilfirstevent", 300f, CVar.SERVERONLY);
 
+    public static readonly CVarDef<int> GameDirectorDebugPlayerCount =
+        CVarDef.Create("gamedirector.debug_player_count", 80, CVar.SERVERONLY);
+
     #endregion
 
     #region Mass Contests

--- a/Content.Goobstation.Shared/StationEvents/IncompatibleGameModesPrototype.cs
+++ b/Content.Goobstation.Shared/StationEvents/IncompatibleGameModesPrototype.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Goobstation.Shared.StationEvents;
+
+[Prototype("incompatibleModes")]
+public sealed class IncompatibleGameModesPrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    [DataField(required: true)]
+    public HashSet<string> Modes = new();
+}

--- a/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
@@ -10,3 +10,42 @@
     BlobGameMode: 0.04
     Wizard: 0.05
     #HonkOps: 0.01 # this test fail was real holy shit it was only a preset the entire a time i was lied too by myself
+
+
+- type: incompatibleModes
+  id: Nukeops
+  modes:
+  - Nukeops
+  - HonkOps
+  - Zombie
+  - Revolutionary
+
+- type: incompatibleModes
+  id: HonkOps
+  modes:
+  - Nukeops
+  - HonkOps
+  - Zombie
+  - Revolutionary
+
+- type: incompatibleModes
+  id: Wizard
+  modes:
+  - Wizard
+
+- type: incompatibleModes
+  id: BlobGameMode
+  modes:
+  - BlobGameMode
+
+- type: incompatibleModes
+  id: Zombie
+  modes:
+  - Nukeops
+  - HonkOps
+
+- type: incompatibleModes
+  id: Revolutionary
+  modes:
+  - Nukeops
+  - HonkOps

--- a/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
@@ -19,6 +19,7 @@
   - HonkOps
   - Zombie
   - Revolutionary
+  - BlobGameMode
 
 - type: incompatibleModes
   id: HonkOps
@@ -27,6 +28,7 @@
   - HonkOps
   - Zombie
   - Revolutionary
+  - BlobGameMode
 
 - type: incompatibleModes
   id: Wizard
@@ -37,6 +39,8 @@
   id: BlobGameMode
   modes:
   - BlobGameMode
+  - Nukeops
+  - HonkOps
 
 - type: incompatibleModes
   id: Zombie


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Some roundstart gamemodes are now incompatible. Like nukies + blob or nukies + zombies or nukies + revs. Also double blob, nukies and wizards.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Read discussion in https://discord.com/channels/1202734573247795300/1354899626439999629
In short, I was requested to do this because some of the gamemodes being selected together is just awful.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Aviu
- add: Roundstart nukeops can no longer spawn with revs, blob or zombies.
- fix: Fixed 2 roundstart nukie squads, 2 blobs or 2 wizards being selected sometimes.