### PR TITLE
Revert "Gamedir roundstart variation (#2384)"

### DIFF
--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -6,7 +6,6 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aineias1 <dmitri.s.kiselev@gmail.com>
-# SPDX-FileCopyrightText: 2025 Aviu00 <aviu00@protonmail.com>
 # SPDX-FileCopyrightText: 2025 FaDeOkno <143940725+FaDeOkno@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
@@ -168,7 +167,6 @@
   minPlayers: 5
   rules:
     - CalmDynamic
-    - BasicRoundstartVariation
     - LavalandStormScheduler # Lavaland Change
     - RareIonStormScheduler
 
@@ -183,6 +181,5 @@
   minPlayers: 25
   rules:
     - CombatDynamic
-    - BasicRoundstartVariation
     - LavalandStormScheduler # Lavaland Change
     - IonStormScheduler

--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -1,13 +1,15 @@
 # SPDX-FileCopyrightText: 2024 Aiden <aiden@djkraz.com>
-# SPDX-FileCopyrightText: 2024 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Fenn <162015305+TooSillyFennec@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Fishbait <Fishbait@git.ml>
 # SPDX-FileCopyrightText: 2024 fishbait <gnesse@gmail.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aineias1 <dmitri.s.kiselev@gmail.com>
+# SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 FaDeOkno <143940725+FaDeOkno@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Gareth Quaile <garethquaile@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 # SPDX-FileCopyrightText: 2025 McBosserson <148172569+McBosserson@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Milon <plmilonpl@gmail.com>


### PR DESCRIPTION
This reverts commit e54c6b6b31352b7cba0daf067dab779d4e19c797.

<!--- LICENSE: AGPL -->
## About the PR
Revert PR 2384

## Why / Balance
The gamedir variant is spawning trash in the SM at roundstart activating it immediately.

Because this is Wizden code and Wiz do not have an SM there is no check in place to ensure that trash does not spawn on SM - This is a problem for us though.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: No more roundstart SM activations

