### PR TITLE
Add re-bindable smart equip for slime storage and storage implant

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -58,6 +58,7 @@
 // SPDX-FileCopyrightText: 2025 August Eymann <august.eymann@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
+// SPDX-FileCopyrightText: 2025 yavuz <58685802+yahay505@users.noreply.github.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -137,6 +137,8 @@ namespace Content.Client.Input
             human.AddFunction(ContentKeyFunctions.SmartEquipBackpack);
             human.AddFunction(ContentKeyFunctions.SmartEquipBelt);
             human.AddFunction(ContentKeyFunctions.SmartEquipBack); // Goobstation - Smart equip to back
+            human.AddFunction(ContentKeyFunctions.SmartEquipSlimeStorage); // Goobstation - Smart equip to slime storage
+            human.AddFunction(ContentKeyFunctions.SmartEquipStorageImplant); // Goobstation - Smart equip to storage implant
             human.AddFunction(ContentKeyFunctions.OpenBackpack);
             human.AddFunction(ContentKeyFunctions.OpenBelt);
             human.AddFunction(ContentKeyFunctions.MouseMiddle);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -45,6 +45,7 @@
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
 // SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
+// SPDX-FileCopyrightText: 2025 yavuz <58685802+yahay505@users.noreply.github.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -249,6 +249,8 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(ContentKeyFunctions.SmartEquipBackpack);
             AddButton(ContentKeyFunctions.SmartEquipBelt);
             AddButton(ContentKeyFunctions.SmartEquipBack); // Goobstation - Equip To Back
+            AddButton(ContentKeyFunctions.SmartEquipSlimeStorage); // Goobstation - Equip To slime storage
+            AddButton(ContentKeyFunctions.SmartEquipStorageImplant); // Goobstation - Equip To storage implant
             AddButton(ContentKeyFunctions.OpenBackpack);
             AddButton(ContentKeyFunctions.OpenBelt);
             AddButton(ContentKeyFunctions.ThrowItemInHand);

--- a/Content.Goobstation.Shared/Interaction/MiscEquipSystem.cs
+++ b/Content.Goobstation.Shared/Interaction/MiscEquipSystem.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
 // SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
+// SPDX-FileCopyrightText: 2025 yavuz <58685802+yahay505@users.noreply.github.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Goobstation.Shared/Interaction/MiscEquipSystem.cs
+++ b/Content.Goobstation.Shared/Interaction/MiscEquipSystem.cs
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
+// SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
+// SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Linq;
+using Content.Shared.ActionBlocker;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Implants.Components;
+using Content.Shared.Input;
+using Content.Shared.Popups;
+using Content.Shared.Stacks;
+using Content.Shared.Storage;
+using Content.Shared.Storage.EntitySystems;
+using Robust.Shared.Containers;
+using Robust.Shared.Input.Binding;
+using Robust.Shared.Player;
+
+namespace Content.Goobstation.Shared.Interaction;
+
+public sealed class MiscEquipSystem : EntitySystem
+{
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+    [Dependency] private readonly SharedStorageSystem _storage = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+
+
+    public override void Initialize()
+    {
+        CommandBinds.Builder
+            .Bind(ContentKeyFunctions.SmartEquipSlimeStorage,
+                InputCmdHandler.FromDelegate(HandleEquipToSlimeStorage,
+                    handle: false,
+                    outsidePrediction: false)) // Goobstation - Smart equip to slime storage
+            .Bind(ContentKeyFunctions.SmartEquipStorageImplant,
+                InputCmdHandler.FromDelegate(HandleEquipToStorageImplant,
+                    handle: false,
+                    outsidePrediction: false)) // Goobstation - Smart equip to storage implant
+            .Register<MiscEquipSystem>();
+    }
+
+    private void HandleEquipToStorageImplant(ICommonSession? session)
+    {
+        if (session is not { } playerSession)
+            return;
+
+        if (playerSession.AttachedEntity is not { Valid: true } uid || !Exists(uid))
+            return;
+
+        if (!TryComp<HandsComponent>(uid, out var hands) || hands.ActiveHand == null)
+            return;
+
+        var handItem = hands.ActiveHand.HeldEntity;
+
+        if (!_actionBlocker.CanInteract(uid, handItem))
+            return;
+        StorageComponent? storage=null;
+        EntityUid implantHolderUid = default;
+        if (TryComp<ImplantedComponent>(uid, out var implantedComp))
+        {
+
+            var implantContainer = _container.EnsureContainer<Container>(uid,"implant");
+            if (implantContainer==null)
+                goto afterContainerSearch; // early out bcs implanted comp can have no implant container? wtf?
+
+            var implants = implantContainer.ContainedEntities;
+
+            foreach (var implant in implants)
+            {
+                if (TryComp(implant, out StorageComponent? comp))
+                {
+                    storage = comp;
+                    implantHolderUid = implant;
+                    break;
+                }
+            }
+        }
+        afterContainerSearch:
+
+        if (storage==null)
+        {
+            _popup.PopupClient(Loc.GetString("smart-equip-missing-equipment-slot", ("slotName", "storage implant")),
+                uid,
+                uid);
+            return;
+        }
+
+        if (handItem != null && !_hands.CanDropHeld(uid, hands.ActiveHand))
+        {
+            _popup.PopupClient(Loc.GetString("smart-equip-cant-drop"), uid, uid);
+            return;
+        }
+
+        switch (handItem)
+        {
+            case null when storage.Container.ContainedEntities.Count == 0:
+                _popup.PopupClient(Loc.GetString("smart-equip-empty-equipment-slot", ("slotName", "storage implant")), uid, uid);
+                return;
+            case null:
+                var removing = storage.Container.ContainedEntities[^1];
+                _container.RemoveEntity(implantHolderUid, removing);
+                _hands.TryPickup(uid, removing, handsComp: hands);
+                return;
+        }
+
+        if (!_storage.CanInsert(implantHolderUid, handItem.Value, out var reason))
+        {
+            if (reason != null)
+                _popup.PopupClient(Loc.GetString(reason), uid, uid);
+
+            return;
+        }
+
+        _hands.TryDrop(uid, hands.ActiveHand, handsComp: hands);
+        _storage.Insert(implantHolderUid, handItem.Value, out var stacked, out _);
+
+        // if the hand item stacked with the things in inventory, but there's no more space left for the rest
+        // of the stack, place the stack back in hand rather than dropping it on the floor
+        if (stacked != null && !_storage.CanInsert(uid, handItem.Value, out _))
+        {
+            if (TryComp<StackComponent>(handItem.Value, out var handStack) && handStack.Count > 0)
+                _hands.TryPickup(uid, handItem.Value, handsComp: hands);
+        }
+
+        return;
+    }
+
+    private void HandleEquipToSlimeStorage(ICommonSession? session)
+    {
+        if (session is not { } playerSession)
+            return;
+
+        if (playerSession.AttachedEntity is not { Valid: true } uid || !Exists(uid))
+            return;
+
+        if (!TryComp<HandsComponent>(uid, out var hands) || hands.ActiveHand == null)
+            return;
+
+        var handItem = hands.ActiveHand.HeldEntity;
+
+        if (!_actionBlocker.CanInteract(uid, handItem))
+            return;
+        if (!TryComp<StorageComponent>(uid, out var slimestorage))
+        {
+            _popup.PopupClient(Loc.GetString("smart-equip-missing-equipment-slot", ("slotName", "slime storage")),
+                uid,
+                uid);
+            return;
+        }
+
+        if (handItem != null && !_hands.CanDropHeld(uid, hands.ActiveHand))
+        {
+            _popup.PopupClient(Loc.GetString("smart-equip-cant-drop"), uid, uid);
+            return;
+        }
+
+        var  storage = slimestorage!;
+        var emptyEquipmentSlotString = Loc.GetString("smart-equip-empty-equipment-slot", ("slotName", "slime storage"));
+
+
+        switch (handItem)
+        {
+            case null when storage.Container.ContainedEntities.Count == 0:
+                _popup.PopupClient(emptyEquipmentSlotString, uid, uid);
+                return;
+            case null:
+                var removing = storage.Container.ContainedEntities[^1];
+                _container.RemoveEntity(uid, removing);
+                _hands.TryPickup(uid, removing, handsComp: hands);
+                return;
+        }
+
+        if (!_storage.CanInsert(uid, handItem.Value, out var reason))
+        {
+            if (reason != null)
+                _popup.PopupClient(Loc.GetString(reason), uid, uid);
+
+            return;
+        }
+
+        _hands.TryDrop(uid, hands.ActiveHand, handsComp: hands);
+        _storage.Insert(uid, handItem.Value, out var stacked, out _);
+
+        // if the hand item stacked with the things in inventory, but there's no more space left for the rest
+        // of the stack, place the stack back in hand rather than dropping it on the floor
+        if (stacked != null && !_storage.CanInsert(uid, handItem.Value, out _))
+        {
+            if (TryComp<StackComponent>(handItem.Value, out var handStack) && handStack.Count > 0)
+                _hands.TryPickup(uid, handItem.Value, handsComp: hands);
+        }
+        return;
+    }
+    public override void Shutdown()
+    {
+        base.Shutdown();
+
+        CommandBinds.Unregister<MiscEquipSystem>();
+    }
+}

--- a/Content.Goobstation.Shared/Interaction/MiscEquipSystem.cs
+++ b/Content.Goobstation.Shared/Interaction/MiscEquipSystem.cs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
 // SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
 // SPDX-FileCopyrightText: 2025 yavuz <58685802+yahay505@users.noreply.github.com>

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -115,6 +115,7 @@
 // SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Rinary <72972221+Rinary1@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
+// SPDX-FileCopyrightText: 2025 yavuz <58685802+yahay505@users.noreply.github.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -153,6 +153,8 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction SmartEquipBackpack = "SmartEquipBackpack";
         public static readonly BoundKeyFunction SmartEquipBelt = "SmartEquipBelt";
         public static readonly BoundKeyFunction SmartEquipBack = "SmartEquipBack"; // Goobstation - Smart equip to back
+        public static readonly BoundKeyFunction SmartEquipSlimeStorage = "SmartEquipSlimeStorage"; // Goobstation - Smart equip to slime storage
+        public static readonly BoundKeyFunction SmartEquipStorageImplant = "SmartEquipStorageImplant"; // Goobstation - Smart equip to storage implant
         public static readonly BoundKeyFunction OpenBackpack = "OpenBackpack";
         public static readonly BoundKeyFunction OpenBelt = "OpenBelt";
         public static readonly BoundKeyFunction OpenAHelp = "OpenAHelp";


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Slime storage and storage implant con now use smart equip.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
MiscEquipSystem is just copied from BackEquipSystem and changed for the different storage types. 
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/80f685bb-83d4-4108-aa50-167696193bb3


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: teneketaro
- add: slimes can now smart equip to their slime storage (dont forget to bind it)
- add: implant storage can now smart equipped to (dont forget to bind it)
