### PR TITLE
Temporarily remove ghost bar antag portal

### DIFF
--- a/Resources/Maps/_Goobstation/Nonstations/ghostbar.yml
+++ b/Resources/Maps/_Goobstation/Nonstations/ghostbar.yml
@@ -12,6 +12,7 @@
 # SPDX-FileCopyrightText: 2024 Rank #1 Jonestown partygoer <mary@thughunt.ing>
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Scruq445 <storchdamien@gmail.com>
 # SPDX-FileCopyrightText: 2025 crasg <109207982+Scruq445@users.noreply.github.com>

--- a/Resources/Maps/_Goobstation/Nonstations/ghostbar.yml
+++ b/Resources/Maps/_Goobstation/Nonstations/ghostbar.yml
@@ -10689,13 +10689,6 @@ entities:
       parent: 4
     - type: AtmosPipeColor
       color: '#FC033DFF'
-- proto: GatewayAntagPlanet
-  entities:
-  - uid: 2289
-    components:
-    - type: Transform
-      pos: 19.5,-9.5
-      parent: 4
 - proto: GhostBarSpawner
   entities:
   - uid: 41


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
## About PR
Removed antag arena portal from ghost bar until we make it optimized for server. Admins still can teleport players to it.

## Why / Balance
It causes too much lags and servers problems. It requires admin to stop spamming there. 

:cl:
- remove: Ghost bar arena portal was temporarily removed.

