### PR TITLE
revert proximity airlocks

### DIFF
--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -296,26 +296,6 @@ public sealed partial class DoorComponent : Component
 
     [DataField(customTypeSerializer: typeof(ConstantSerializer<DrawDepthTag>))]
     public int ClosedDrawDepth = (int) DrawDepth.DrawDepth.Doors;
-
-    // <Goobstation>
-    /// <summary>
-    /// Fixture id collisions with which open the door. Used for predictive door opening. Unused if null.
-    /// </summary>
-    [DataField]
-    public string? ProximityFixtureId = null; // unused if null
-
-    /// <summary>
-    /// Affects how towards the door we have to be going for it to proximity open
-    /// </summary>
-    [DataField]
-    public float ProximityOpenThreshold = 0.7f;
-
-    /// <summary>
-    /// How fast you have to be going for the door to proximity open
-    /// </summary>
-    [DataField]
-    public float ProximityOpenSpeedThreshold = 1.5f; // doesn't proximity open if you're crawling
-    // </Goobstation>
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -1,6 +1,4 @@
 using System.Linq;
-using System.Numerics; // Goobstation
-using Content.Shared.Access; // Goobstation
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Administration.Logs;
@@ -14,7 +12,6 @@ using Content.Shared.Popups;
 using Content.Shared.Power.EntitySystems;
 using Content.Shared.Prying.Components;
 using Content.Shared.Prying.Systems;
-using Content.Shared.StationRecords; // Goobstation
 using Content.Shared.Stunnable;
 using Content.Shared.Tag;
 using Content.Shared.Tools.Systems;
@@ -26,7 +23,6 @@ using Robust.Shared.Timing;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Map.Components;
-using Robust.Shared.Prototypes; // Goobstation
 
 namespace Content.Shared.Doors.Systems;
 
@@ -613,12 +609,6 @@ public abstract partial class SharedDoorSystem : EntitySystem
         }
     }
 
-    // Goobstation - because of course access reader system has no easy way to check if something has empty accesses
-    // if you find yourself having to copy this, please do not, and instead just add a method to AccessReaderSystem that does what you want
-    // also rewrite this if you do
-    private List<ProtoId<AccessLevelPrototype>> EmptyAccessList = new();
-    private List<StationRecordKey> EmptyRecordList = new();
-
     /// <summary>
     ///     Open a door if a player or door-bumper (PDA, ID-card) collide with the door. Sadly, bullets no longer
     ///     generate "access denied" sounds as you fire at a door.
@@ -633,21 +623,8 @@ public abstract partial class SharedDoorSystem : EntitySystem
 
         var otherUid = args.OtherEntity;
 
-        // Goobstation
-        bool isProximity = args.OurFixtureId == door.ProximityFixtureId;
-        if (isProximity && TryComp<PhysicsComponent>(args.OtherEntity, out var otherPhysics) &&
-            (
-                otherPhysics.LinearVelocity.Length() < door.ProximityOpenSpeedThreshold // only proximity open us if the other entity is going fast enough
-                || Vector2.Dot((Transform(uid).WorldPosition - Transform(args.OtherEntity).WorldPosition).Normalized(), otherPhysics.LinearVelocity.Normalized()) < door.ProximityOpenThreshold // only proximity open us if the other entity is going towards us
-            )
-        )
-            return;
-        // only proximity open us if we're an access-less door
-        if (isProximity && TryComp<AccessReaderComponent>(uid, out var reader) && !_accessReaderSystem.IsAllowed(EmptyAccessList, EmptyRecordList, uid, reader))
-            return;
-
         if (Tags.HasTag(otherUid, DoorBumpTag))
-            TryOpen(uid, door, otherUid, quiet: door.State == DoorState.Denying || isProximity, predicted: true); // Goobstation
+            TryOpen(uid, door, otherUid, quiet: door.State == DoorState.Denying, predicted: true);
     }
     #endregion
 

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -54,16 +54,6 @@
         - FullTileMask
         layer:
         - AirlockLayer
-      # Goobstation
-      proximity:
-        shape:
-          !type:PhysShapeCircle
-          radius: 2.5
-        hard: false
-        layer:
-        - LowImpassable
-        - MidImpassable
-        - HighImpassable
   - type: LayerChangeOnWeld
     unWeldedLayer: AirlockLayer
     weldedLayer: WallLayer
@@ -82,8 +72,6 @@
       path: /Audio/Machines/airlock_close.ogg
     denySound:
       path: /Audio/Machines/airlock_deny.ogg
-    # Goobstation
-    proximityFixtureId: proximity
   - type: ContainerContainer
     containers:
       board: !type:Container
@@ -226,16 +214,6 @@
         - FullTileMask
         layer:     #removed opaque from the layer, allowing lasers to pass through glass airlocks
         - GlassAirlockLayer
-      # Goobstation
-      proximity:
-        shape:
-          !type:PhysShapeCircle
-          radius: 2.5
-        hard: false
-        layer:
-        - LowImpassable
-        - MidImpassable
-        - HighImpassable
   - type: LayerChangeOnWeld
     unWeldedLayer: GlassAirlockLayer
     weldedLayer: GlassLayer


### PR DESCRIPTION
## About the PR
title

## Why / Balance
many bug reports and many issue reports so it doesn't seem like this was a good idea afterall

might make another PR readding them as their own proto later so not every airlock has this

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Proximity airlock opening.
