### PR TITLE
Revert "Increse the ammount of inventry you can have open at one time"

### DIFF
--- a/Content.Shared/CCVar/CCVars.Interactions.cs
+++ b/Content.Shared/CCVar/CCVars.Interactions.cs
@@ -63,7 +63,7 @@ public sealed partial class CCVars
     /// Recommended that you utilise this in conjunction with <see cref="StaticStorageUI"/>
     /// </summary>
     public static readonly CVarDef<int> StorageLimit =
-        CVarDef.Create("control.storage_limit", 5, CVar.REPLICATED | CVar.SERVER); // Goobstation  1 => 5
+        CVarDef.Create("control.storage_limit", 1, CVar.REPLICATED | CVar.SERVER);
 
     /// <summary>
     /// Whether or not storage can be opened recursively.


### PR DESCRIPTION
Reverts Goob-Station/Goob-Station#2131

who the fuck told you this does not look awful and is a good idea
![image](https://github.com/user-attachments/assets/f32c4938-a4cb-45c9-b3b8-9cbced1f0133)
even then who the fuck told you to use specifically 5 and not -1
and finally who the fuck told you to put it into default cvar values instead of asking durk to put it into server config

![image](https://github.com/user-attachments/assets/1732b0f3-aa4a-41d4-af54-c27fe268aa1e)
![image](https://github.com/user-attachments/assets/16941114-a5ee-4fed-b7a6-1d46247cf86c)
![image](https://github.com/user-attachments/assets/97b00266-1742-4c48-94ab-eb32cb56384a)

btw no, this is not mald pr, mald pr is the original one, where the average ipc player with skill issues does not know what hotkey is

:cl: pheenty
- tweak: Multiple storage behavior was reverted.