### PR TITLE
Resomi now take 15% more brute damage

### DIFF
--- a/Resources/Prototypes/_Floofstation/Damage/modifier.sets.yml
+++ b/Resources/Prototypes/_Floofstation/Damage/modifier.sets.yml
@@ -6,5 +6,6 @@
 - type: damageModifierSet
   id: Resomi
   coefficients: # Goobstation - natural cold resistance should reduce damage, but higher intolerance to heat should take more damage.
+    Brute: 1.15
     Heat: 1.1
     Cold: 0.7

--- a/Resources/Prototypes/_Floofstation/Damage/modifier.sets.yml
+++ b/Resources/Prototypes/_Floofstation/Damage/modifier.sets.yml
@@ -6,6 +6,8 @@
 - type: damageModifierSet
   id: Resomi
   coefficients: # Goobstation - natural cold resistance should reduce damage, but higher intolerance to heat should take more damage.
-    Brute: 1.15
+    Blunt: 1.15
+    Slash: 1.15
+    Piercing: 1.15
     Heat: 1.1
     Cold: 0.7


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Resomi now take 15% more brute damage
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
1. It is a fact of life that smaller things are easier to kill
2. Resomi have a smaller hitbox
3. only taking a little more heat and a bit less cold is BORING design
4. They've had it too easy for too long

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl: JoeHammad
- tweak: Resomi now take 15% more brute damage
