### PR TITLE
Limit Enchanting to Chaplain/Heretic/Wizard

### DIFF
--- a/Content.Goobstation.Shared/Enchanting/Components/CanEnchantComponent.cs
+++ b/Content.Goobstation.Shared/Enchanting/Components/CanEnchantComponent.cs
@@ -6,5 +6,10 @@
 using Robust.Shared.GameStates;
 
 namespace Content.Goobstation.Shared.Enchanting.Components;
+
+/// <summary>
+/// Component checked for by EnchanterSystem before enchanting.
+/// Place this on any entity you want to allow to enchant... e.g. Chaplain, Heretic or Wizard.
+/// </summary>
 [RegisterComponent, NetworkedComponent]
 public sealed partial class CanEnchantComponent : Component;

--- a/Content.Goobstation.Shared/Enchanting/Components/CanEnchantComponent.cs
+++ b/Content.Goobstation.Shared/Enchanting/Components/CanEnchantComponent.cs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.GameStates;
+
+namespace Content.Goobstation.Shared.Enchanting.Components;
+[RegisterComponent, NetworkedComponent]
+public sealed partial class CanEnchantComponent : Component;

--- a/Content.Goobstation.Shared/Enchanting/Systems/EnchanterSystem.cs
+++ b/Content.Goobstation.Shared/Enchanting/Systems/EnchanterSystem.cs
@@ -33,10 +33,13 @@ public sealed class EnchanterSystem : EntitySystem
     [Dependency] private readonly SharedStackSystem _stack = default!;
 
     private List<EntProtoId<EnchantComponent>> _pool = new();
+    private EntityQuery<CanEnchantComponent> _userQuery;
 
     public override void Initialize()
     {
         base.Initialize();
+
+        _userQuery = GetEntityQuery<CanEnchantComponent>();
 
         SubscribeLocalEvent<EnchanterComponent, ExaminedEvent>(OnExamined);
 
@@ -79,18 +82,7 @@ public sealed class EnchanterSystem : EntitySystem
             return;
         }
 
-        var query = EntityManager.EntityQueryEnumerator<CanEnchantComponent>();
-        bool canEnchant = false;
-        while (query.MoveNext(out var entity, out _))
-        {
-            if (entity == user)
-            {
-                canEnchant = true;
-                break;
-            }
-        }
-
-        if (!canEnchant)
+        if (_userQuery.HasComp(user) == false)
         {
             _popup.PopupClient(Loc.GetString("enchanter-disallowed-enchant"), user, user);
             return;

--- a/Content.Goobstation.Shared/Enchanting/Systems/EnchanterSystem.cs
+++ b/Content.Goobstation.Shared/Enchanting/Systems/EnchanterSystem.cs
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
@@ -74,6 +76,23 @@ public sealed class EnchanterSystem : EntitySystem
         if (_enchanting.FindEnchanter(item) is not {} enchanter)
         {
             _popup.PopupClient(Loc.GetString("enchanting-tool-no-enchanter"), user, user);
+            return;
+        }
+
+        var query = EntityManager.EntityQueryEnumerator<CanEnchantComponent>();
+        bool canEnchant = false;
+        while (query.MoveNext(out var entity, out _))
+        {
+            if (entity == user)
+            {
+                canEnchant = true;
+                break;
+            }
+        }
+
+        if (!canEnchant)
+        {
+            _popup.PopupClient(Loc.GetString("enchanter-disallowed-enchant"), user, user);
             return;
         }
 

--- a/Resources/Locale/en-US/_Goobstation/enchanting/enchanter.ftl
+++ b/Resources/Locale/en-US/_Goobstation/enchanting/enchanter.ftl
@@ -1,6 +1,7 @@
 enchanter-examine = [color=lightblue]This item can be used as a source of enchants.[/color]
 enchanting-tool-examine = [color=lightblue]This can enchant items with a source item on an altar.[/color]
 
+enchanter-disallowed-enchant = You are not worthy!
 enchanter-cant-enchant = You can't enchant that using this item!
 enchanter-enchanted = A magical aura shimmers across {THE($item)}!
 enchanting-tool-no-enchanter = You need to put an enchanting source with the target item.

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -107,6 +107,7 @@
 # SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
 # SPDX-FileCopyrightText: 2025 Errant <35878406+Errant-4@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 MilenVolf <63782763+MilenVolf@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -297,7 +297,7 @@
   id: ERTChaplain
   parent: ERTLeader
   components:
-    - type: CanEnchant
+    - type: CanEnchant #GoobStation
     - type: BibleUser
     - type: GhostRole
       name: ghost-role-information-ert-chaplain-name

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -41,7 +41,6 @@
 # SPDX-FileCopyrightText: 2024 Lye <128915833+Lyroth001@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 MerrytheManokit <167581110+MerrytheManokit@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Mervill <mervills.email@gmail.com>
-# SPDX-FileCopyrightText: 2024 MilenVolf <63782763+MilenVolf@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Mota <belochuc@gmail.com>
 # SPDX-FileCopyrightText: 2024 Mr. 27 <45323883+Dutch-VanDerLinde@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 MureixloI <132683811+MureixloI@users.noreply.github.com>
@@ -108,8 +107,10 @@
 # SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
 # SPDX-FileCopyrightText: 2025 Errant <35878406+Errant-4@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 MilenVolf <63782763+MilenVolf@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+# SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -295,6 +295,7 @@
   id: ERTChaplain
   parent: ERTLeader
   components:
+    - type: CanEnchant
     - type: BibleUser
     - type: GhostRole
       name: ghost-role-information-ert-chaplain-name

--- a/Resources/Prototypes/Entities/Objects/Magic/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Magic/books.yml
@@ -44,6 +44,7 @@
       - state: icon_pentagramm
         color: "#f7e19f"
     - type: Spellbook
+    - type: EnchantingTool
     - type: Tag
       tags:
       - Spellbook
@@ -79,6 +80,7 @@
       ownerOnly: true # get your own tome!
       balance:
         WizCoin: 10 # prices are balanced around this 10 point maximum and how strong the spells are
+    - type: EnchantingTool
     - type: GuideHelp # Goobstation
       guides:
       - Wizard
@@ -117,6 +119,7 @@
     - type: GuideHelp # Goobstation
       guides:
       - Wizard
+    - type: EnchantingTool
     - type: Tag
       tags:
       - GrimoireGhost

--- a/Resources/Prototypes/Entities/Objects/Magic/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Magic/books.yml
@@ -23,6 +23,7 @@
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Scruq445 <storchdamien@gmail.com>
+# SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 crasg <109207982+Scruq445@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -200,7 +200,7 @@
   - !type:AddComponentSpecial
     components:
     - type: BibleUser #Lets them heal with bibles
-    - type: CanEnchant
+    - type: CanEnchant #GoobStation
 
 - type: startingGear
   id: ERTChaplainGear

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -102,6 +102,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Alpha-Two <92269094+Alpha-Two@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 blobadoodle <me@bloba.dev>

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -103,6 +103,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Alpha-Two <92269094+Alpha-Two@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+# SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 blobadoodle <me@bloba.dev>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
 #

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -198,6 +198,7 @@
   - !type:AddComponentSpecial
     components:
     - type: BibleUser #Lets them heal with bibles
+    - type: CanEnchant
 
 - type: startingGear
   id: ERTChaplainGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -79,7 +79,7 @@
   - !type:AddComponentSpecial
     components:
     - type: BibleUser #Lets them heal with bibles
-    - type: CanEnchant
+    - type: CanEnchant #GoobStation
 
 - type: startingGear
   id: ChaplainGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -76,6 +76,7 @@
   - !type:AddComponentSpecial
     components:
     - type: BibleUser #Lets them heal with bibles
+    - type: CanEnchant
 
 - type: startingGear
   id: ChaplainGear

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -57,6 +57,9 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+# SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Specific/heretic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Specific/heretic.yml
@@ -42,6 +42,7 @@
   - type: ItemToggleSize
     activatedSize: Normal
   - type: ToggleAnimation
+  - type: EnchantingTool
   - type: Tag
     tags:
     - HereticItem

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Specific/heretic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Specific/heretic.yml
@@ -5,6 +5,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Specific/heretic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Specific/heretic.yml
@@ -5,6 +5,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Structures/Specific/Heretic/ritual_rune.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Structures/Specific/Heretic/ritual_rune.yml
@@ -8,6 +8,7 @@
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <aviu00@protonmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Structures/Specific/Heretic/ritual_rune.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Structures/Specific/Heretic/ritual_rune.yml
@@ -45,6 +45,7 @@
       - !type:PlaySoundBehavior
         sound:
           path: /Audio/_Goobstation/Heretic/runebreak.ogg
+  - type: EnchantingTable
 
 - type: entity
   id: HereticRuneRitualDrawAnimation

--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -5,6 +5,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>

--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -5,6 +5,8 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
+# SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -31,6 +31,8 @@
       lateJoinAdditional: true
       mindRoles:
       - MindRoleHeretic
+      components:
+      - type: CanEnchant
   - type: Tag
     tags:
       - RoundstartAntag
@@ -57,6 +59,8 @@
       lateJoinAdditional: true
       mindRoles:
       - MindRoleHeretic
+      components:
+      - type: CanEnchant
   - type: Tag
     tags:
       - CalmAntag

--- a/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>

--- a/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
@@ -39,6 +39,7 @@
       components:
       - type: Wizard
       - type: RandomMetadata
+      - type: CanEnchant
         nameSegments:
         - wizard_first
         - wizard_last
@@ -92,6 +93,7 @@
       components:
       - type: Wizard
       - type: RandomMetadata
+      - type: CanEnchant
         nameSegments:
         - wizard_first
         - wizard_last
@@ -121,6 +123,7 @@
       - MindRoleApprentice
       components:
       - type: Apprentice
+      - type: CanEnchant
       - type: NpcFactionMember
         factions:
         - Wizard

--- a/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
+# SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
 #


### PR DESCRIPTION
## Why / Balance

You now have a reason to interact with Chaplain. You will not steal his bibles and raid chapel without saying a word. 

**Changelog**

:cl:
- tweak: Only heretic, wizard and chaplain have ability to enchant items now.
