### PR TITLE
fix protection enchant

### DIFF
--- a/Content.Goobstation.Shared/Enchanting/Systems/EnchantRelaySystem.cs
+++ b/Content.Goobstation.Shared/Enchanting/Systems/EnchantRelaySystem.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Goobstation.Shared/Enchanting/Systems/EnchantRelaySystem.cs
+++ b/Content.Goobstation.Shared/Enchanting/Systems/EnchantRelaySystem.cs
@@ -25,7 +25,7 @@ public sealed class EnchantRelaySystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<EnchantedComponent, DamageModifyEvent>(RelayEvent);
+        SubInventory<DamageModifyEvent>();
         SubscribeLocalEvent<EnchantedComponent, MeleeHitEvent>(RelayEvent);
         SubInventory<AttackedEvent>(true);
         SubInventory<StepTriggerAttemptEvent>(true);


### PR DESCRIPTION
goidacode only raised InventoryRelayedEvent<DamageModifyEvent> on clothing so changed the thing to raise the proper event

fixes #2419

:cl:
- fix: Fixed protection enchant not working.