### PR TITLE
[BOUNTY] Better wiz chances

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2025 August Eymann <august.eymann@gmail.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 IrisTheAmped <iristheamped@gmail.com>
 # SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>

--- a/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
@@ -21,7 +21,7 @@
     Zombie: 0.04
     Heretic: 0.11
     BlobGameMode: 0.05
-    Wizard: 0.02
+    Wizard: 0.025
     CosmicCult: 0.12 # make it semi often so we can test it
     #HonkOps: 0.01 # this test fail was real holy shit it was only a preset the entire a time i was lied too by myself
 

--- a/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
@@ -21,7 +21,7 @@
     Zombie: 0.04
     Heretic: 0.11
     BlobGameMode: 0.05
-    Wizard: 0.007
+    Wizard: 0.02
     CosmicCult: 0.12 # make it semi often so we can test it
     #HonkOps: 0.01 # this test fail was real holy shit it was only a preset the entire a time i was lied too by myself
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Wiz weight from .007 to .025 bringing it from approx 0.9% chance to 3.14%.
Wizards are meant to be rare yea but unlike any other game mode only 1 person gets it, combined with the chance made it stupidly rare to actually roll a wizard. Math in the bounty brought it to something like 4000 hours average for someone to roll wizard. Not to mention while wizards are meant to be round changing a lot of players like to just play wizards that are either friendly or take so long to do anything, I've seen 1 wizard since the change and they casted no magic all round because they were hidden as a tider trying to set up a gimmick.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Balance: There is none just people wanna play wiz more.
Why: Bounty https://discord.com/channels/1202734573247795300/1371226249183100999/1371226249183100999

## Technical details
<!-- Summary of code changes for easier review. -->
1 line yaml change

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Wizards are now an around 3.1% chance spawn.


