### PR TITLE
add bz canisters to cargo catalog

### DIFF
--- a/Resources/Prototypes/_Goobstation/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Cargo/cargo_atmospherics.yml
@@ -1,0 +1,10 @@
+# Assmos - /tg/ gases
+- type: cargoProduct
+  id: AtmosphericsBZ
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: purple
+  product: BZCanister
+  cost: 6500
+  category: cargoproduct-category-name-atmospherics
+  group: market


### PR DESCRIPTION
## About the PR
This PR adds canisters of BZ to the cargo catalog for 6500 specos each. 

## Why / Balance
Atmos players should be able to experiment with mixing nitrium and healium without needing to make mass amounts of BZ, which is very difficult to make in mass quantities. 

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- tweak: BZ canisters can be purchased through the cargo catalog.
