### PR TITLE
Ghost Spawners with time locks now properly group together.

### DIFF
--- a/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
@@ -175,10 +175,9 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
             var spriteSystem = sysManager.GetEntitySystem<SpriteSystem>();
             var requirementsManager = IoCManager.Resolve<JobRequirementsManager>();
 
-            // Ghost roles with the same name and description but different requirement instances
-+           // should be grouped together. We only use the name and description for grouping,
-+           // and take the requirements from the first role in each group
-            // Grouping roles
+            // We only use the name and description for grouping,
+            // and take the requirements from the first role in each group.
+            // TLDR: DON'T USE THE SAME NAME AND DESC FOR DIFFERENT ROLE REQUIREMENTS OR I WILL BEAT YOU WITH HAMMERS (PLURAL)
             var groupedRoles = ghostState.GhostRoles.GroupBy(
                 role => (role.Name, role.Description)); //goobstation edit, less polluted ghost spawners menu
 

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
@@ -176,16 +176,16 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
             // TODO: role.Requirements value doesn't work at all as an equality key, this must be fixed
             // Grouping roles
             var groupedRoles = ghostState.GhostRoles.GroupBy(
-                role => (role.Name, role.Description));
+                role => (role.Name, role.Description)); //goobstation edit, less polluted ghost spawners menu
 
             // Add a new entry for each role group
             foreach (var group in groupedRoles)
             {
                 var name = group.Key.Name;
                 var description = group.Key.Description;
-                var group_req = group.First(); //since reqs can't be grouped fuckery
+                var group_req = group.First(); //goobstation edit - since reqs can't be grouped fuckery
                 var hasAccess = requirementsManager.CheckRoleRequirements(
-                    group_req.Requirements,
+                    group_req.Requirements, //goobstation edit, less polluted ghost spawners menu
                     null,
                     out var reason);
 

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
@@ -175,7 +175,9 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
             var spriteSystem = sysManager.GetEntitySystem<SpriteSystem>();
             var requirementsManager = IoCManager.Resolve<JobRequirementsManager>();
 
-            // TODO: role.Requirements value doesn't work at all as an equality key, this must be fixed
+            // Ghost roles with the same name and description but different requirement instances
++           // should be grouped together. We only use the name and description for grouping,
++           // and take the requirements from the first role in each group
             // Grouping roles
             var groupedRoles = ghostState.GhostRoles.GroupBy(
                 role => (role.Name, role.Description)); //goobstation edit, less polluted ghost spawners menu
@@ -185,9 +187,9 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
             {
                 var name = group.Key.Name;
                 var description = group.Key.Description;
-                var group_req = group.First(); //goobstation edit - since reqs can't be grouped fuckery
+                var groupReq = group.First(); //goobstation edit - since reqs can't be grouped fuckery
                 var hasAccess = requirementsManager.CheckRoleRequirements(
-                    group_req.Requirements, //goobstation edit, less polluted ghost spawners menu
+                    groupReq.Requirements, //goobstation edit, less polluted ghost spawners menu
                     null,
                     out var reason);
 

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/Roles/GhostRolesEui.cs
@@ -176,15 +176,16 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls.Roles
             // TODO: role.Requirements value doesn't work at all as an equality key, this must be fixed
             // Grouping roles
             var groupedRoles = ghostState.GhostRoles.GroupBy(
-                role => (role.Name, role.Description, role.Requirements));
+                role => (role.Name, role.Description));
 
             // Add a new entry for each role group
             foreach (var group in groupedRoles)
             {
                 var name = group.Key.Name;
                 var description = group.Key.Description;
+                var group_req = group.First(); //since reqs can't be grouped fuckery
                 var hasAccess = requirementsManager.CheckRoleRequirements(
-                    group.Key.Requirements,
+                    group_req.Requirements,
                     null,
                     out var reason);
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Ghost Spawners with time locks now properly group together. so... really. stuff like maintenance drones don't have to pollute the ghost roles anymore.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
So it doesn't look like this anymore:
![image](https://github.com/user-attachments/assets/b6fec5b5-98b1-491d-be2d-c79f23816608)

## Technical details
<!-- Summary of code changes for easier review. -->
Heads up, this is baby's literal first C# project. so please bear with me if i'm comitting sacrilege with this. But. the grouping function of ghost roles doesn't group for class? prototype? type? (I don't know the terminology) of the requirements, just the UID/instance of those ghost spawners requirements. which are different on every ghost role spawners.

This fixes it by not grouping by those. just by the name and description. and does the requirements by using the first indexed requirements. later down the code. this can cause problems sure. but you really shouldn't have the same exact name and desc with different requirements anyways.

Probably wrote too much here for a simple fix. but hey, it's good learning by explaining what i'm doing. something2 rubber ducky
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Ghost roles with requirements (such as maint drones) are now grouped together correctly!
