### PR TITLE
The Great TTK Raising (1/2 done)

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -512,12 +512,14 @@
     attackRate: 4
     damage:
       types:
-       Blunt: 8
+       Blunt: 5 #Goob
     soundHit:
       collection: Punch
     animation: WeaponArcFist
     mustBeEquippedToUse: true
-    heavyStaminaCost: 3 # goob edit
+    armorPenetration: 0.3 # Goobstation
+    clickPartDamageMultiplier: .25 # Goobstation
+    heavyPartDamageMultiplier: .25 # Goobstation
   - type: Fiber
     fiberMaterial: fibers-leather
     fiberColor: fibers-blue

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -109,6 +109,7 @@
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 BramvanZijp <56019239+BramvanZijp@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Coolsurf6 <coolsurf24@yahoo.com.au>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Killerqu00 <47712032+Killerqu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -30,7 +30,6 @@
 # SPDX-FileCopyrightText: 2024 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2024 Alzore <140123969+Blackern5000@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 ArZarLordOfMango <96249677+ArZarLordOfMango@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Brandon Hu <103440971+Brandon-Huu@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 CaasGit <87243814+CaasGit@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Chief-Engineer <119664036+Chief-Engineer@users.noreply.github.com>
@@ -86,7 +85,6 @@
 # SPDX-FileCopyrightText: 2024 Winkarst <74284083+Winkarst-cpu@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 beck-thompson <107373427+beck-thompson@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 deathride58 <deathride58@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
 # SPDX-FileCopyrightText: 2024 dffdff2423 <dffdff2423@gmail.com>
 # SPDX-FileCopyrightText: 2024 eoineoineoin <github@eoinrul.es>
@@ -108,10 +106,12 @@
 # SPDX-FileCopyrightText: 2024 to4no_fix <156101927+chavonadelal@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 voidnull000 <18663194+voidnull000@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 BramvanZijp <56019239+BramvanZijp@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Coolsurf6 <coolsurf24@yahoo.com.au>
 # SPDX-FileCopyrightText: 2025 Killerqu00 <47712032+Killerqu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 tetra <169831122+Foralemes@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -21,6 +21,7 @@
 # SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 themias <89101928+themias@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -43,6 +43,8 @@
     damage:
       types:
         Slash: 6
+    clickPartDamageMultiplier: .25 # Goobstation
+    heavyPartDamageMultiplier: .25 # Goobstation
   - type: Item
     sprite: Objects/Tools/Hydroponics/hoe.rsi
 
@@ -63,6 +65,8 @@
     damage:
       types:
         Slash: 7
+    clickPartDamageMultiplier: .25 # Goobstation
+    heavyPartDamageMultiplier: .25 # Goobstation
   - type: Item
     sprite: Objects/Tools/Hydroponics/clippers.rsi
     storedRotation: -90
@@ -91,6 +95,8 @@
     damage:
       types:
         Slash: 10
+    armorPenetration: -.75
+    clickPartDamageMultiplier: 1.5 # Goobstation
   - type: Item
     size: Normal
   - type: Clothing
@@ -120,6 +126,8 @@
       types:
         Slash: 8
         Piercing: 2
+    armorPenetration: -.75
+    clickPartDamageMultiplier: 1.5 # Goobstation
   - type: Item
     sprite: Objects/Tools/Hydroponics/hatchet.rsi
   - type: BoneSaw # Shitmed
@@ -146,6 +154,9 @@
       types:
         Blunt: 8
         Piercing: 2 # I guess you can stab it into them?
+    armorPenetration: -.75
+    clickPartDamageMultiplier: .25 # Goobstation
+    heavyPartDamageMultiplier: .25 # Goobstation
     soundHit:
       collection: MetalThud
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -22,6 +22,7 @@
 # SPDX-FileCopyrightText: 2024 themias <89101928+themias@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -125,6 +125,7 @@
 # SPDX-FileCopyrightText: 2024 zzylex <146784470+zzylex@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Арт <123451459+JustArt1m@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>
 # SPDX-FileCopyrightText: 2025 fishbait <gnesse@gmail.com>
 #

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -127,6 +127,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 fishbait <gnesse@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -152,7 +152,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 10
+        Blunt: 5 #Goob
     soundHit:
       collection: MetalThud
   - type: Spillable
@@ -161,7 +161,7 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 5
+        Blunt: 7 # Goob
   - type: Item
     size: Large
     sprite: Objects/Specific/Janitorial/mop.rsi
@@ -184,6 +184,9 @@
     guides:
     - Janitorial
   - type: DnaSubstanceTrace
+  - type: SpeedModifiedOnWield
+    walkModifier: 0.9 # goob edit
+    sprintModifier: 0.9 # goob edit
 
 - type: entity
   parent: BaseItem
@@ -207,7 +210,7 @@
     - type: MeleeWeapon
       damage:
         types:
-          Blunt: 10
+          Blunt: 5 #Goob
       soundHit:
          collection: MetalThud
     - type: Spillable
@@ -216,7 +219,7 @@
     - type: IncreaseDamageOnWield
       damage:
         types:
-          Blunt: 5
+          Blunt: 7 #Goob
     - type: Item
       size: Large
       sprite: Objects/Specific/Janitorial/advmop.rsi

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -108,7 +108,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Piercing: 10
+        Piercing: 8 #Goob
     soundHit:
       path: /Audio/Items/drill_hit.ogg
   - type: StaticPrice
@@ -148,9 +148,12 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 8
+        Slash: 6 #Goob
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
+    armorPenetration: -.75 # Goobstation
+    clickPartDamageMultiplier: 1.5 # Goobstation
+    heavyPartDamageMultiplier: 1 # Goobstation
   # Shitmed Change
   - type: SurgeryTool
     startSound:
@@ -193,7 +196,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Slash: 12
+        Slash: 8 #Goob
   - type: Scalpel # Shitmed
     speed: 1.25
 
@@ -212,6 +215,11 @@
     heldPrefix: laser
   - type: Scalpel # Shitmed
     speed: 1.5
+  - type: MeleeWeapon
+    damage:
+      types:
+        Heat: 3 #Goob
+        Slash: 3 #Goob
   # TODO: prevent bleeding from incisions
 
 # Retractor
@@ -336,6 +344,8 @@
         Brute: 10
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
+    armorPenetration: -1 # Goobstation
+    clickPartDamageMultiplier: 1.5 # Goobstation
   - type: Tool
     speedModifier: 0.5
   - type: BoneSaw # Shitmed
@@ -356,9 +366,12 @@
   - type: MeleeWeapon
     damage:
       groups:
-        Brute: 15
+        Brute: 4
     soundHit:
       path: /Audio/Items/drill_hit.ogg
+    attackRate: 3 #Goob
+    armorPenetration: -.5 # Goobstation
+    clickPartDamageMultiplier: 1.25 # Goobstation
   - type: Tool
     speedModifier: 1.5
   - type: BoneSaw # Shitmed
@@ -382,7 +395,7 @@
     storedRotation: 90
     heldPrefix: advanced
   - type: MeleeWeapon
-    attackRate: 1.5
+    attackRate: 4 #Goob
   - type: Tool
     speedModifier: 2.0
   - type: BoneSaw # Shitmed
@@ -409,7 +422,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Piercing: 10
+        Piercing: 7 #Goob
         Heat: 1
   - type: PhysicalComposition #Goobstation - Recycle update
     materialComposition:
@@ -467,7 +480,7 @@
   - type: MeleeWeapon
     damage:
       types:
-        Slash: 10
+        Slash: 7 #Goob
         Heat: 1
   - type: PhysicalComposition #Goobstation - Recycle update
     materialComposition:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -42,6 +42,7 @@
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ColonicAcid <claudiomota1990@googlemail.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -39,6 +39,7 @@
 # SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ColonicAcid <claudiomota1990@googlemail.com>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -466,12 +466,12 @@
     price: 100
   - type: MeleeWeapon
     wideAnimationRotation: -90
-    attackRate: 1.5
+    attackRate: 1 #Goob
     animationRotation: 90 # WWDP
     range: 1.4
     damage:
       types:
-        Piercing: 10
+        Piercing: 8 #Goob
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"
   - type: Tending # Shitmed
@@ -707,7 +707,7 @@
     wideAnimationRotation: 45
     damage:
       types:
-        Blunt: 14
+        Blunt: 10 #Goob
     soundHit:
       collection: MetalThud
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -138,6 +138,7 @@
 # SPDX-FileCopyrightText: 2025 Booblesnoot42 <108703193+Booblesnoot42@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Eagle <lincoln.mcqueen@gmail.com>
 # SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Lenny <187471588+Bynnel@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Theodore Lukin <66275205+pheenty@users.noreply.github.com>

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -133,6 +133,7 @@
 # SPDX-FileCopyrightText: 2024 whateverusername0 <whateveremail>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ArtisticRoomba <145879011+ArtisticRoomba@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Booblesnoot42 <108703193+Booblesnoot42@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Eagle <lincoln.mcqueen@gmail.com>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baguette.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baguette.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 themias <89101928+themias@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 fishbait <gnesse@gmail.com>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baguette.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baguette.yml
@@ -20,6 +20,9 @@
         Slash: 16
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
+    armorPenetration: -.5 # Goobstation
+    clickPartDamageMultiplier: 2.5 # Goobstation
+    heavyPartDamageMultiplier: 1 # Goobstation
   - type: Reflect
     reflectProb: 0.05
     spread: 90

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baguette.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baguette.yml
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 fishbait <gnesse@gmail.com>
 #

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
@@ -27,6 +27,7 @@
 # SPDX-FileCopyrightText: 2025 ActiveMammmoth <kmcsmooth@gmail.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Eagle <lincoln.mcqueen@gmail.com>
 # SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>
 # SPDX-FileCopyrightText: 2025 Killerqu00 <killerqueen1777@gmail.com>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
@@ -30,6 +30,7 @@
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Eagle <lincoln.mcqueen@gmail.com>
 # SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Killerqu00 <killerqueen1777@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 VMSolidus <evilexecutive@gmail.com>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/baseball_bat.yml
@@ -55,10 +55,13 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Blunt: 10
+        Blunt: 7 #Goob
         Structural: 5
     soundHit:
       collection: MetalThud
+    armorPenetration: 0.2
+    clickPartDamageMultiplier: .25 # Goobstation
+    heavyPartDamageMultiplier: .25 # Goobstation
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
@@ -68,7 +71,9 @@
   - type: StaminaDamageOnHit # goob - bat makes you hurt and tired (but not as much as the real stun stick)
     damage: 7.5 # goob - 9 hits to stamcrit someone with armor vest + helmet
   - type: Item
-    size: Normal
+    size: Large # goobstation
+    shape:
+      - 0,0,4,1
   - type: Tool
     qualities:
     - Rolling
@@ -89,6 +94,12 @@
     tags:
     - BaseballBat
   - type: UndetectableContraband #Goobstation-Contraband detector
+  - type: SpeedModifiedOnWield
+    walkModifier: 0.9 # goob edit
+    sprintModifier: 0.9 # goob edit
+  - type: MeleeThrowOnHit
+    distance: 1 # Goobstation
+    speed: 2
 
 - type: entity
   name: incomplete baseball bat

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
@@ -7,9 +7,11 @@
 # SPDX-FileCopyrightText: 2024 metalgearsloth <comedian_vs_clown@hotmail.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Eagle <lincoln.mcqueen@gmail.com>
 # SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 VMSolidus <evilexecutive@gmail.com>
 # SPDX-FileCopyrightText: 2025 fishbait <gnesse@gmail.com>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/cane.yml
@@ -64,9 +64,12 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 16 # Goobstation
+        Slash: 13 # Goobstation
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
+    armorPenetration: -.5 # Goobstation
+    clickPartDamageMultiplier: 2.5 # Goobstation
+    heavyPartDamageMultiplier: 1 # Goobstation
   - type: Item
     size: Normal
     sprite: Objects/Weapons/Melee/cane_blade.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/chainsaw.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/chainsaw.yml
@@ -39,13 +39,15 @@
     attackRate: 4
     damage:
       types:
-        Slash: 2
-        Blunt: 2
+        Slash: 1 #Goob
+        Blunt: 1 #Goob
         Structural: 4
     soundHit:
       path: /Audio/Weapons/chainsaw.ogg
       params:
         volume: -3
+    clickPartDamageMultiplier: 2 # Goobstation
+    heavyPartDamageMultiplier: 1 # Goobstation
   - type: IncreaseDamageOnWield
     damage:
       types:
@@ -73,3 +75,6 @@
       path: /Audio/Weapons/chainsawwield.ogg
     endSound:
       path: /Audio/Weapons/chainsaw.ogg
+  - type: SpeedModifiedOnWield
+    walkModifier: 0.8 # goob edit
+    sprintModifier: 0.8 # goob edit

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/chainsaw.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/chainsaw.yml
@@ -13,6 +13,7 @@
 # SPDX-FileCopyrightText: 2024 username <113782077+whateverusername0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 whateverusername0 <whateveremail>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/chainsaw.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/chainsaw.yml
@@ -14,6 +14,7 @@
 # SPDX-FileCopyrightText: 2024 whateverusername0 <whateveremail>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -112,6 +112,7 @@
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Eagle <lincoln.mcqueen@gmail.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 John <35928781+sporkyz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 VMSolidus <evilexecutive@gmail.com>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -23,7 +23,6 @@
 # SPDX-FileCopyrightText: 2024 Alice "Arimah" Heurlin <30327355+arimah@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Alzore <140123969+Blackern5000@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 ArkiveDev <95712736+ArkiveDev@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 ArtisticRoomba <145879011+ArtisticRoomba@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Boaz1111 <149967078+Boaz1111@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Brandon Hu <103440971+Brandon-Huu@users.noreply.github.com>
@@ -110,6 +109,7 @@
 # SPDX-FileCopyrightText: 2024 whateverusername0 <whateveremail>
 # SPDX-FileCopyrightText: 2024 Арт <123451459+JustArt1m@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Eagle <lincoln.mcqueen@gmail.com>
 # SPDX-FileCopyrightText: 2025 John <35928781+sporkyz@users.noreply.github.com>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -194,6 +194,7 @@
       types:
         Blunt: 4.5
     clickPartDamageMultiplier: 4 #goob content
+    armorPenetration: -.5 # Goobstation
   - type: Item
     size: Small
   - type: UseDelay
@@ -354,6 +355,9 @@
       types:
         Slash: 10
         Heat: 10
+    armorPenetration: -.75 # Goobstation
+    clickPartDamageMultiplier: 1.5 # Goobstation
+    heavyPartDamageMultiplier: 1 # Goobstation
   - type: ComponentToggler
     components:
     - type: Sharp

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -38,6 +38,7 @@
 # SPDX-FileCopyrightText: 2024 whateverusername0 <whateveremail>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -66,10 +66,13 @@
       types:
         # axes are kinda like sharp hammers, you know?
         Blunt: 5
-        Slash: 10
+        Slash: 5
         Structural: 10
     soundHit:
       collection: MetalThud
+    armorPenetration: .25 # Goobstation
+    clickPartDamageMultiplier: 2 # Goobstation
+    heavyPartDamageMultiplier: 1 # Goobstation
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
@@ -109,6 +112,9 @@
     enchants:
     - EnchantFireAspect
     - EnchantSharpness
+  - type: SpeedModifiedOnWield
+    walkModifier: 0.6 # goob edit
+    sprintModifier: 0.6 # goob edit
 
 - type: entity
   id: FireAxeFlaming
@@ -120,6 +126,11 @@
     wideAnimationRotation: 90
     heavyStaminaCost: 35 # goob edit
     attackRate: 0.5  # goob edit
+  - type: IncreaseDamageOnWield
+    damage:
+      types:
+        Slash: 10
+        Structural: 60
   - type: IgniteOnMeleeHit
     fireStacks: 5 #Goobchange
   - type: Sprite
@@ -134,3 +145,6 @@
   - type: Tool
     qualities:
       - Prying
+  - type: SpeedModifiedOnWield
+    walkModifier: 0.8 # goob edit
+    sprintModifier: 0.8 # goob edit

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -18,7 +18,6 @@
 # SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2023 notquitehadouken <1isthisameme>
 # SPDX-FileCopyrightText: 2023 stopbreaking <126102320+stopbreaking@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 EmoGarbage404 <retron404@gmail.com>
 # SPDX-FileCopyrightText: 2024 Flareguy <78941145+Flareguy@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Hmeister <nathan.springfredfoxbon4@gmail.com>
@@ -30,7 +29,6 @@
 # SPDX-FileCopyrightText: 2024 Scribbles0 <91828755+Scribbles0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Whisper <121047731+QuietlyWhisper@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Winkarst <74284083+Winkarst-cpu@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
 # SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
@@ -39,6 +37,8 @@
 # SPDX-FileCopyrightText: 2024 username <113782077+whateverusername0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 whateverusername0 <whateveremail>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: 2025 ActiveMammmoth <140334666+ActiveMammmoth@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ActiveMammmoth <kmcsmooth@gmail.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
 # SPDX-FileCopyrightText: 2025 keronshb <54602815+keronshb@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/hammers.yml
@@ -25,6 +25,9 @@
         Structural: 10
     soundHit:
       collection: MetalThud
+    armorPenetration: .1 # Goobstation
+    clickPartDamageMultiplier: 0.25 # Goobstation
+    heavyPartDamageMultiplier: 0.25 # Goobstation
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
@@ -33,6 +36,9 @@
         Structural: 10
   - type: Item
     size: Large
+  - type: SpeedModifiedOnWield
+    walkModifier: 0.6 # goob edit
+    sprintModifier: 0.6 # goob edit
 
 - type: entity
   id: Mjollnir

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -101,6 +101,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aineias1 <dmitri.s.kiselev@gmail.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 BramvanZijp <56019239+BramvanZijp@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Eagle <lincoln.mcqueen@gmail.com>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -152,6 +152,8 @@
         Slash: 10
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
+    armorPenetration: -0.75 # Goobstation
+    clickPartDamageMultiplier: 1.5
   - type: Sprite
   - type: Item
     size: Small
@@ -173,6 +175,8 @@
     tags:
     - Knife
     - KitchenKnife
+  - type: MeleeWeapon
+    attackRate: 1.2 #Goob
   - type: Sprite
     sprite: Objects/Weapons/Melee/kitchen_knife.rsi
     state: icon
@@ -198,10 +202,10 @@
     state: butch
   - type: MeleeWeapon
     wideAnimationRotation: -115
-    attackRate: 1.5
+    attackRate: 1.3 #Goob
     damage:
       types:
-        Slash: 13
+        Slash: 10 #Goob
   - type: Item
     size: Normal
     sprite: Objects/Weapons/Melee/cleaver.rsi
@@ -232,7 +236,7 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 12
+        Slash: 10 #Goob
   - type: EmbeddableProjectile
     sound: /Audio/Weapons/star_hit.ogg
     offset: -0.15,0.0
@@ -240,7 +244,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Slash: 10
+        Slash: 20 #Goob
   - type: Item
     sprite: Objects/Weapons/Melee/combat_knife.rsi
     storedSprite:
@@ -267,6 +271,8 @@
       state: storage
       sprite: Objects/Weapons/Melee/survival_knife.rsi
   - type: AttachmentBayonet # Lavaland Change
+  - type: MeleeWeapon
+    attackRate: 1.3 #Goob
 
 - type: entity
   name: kukri knife
@@ -348,7 +354,8 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 5.5
+        Slash: 5 #Goob
+    armorPenetration: -1 # Goobstation
   - type: Item
     sprite: Objects/Weapons/Melee/shiv.rsi
   - type: DisarmMalus
@@ -368,7 +375,7 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 7 #each "tier" grants an additional 2 damage
+        Slash: 6 #Goob
   - type: Item
     sprite: Objects/Weapons/Melee/reinforced_shiv.rsi
   - type: Sprite
@@ -387,7 +394,7 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 9
+        Slash: 7 #Goob
   - type: Item
     sprite: Objects/Weapons/Melee/plasma_shiv.rsi
   - type: Sprite
@@ -406,7 +413,7 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 7
+        Slash: 2 #Goob
         Radiation: 4
   - type: Item
     sprite: Objects/Weapons/Melee/uranium_shiv.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -99,6 +99,7 @@
     damage:
       groups:
         Brute: 5
+    armorPenetration: -0.5 # Goobstation
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -49,6 +49,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aineias1 <dmitri.s.kiselev@gmail.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Eagle <lincoln.mcqueen@gmail.com>
 # SPDX-FileCopyrightText: 2025 FaDeOkno <143940725+FaDeOkno@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -58,6 +58,7 @@
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Eagle <lincoln.mcqueen@gmail.com>
 # SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 VMSolidus <evilexecutive@gmail.com>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -54,6 +54,7 @@
 # SPDX-FileCopyrightText: 2024 starch <starchpersonal@gmail.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Eagle <lincoln.mcqueen@gmail.com>
 # SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -107,7 +107,7 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Piercing: 12
+        Piercing: 8
     angle: 0
     animation: WeaponArcThrust
     soundHit:
@@ -118,6 +118,8 @@
         Piercing: 15
   - type: Item
     size: Large # goobstation
+    shape:
+      - 0,0,7,0
   - type: Clothing
     quickEquip: false
     slots:
@@ -189,7 +191,9 @@
     equippedMaxFillLevels: 1
   - type: ThrowableBlocked # Goobstation
   - type: UndetectableContraband #Goobstation-Contraband detector
-
+  - type: SpeedModifiedOnWield
+    walkModifier: 0.9 # goob edit
+    sprintModifier: 0.9 # goob edit
 
 - type: entity
   name: reinforced spear
@@ -204,7 +208,7 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Piercing: 15
+        Piercing: 9
   - type: DamageOtherOnHit
     damage:
       types:
@@ -225,7 +229,7 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Piercing: 18
+        Piercing: 10
   - type: DamageOtherOnHit
     damage:
       types:
@@ -246,7 +250,7 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Piercing: 10
+        Piercing: 2
         Radiation: 8
   - type: DamageOtherOnHit
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -149,6 +149,8 @@
   - type: MeleeWeapon
     animationRotation: -45 # WWDP
     wideAnimationRotation: -135
+    armorPenetration: -0.5 # Goobstation
+    clickPartDamageMultiplier: 2.5
   - type: Sprite
     state: icon
   - type: Item
@@ -161,7 +163,7 @@
     - Slicing
 
 - type: entity
-  name: captain's sabre
+  name: ceremonial sabre #goob
   parent: [ BaseSword, BaseCommandContraband ]
   id: CaptainSabre
   description: A ceremonial weapon belonging to the captain of the station.
@@ -175,7 +177,7 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 19 #cmon, it has to be at least BETTER than the rest. # Goob edit
+        Slash: 13 #cmon, it has to be at least BETTER than the rest. # Goob edit
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Reflect # change this and i will fucking GUT YOU. YOU HEAR ME AVIU??
@@ -206,9 +208,10 @@
   - type: Sprite
     sprite: Objects/Weapons/Melee/katana.rsi
   - type: MeleeWeapon
+    attackRate: 3 #goob
     damage:
       types:
-        Slash: 15
+        Slash: 9 #goob
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Item
@@ -227,7 +230,7 @@
     wideAnimationRotation: -60
     damage:
       types:
-        Slash: 30
+        Slash: 9 #goob
   - type: Item
     sprite: Objects/Weapons/Melee/energykatana.rsi
   - type: EnergyKatana
@@ -301,9 +304,10 @@
   - type: Sprite
     sprite: Objects/Weapons/Melee/cutlass.rsi
   - type: MeleeWeapon
+    attackRate: 1.5 #goob
     damage:
       types:
-        Slash: 16
+        Slash: 13 #goob
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Item

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -131,6 +131,7 @@
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Eagle <lincoln.mcqueen@gmail.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 VMSolidus <evilexecutive@gmail.com>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -128,6 +128,7 @@
 # SPDX-FileCopyrightText: 2024 whateverusername0 <whateveremail>
 # SPDX-FileCopyrightText: 2024 Арт <123451459+JustArt1m@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Eagle <lincoln.mcqueen@gmail.com>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/weapon_toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/weapon_toolbox.yml
@@ -6,6 +6,7 @@
 # SPDX-FileCopyrightText: 2023 notquitehadouken <1isthisameme>
 # SPDX-FileCopyrightText: 2024 Mr. 27 <45323883+Dutch-VanDerLinde@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Killerqu00 <killerqueen1777@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/weapon_toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/weapon_toolbox.yml
@@ -7,6 +7,7 @@
 # SPDX-FileCopyrightText: 2024 Mr. 27 <45323883+Dutch-VanDerLinde@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Killerqu00 <killerqueen1777@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/weapon_toolbox.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/weapon_toolbox.yml
@@ -28,6 +28,8 @@
     attackRate: 1.5
     damage:
       types:
-        Blunt: 20
+        Blunt: 12
     soundHit:
       path: "/Audio/Weapons/smash.ogg"
+    clickPartDamageMultiplier: .25 #Goob
+    heavyPartDamageMultiplier: .25 #Goob

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -256,10 +256,13 @@
     wideAnimationRotation: -135
     damage:
       types:
-        Blunt: 20
+        Blunt: 16 #Goob
     soundHit:
       collection: MetalThud
     bluntStaminaDamageFactor: 1.5
+    armorPenetration: .2 # Goobstation
+    clickPartDamageMultiplier: .25 # Goobstation
+    heavyPartDamageMultiplier: .25 # Goobstation
   - type: Item
     size: Normal
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -114,6 +114,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <aviu00@protonmail.com>
 # SPDX-FileCopyrightText: 2025 BramvanZijp <56019239+BramvanZijp@users.noreply.github.com>

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/cane.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/cane.yml
@@ -24,6 +24,9 @@
         Slash: 10
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
+    armorPenetration: -.5 # Goobstation
+    clickPartDamageMultiplier: 2.5 # Goobstation
+    heavyPartDamageMultiplier: 1 # Goobstation
   - type: Item
     size: Normal
     sprite: Objects/Weapons/Melee/cane_blade.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/cane.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/cane.yml
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/cane.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/cane.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2024 BombasterDS <115770678+BombasterDS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/hammer.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/hammer.yml
@@ -17,7 +17,7 @@
     attackRate: 1
     damage:
       types:
-        Blunt: 12
+        Blunt: 8
     heavyStaminaCost: 6
     soundHit:
       collection: MetalThud

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/hammer.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/hammer.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/hammer.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/hammer.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/lollychop.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/lollychop.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/lollychop.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/lollychop.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/lollychop.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/lollychop.yml
@@ -25,16 +25,17 @@
     attackRate: 0.75
     damage:
       types:
-        Blunt: 10
-        Slash: 5
+        Blunt: 1
         Structural: 10
     soundHit:
       collection: MetalThud
+    clickPartDamageMultiplier: .25
+    heavyPartDamageMultiplier: .25
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 10
+        Blunt: 1
         Structural: 40
   - type: Item
     size: Huge
@@ -71,5 +72,8 @@
       - ReagentId: Amatoxin
         Quantity: 5
   - type: MeleeChemicalInjector
-    transferAmount: 5
+    transferAmount: 2.5
     solution: melee
+  - type: SpeedModifiedOnWield
+    walkModifier: 0.8 # goob edit
+    sprintModifier: 0.8 # goob edit


### PR DESCRIPTION
## Why / Balance
Super fast TKK sucks ass

Rework damage for most weapons in the game, refer to my spreadsheet for more info / progress
https://docs.google.com/spreadsheets/d/19H_GNTx7Qwq5L6ajltU3saF4j8tG8U31idngwwx7t_c/edit?usp=sharing

To do: 
Tweak all armor to resist stam damage
Separate bullet types
Reduce gun TTS in line with melee weapons

:cl: Armok
- tweak: Raise TTK for every weapon in the game with a few exceptions.
- tweak: Add AP values to most weapons in the game.
- tweak: Improv weapons (spear, shiv, ect.) are FAR worse against armored opponents
- tweak: Swords / knives are better against unarmored opponents and delimb faster
- tweak: Blunt weapons are better against armored opponents and have varying degree of AP
- tweak: Melee weapons that require wielding reduce speed when wielded 
- tweak: Gun TTK significantly reduced
- add: Break bullets into HP, FMJ, and AP rounds, all three occupy their niches.
- remove: Uranium bullets, they are now AP bullets

