### PR TITLE
Visitor Aliens now have Fanny Packs and totally real Jordans

### DIFF
--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -8,8 +8,8 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitHawaiBlack
     eyes: ClothingEyesGlassesCheapSunglasses
-    shoes: ClothingShoesColorBrown
+    shoes: ClothingShoesFakeJordans
     head: ClothingHeadHatStrawHat
     id: VisitorPDA
-    back: ClothingBackpack
+    waist: ClothingBeltStorageWaistbag
     ears: ClothingHeadsetGrey

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -1,4 +1,6 @@
+# SPDX-FileCopyrightText: 2025 GMWQ <garethquaile@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -11,5 +11,5 @@
     shoes: ClothingShoesFakeJordans
     head: ClothingHeadHatStrawHat
     id: VisitorPDA
-    waist: ClothingBeltStorageWaistbag
+    belt: ClothingBeltStorageWaistbag
     ears: ClothingHeadsetGrey


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
Alien tourists had mediocre drip, now they really have that shit on.
(Discussed this with Ilya after original PR, fun little tweak)

## Why / Balance
I pictured the average dad on holiday and realised a fanny pack is more appropriate than a backpack.

## Technical details
Following loadout items changed:
Shoes slot changed from regular shoes -> Fake Jordans
Back slot removed
Waist slot added Leather Waist bag

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

##Media 
![image](https://github.com/user-attachments/assets/246ac46b-b03d-4e0d-bbee-60a64e7d7f77)

:cl:
- tweak: Dripped out the Alien Tourist

