### PR TITLE
Crash "Fix", tidemind will not randomly occur anymore.

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/events.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Rinary <72972221+Rinary1@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>

--- a/Resources/Prototypes/_Goobstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/events.yml
@@ -12,7 +12,7 @@
   parent: BaseGameRule
   components:
   - type: StationEvent
-    weight: 3 # rare
+    weight: 0 # rare to changed to not happen
     duration: 1
     # no occurences limit so newly arriving tiders can also get it
   - type: JobAddTagsRule

--- a/Resources/Prototypes/_Goobstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/events.yml
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Rinary <72972221+Rinary1@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+# SPDX-FileCopyrightText: 2025 THENUCLEAROPTION <robotiamabot@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 


### PR DESCRIPTION
Tidemind must be admin spawned in because otherwise it will crash the entire server if there are 0 passengers in the game.

:) ! 
Changes weight from 3 (rare) to 0 (won't occur) but changes nothing else.