### PR TITLE
Roundstart grenade tech SECOND TRY

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -175,7 +175,6 @@
 # SPDX-FileCopyrightText: 2024 Simon <63975668+Simyon264@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Speebro <100388782+Speebr0@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Speebro <speebro@notreal.com>
 # SPDX-FileCopyrightText: 2024 Spessmann <156740760+Spessmann@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Stalen <33173619+stalengd@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 TakoDragon <69509841+BackeTako@users.noreply.github.com>
@@ -250,6 +249,7 @@
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 Southbridge <7013162+southbridge-fur@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Spatison <137375981+Spatison@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Theodore Lukin <66275205+pheenty@users.noreply.github.com>

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -407,12 +407,14 @@
     # Goobstation
     - LatheMiscStatic
     - MedicalVehiclesStatic
+    - GrenadeTriggersStatic
   - type: EmagLatheRecipes
     emagStaticPacks:
     - SecurityAmmoStatic
     # Goobstation
     - SecurityAmmoStaticGoob
     - SyndicateAmmoLightStatic
+    - ScienceExplosives
   - type: BlueprintReceiver
     whitelist:
       tags:
@@ -718,6 +720,8 @@
     - SecurityBoardsStaticGoob
     - SecurityBoardsStaticGoob
     - PowerCellsStatic
+    - ScienceExplosives
+    - GrenadeTriggersStatic
     dynamicPacks:
     - SecurityEquipment
     - SecurityBoards
@@ -823,6 +827,7 @@
     - MedicalBoardsStatic
     - MedicalBoardsStaticGoob
     - PowerCellsStatic
+    - GrenadeTriggersStatic
     dynamicPacks:
     - Chemistry
     # Goobstation Packs

--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
+# SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 ## Static

--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>
 #

--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -19,6 +19,7 @@
   - Syringe
   - PillCanister
   - HandLabeler
+  - ChemicalPayload
 
 - type: latheRecipePack
   parent: BasicChemistryStatic
@@ -91,7 +92,6 @@
 - type: latheRecipePack
   id: Chemistry
   recipes:
-  - ChemicalPayload
   - CryostasisBeaker
   - SyringeCryostasis
   - BluespaceBeaker

--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>

--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
+# SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -24,6 +24,13 @@
   - FloorBlueCircuit
   - FloorRedCircuit
 
+# Keeps flash payloads out of the hands of tiders, I guess. All triggers roundstart for autolathes
+- type: latheRecipePack
+  id: ScienceExplosives
+  recipes:
+  - ChemicalPayload
+  - FlashPayload
+
 ## Dynamic
 
 - type: latheRecipePack
@@ -73,16 +80,6 @@
   - FauxTileAstroIce
   - FauxTileAstroSnow
   - FauxTileAstroAsteroidSand
-
-# Only contains parts for making basic modular grenades, no actual explosives
-- type: latheRecipePack
-  id: ScienceExplosives
-  recipes:
-  - ChemicalPayload
-  - FlashPayload
-  - TimerTrigger
-  - SignalTrigger
-  - VoiceTrigger
 
 - type: latheRecipePack
   id: ScienceBoards

--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -24,7 +24,7 @@
   - FloorBlueCircuit
   - FloorRedCircuit
 
-# Keeps flash payloads out of the hands of tiders, I guess. All triggers roundstart for autolathes
+# Keeps flash payloads out of the hands of tiders, I guess. All triggers roundstart for autolathes and med/sci/secfab
 - type: latheRecipePack
   id: ScienceExplosives
   recipes:

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+# SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -56,6 +56,7 @@
   - MagazineShotgunSlug
   - SpeedLoaderMagnum
   - SpeedLoaderMagnumEmpty
+  - ExplosivePayload
 
 - type: latheRecipePack
   id: SecurityWeaponsStatic
@@ -87,11 +88,8 @@
   - ShuttleGunSvalinnMachineGunCircuitboard
 
 - type: latheRecipePack
-  parent:
-  - ScienceExplosives # sec gets everything for modular grenade making that sci does
   id: SecurityExplosives
   recipes:
-  - ExplosivePayload
   - GrenadeBlast
   - GrenadeEMP
   - GrenadeFlash

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -199,27 +199,6 @@
   # Goobstation R&D Console rework end
 
 - type: technology
-  id: ExplosiveTechnology
-  name: research-technology-explosive-technology
-  icon:
-    sprite: Objects/Devices/payload.rsi
-    state: payload-explosive-armed
-  discipline: Arsenal
-  tier: 1
-  cost: 10000
-  recipeUnlocks:
-  - SignallerAdvanced
-  - SignalTrigger
-  - VoiceTrigger
-  - TimerTrigger
-  - FlashPayload
-  - ExplosivePayload
-  - ChemicalPayload
-  technologyPrerequisites:
-  - SalvageWeapons # Goobstation R&D Console rework
-  position: 2,-1  # Goobstation R&D Console rework
-
-- type: technology
   id: SpecialMeans
   name: research-technology-special-means
   icon:
@@ -289,7 +268,6 @@
   - ShuttleGunPerforatorCircuitboard
   - ShuttleGunFriendshipCircuitboard
   technologyPrerequisites:
-  - ExplosiveTechnology # Goobstation R&D Console rework
   - Shuttlecraft  # Goobstation R&D Console rework
   position: 3,-4  # Goobstation R&D Console rework
 

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -60,6 +60,7 @@
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+# SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 #

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -57,6 +57,7 @@
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 FaDeOkno <143940725+FaDeOkno@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 FaDeOkno <logkedr18@gmail.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -58,6 +58,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 FaDeOkno <143940725+FaDeOkno@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 FaDeOkno <logkedr18@gmail.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -59,6 +59,7 @@
 # SPDX-FileCopyrightText: 2025 FaDeOkno <143940725+FaDeOkno@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 FaDeOkno <logkedr18@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
+# SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 beck-thompson <107373427+beck-thompson@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -280,6 +280,7 @@
     - PowerDrill
     - JawsOfLife
     - BorgModuleAdvancedTool
+    - SignallerAdvanced # Moved from explosives research
   # Goobstation R&D Console rework start
   position: 2,-5
   technologyPrerequisites:

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
@@ -167,10 +167,11 @@
     - ElectronicsStatic
     - SurgeryStatic
     - ScienceBoardsStatic
+    - ScienceExplosives # Goobstation - Roundstart Grenade Tech
+    - GrenadeTriggersStatic # Goobstation - Roundstart Grenade Tech
     dynamicPacks:
     - AdvancedTools
     - ScienceEquipment
-    - ScienceExplosives
     - ScienceClothing
     - ScienceWeapons
     - AtmosTools

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
+# SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 #

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/science.yml
@@ -3,6 +3,18 @@
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
+# Static
+- type: latheRecipePack
+  id: GrenadeTriggers
+  recipes:
+  - TimerTrigger
+  - SignalTrigger
+  - VoiceTrigger
+
+- type: latheRecipePack
+  id: FlashPayload
+  recipes:
+  - FlashPayload # I would have put this with the SciFlash in robotics, but this is so it can be printed from the sci techfab
 # Dynamic
 - type: latheRecipePack
   id: BluespaceTheory

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/science.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
+# SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Dynamic

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/science.yml
@@ -3,18 +3,6 @@
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
-# Static
-- type: latheRecipePack
-  id: GrenadeTriggers
-  recipes:
-  - TimerTrigger
-  - SignalTrigger
-  - VoiceTrigger
-
-- type: latheRecipePack
-  id: FlashPayload
-  recipes:
-  - FlashPayload # I would have put this with the SciFlash in robotics, but this is so it can be printed from the sci techfab
 # Dynamic
 - type: latheRecipePack
   id: BluespaceTheory

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/science.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/shared.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
+# SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/shared.yml
@@ -12,7 +12,7 @@
   - CircuitImprinterMachineCircuitboard
 
 - type: latheRecipePack
-  id: GrenadeTriggers
+  id: GrenadeTriggersStatic
   recipes:
   - TimerTrigger
   - SignalTrigger

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/shared.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/shared.yml
@@ -11,6 +11,13 @@
   - AutolatheMachineCircuitboard
   - CircuitImprinterMachineCircuitboard
 
+- type: latheRecipePack
+  id: GrenadeTriggers
+  recipes:
+  - TimerTrigger
+  - SignalTrigger
+  - VoiceTrigger
+
 #Dynamic
 - type: latheRecipePack
   id: SharedBoards

--- a/Resources/Prototypes/_Goobstation/Research/arsenal.yml
+++ b/Resources/Prototypes/_Goobstation/Research/arsenal.yml
@@ -7,6 +7,7 @@
 # SPDX-FileCopyrightText: 2025 Creatorbot01 <creatorbot02@gmail.com>
 # SPDX-FileCopyrightText: 2025 FaDeOkno <143940725+FaDeOkno@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 FaDeOkno <logkedr18@gmail.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>

--- a/Resources/Prototypes/_Goobstation/Research/arsenal.yml
+++ b/Resources/Prototypes/_Goobstation/Research/arsenal.yml
@@ -9,6 +9,7 @@
 # SPDX-FileCopyrightText: 2025 FaDeOkno <logkedr18@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+# SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 #

--- a/Resources/Prototypes/_Goobstation/Research/arsenal.yml
+++ b/Resources/Prototypes/_Goobstation/Research/arsenal.yml
@@ -56,7 +56,7 @@
   technologyPrerequisites:
   - RipleyAPLU
   - ExplosiveTechnology
-  position: 3,-1
+  position: 2,-1
 
 - type: technology
   id: AdvancedWeaponry
@@ -107,7 +107,7 @@
   - WeaponMechCombatMissileRack8
   technologyPrerequisites:
   - Gygax
-  position: 4,-2
+  position: 3,-2
 
 - type: technology
   id: Durand
@@ -133,7 +133,7 @@
   - WeaponMechCombatShotgunIncendiary
   technologyPrerequisites:
   - Gygax
-  position: 4,-1
+  position: 3,-1
 
 - type: technology
   id: SmartWeaponry

--- a/Resources/Prototypes/_Goobstation/Research/arsenal.yml
+++ b/Resources/Prototypes/_Goobstation/Research/arsenal.yml
@@ -55,7 +55,6 @@
   - WeaponMechCombatUltraRifle
   technologyPrerequisites:
   - RipleyAPLU
-  - ExplosiveTechnology
   position: 2,-1
 
 - type: technology


### PR DESCRIPTION
## About the PR
Removed the explosives research and made all grenade components roundstart. The advanced remote signaller was moved to advanced tools research.

## Why / Balance
Hoping to see modular grenades made more often, reusable cleanades, lube bombs, bomb bombs, and such. Makes acquiring explosives without spending TC a bit easier for traitors, makes jugmixing your funny carpetium bombs as a chemist less necessary.

## Technical details
- Removed explosives research and made the payloads and triggers static for lathes
- Moved advanced remote signaller to advanced tools research
- Added triggers to their own recipe pack in the goobstation shared packs
- Chemical payload moved to BasicChemistryStatic pack
- Autolathes, Security, Science, and Medical techfabs have access to triggers roundstart
- Security techfab has access to all payloads
- Science techfab has access to flash and chemical payloads
- Medical techfab and Autolathe have access to chemical payloads

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Grenade research is now roundstart in techfabs and autolathes, nothing stops the mail!
- tweak: Advanced Remote Signaller moved to advanced tools research in Industrial
