### PR TITLE
Fix errors when other player is fishing at the edge of PVS

### DIFF
--- a/Content.Goobstation.Server/Fishing/FishingSystem.cs
+++ b/Content.Goobstation.Server/Fishing/FishingSystem.cs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 Rouden <149893554+Roudenn@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Roudenn <romabond091@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Goobstation.Shared/Fishing/Systems/SharedFishingSystem.cs
+++ b/Content.Goobstation.Shared/Fishing/Systems/SharedFishingSystem.cs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 Rouden <149893554+Roudenn@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Roudenn <romabond091@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
Active fishing spots now update only on server side, because previously it caused errors when predicting fishing startup. Really hard.