### PR TITLE
Origin of Flapoob

### DIFF
--- a/Resources/Locale/en-US/prototypes/roles/antags.ftl
+++ b/Resources/Locale/en-US/prototypes/roles/antags.ftl
@@ -37,3 +37,9 @@ roles-antag-thief-objective = Add some NT property to your personal collection w
 
 roles-antag-dragon-name = Space Dragon
 roles-antag-dragon-objective = Create a carp army to take over this quadrant.
+
+roles-antag-flapoob-name = Flapoob
+roles-antag-flapoob-objective = You are Flapoob, creator of all catgirls, enslave and conquer the station to serve as your new lab.
+
+roles-antag-flapoob-agent-name = Flapoob agent
+roles-antag-flapoob-agent-objective = An agent of Flapoob, help him enslave the station.

--- a/Resources/Prototypes/Roles/Antags/flapoob.yml
+++ b/Resources/Prototypes/Roles/Antags/flapoob.yml
@@ -1,0 +1,21 @@
+- type: antag
+  id: Flapoob
+  name: roles-antag-flapoob-name
+  antagonist: true
+  setPreference: true
+  objective: roles-antag-flapoob-objective
+  guides: [ Flapoob ]
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorGrey
+    back: ClothingBackpackChameleonFill
+
+- type: antag
+  id: FlapoobAgent
+  name: roles-antag-flapoob-agent-name
+  antagonist: true
+  setPreference: true
+  objective: roles-antag-flapoob-agent-objective
+  guides: [ Flapoob ]
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorGrey
+    back: ClothingBackpackChameleonFill


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Goal: Conquer the station to use as your new lab. Enslave all crew to do your bidding, capture crew with your slaves to brainwash them, and use your schizophrenia ray to sow chaos, use the Power of Friendship™️  to evade the authorities, whilst slowly assembling your powerbase

Spawns with Flapoob and 3 minions in the spawn area, equipped with chameleon clothes and agent IDs, with a pistol and 3 mags each. Will take the shuttle to the station when they have assumed their disguises. Flapoob has a variety of psionic powers, a brainwashing spell, and all Flapoobian minions have access to the Flapoobian hivemind.

From the planet Gleepnar, the same species as abductors, Flapoob was expelled after his experiments were deemed too unethical. Flapoob eventually landed on earth in the year 2030, where he became obsessed with humans and cats, he decided to combine both of them into 'Catgirls', naming the new race Tajaran. He has come out of hiding to expand his influence onto one of NanoTrasen's stations

## Technical details
Flapoob Abilities:
Create Catgirl: spawns a ghost role Tajaran who will fight for you (cooldown 5 minutes, inactive in spawn area)
Schizophrenia ray: Turns victim schizophrenic like abductors do, blanks short term memory (cooldown 5 minutes)
Friendship blast: polymorphs crit individual into Tajarans, brainwashing them into serving you, goes through mindshield (cooldown 5 minutes)
Attraction beam: Flings items out of the hands of the target, landing in Flapoob's hands, (cooldown 5 minutes)
Flapoob Hivemind

## Why / Balance
I think it is an interesting asymmetrical antag. As it will spawn with limited equipment, they will have to rely on stealth and teamwork to survive, the create minion ability is tempered with the fact they will have to equip them themselves and increases the risk of detection, but gives a much needed source of power to convert the crew
The schizophrenia ray is a fun ability that will cause distractions for the Yakub team, and help silence any witness who sees their operations
The Friendship Blast will be the most powerful ability, only acting on crit crew, it provides a much needed avenue for converting the crew, balanced by the fact it is painfully obvious the converted is not who they once where if they were not already Tajaran

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added Flapoob Midround antag
-->
