### PR TITLE
move protection enchant to sec hardsuit

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -145,10 +145,6 @@
     tags:
     - WhitelistChameleon
     - SecurityHelmet
-  - type: Enchanter # Goobstation
-    maxLevel: 2.5 # Decent chance of getting prot II
-    enchants:
-    - EnchantProtection
 
 #Mercenary Helmet
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -433,6 +433,10 @@
   - type: ModifyDelayedKnockdown # Goobstation
     delayDelta: 3
     knockdownTimeDelta: -3
+  - type: Enchanter # Goobstation
+    maxLevel: 2.5 # Decent chance of getting prot II
+    enchants:
+    - EnchantProtection
 
 #Brigmedic Hardsuit
 - type: entity


### PR DESCRIPTION
## About the PR
sec shouldnt be powergaming it was for tiders to steal, they probably wont give up their hardsuits though

**Changelog**
:cl:
- tweak: Security hardsuits now give the protection enchant instead of helmets.