### PR TITLE
Make Resomi go less slow when cold

### DIFF
--- a/Resources/Prototypes/_Floofstation/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Floofstation/Entities/Mobs/Species/resomi.yml
@@ -197,6 +197,11 @@
     heatDamage:
       types:
         Heat : 3 #per second, scales with temperature & other constants
+  - type: TemperatureSpeed # Goobstation - You're supposed to be used to the cold why are you so slow
+    thresholds: # Goobstation - Calculated based on UI alert thresholds, rounded up
+      272: 0.8
+      242: 0.6
+      196: 0.4
   - type: MovementSpeedModifier
     weightlessAcceleration: 2.5 # Goobstation - Birb move fast in zero-g
   - type: PseudoItem # Goobstation - Baggable; certified smol ops

--- a/Resources/Prototypes/_Floofstation/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Floofstation/Entities/Mobs/Species/resomi.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 AstroDogeDX <48888500+AstroDogeDX@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 PeccNeck <74548962+PeccNeck@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 #

--- a/Resources/Prototypes/_Floofstation/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Floofstation/Entities/Mobs/Species/resomi.yml
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 AstroDogeDX <48888500+AstroDogeDX@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
+# SPDX-FileCopyrightText: 2025 PeccNeck <74548962+PeccNeck@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
## About the PR
Alters Resomi race's cold-based movement speed changes to match with their lower temperature tolerances (and parity with the UI element).

## Why / Balance
For an ice-world race, they sure do seem quite crippled in mobility by the slightest of breezes.

## Technical details
YML changes. Thresholds calculated based on the alert scale from TemperatureSystem and rounded up, where:
`ceil(((normalBodyTemperature - coldDamageThreshold) * alertThreshold) + coldDamageThreshold)`
with the alert thresholds being 0.66, 0.4, and 0.

This is also the same fashion in which they were calculated for BaseMobSpeciesOrganic (albeit it was rounded down there), so parity there as well.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- tweak: Resomi are slowed less by cold temperatures
