### PR TITLE
Syndicate Stealth Suit Nerf

### DIFF
--- a/Content.Shared/Stealth/Components/StealthOnMoveComponent.cs
+++ b/Content.Shared/Stealth/Components/StealthOnMoveComponent.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
+// SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 // SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Shared/Stealth/Components/StealthOnMoveComponent.cs
+++ b/Content.Shared/Stealth/Components/StealthOnMoveComponent.cs
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared.Stealth.Components
 {
@@ -46,6 +47,14 @@ namespace Content.Shared.Stealth.Components
         [DataField]
         [AutoNetworkedField] // Goobstation
         public float MaxInvisibilityPenalty = 0.5f;
+
+        // Goobstation - Wait before stealth start accumulating 
+        /// <summary>
+        /// How long you shouldn't move to start accumulating stealth.
+        /// </summary>
+        [DataField]
+        [AutoNetworkedField]
+        public TimeSpan NoMoveTime = TimeSpan.Zero;
         // </Goobstation>
     }
 }

--- a/Content.Shared/Stealth/Components/StealthOnMoveComponent.cs
+++ b/Content.Shared/Stealth/Components/StealthOnMoveComponent.cs
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Shared/Stealth/SharedStealthSystem.cs
+++ b/Content.Shared/Stealth/SharedStealthSystem.cs
@@ -15,6 +15,7 @@
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Shared/Stealth/SharedStealthSystem.cs
+++ b/Content.Shared/Stealth/SharedStealthSystem.cs
@@ -22,7 +22,6 @@ using Content.Shared.Examine;
 using Content.Shared.Mobs;
 using Content.Shared.Stealth.Components;
 using Robust.Shared.Physics.Components; // Goobstation
-using Robust.Shared.GameStates;
 using Robust.Shared.Timing;
 
 namespace Content.Shared.Stealth;
@@ -126,8 +125,13 @@ public abstract class SharedStealthSystem : EntitySystem
         if (args.NewPosition.EntityId != args.OldPosition.EntityId)
             return;
 
+        // Goobstation - Fixing stealth suit resolve error
+        if (!TryComp<StealthComponent>(uid, out var stealthComp))
+            return;
+
         var delta = component.MovementVisibilityRate * (args.NewPosition.Position - args.OldPosition.Position).Length();
-        ModifyVisibility(uid, delta);
+
+        ModifyVisibility(uid, delta, stealthComp); // Goobstation - Fixing stealth suit resolve error
     }
 
     // Goobstation - Proper invisibility
@@ -137,8 +141,11 @@ public abstract class SharedStealthSystem : EntitySystem
         if (TryComp<PhysicsComponent>(uid, out var phys))
             limit += Math.Min(component.MaxInvisibilityPenalty, phys.LinearVelocity.Length() * component.InvisibilityPenalty);
 
-        if (args.Stealth.LastVisibility > limit)
-            args.FlatModifier += args.SecondsSinceUpdate * component.PassiveVisibilityRate;
+        // Goobstation - Wait before accumulating stealth
+        var noMoveTime = (float) component.NoMoveTime.TotalSeconds;
+
+        if (args.Stealth.LastVisibility > limit && args.SecondsSinceUpdate > noMoveTime)
+            args.FlatModifier += (args.SecondsSinceUpdate - noMoveTime) * component.PassiveVisibilityRate;
     }
 
     /// <summary>

--- a/Content.Shared/Stealth/SharedStealthSystem.cs
+++ b/Content.Shared/Stealth/SharedStealthSystem.cs
@@ -14,6 +14,7 @@
 // SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
+// SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 // SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -166,8 +166,8 @@
       coefficients:
         Blunt: 0.65
         Slash: 0.65
-        Piercing: 0.6
-        Heat: 0.6
+        Piercing: 0.65
+        Heat: 0.75
         Radiation: 0.55
         Caustic: 0.7
   - type: ClothingSpeedModifier
@@ -186,6 +186,7 @@
     - type: StealthOnMove
       passiveVisibilityRate: -0.5
       movementVisibilityRate: 0.6
+      noMoveTime: 3 
   - type: ModifyDelayedKnockdown # Goobstation
     delayDelta: 3
     knockdownTimeDelta: -3


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
- Syndicate Stealth Suit resistance decreased (pierce 40% -> 35%, heat 35% -> 25%)
- Syndicate Stealth Suit now requires 3 seconds of no stealth losing (no moving, attacking someone) to start accumulating stealth.

## Why / Balance
Stealth suit was overpowered for it's price. For 75 TC you was absolutely invisible even if you moved slightly. It was hard to counterplay (and it's still hard to play against)

## Media

https://github.com/user-attachments/assets/be70a1e3-8329-432d-87cd-c57580618594

**Changelog**
:cl:
- tweak: Syndicate stealth suit heat and pierce protection was decreased.
- tweak: Syndicate stealth suit now requires 3 second of no-stealth loss to start accumulating stealth.


