### PR TITLE
fix upgrade kits being in circuit printer

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -500,6 +500,7 @@
     - SpecOpsGoogles
     - MedicalMisc
     - MedicalVehiclesAdvanced
+    - UpgradeKits
   - type: EmagLatheRecipes
     emagDynamicPacks:
     - SecurityAmmo
@@ -567,7 +568,6 @@
     - ShuttleBoards
     # Goobstation Packs
     - SharedBoards
-    - UpgradeKits
   - type: MaterialStorage
     whitelist:
       tags:


### PR DESCRIPTION
its in protolathe now not circuit printer idk why i put it there

**Changelog**
:cl:
- fix: Fixed upgrade kits not being in the protolathe.