### PR TITLE
make fax automatable

### DIFF
--- a/Content.Goobstation.Server/Fax/FaxSignalSystem.cs
+++ b/Content.Goobstation.Server/Fax/FaxSignalSystem.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Goobstation.Server/Fax/FaxSignalSystem.cs
+++ b/Content.Goobstation.Server/Fax/FaxSignalSystem.cs
@@ -4,8 +4,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using Content.Server.DeviceLinking.Events;
 using Content.Shared.DeviceLinking;
+using Content.Shared.DeviceLinking.Events;
 using Content.Shared.Fax;
 using Content.Shared.Fax.Components;
 using Robust.Shared.Prototypes;

--- a/Content.Goobstation.Server/Fax/FaxSignalSystem.cs
+++ b/Content.Goobstation.Server/Fax/FaxSignalSystem.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Goobstation.Server/Fax/FaxSignalSystem.cs
+++ b/Content.Goobstation.Server/Fax/FaxSignalSystem.cs
@@ -17,7 +17,6 @@ namespace Content.Goobstation.Server.Fax;
 public sealed class FaxSignalSystem : EntitySystem
 {
     public static readonly ProtoId<SinkPortPrototype> CopyPort = "FaxCopy";
-    public static readonly ProtoId<SinkPortPrototype> SendPort = "FaxSend";
 
     public override void Initialize()
     {
@@ -30,7 +29,5 @@ public sealed class FaxSignalSystem : EntitySystem
     {
         if (args.Port == CopyPort)
             RaiseLocalEvent(ent, new FaxCopyMessage());
-        else if (args.Port == SendPort)
-            RaiseLocalEvent(ent, new FaxSendMessage());
     }
 }

--- a/Content.Goobstation.Server/Fax/FaxSignalSystem.cs
+++ b/Content.Goobstation.Server/Fax/FaxSignalSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server.DeviceLinking.Events;
 using Content.Shared.DeviceLinking;
 using Content.Shared.Fax;

--- a/Content.Goobstation.Server/Fax/FaxSignalSystem.cs
+++ b/Content.Goobstation.Server/Fax/FaxSignalSystem.cs
@@ -1,0 +1,31 @@
+using Content.Server.DeviceLinking.Events;
+using Content.Shared.DeviceLinking;
+using Content.Shared.Fax;
+using Content.Shared.Fax.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Goobstation.Server.Fax;
+
+/// <summary>
+/// Handles signals for automated fax machines.
+/// </summary>
+public sealed class FaxSignalSystem : EntitySystem
+{
+    public static readonly ProtoId<SinkPortPrototype> CopyPort = "FaxCopy";
+    public static readonly ProtoId<SinkPortPrototype> SendPort = "FaxSend";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<FaxMachineComponent, SignalReceivedEvent>(OnSignalReceived);
+    }
+
+    private void OnSignalReceived(Entity<FaxMachineComponent> ent, ref SignalReceivedEvent args)
+    {
+        if (args.Port == CopyPort)
+            RaiseLocalEvent(ent, new FaxCopyMessage());
+        else if (args.Port == SendPort)
+            RaiseLocalEvent(ent, new FaxSendMessage());
+    }
+}

--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -596,7 +596,8 @@ public sealed class FaxSystem : EntitySystem
 
         UpdateUserInterface(uid, component);
 
-        if (!args.Actor.IsValid()) return; // Goobstation - no log for automation
+        if (!args.Actor.IsValid()) // Goobstation - no log for automation
+            return;
 
         _adminLogger.Add(LogType.Action,
             LogImpact.Low,

--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -78,7 +78,6 @@
 // SPDX-FileCopyrightText: 2024 brainfood1183 <113240905+brainfood1183@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 deathride58 <deathride58@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
 // SPDX-FileCopyrightText: 2024 dffdff2423 <dffdff2423@gmail.com>
 // SPDX-FileCopyrightText: 2024 eoineoineoin <github@eoinrul.es>
 // SPDX-FileCopyrightText: 2024 exincore <me@exin.xyz>
@@ -103,6 +102,7 @@
 // SPDX-FileCopyrightText: 2025 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 // SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
+// SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 // SPDX-FileCopyrightText: 2025 themias <89101928+themias@users.noreply.github.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -103,6 +103,7 @@
 // SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
 // SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
+// SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 themias <89101928+themias@users.noreply.github.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -263,7 +263,7 @@ public sealed class FaxSystem : EntitySystem
         if (_itemSlotsSystem.TryGetSlot(uid, PaperSlotId, out var slot))
             component.PaperSlot = slot;
         else
-            throw new InvalidOperationException($"{ToPrettyString(uid)} missing paper slot {PaperSlotId}");
+            _itemSlotsSystem.AddItemSlot(uid, PaperSlotId, component.PaperSlot);
         // </Goobstation>
         UpdateAppearance(uid, component);
     }

--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -591,6 +591,8 @@ public sealed class FaxSystem : EntitySystem
 
         UpdateUserInterface(uid, component);
 
+        if (!args.Actor.IsValid()) return; // Goobstation - no log for automation
+
         _adminLogger.Add(LogType.Action,
             LogImpact.Low,
             $"{ToPrettyString(args.Actor):actor} " +
@@ -654,6 +656,7 @@ public sealed class FaxSystem : EntitySystem
 
         _deviceNetworkSystem.QueuePacket(uid, component.DestinationFaxAddress, payload);
 
+        if (!args.Actor.IsValid()) // Goobstation - no log for automation
         _adminLogger.Add(LogType.Action,
             LogImpact.Low,
             $"{ToPrettyString(args.Actor):actor} " +

--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -259,7 +259,10 @@ public sealed class FaxSystem : EntitySystem
 
     private void OnComponentInit(EntityUid uid, FaxMachineComponent component, ComponentInit args)
     {
-        _itemSlotsSystem.AddItemSlot(uid, PaperSlotId, component.PaperSlot);
+        // <Goobstation> - define the slot in ItemSlots instead of adding it
+        _itemSlotsSystem.TryGetSlot(uid, PaperSlotId, out var slot);
+        component.PaperSlot = slot!;
+        // </Goobstation>
         UpdateAppearance(uid, component);
     }
 

--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -77,7 +77,6 @@
 // SPDX-FileCopyrightText: 2024 beck-thompson <107373427+beck-thompson@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 brainfood1183 <113240905+brainfood1183@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 deathride58 <deathride58@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 dffdff2423 <dffdff2423@gmail.com>
 // SPDX-FileCopyrightText: 2024 eoineoineoin <github@eoinrul.es>
 // SPDX-FileCopyrightText: 2024 exincore <me@exin.xyz>
@@ -102,6 +101,7 @@
 // SPDX-FileCopyrightText: 2025 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 // SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
+// SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 // SPDX-FileCopyrightText: 2025 themias <89101928+themias@users.noreply.github.com>
 //

--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -260,8 +260,10 @@ public sealed class FaxSystem : EntitySystem
     private void OnComponentInit(EntityUid uid, FaxMachineComponent component, ComponentInit args)
     {
         // <Goobstation> - define the slot in ItemSlots instead of adding it
-        _itemSlotsSystem.TryGetSlot(uid, PaperSlotId, out var slot);
-        component.PaperSlot = slot!;
+        if (_itemSlotsSystem.TryGetSlot(uid, PaperSlotId, out var slot))
+            component.PaperSlot = slot;
+        else
+            throw new InvalidOperationException($"{ToPrettyString(uid)} missing paper slot {PaperSlotId}");
         // </Goobstation>
         UpdateAppearance(uid, component);
     }

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -233,7 +233,7 @@ namespace Content.Shared.Containers.ItemSlots
         {
             itemSlot = null;
 
-            if (!Resolve(uid, ref component))
+            if (!Resolve(uid, ref component, false)) // Goobstation - sane API
                 return false;
 
             return component.Slots.TryGetValue(slotId, out itemSlot);

--- a/Resources/Locale/en-US/_Goobstation/machines/automation.ftl
+++ b/Resources/Locale/en-US/_Goobstation/machines/automation.ftl
@@ -49,3 +49,11 @@ signal-port-description-storage-inserted = Signal port that gets pulsed after an
 
 signal-port-name-storage-removed = Removed
 signal-port-description-storage-removed = Signal port that gets pulsed after an item is removed from a storage bin.
+
+# Fax Machine
+
+signal-port-name-automation-slot-paper = Item: Paper
+signal-port-description-automation-slot-paper = An automation slot for a fax machine's paper tray.
+
+signal-port-name-fax-copy = Copy Fax
+signal-port-description-fax-copy = Signal port to copy a fax machine's paper.

--- a/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
@@ -142,9 +142,25 @@
           Printing: { state: printing }
           Normal: {state: idle}
   - type: ItemSlots
+    slots: # Goobstation - so automation slots work
+      Paper:
+        insertSound: /Audio/Machines/scanning.ogg
+        ejectSound: /Audio/Machines/tray_eject.ogg
+        whitelist:
+          components:
+          - FaxableObject
   - type: ContainerContainer
     containers:
       Paper: !type:ContainerSlot
+  - type: AutomationSlots # Goobstation
+    slots:
+    - !type:AutomatedItemSlot
+      input: AutomationSlotPaper
+      output: AutomationSlotPaper
+      slotId: Paper
+    - !type:AutomatedPorts
+      sinks:
+      - FaxCopy
   - type: DeviceNetworkRequiresPower
   - type: DeviceNetwork
     deviceNetId: Wireless

--- a/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
@@ -76,6 +76,7 @@
 # SPDX-FileCopyrightText: 2024 to4no_fix <156101927+chavonadelal@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 voidnull000 <18663194+voidnull000@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 #

--- a/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
@@ -58,7 +58,6 @@
 # SPDX-FileCopyrightText: 2024 deathride58 <deathride58@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 degradka <69397649+degradka@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
 # SPDX-FileCopyrightText: 2024 dffdff2423 <dffdff2423@gmail.com>
 # SPDX-FileCopyrightText: 2024 eoineoineoin <github@eoinrul.es>
 # SPDX-FileCopyrightText: 2024 foboscheshir <156405958+foboscheshir@users.noreply.github.com>
@@ -78,6 +77,7 @@
 # SPDX-FileCopyrightText: 2024 voidnull000 <18663194+voidnull000@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Goobstation/DeviceLink/sink_ports.yml
+++ b/Resources/Prototypes/_Goobstation/DeviceLink/sink_ports.yml
@@ -65,3 +65,15 @@
   id: AutomationSlotStorage
   name: signal-port-name-automation-slot-storage
   description: signal-port-description-automation-slot-storage
+
+# Fax Machine
+
+- type: sinkPort
+  id: AutomationSlotPaper
+  name: signal-port-name-automation-slot-paper
+  description: signal-port-description-automation-slot-paper
+
+- type: sinkPort
+  id: FaxCopy
+  name: signal-port-name-fax-copy
+  description: signal-port-description-fax-copy

--- a/Resources/Prototypes/_Goobstation/DeviceLink/sink_ports.yml
+++ b/Resources/Prototypes/_Goobstation/DeviceLink/sink_ports.yml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2024 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Goobstation/DeviceLink/sink_ports.yml
+++ b/Resources/Prototypes/_Goobstation/DeviceLink/sink_ports.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 #

--- a/Resources/Prototypes/_Goobstation/DeviceLink/source_ports.yml
+++ b/Resources/Prototypes/_Goobstation/DeviceLink/source_ports.yml
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 # SPDX-FileCopyrightText: 2025 fishbait <gnesse@gmail.com>

--- a/Resources/Prototypes/_Goobstation/DeviceLink/source_ports.yml
+++ b/Resources/Prototypes/_Goobstation/DeviceLink/source_ports.yml
@@ -77,3 +77,10 @@
   id: StorageRemoved
   name: signal-port-name-storage-removed
   description: signal-port-description-storage-removed
+
+# Fax Machine
+
+- type: sourcePort
+  id: AutomationSlotPaper
+  name: signal-port-name-automation-slot-paper
+  description: signal-port-description-automation-slot-paper

--- a/Resources/Prototypes/_Goobstation/DeviceLink/source_ports.yml
+++ b/Resources/Prototypes/_Goobstation/DeviceLink/source_ports.yml
@@ -3,6 +3,8 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>
+# SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 # SPDX-FileCopyrightText: 2025 fishbait <gnesse@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/tools.yml
@@ -162,6 +162,13 @@
     receiveFrequencyId: Fax
     transmitFrequencyId: Fax
   - type: ItemSlots
+    slots:
+      paperSlot:
+        insertSound: /Audio/Machines/scanning.ogg
+        ejectSound: /Audio/Machines/tray_eject.ogg
+        whitelist:
+          components:
+            - FaxableObject #used to be PaperComponent - brainfood1183
   - type: ContainerContainer
     containers:
       Paper: !type:ContainerSlot

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/tools.yml
@@ -143,7 +143,7 @@
     needsPower: false
     powerLoad: 250
   - type: FaxMachine
-    paperSlot:
+    Paper:
       insertSound: /Audio/Machines/scanning.ogg
       ejectSound: /Audio/Machines/tray_eject.ogg
       whitelist:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/tools.yml
@@ -6,8 +6,10 @@
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+# SPDX-FileCopyrightText: 2025 acatrw <96485972+acatrw@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 acatrw <wispycat07@gmail.com>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/tools.yml
@@ -144,7 +144,7 @@
     needsPower: false
     powerLoad: 250
   - type: FaxMachine
-    Paper:
+    paperSlot:
       insertSound: /Audio/Machines/scanning.ogg
       ejectSound: /Audio/Machines/tray_eject.ogg
       whitelist:
@@ -166,7 +166,7 @@
     transmitFrequencyId: Fax
   - type: ItemSlots
     slots:
-      paperSlot:
+      Paper:
         insertSound: /Audio/Machines/scanning.ogg
         ejectSound: /Audio/Machines/tray_eject.ogg
         whitelist:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/tools.yml
@@ -9,6 +9,7 @@
 # SPDX-FileCopyrightText: 2025 acatrw <96485972+acatrw@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 acatrw <wispycat07@gmail.com>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
you can use automation upgrade on fax to copy paper on signal and manipulate the paper slot

due to device network goidacode it also breaks fax sending but its fine because automated spamming is bad

## Why / Balance
part 1 of automating tider money printing sweatshop

## Media
![09:21:18](https://github.com/user-attachments/assets/1a2c99ab-e1b4-4cd0-bca3-3e755a527994)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Faxes now accept automation upgrades.
