### PR TITLE
Fix broken UI in research menu

### DIFF
--- a/Content.Goobstation.Client/Research/UI/FancyResearchConsoleMenu.xaml.cs
+++ b/Content.Goobstation.Client/Research/UI/FancyResearchConsoleMenu.xaml.cs
@@ -82,6 +82,8 @@ public sealed partial class FancyResearchConsoleMenu : FancyWindow
         _sprite = _entity.System<SpriteSystem>();
         _accessReader = _entity.System<AccessReaderSystem>();
         StaticSprite.SetFromSpriteSpecifier(new SpriteSpecifier.Rsi(new("_Goobstation/Interface/rnd-static.rsi"), "static"));
+        StaticSprite.DisplayRect.CanShrink = true;
+        StaticSprite.DisplayRect.Stretch = TextureRect.StretchMode.Scale;
 
         ServerButton.OnPressed += _ => OnServerButtonPressed?.Invoke();
         DragContainer.OnKeyBindDown += OnKeybindDown;

--- a/Content.Goobstation.Client/Research/UI/FancyResearchConsoleMenu.xaml.cs
+++ b/Content.Goobstation.Client/Research/UI/FancyResearchConsoleMenu.xaml.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2025 FaDeOkno <143940725+FaDeOkno@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 FaDeOkno <logkedr18@gmail.com>
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>

--- a/Content.Goobstation.Client/Research/UI/FancyResearchConsoleMenu.xaml.cs
+++ b/Content.Goobstation.Client/Research/UI/FancyResearchConsoleMenu.xaml.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2025 FaDeOkno <143940725+FaDeOkno@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 FaDeOkno <logkedr18@gmail.com>
+// SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 //


### PR DESCRIPTION
## About the PR
Research menu doesn't look bad now

## Why / Balance
Was broken, look at media

## Tech deets
BG was not scaling up/down (usually good thing), which didn't leave space for sidebar on undersized screens - which is the default. 
It's caused by v249.0.0 fixing dynamic scaling allowing elements (static bg in this case) to go <min size. Or rather, before this change, they could go <min, which was used in the system. Now that it's fixed, it has to be explicitly set.

## Media
Before: 

![image](https://github.com/user-attachments/assets/3c1f8e53-1c26-4989-ba06-06089d62c5e9)
Undersize - no bg on sidebar

![image](https://github.com/user-attachments/assets/a2c9bab5-4697-4130-869a-4dd423a71f8c)
Oversize - black bg and no stretch

After:

![{79408973-DEC5-4A8A-87BC-D44A94BF63A8}](https://github.com/user-attachments/assets/7fbba595-56e8-4f84-a22f-8fe46b250b31)
Undersize - yes bg on sidebar

![{F1B2F960-5C9B-45CD-BDEB-26C016E05092}](https://github.com/user-attachments/assets/38479c32-38eb-4b5c-be27-3d3f8442b74a)
Oversize - nice stretch

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed research menu sidebar/bg