### PR TITLE
Fixwelderswords

### DIFF
--- a/Resources/Changelog/GoobChangelog.yml
+++ b/Resources/Changelog/GoobChangelog.yml
@@ -7879,3 +7879,11 @@ Entries:
       message: Changelings can no longer use martial arts or have a holo-parasite.
   id: 914
   time: '2025-04-25T23:53:39.0000000+00:00'
+- author: PunishedJoe
+  changes:
+    - type: Tweak
+      message: resomi's now take 30% more brute damage
+    - type: Tweak
+      message: resomi fit in bags again
+  id: 915
+  time: '2025-04-26T18:31:32.0000000+00:00'

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/e_sword_welder.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/e_sword_welder.yml
@@ -38,8 +38,8 @@
         variation: 0.125
     activatedDamage:
         types:
-            Slash: 4
-            Heat: 11
+            Slash: 5
+            Heat: 10
   - type: ItemToggle
     predictable: false
     soundActivate:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/e_sword_welder.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/e_sword_welder.yml
@@ -38,7 +38,7 @@
         variation: 0.125
     activatedDamage:
         types:
-            Slash: 5
+            Slash: 5d
             Heat: 10
   - type: ItemToggle
     predictable: false
@@ -52,6 +52,8 @@
   - type: SurgeryTool # Shitmed
     startSound:
       path: /Audio/_Goobstation/Weapons/EswordWelder/hum.ogg
+      params:
+        volume: -3
     endSound:
       path: /Audio/_Goobstation/Weapons/EswordWelder/eblade1.ogg
       params:
@@ -73,12 +75,6 @@
   - type: EnergySword
     activatedColor: LightSalmon
     colorOptions: []
-  - type: ThrowableBlocker
-    blockSound:
-      path: /Audio/_Goobstation/Weapons/EswordWelder/eblade1.ogg
-      params:
-        variation: 0.250
-        volume: -2
   - type: RefillableSolution
     solution: Welder
   - type: Construction

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/e_sword_welder.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/e_sword_welder.yml
@@ -20,6 +20,8 @@
       map: [ "blade" ]
   - type: Item
     sprite: _Goobstation/Objects/Weapons/Melee/e_sword_welder-inhands.rsi
+  - type: MeleeWeapon
+    clickPartDamageMultiplier: 2 #goob content
   - type: ItemToggleMeleeWeapon
     activatedSoundOnHit:
       path: /Audio/_Goobstation/Weapons/EswordWelder/eblade1.ogg
@@ -55,7 +57,7 @@
       params:
         variation: 0.250
   - type: Reflect
-    reflectProb: 0
+    reflectProb: 0.1
     otherTypeReflectProb: 0
     reflects:
       - Energy
@@ -71,9 +73,6 @@
   - type: EnergySword
     activatedColor: LightSalmon
     colorOptions: []
-  - type: Tag # WD EDIT
-    tags:
-    - EnergySword
   - type: ThrowableBlocker
     blockSound:
       path: /Audio/_Goobstation/Weapons/EswordWelder/eblade1.ogg

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/e_sword_welder.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/e_sword_welder.yml
@@ -39,7 +39,7 @@
         variation: 0.125
     activatedDamage:
         types:
-            Slash: 5d
+            Slash: 5
             Heat: 10
   - type: ItemToggle
     predictable: false


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
welder sword is now slightly less effective against blob, 10/5 heat/slash instead of 11/4, also looks better. also it's no longer 4 times limb damage as the real esword, this was too much. in exchange it has 10% prob to reflect lasers (epen has 25%) because it's cool (antags don't use lasers anyway). also it's no longer usable to craft double energy swords.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!---->
:cl:
- tweak: Welder energy swords now have 10% chance of reflecting lasers, deal 5/10 damage instead of 4/11, and are half as effective in damaging limbs as the real eswords.
- fix: You can no longer use welder energy swords to craft a real double energy sword.