### PR TITLE
Move tide flipper to major contra

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/Crafting/ghetto_stuff.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/Crafting/ghetto_stuff.yml
@@ -198,7 +198,7 @@
 
 - type: entity
   id: TideFlipperZero
-  parent: [ DoorRemoteDefault, BaseMinorContraband ]
+  parent: [ DoorRemoteDefault, BaseMajorContraband ]
   name: tide flipper
   description: A makeshift device that can hack doors without access.
   components:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/Crafting/ghetto_stuff.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/Crafting/ghetto_stuff.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 LuciferEOS <stepanteliatnik2022@gmail.com>
+# SPDX-FileCopyrightText: 2025 LuciferMkshelter <154002422+LuciferEOS@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 


### PR DESCRIPTION
## About the PR
Tide Flipper is now considered major contraband.

## Why / Balance
people are starting to mald about it, but sec should do their job in confiscation of these things

## Technical details
1 line yaml

## Media
![image](https://github.com/user-attachments/assets/e52249d2-a4db-43a1-baf8-0fa1e10f6285)


## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes

**Changelog**

:cl: LuciferEOS
- tweak: Tide flipper is now considered a major contraband.

