### PR TITLE
Woundmed Fixes 1

### DIFF
--- a/Content.Server/EntityEffects/Effects/HealthChange.cs
+++ b/Content.Server/EntityEffects/Effects/HealthChange.cs
@@ -103,7 +103,7 @@ namespace Content.Server.EntityEffects.Effects
 
         [DataField]
         [JsonPropertyName("healingDamageMultiplier")]
-        public float HealingDamageMultiplier = 11f; // Shitmed Change
+        public float HealingDamageMultiplier = 220f; // Shitmed Change
 
         [DataField]
         [JsonPropertyName("damageMultiplier")]
@@ -245,7 +245,7 @@ namespace Content.Server.EntityEffects.Effects
             args.EntityManager.System<DamageableSystem>()
                 .TryChangeDamage(
                     args.TargetEntity,
-                    damageSpec * scale, // 8 represents the average number of parts on a humanoid.
+                    damageSpec * scale,
                     IgnoreResistances,
                     interruptsDoAfters: false,
                     targetPart: TargetBodyPart.All,

--- a/Content.Server/EntityEffects/Effects/HealthChange.cs
+++ b/Content.Server/EntityEffects/Effects/HealthChange.cs
@@ -43,6 +43,7 @@
 // SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 // SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>

--- a/Content.Server/EntityEffects/Effects/HealthChange.cs
+++ b/Content.Server/EntityEffects/Effects/HealthChange.cs
@@ -40,12 +40,13 @@
 // SPDX-FileCopyrightText: 2023 moonheart08 <moonheart08@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 KrasnoshchekovPavel <119816022+KrasnoshchekovPavel@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
-// SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2025 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+// SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 // SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Shared/Body/Components/BodyComponent.cs
+++ b/Content.Shared/Body/Components/BodyComponent.cs
@@ -13,10 +13,12 @@
 
 using Content.Shared.Body.Prototypes;
 using Content.Shared.Body.Systems;
+using Content.Shared._Shitmed.Body;
 using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+
 
 namespace Content.Shared.Body.Components;
 
@@ -59,4 +61,8 @@ public sealed partial class BodyComponent : Component
     [DataField, AutoNetworkedField]
     public bool ThermalVisibility = true;
     // WD EDIT END
+
+    // Shitmed Change - Fuck borgs.
+    [DataField]
+    public BodyType BodyType = BodyType.Complex;
 }

--- a/Content.Shared/Body/Components/BodyComponent.cs
+++ b/Content.Shared/Body/Components/BodyComponent.cs
@@ -8,8 +8,10 @@
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 // SPDX-FileCopyrightText: 2025 Spatison <137375981+Spatison@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -34,20 +34,25 @@
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2025 Aineias1 <dmitri.s.kiselev@gmail.com>
+// SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aviu00 <aviu00@protonmail.com>
 // SPDX-FileCopyrightText: 2025 FaDeOkno <143940725+FaDeOkno@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Kayzel <43700376+KayzelW@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 McBosserson <148172569+McBosserson@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Milon <plmilonpl@gmail.com>
 // SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 // SPDX-FileCopyrightText: 2025 Rouden <149893554+Roudenn@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Roudenn <romabond091@gmail.com>
 // SPDX-FileCopyrightText: 2025 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
-// SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 // SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
+// SPDX-FileCopyrightText: 2025 Spatison <137375981+Spatison@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Trest <144359854+trest100@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Unlumination <144041835+Unlumy@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 chromiumboy <50505512+chromiumboy@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
@@ -55,13 +60,9 @@
 // SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 // SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
 // SPDX-FileCopyrightText: 2025 keronshb <54602815+keronshb@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 kurokoTurbo <92106367+kurokoTurbo@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 username <113782077+whateverusername0@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 whateverusername0 <whateveremail>
-// SPDX-FileCopyrightText: 2025 Spatison <137375981+Spatison@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 kurokoTurbo <92106367+kurokoTurbo@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Trest <144359854+trest100@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Roudenn <romabond091@gmail.com>
-// SPDX-FileCopyrightText: 2025 Kayzel <43700376+KayzelW@users.noreply.github.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -83,6 +83,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
 // Shitmed Change
+using Content.Shared._Shitmed.Body;
 using Content.Shared._Shitmed.Medical.Surgery.Consciousness.Components;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds.Components;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds.Systems;
@@ -290,7 +291,8 @@ namespace Content.Shared.Damage
                 return null;
 
             // For entities with a body, route damage through body parts and then sum it up
-            if (_bodyQuery.HasComp(uid.Value))
+            if (_bodyQuery.TryGetComponent(uid.Value, out var body)
+                && body.BodyType == BodyType.Complex)
             {
                 var appliedDamage = ApplyDamageToBodyParts(uid.Value, damage, origin, ignoreResistances,
                     interruptsDoAfters, targetPart, partMultiplier, ignoreBlockers);

--- a/Content.Shared/_Shitmed/Body/Components/BodyTypeEnums.cs
+++ b/Content.Shared/_Shitmed/Body/Components/BodyTypeEnums.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Shared/_Shitmed/Body/Components/BodyTypeEnums.cs
+++ b/Content.Shared/_Shitmed/Body/Components/BodyTypeEnums.cs
@@ -1,0 +1,7 @@
+namespace Content.Shared._Shitmed.Body;
+
+public enum BodyType : byte
+{
+    Simple,
+    Complex
+}

--- a/Content.Shared/_Shitmed/Body/Components/BodyTypeEnums.cs
+++ b/Content.Shared/_Shitmed/Body/Components/BodyTypeEnums.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 namespace Content.Shared._Shitmed.Body;
 
 public enum BodyType : byte

--- a/Content.Shared/_Shitmed/Surgery/Consciousness/Systems/ConsciousnessSystem.Networking.cs
+++ b/Content.Shared/_Shitmed/Surgery/Consciousness/Systems/ConsciousnessSystem.Networking.cs
@@ -1,4 +1,9 @@
-﻿using Content.Shared._Shitmed.Medical.Surgery.Consciousness.Components;
+// SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared._Shitmed.Medical.Surgery.Consciousness.Components;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._Shitmed.Medical.Surgery.Consciousness.Systems;

--- a/Content.Shared/_Shitmed/Surgery/Consciousness/Systems/ConsciousnessSystem.Networking.cs
+++ b/Content.Shared/_Shitmed/Surgery/Consciousness/Systems/ConsciousnessSystem.Networking.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 //

--- a/Content.Shared/_Shitmed/Surgery/Consciousness/Systems/ConsciousnessSystem.Networking.cs
+++ b/Content.Shared/_Shitmed/Surgery/Consciousness/Systems/ConsciousnessSystem.Networking.cs
@@ -28,13 +28,13 @@ public partial class ConsciousnessSystem
         component.RequiredConsciousnessParts.Clear();
 
         foreach (var ((modEntity, modType), modifier) in state.Modifiers)
-            component.Modifiers.Add((GetEntity(modEntity), modType), modifier);
+            component.Modifiers.TryAdd((GetEntity(modEntity), modType), modifier);
 
         foreach (var ((multiplierEntity, multiplierType), modifier) in state.Multipliers)
-            component.Multipliers.Add((GetEntity(multiplierEntity), multiplierType), modifier);
+            component.Multipliers.TryAdd((GetEntity(multiplierEntity), multiplierType), modifier);
 
         foreach (var (id, (entity, causesDeath, isLost)) in state.RequiredConsciousnessParts)
-            component.RequiredConsciousnessParts.Add(id, (GetEntity(entity), causesDeath, isLost));
+            component.RequiredConsciousnessParts.TryAdd(id, (GetEntity(entity), causesDeath, isLost));
     }
 
     private void OnComponentGet(EntityUid uid, ConsciousnessComponent comp, ref ComponentGetState args)
@@ -51,15 +51,15 @@ public partial class ConsciousnessSystem
 
         foreach (var ((modEntity, modType), modifier) in comp.Modifiers)
             if (!TerminatingOrDeleted(modEntity))
-                state.Modifiers.Add((GetNetEntity(modEntity), modType), modifier);
+                state.Modifiers.TryAdd((GetNetEntity(modEntity), modType), modifier);
 
         foreach (var ((multiplierEntity, multiplierType), modifier) in comp.Multipliers)
             if (!TerminatingOrDeleted(multiplierEntity))
-                state.Multipliers.Add((GetNetEntity(multiplierEntity), multiplierType), modifier);
+                state.Multipliers.TryAdd((GetNetEntity(multiplierEntity), multiplierType), modifier);
 
         foreach (var (id, (entity, causesDeath, isLost)) in comp.RequiredConsciousnessParts)
             if (!TerminatingOrDeleted(entity))
-                state.RequiredConsciousnessParts.Add(id, (GetNetEntity(entity), causesDeath, isLost));
+                state.RequiredConsciousnessParts.TryAdd(id, (GetNetEntity(entity), causesDeath, isLost));
 
         args.State = state;
     }

--- a/Content.Shared/_Shitmed/Surgery/Pain/Components/NerveSystemComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Pain/Components/NerveSystemComponent.cs
@@ -1,4 +1,9 @@
-﻿using Content.Goobstation.Maths.FixedPoint;
+// SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Goobstation.Maths.FixedPoint;
 using Content.Shared.Humanoid;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Components;

--- a/Content.Shared/_Shitmed/Surgery/Pain/Components/NerveSystemComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Pain/Components/NerveSystemComponent.cs
@@ -19,7 +19,7 @@ public sealed partial class NerveSystemComponent : Component
     /// How much of typical wound pain can this nerve system hold?
     /// </summary>
     [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadOnly)]
-    public FixedPoint2 SoftPainCap = 90f;
+    public FixedPoint2 SoftPainCap = 120f;
 
     /// <summary>
     /// How much Pain can this nerve system hold.
@@ -51,7 +51,7 @@ public sealed partial class NerveSystemComponent : Component
     public TimeSpan PainReactionTime = TimeSpan.FromSeconds(0.07f);
 
     [DataField("adrenalineTime")]
-    public TimeSpan PainShockAdrenalineTime = TimeSpan.FromSeconds(40f);
+    public TimeSpan PainShockAdrenalineTime = TimeSpan.FromSeconds(60f);
 
     [DataField]
     public TimeSpan CritScreamsIntervalMin = TimeSpan.FromSeconds(13f);
@@ -63,7 +63,7 @@ public sealed partial class NerveSystemComponent : Component
     public TimeSpan NextCritScream;
 
     [DataField("painShockStun")]
-    public TimeSpan PainShockStunTime = TimeSpan.FromSeconds(7f);
+    public TimeSpan PainShockStunTime = TimeSpan.FromSeconds(2f);
 
     [DataField("organDamageStun")]
     public TimeSpan OrganDamageStunTime = TimeSpan.FromSeconds(12f);
@@ -235,13 +235,13 @@ public sealed partial class NerveSystemComponent : Component
     [DataField("reflexThresholds"), ViewVariables(VVAccess.ReadOnly)]
     public Dictionary<PainThresholdTypes, FixedPoint2> PainThresholds = new()
     {
-        { PainThresholdTypes.PainFlinch, 5 },
-        { PainThresholdTypes.Agony, 20 },
+        { PainThresholdTypes.PainFlinch, 35 },
+        { PainThresholdTypes.Agony, 50 },
         // Just having 'PainFlinch' is lame, people scream for a few seconds before passing out / getting pain shocked, so I added agony.
         // A lot of screams (individual pain screams poll), for the funnies.
-        { PainThresholdTypes.PainShock, 42 },
+        { PainThresholdTypes.PainShock, 72 },
         // usually appears after an explosion. or some ultra big damage output thing, you might survive, and most importantly, you will fall down in pain.
         // :troll:
-        { PainThresholdTypes.PainShockAndAgony, 70 },
+        { PainThresholdTypes.PainShockAndAgony, 100 },
     };
 }

--- a/Content.Shared/_Shitmed/Surgery/Pain/Components/NerveSystemComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Pain/Components/NerveSystemComponent.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 //

--- a/Content.Shared/_Shitmed/Surgery/Pain/Systems/PainSystem.Damage.cs
+++ b/Content.Shared/_Shitmed/Surgery/Pain/Systems/PainSystem.Damage.cs
@@ -789,7 +789,7 @@ public partial class PainSystem
                 TryAddPainMultiplier(
                     nerveSys,
                     PainAdrenalineIdentifier,
-                    0.7f,
+                    0.3f,
                     PainDamageTypes.WoundPain,
                     nerveSys,
                     nerveSys.Comp.PainShockAdrenalineTime);

--- a/Content.Shared/_Shitmed/Surgery/Pain/Systems/PainSystem.Damage.cs
+++ b/Content.Shared/_Shitmed/Surgery/Pain/Systems/PainSystem.Damage.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 //

--- a/Content.Shared/_Shitmed/Surgery/Pain/Systems/PainSystem.Damage.cs
+++ b/Content.Shared/_Shitmed/Surgery/Pain/Systems/PainSystem.Damage.cs
@@ -1,4 +1,9 @@
-﻿using System.Diagnostics.CodeAnalysis;
+// SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Process.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Process.cs
@@ -500,10 +500,14 @@ public partial class TraumaSystem
         FixedPoint2 severity,
         (BodyPartType, BodyPartSymmetry)? targetType = null)
     {
+        if (TerminatingOrDeleted(inflicter))
+            return EntityUid.Invalid;
+
         foreach (var trauma in inflicter.Comp.TraumaContainer.ContainedEntities)
         {
             var containedTraumaComp = Comp<TraumaComponent>(trauma);
-            if (containedTraumaComp.TraumaType != traumaType || containedTraumaComp.TraumaTarget != target)
+            if (containedTraumaComp.TraumaType != traumaType
+                || containedTraumaComp.TraumaTarget != target)
                 continue;
             // Check for TraumaTarget isn't really necessary..
             // Right now wounds on a specified woundable can't wound other woundables, but in case IF something happens or IF someone decides to do that
@@ -647,8 +651,11 @@ public partial class TraumaSystem
                 case TraumaType.OrganDamage:
                     var traumaEnt = AddTrauma(targetChosen.Value, target, inflicter, TraumaType.OrganDamage, severity);
 
-                    if (!TryChangeOrganDamageModifier(targetChosen.Value, severity, traumaEnt, "WoundableDamage"))
+                    if (traumaEnt != EntityUid.Invalid
+                        && !TryChangeOrganDamageModifier(targetChosen.Value, severity, traumaEnt, "WoundableDamage"))
+                    {
                         TryCreateOrganDamageModifier(targetChosen.Value, severity, traumaEnt, "WoundableDamage");
+                    }
 
                     break;
 

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Process.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Process.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 //

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Process.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Process.cs
@@ -1,4 +1,9 @@
-﻿using System.Linq;
+// SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Linq;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds.Components;
 using Content.Shared._Shitmed.Medical.Surgery.Pain;

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
@@ -21,6 +21,7 @@
 # SPDX-FileCopyrightText: 2024 Hanz <41141796+Hanzdegloker@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Mr. 27 <45323883+Dutch-VanDerLinde@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Smith <182301147+AgentSmithRadio@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
@@ -22,6 +22,8 @@
 # SPDX-FileCopyrightText: 2024 Mr. 27 <45323883+Dutch-VanDerLinde@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
+# SPDX-FileCopyrightText: 2025 Smith <182301147+AgentSmithRadio@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
@@ -38,7 +38,8 @@
     HandheldHealthAnalyzer: 3
     Scalpel: 2
     SawElectric: 2
-    #Bonesetter: 2 add when robotics
+    Bonesetter: 2
+    MedicalStitches: 2
     NitrousOxideTankFilled: 2
     ClothingMaskBreathMedical: 5
     ClothingHeadHatWeldingMaskFlame: 1

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -302,6 +302,7 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
   - type: Body
+    bodyType: Simple
   - type: StatusEffects
     allowed:
     - Stun

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -143,9 +143,11 @@
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
+# SPDX-FileCopyrightText: 2025 Quantum-cross <7065792+Quantum-cross@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Theodore Lukin <66275205+pheenty@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 chromiumboy <50505512+chromiumboy@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 # SPDX-FileCopyrightText: 2025 lzk <124214523+lzk228@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 #

--- a/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
@@ -210,7 +210,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      240: Dead # Goob - 6 PKA shots, 3 crusher destabilised hits
+      200: Dead # Goob - 6 PKA shots, 3 crusher destabilised hits
 
 - type: entity
   id: MobWatcherMagmawing
@@ -235,7 +235,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      240: Dead # Goob - 6 PKA shots, 3 crusher destabilised hits
+      200: Dead # Goob - 6 PKA shots, 3 crusher destabilised hits
 
 - type: entity
   id: MobWatcherPride

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -109,6 +109,7 @@
 # SPDX-FileCopyrightText: 2025 cheetah1984 <152602630+cheetah1984@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 cheetah1984 <davidc71114@gmail.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 # SPDX-FileCopyrightText: 2025 mubururu_ <139181059+muburu@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 #

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1052,6 +1052,8 @@
     - Cautery
     - SawElectric
     - BoneGel
+    - MedicalStitches
+    - Bonesetter
     # Frontier: droppable borg items
   - type: DroppableBorgModule
     moduleId: Surgery
@@ -1082,6 +1084,8 @@
     - EnergyCautery
     - AdvancedRetractor
     - BoneGel
+    - Bonesetter
+    - MedicalStitches
     # Frontier: droppable borg items
   - type: DroppableBorgModule
     moduleId: AdvancedSurgery

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/medical.yml
@@ -7,6 +7,7 @@
 # SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Thom <119594676+ItsMeThom@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 # SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/medical.yml
@@ -33,6 +33,8 @@
   id: SurgeryStaticGoob
   recipes:
   - BoneGel
+  - MedicalStitches
+  - Bonesetter
 
 - type: latheRecipePack
   id: MedicalVehiclesStatic

--- a/Resources/Prototypes/_Shitmed/Body/Parts/animal.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Parts/animal.yml
@@ -14,3 +14,93 @@
   - type: Sprite
     layers:
     - state: head_m
+
+- type: entity
+  parent: [PartAnimalBase, ChestAnimal]
+  id: ChestGoliath
+  name: goliath chest
+  components:
+  - type: Woundable
+    integrity: 350
+    integrityCap: 350
+    thresholds:
+      Minor: 315
+      Moderate: 240
+      Severe: 120
+      Critical: 60
+      Loss: 0
+
+- type: entity
+  parent: [PartAnimalBase, GroinAnimal]
+  id: GroinGoliath
+  name: goliath groin
+  components:
+  - type: Woundable
+    integrity: 350
+    integrityCap: 350
+    thresholds:
+      Minor: 315
+      Moderate: 240
+      Severe: 120
+      Critical: 60
+      Loss: 0
+
+- type: entity
+  parent: [PartAnimalBase, LegsAnimal]
+  id: LegsGoliath
+  name: goliath legs
+  components:
+  - type: Woundable
+    integrity: 350
+    integrityCap: 350
+    thresholds:
+      Minor: 315
+      Moderate: 240
+      Severe: 120
+      Critical: 60
+      Loss: 0
+
+- type: entity
+  parent: [PartAnimalBase, ChestAnimal]
+  id: ChestDragon
+  name: dragon chest
+  components:
+  - type: Woundable
+    integrity: 500
+    integrityCap: 500
+    thresholds:
+      Minor: 450
+      Moderate: 350
+      Severe: 200
+      Critical: 100
+      Loss: 0
+
+- type: entity
+  parent: [PartAnimalBase, GroinAnimal]
+  id: GroinDragon
+  name: dragon groin
+  components:
+  - type: Woundable
+    integrity: 500
+    integrityCap: 500
+    thresholds:
+      Minor: 450
+      Moderate: 350
+      Severe: 200
+      Critical: 100
+      Loss: 0
+
+- type: entity
+  parent: [PartAnimalBase, LegsAnimal]
+  id: LegsDragon
+  name: dragon legs
+  components:
+  - type: Woundable
+    integrity: 500
+    integrityCap: 500
+    thresholds:
+      Minor: 450
+      Moderate: 350
+      Severe: 200
+      Critical: 100
+      Loss: 0

--- a/Resources/Prototypes/_Shitmed/Body/Parts/animal.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Parts/animal.yml
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
+# SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Monkey head for borging/transplanting pun pun

--- a/Resources/Prototypes/_Shitmed/Body/Parts/animal.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Parts/animal.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 # SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>

--- a/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/dragon.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/dragon.yml
@@ -2,9 +2,10 @@
 # SPDX-FileCopyrightText: 2022 Jezithyr <Jezithyr@gmail.com>
 # SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
 # SPDX-FileCopyrightText: 2023 brainfood1183 <113240905+brainfood1183@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ExponentialWizard <38435756+ExponentialWizard@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/dragon.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/dragon.yml
@@ -14,14 +14,14 @@
   root: chest
   slots:
     chest:
-      part: ChestAnimal
+      part: ChestDragon
       connections:
       - groin
       organs:
         lungs: OrganDragonLungs # Fire breathing
         heart: OrganSpaceAnimalHeart # Immunity to pressure
     groin:
-      part: GroinAnimal
+      part: GroinDragon
       connections:
       - legs
       organs:
@@ -29,7 +29,7 @@
         stomach: OrganAnimalStomach
         kidneys: OrganAnimalKidneys
     legs:
-      part: LegsAnimal
+      part: LegsDragon
       connections:
       - feet
     feet:

--- a/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/dragon.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/dragon.yml
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2023 brainfood1183 <113240905+brainfood1183@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ExponentialWizard <38435756+ExponentialWizard@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 #

--- a/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/goliath.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/goliath.yml
@@ -13,14 +13,14 @@
   root: chest
   slots:
     chest:
-      part: ChestAnimal
+      part: ChestGoliath
       connections:
       - groin
       organs:
         lungs: OrganAnimalLungs
         heart: OrganGoliathHeart # Allows you to use a slower version of their tentacles.
     groin:
-      part: GroinAnimal
+      part: GroinGoliath
       connections:
       - legs
       organs:
@@ -28,7 +28,7 @@
         liver: OrganAnimalLiver
         kidneys: OrganAnimalKidneys
     legs:
-      part: LegsAnimal
+      part: LegsGoliath
       connections:
       - feet
     feet:

--- a/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/goliath.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/goliath.yml
@@ -2,8 +2,9 @@
 # SPDX-FileCopyrightText: 2022 Jezithyr <Jezithyr@gmail.com>
 # SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
 # SPDX-FileCopyrightText: 2023 brainfood1183 <113240905+brainfood1183@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/goliath.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/goliath.yml
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
 # SPDX-FileCopyrightText: 2023 brainfood1183 <113240905+brainfood1183@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 #

--- a/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/laserraptor.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/laserraptor.yml
@@ -2,8 +2,9 @@
 # SPDX-FileCopyrightText: 2022 Jezithyr <Jezithyr@gmail.com>
 # SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
 # SPDX-FileCopyrightText: 2023 brainfood1183 <113240905+brainfood1183@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/laserraptor.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/laserraptor.yml
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
 # SPDX-FileCopyrightText: 2023 brainfood1183 <113240905+brainfood1183@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 #

--- a/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/laserraptor.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/laserraptor.yml
@@ -9,7 +9,7 @@
 
 - type: body
   id: LaserRaptor
-  name: "space dragon"
+  name: "laser raptor"
   root: chest
   slots:
     head:

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/wounds.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/wounds.yml
@@ -41,7 +41,7 @@
     mangledMultipliers:
       BoneDamage: 1
   - type: PainInflicter
-    multiplier: 0.87
+    multiplier: 0.48
   - type: BleedInflicter
     scalingSpeed: 0.8
     severityThreshold: 8
@@ -77,7 +77,7 @@
     mangledMultipliers:
       BoneDamage: 0.75
   - type: PainInflicter
-    multiplier: 0.67
+    multiplier: 0.32
   - type: BleedInflicter
     severityThreshold: 9
     scalingSpeed: 0.5
@@ -106,7 +106,7 @@
       VeinsDamage: -0.4
       NerveDamage: -0.4
   - type: PainInflicter
-    multiplier: 0.44
+    multiplier: 0.24
   - type: BleedInflicter
     scalingSpeed: 0.34
     severityThreshold: 5
@@ -142,7 +142,7 @@
     mangledMultipliers:
       BoneDamage: 0.6
   - type: PainInflicter
-    multiplier: 0.67
+    multiplier: 0.32
   - type: BleedInflicter
     scalingSpeed: 1.7
 
@@ -176,7 +176,7 @@
     mangledMultipliers:
       BoneDamage: 1
   - type: PainInflicter
-    multiplier: 1.1
+    multiplier: 0.6
   - type: BleedRemover
     severityThreshold: 3
 
@@ -203,7 +203,7 @@
       VeinsDamage: 0.5
       NerveDamage: 0.5
   - type: PainInflicter
-    multiplier: 1.5 # it hurts
+    multiplier: 0.75 # it hurts
 
 - type: entity
   id: Holy
@@ -226,7 +226,7 @@
       VeinsDamage: 0
       NerveDamage: 0.777
   - type: PainInflicter
-    multiplier: 0.777
+    multiplier: 0.34
 
 - type: entity
   id: Shock
@@ -252,7 +252,7 @@
       VeinsDamage: 0.34 # People are great conductors
       NerveDamage: 0.34
   - type: PainInflicter
-    multiplier: 1.4
+    multiplier: 0.7
 
 - type: entity
   id: Cellular
@@ -280,7 +280,7 @@
       NerveDamage: 0.17
   - type: PainInflicter
     painType: TraumaticPain
-    multiplier: 0.67
+    multiplier: 0.32
 
 - type: entity
   id: Caustic
@@ -361,7 +361,7 @@
       NerveDamage: 0.12
   - type: PainInflicter
     painType: TraumaticPain
-    multiplier: 1.4
+    multiplier: 0.7
 
 - type: entity
   id: BoneDamage

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/wounds.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/wounds.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 #

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/wounds.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/wounds.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   id: WoundBase
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_Shitmed/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_Shitmed/Recipes/Lathes/medical.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Shitmed Recipes

--- a/Resources/Prototypes/_Shitmed/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_Shitmed/Recipes/Lathes/medical.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 #

--- a/Resources/Prototypes/_Shitmed/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_Shitmed/Recipes/Lathes/medical.yml
@@ -14,6 +14,22 @@
     Plasma: 200
 
 - type: latheRecipe
+  id: MedicalStitches
+  result: MedicalStitches
+  completetime: 2
+  materials:
+    Steel: 300
+    Plastic: 10
+
+- type: latheRecipe
+  id: Bonesetter
+  result: Bonesetter
+  completetime: 2
+  materials:
+    Steel: 400
+    Plastic: 200
+
+- type: latheRecipe
   id: MedicalCyberneticEyes
   result: MedicalCyberneticEyes
   categories:


### PR DESCRIPTION
## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
🆑Mocho
- tweak: Reduced paincrit duration, increased adrenaline pain reduction and pain thresholds, and reduced wound pain multipliers.
- tweak: Added stitches and bonesetters to borg inventories and lathes.
- fix: Attempted some fixes at PVS/flickering issues
- fix: Dragons, goliaths, watchers and cyborgs are not immortal anymore.
- fix: Fixed chemicals being 1/11th of their intended values.