### PR TITLE
Steel tile tilemovement

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/specific.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/specific.yml
@@ -103,3 +103,6 @@
     sprite: _Goobstation/Clothing/Uniforms/Jumpsuit/budget_stealth.rsi
   - type: Clothing
     sprite: _Goobstation/Clothing/Uniforms/Jumpsuit/budget_stealth.rsi
+  - type: ClothingGrantComponent
+    component:
+    - type: TileMovement


### PR DESCRIPTION
## About the PR
Steel tile suit now grants tilemovement on wearing

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: LuciferEOS
- tweak: Steel tile suit now gives tile movement on wearing, go nuts.
