### PR TITLE
1984 wizard spawn rates and antag token

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,9 @@
 <!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
-<!--
-LICENSE: AGPL
-The license you want applied to new files, currently available licenses are AGPL, MPL, and MIT. Uncomment if you want to change from default (AGPL). -->
+<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
+The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
+integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
+Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
+<!--- License: AGPL -->
 ## About the PR
 <!-- What did you change? -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
 integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
 Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
-<!--- License: AGPL -->
+<!--- LICENSE: AGPL -->
 ## About the PR
 <!-- What did you change? -->
 

--- a/Resources/Locale/en-US/_Goobstation/servercurrency/server_currency.ftl
+++ b/Resources/Locale/en-US/_Goobstation/servercurrency/server_currency.ftl
@@ -69,7 +69,7 @@ gs-balanceui-shop-token-lowtier-antag = Low tier antag token
 gs-balanceui-shop-token-ghost = Ghost role token
 gs-balanceui-shop-token-admin-abuse = Admin abuse token
 
-gs-balanceui-shop-buy-token-hightier-antag-desc = Allows you become a Headrev, Nukie, Wizard, Initial Infected, or any antagonist from a lower tier.
+gs-balanceui-shop-buy-token-hightier-antag-desc = Allows you become a Headrev, Nukie, Initial Infected, or any antagonist from a lower tier.
 gs-balanceui-shop-buy-token-midtier-antag-desc = Allows you become a Traitor, Changeling, Heretic, or any antagonist from a lower tier.
 gs-balanceui-shop-buy-token-lowtier-antag-desc = Allows you become a Thief or Blob.
 gs-balanceui-shop-buy-token-ghost-desc = Allows you request a ghost role antagonist to be spawned.

--- a/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
@@ -19,7 +19,7 @@
     Zombie: 0.04
     Heretic: 0.11
     BlobGameMode: 0.05
-    Wizard: 0.01
+    Wizard: 0.007
     #HonkOps: 0.01 # this test fail was real holy shit it was only a preset the entire a time i was lied too by myself
 
 

--- a/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
@@ -17,7 +17,7 @@
     Zombie: 0.03
     Heretic: 0.10
     BlobGameMode: 0.04
-    Wizard: 0.05
+    Wizard: 0.001
     #HonkOps: 0.01 # this test fail was real holy shit it was only a preset the entire a time i was lied too by myself
 
 

--- a/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
@@ -13,11 +13,11 @@
     Traitor: 0.25
     Changeling: 0.10
     Nukeops: 0.05
-    Revolutionary: 0.04
-    Zombie: 0.03
-    Heretic: 0.10
-    BlobGameMode: 0.04
-    Wizard: 0.001
+    Revolutionary: 0.05
+    Zombie: 0.04
+    Heretic: 0.11
+    BlobGameMode: 0.05
+    Wizard: 0.01
     #HonkOps: 0.01 # this test fail was real holy shit it was only a preset the entire a time i was lied too by myself
 
 


### PR DESCRIPTION
## About the PR
Made wizard a low number as its intended to be. The whole reasoning its this strong compared to a normal antag is because its 1. supposed to be a solo antag that drives the entire round, 2. is INCREDIBLY uncommon in 13, which discredits a lot of the malding over the OP skills when you only have to deal with them once every few hundred rounds if not more.

Also killed the wiz token in high tier since Rouge and Nigel have both expressed interest in just either 1984ing it or moving it into its own thing.

No I will not increase prices, nor create a special token for wizard in this PR, go nag the agmins to get their shit together, its been a month since the last time we heard of their "we're reworking them internally" uh huh.


PS: I might be regarded and unable to math here, presumably 0.007 / 0.657 should be very damn close to 1%. Unsure if this is enough or if it should be even lower, guess we'll find out.

**Changelog**
:cl: Mocho
- tweak: Wizard *should be* fairly rare (1%), please report wizard sightings to corroborate if its working well :trollface:.
- tweak: High tier antag tokens cannot be exchanged for wizard.
