### PR TITLE
1984 byond curse, april fools is over sadly

### DIFF
--- a/Resources/Prototypes/_Goobstation/Wizard/actions.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/actions.yml
@@ -999,31 +999,31 @@
     requiresSpeech: true
     school: Conjuration
 
-- type: entity
-  id: ActionCurseOfByond
-  name: Curse of Byond
-  description: Curse the target, causing them to be unable to move properly.
-  components:
-  - type: EntityTargetAction
-    raiseOnUser: true
-    checkCanAccess: false
-    checkCanInteract: false
-    useDelay: 30
-    range: 40
-    whitelist:
-      requireAll: true
-      components:
-      - MobState
-      - Body
-      - MindContainer
-    itemIconStyle: BigAction
-    icon:
-      sprite: _Goobstation/Wizard/actions.rsi
-      state: curseofbyond
-    event: !type:PredictionToggleSpellEvent
-      speech: action-speech-spell-curse-of-byond
-      sound:
-        path: /Audio/_Goobstation/Wizard/phasein.ogg
-  - type: Magic
-    requiresSpeech: true
-    school: Conjuration
+#- type: entity
+#  id: ActionCurseOfByond
+#  name: Curse of Byond
+#  description: Curse the target, causing them to be unable to move properly.
+#  components:
+#  - type: EntityTargetAction
+#    raiseOnUser: true
+#    checkCanAccess: false
+#    checkCanInteract: false
+#    useDelay: 30
+#    range: 40
+#   whitelist:
+#      requireAll: true
+#      components:
+#      - MobState
+#      - Body
+#      - MindContainer
+#    itemIconStyle: BigAction
+#    icon:
+#      sprite: _Goobstation/Wizard/actions.rsi
+#      state: curseofbyond
+#    event: !type:PredictionToggleSpellEvent
+#      speech: action-speech-spell-curse-of-byond
+#      sound:
+#        path: /Audio/_Goobstation/Wizard/phasein.ogg
+#  - type: Magic
+#    requiresSpeech: true
+#    school: Conjuration

--- a/Resources/Prototypes/_Goobstation/Wizard/spellbook_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/spellbook_catalog.yml
@@ -601,24 +601,24 @@
     - SpellbookFullRandom
     - SpellbookSemiRandom
 
-- type: listing
-  id: SpellbookCurseOfByond
-  name: spellbook-curse-of-byond-name
-  description: spellbook-curse-of-byond-description
-  productAction: ActionCurseOfByond
-  cost:
-    WizCoin: 1
-  categories:
-  - SpellbookUtility
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-  - !type:BuyBeforeCondition
-    whitelist:
-      - SpellbookTileToggle
-    blacklist:
-    - SpellbookFullRandom
-    - SpellbookSemiRandom
+#- type: listing
+#  id: SpellbookCurseOfByond
+#  name: spellbook-curse-of-byond-name
+#  description: spellbook-curse-of-byond-description
+#  productAction: ActionCurseOfByond
+#  cost:
+#    WizCoin: 1
+#  categories:
+#  - SpellbookUtility
+#  conditions:
+#  - !type:ListingLimitedStockCondition
+#    stock: 1
+#  - !type:BuyBeforeCondition
+#    whitelist:
+#      - SpellbookTileToggle
+#    blacklist:
+#    - SpellbookFullRandom
+#    - SpellbookSemiRandom
 
 # Equipment
 - type: listing

--- a/Resources/Prototypes/_Goobstation/Wizard/spellbook_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/spellbook_catalog.yml
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 # SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
 # SPDX-FileCopyrightText: 2025 keronshb <54602815+keronshb@users.noreply.github.com>
 #

--- a/Resources/Prototypes/_Goobstation/Wizard/spellbook_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/spellbook_catalog.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2025 ActiveMammmoth <kmcsmooth@gmail.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 # SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>


### PR DESCRIPTION
## About the PR
It was a really funny bit to abuse, I regret nothing. I doubt the admins do either :trollface:

## Why / Balance
Disabling prediction breaks things, which is a nothingburger when people only play our server, but since wizden 1984d the network tab from everywhere that makes fixing it only possible on goob (peak)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: Mocho
- remove: 1984d curse of byond spell, admins can still use though
