### PR TITLE
fix ap examine + basicammoprovider examine

### DIFF
--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -135,8 +135,8 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         if (ap == 0)
             return;
 
-        var absap = Math.Abs(ap);
-        args.Message.AddMarkupPermissive("\n" + (Loc.GetString("armor-penetration", ("absap", absap), ("ap", ap))));
+        var abs = Math.Abs(ap);
+        args.Message.AddMarkupPermissive("\n" + Loc.GetString("armor-penetration", ("arg", ap/abs), ("abs", abs)));
     }
 
     protected override bool ArcRaySuccessful(EntityUid targetUid,

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Battery.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Battery.cs
@@ -102,8 +102,8 @@ public sealed partial class GunSystem
         if (ap == 0)
             return;
 
-        var absap = Math.Abs(ap);
-        args.Message.AddMarkupPermissive(Loc.GetString("armor-penetration", ("absap", absap), ("ap", ap)));
+        var abs = Math.Abs(ap);
+        args.Message.AddMarkupPermissive("\n" + Loc.GetString("armor-penetration", ("arg", ap/abs), ("abs", abs)));
     }
 
     private DamageSpecifier? GetDamage(BatteryAmmoProviderComponent component)

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.Cartridges.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.Cartridges.cs
@@ -104,7 +104,7 @@ public sealed partial class GunSystem
     private int GetProjectilePenetration(string proto)
     {
         if (!ProtoManager.TryIndex<EntityPrototype>(proto, out var entityProto)
-            || !entityProto.Components.TryGetValue(_factory.GetComponentName<ProjectileComponent>(), out var projectile))
+        || !entityProto.Components.TryGetValue(_factory.GetComponentName<ProjectileComponent>(), out var projectile))
             return 0;
 
         var p = (ProjectileComponent) projectile.Component;

--- a/Resources/Locale/en-US/_Goobstation/damage/damage-examine.ftl
+++ b/Resources/Locale/en-US/_Goobstation/damage/damage-examine.ftl
@@ -1,6 +1,6 @@
 damage-hits-to-kill = Our heroic interns have shown that one can theoretically stay standing after [color=red][bold]{$count}[/bold][/color] hits before collapsing from their wounds.
 
-armor-penetration = It penetrates armor { $ap ->
-        [negative] [color=blue]{$absap}% worse[/color]
-        *[other] [color=red]{$absap}% better[/color]
+armor-penetration = It penetrates armor { $arg ->
+        [1] [color=red]{$abs}% better[/color]
+        *[other] [color=blue]{$abs}% worse[/color]
     } than an average damage source.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
armor piercing examine now works properly with negative values, i'm an idiot and didn't test it properly in #2458
also BasicEntityAmmoProviders (like anaconda) now also have a damage examine
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
fix
qol
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/36d8cfcc-5ce3-46bb-b1ce-cfcd67f329f4)
![image](https://github.com/user-attachments/assets/8a317916-3051-4dee-8e46-511ae513361e)
![image](https://github.com/user-attachments/assets/e879f431-d075-4bba-b4e8-c00a5977efa8)
![image](https://github.com/user-attachments/assets/3940b177-d001-4b93-92d0-a05e1e79c781)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
no cl its not in the game yet
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
