### PR TITLE
add group retaliation

### DIFF
--- a/Content.Goobstation.Server/NPC/GroupRetaliationComponent.cs
+++ b/Content.Goobstation.Server/NPC/GroupRetaliationComponent.cs
@@ -1,0 +1,15 @@
+namespace Content.Goobstation.Server.NPC;
+
+/// <summary>
+/// Entities with this component will retaliate against those who physically attack them.
+/// It has an optional "memory" specification wherein it will only attack those entities for a specified length of time.
+/// </summary>
+[RegisterComponent, Access(typeof(GroupRetaliationSystem))]
+public sealed partial class GroupRetaliationComponent : Component
+{
+    /// <summary>
+    /// If retaliating, provoke an identical retaliation in friendly entities in this radius.
+    /// </summary>
+    [DataField]
+    public float Range = 10;
+}

--- a/Content.Goobstation.Server/NPC/GroupRetaliationSystem.cs
+++ b/Content.Goobstation.Server/NPC/GroupRetaliationSystem.cs
@@ -1,0 +1,36 @@
+using Content.Server.NPC.Components;
+using Content.Server.NPC.Events;
+using Content.Server.NPC.Systems;
+using Content.Shared.NPC.Systems;
+
+namespace Content.Goobstation.Server.NPC;
+
+/// <summary>
+///     Handles NPC which become aggressive after being attacked.
+/// </summary>
+public sealed class GroupRetaliationSystem : EntitySystem
+{
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
+    [Dependency] private readonly NPCRetaliationSystem _retaliation = default!;
+
+    /// <inheritdoc />
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<GroupRetaliationComponent, NPCRetaliatedEvent>(OnRetaliated);
+    }
+
+    private void OnRetaliated(Entity<GroupRetaliationComponent> ent, ref NPCRetaliatedEvent args)
+    {
+        if (args.Secondary)
+            return;
+
+        foreach (var uid in _lookup.GetEntitiesInRange<GroupRetaliationComponent>(Transform(args.Ent).Coordinates, ent.Comp.Range))
+        {
+            if (!_npcFaction.IsEntityFriendly(ent.Owner, uid.Owner) || !TryComp<NPCRetaliationComponent>(uid, out var npcRetaliation))
+                continue;
+
+            _retaliation.TryRetaliate((uid, npcRetaliation), args.Against, true);
+        }
+    }
+}

--- a/Content.Server/NPC/Events/NPCRetaliatedEvent.cs
+++ b/Content.Server/NPC/Events/NPCRetaliatedEvent.cs
@@ -1,0 +1,18 @@
+// goobstation - entire file; goobmod moment
+using Content.Server.NPC.Components;
+
+namespace Content.Server.NPC.Events;
+
+public sealed class NPCRetaliatedEvent : EntityEventArgs
+{
+    public readonly Entity<NPCRetaliationComponent> Ent;
+    public readonly EntityUid Against;
+    public readonly bool Secondary;
+
+    public NPCRetaliatedEvent(Entity<NPCRetaliationComponent> ent, EntityUid against, bool secondary)
+    {
+        Ent = ent;
+        Against = against;
+        Secondary = secondary;
+    }
+}

--- a/Content.Server/NPC/Systems/NPCRetaliationSystem.cs
+++ b/Content.Server/NPC/Systems/NPCRetaliationSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.NPC.Components;
+using Content.Server.NPC.Events; // Goobstation
 using Content.Shared.CombatMode;
 using Content.Shared.Damage;
 using Content.Shared.Mobs.Components;
@@ -40,7 +41,8 @@ public sealed class NPCRetaliationSystem : EntitySystem
         TryRetaliate(ent, args.Source);
     }
 
-    public bool TryRetaliate(Entity<NPCRetaliationComponent> ent, EntityUid target)
+    public bool TryRetaliate(Entity<NPCRetaliationComponent> ent, EntityUid target,
+                             bool secondary = false) // Goobstation - whether this should trigger group retaliation
     {
         // don't retaliate against inanimate objects.
         if (!HasComp<MobStateComponent>(target))
@@ -53,6 +55,10 @@ public sealed class NPCRetaliationSystem : EntitySystem
         _npcFaction.AggroEntity(ent.Owner, target);
         if (ent.Comp.AttackMemoryLength is {} memoryLength)
             ent.Comp.AttackMemories[target] = _timing.CurTime + memoryLength;
+
+        // Goobstation
+        var ev = new NPCRetaliatedEvent(ent, target, secondary);
+        RaiseLocalEvent(ent, ev);
 
         return true;
     }

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1397,6 +1397,9 @@
   - type: CanHostGuardian
   - type: NPCRetaliation
     attackMemoryLength: 10
+  # Goobstation
+  - type: GroupRetaliation
+    range: 8
   - type: FactionException
   - type: NpcFactionMember
     factions:
@@ -1859,6 +1862,10 @@
   - type: Stamina
     critThreshold: 20
   - type: LayingDown
+  - type: NPCRetaliation
+    attackMemoryLength: 5 # stop caring fast if you don't keep hitting
+  - type: GroupRetaliation
+    range: 5 # slightly lower for mice
   # </Goobstation>
 
 - type: entity

--- a/Resources/Prototypes/NPCs/mob.yml
+++ b/Resources/Prototypes/NPCs/mob.yml
@@ -28,6 +28,10 @@
     - tasks:
         - !type:HTNCompoundTask
           task: FoodCompound
+    # Goobstation - for retaliation; yes, they care about food more
+    - tasks:
+        - !type:HTNCompoundTask
+          task: MeleeCombatCompound
     - tasks:
         - !type:HTNCompoundTask
           task: IdleCompound

--- a/Resources/Prototypes/_Goobstation/Reagents/narcotics.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/narcotics.yml
@@ -266,7 +266,7 @@
         prototype: MouseSentient
         conditions:
         - !type:ReagentThreshold
-          min: 30
+          min: 50 # raised because mouse retaliation is now a thing
       - !type:PopupMessage
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -32,9 +32,7 @@
 
 - type: npcFaction
   id: Mouse
-  hostile:
-    - PetsNT
-    - AllHostile
+  # not hostile to anything so they don't attack things
 
 - type: npcFaction
   id: Passive

--- a/Resources/Prototypes/ai_factions.yml
+++ b/Resources/Prototypes/ai_factions.yml
@@ -32,7 +32,7 @@
 
 - type: npcFaction
   id: Mouse
-  # not hostile to anything so they don't attack things
+  # Goobstation - not hostile to anything so they don't attack things
 
 - type: npcFaction
   id: Passive


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
add NPC group retaliation and adds it to mice and monkeys
if you hit a NPC with group retaliation, it will also aggro all nearby NPCs
mouse retaliation times out after 5 seconds
raised mousebites polymorph threshold to 50

## Why / Balance
good
monkeys needed this
gave to mice because funny, from testing it can't really damage you much

## Media
https://github.com/user-attachments/assets/52855563-ac8c-4e70-a780-18e4e445b57a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Group retaliation to monkeys and mice.
