### PR TITLE
Bluespace shelters: Remove preloaded grids

### DIFF
--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Specific/Salvage/shelter.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Specific/Salvage/shelter.yml
@@ -5,6 +5,7 @@
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 McBosserson <148172569+McBosserson@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Milon <plmilonpl@gmail.com>
+# SPDX-FileCopyrightText: 2025 PeccNeck <74548962+PeccNeck@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 Rouden <149893554+Roudenn@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Specific/Salvage/shelter.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Specific/Salvage/shelter.yml
@@ -61,9 +61,9 @@
 - type: preloadedGrid
   id: ShelterCapsule5x5
   path: /Maps/_Lavaland/Shelters/shelter_5x5.yml
-  copies: 5
+  copies: 0
 
 - type: preloadedGrid
   id: ShelterCapsule7x7
   path: /Maps/_Lavaland/Shelters/shelter_7x7.yml
-  copies: 3
+  copies: 0


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
Removes grid preloading from bluespace shelter capsules, as it was causing buggy behavior. This is probably a band-aid fix.

## Why / Balance
Buggy behavior to do with the preloaded grids not being initialized properly. Most notably, there is no light tube, and door accesses are not loaded correctly, leading to doors always being locked (even with admin ID) instead of never being locked.

## Technical details
Changed two lines in YML from 5 and 3 to 0.

From what I can tell (and I don't know much C#, or any really), bluespace shelter capsules use the same grid pre-loading system that shuttle events do, loading the grids onto an uninitialized map. The difference, however, is that shuttle events first move the grids into an entirely new map, which is only then initialized.

Preloaded shelter capsules don't do this; they directly transport the uninitialized grid into an initialized map, which apparently doesn't do things quite right. Interestingly, the code is already there to load a new shelter into a new map and initialize it if no preloaded shelters are found; so even in live servers, you could spawn 5 broken capsules, and your 6th will be handled correctly.

This does come with the caveat of creating a new (empty) map every time you place a new capsule. Not ideal. I'm open to suggestions.

## Media
Without "fix" (preloading, current behavior)
![image](https://github.com/user-attachments/assets/6ac4eb65-c44c-4e6c-9421-57973a4f296f)

With "fix" (no preloading)
![image](https://github.com/user-attachments/assets/8ec0788b-a8bf-4cc6-8bd5-3c8dfb34fdf1)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Bluespace shelter capsules now load correctly