### PR TITLE
Derotate Oasis

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -59,7 +59,7 @@
   - Loop
   - Marathon
   - Meta
-  - Oasis
+#  - Oasis - Goobstation - Derotated Oasis
   - Omega
   - Origin
   - Saltern
@@ -67,7 +67,7 @@
   - Reach
 #  - Train # Goobstation - all my friends hate train
   - FlandHighPop
-  - OasisHighPop
+#  - OasisHighPop - Goobstation - Derotated Oasis
   - Barratry # Goobstation - Re-add barratry
   - Kettle # Goobstation - Re-add kettle (before it was gemini!)
   - Submarine # goobstation - kill yourse


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## Why / Balance
1. Oasis have smallest highpop maints i ever see. It's hard to play on any antag on this map.
2. Oasis still don't have new stuff like holopads and other.
3. No one really want to maintain it.

:cl:
- remove: Oasis was derotated.

