### PR TITLE
Kitchen knifes do damage when thrown

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -182,6 +182,14 @@
     guides:
     - Chef
     - FoodRecipes
+  - type: EmbeddableProjectile # Goobstation
+    sound: /Audio/Weapons/star_hit.ogg
+    offset: -0.15,0.0
+  - type: LandAtCursor # Goobstation
+  - type: DamageOtherOnHit # Goobstation
+    damage:
+      types:
+        Slash: 10
 
 - type: entity
   name: butcher's cleaver

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -108,6 +108,7 @@
 # SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Killerqu00 <47712032+Killerqu00@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 LuciferEOS <stepanteliatnik2022@gmail.com>
 # SPDX-FileCopyrightText: 2025 McBosserson <148172569+McBosserson@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Milon <plmilonpl@gmail.com>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>


### PR DESCRIPTION
## About the PR
Kitchen knifes now can be thrown like combat knifes.

## Why / Balance
Even glass shards can be thrown like that

## Technical details
copied comps from combat knife, throwing knifes is useless but it is fun sometimes
also tested, works

## Media
trust.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl: LuciferEOS
- tweak: Kitchen knifes now do damage when thrown at somebody.