### PR TITLE
make mining a doafter like ss13

### DIFF
--- a/Content.Goobstation.Client/Gatherable/ToolGatherableSystem.cs
+++ b/Content.Goobstation.Client/Gatherable/ToolGatherableSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Goobstation.Shared.Gatherable;
 
 namespace Content.Goobstation.Client.Gatherable;

--- a/Content.Goobstation.Client/Gatherable/ToolGatherableSystem.cs
+++ b/Content.Goobstation.Client/Gatherable/ToolGatherableSystem.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Goobstation.Client/Gatherable/ToolGatherableSystem.cs
+++ b/Content.Goobstation.Client/Gatherable/ToolGatherableSystem.cs
@@ -1,0 +1,17 @@
+using Content.Goobstation.Shared.Gatherable;
+
+namespace Content.Goobstation.Client.Gatherable;
+
+public sealed class ToolGatherableSystem : SharedToolGatherableSystem
+{
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    protected override void Gather(Entity<ToolGatherableComponent> ent, EntityUid user)
+    {
+        base.Gather(ent, user);
+
+        // only predict the entity being destroyed TODO replace with PredictedDel(ent) after engine update
+        _transform.DetachEntity(ent.Owner, Transform(ent));
+        // server will do the sound drops etc don't try to predict any of that
+    }
+}

--- a/Content.Goobstation.Server/Gatherable/ToolGatherableSystem.cs
+++ b/Content.Goobstation.Server/Gatherable/ToolGatherableSystem.cs
@@ -1,0 +1,16 @@
+using Content.Goobstation.Shared.Gatherable;
+using Content.Server.Gatherable;
+
+namespace Content.Goobstation.Server.Gatherable;
+
+public sealed class ToolGatherableSystem : SharedToolGatherableSystem
+{
+    [Dependency] private readonly GatherableSystem _gatherable = default!;
+
+    protected override void Gather(Entity<ToolGatherableComponent> ent, EntityUid user)
+    {
+        base.Gather(ent, user);
+
+        _gatherable.Gather(ent.Owner, user);
+    }
+}

--- a/Content.Goobstation.Server/Gatherable/ToolGatherableSystem.cs
+++ b/Content.Goobstation.Server/Gatherable/ToolGatherableSystem.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Goobstation.Server/Gatherable/ToolGatherableSystem.cs
+++ b/Content.Goobstation.Server/Gatherable/ToolGatherableSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Goobstation.Shared.Gatherable;
 using Content.Server.Gatherable;
 

--- a/Content.Goobstation.Shared/Gatherable/SharedToolGatherableSystem.cs
+++ b/Content.Goobstation.Shared/Gatherable/SharedToolGatherableSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared.DoAfter;
 using Content.Shared.Interaction;
 using Content.Shared.Tools.Systems;

--- a/Content.Goobstation.Shared/Gatherable/SharedToolGatherableSystem.cs
+++ b/Content.Goobstation.Shared/Gatherable/SharedToolGatherableSystem.cs
@@ -1,0 +1,49 @@
+using Content.Shared.DoAfter;
+using Content.Shared.Interaction;
+using Content.Shared.Tools.Systems;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Serialization;
+
+namespace Content.Goobstation.Shared.Gatherable;
+
+/// <summary>
+/// Handles interaction with gatherable entities.
+/// Actual gathering is done serverside, client just predicts it being deleted.
+/// </summary>
+public abstract class SharedToolGatherableSystem : EntitySystem
+{
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedToolSystem _tool = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ToolGatherableComponent, InteractUsingEvent>(OnInteractUsing);
+        SubscribeLocalEvent<ToolGatherableComponent, GatherDoAfterEvent>(OnDoAfter);
+    }
+
+    private void OnInteractUsing(Entity<ToolGatherableComponent> ent, ref InteractUsingEvent args)
+    {
+        args.Handled = _tool.UseTool(
+            tool: args.Used,
+            user: args.User,
+            target: args.Target,
+            doAfterDelay: (float) ent.Comp.GatherTime.TotalSeconds,
+            toolQualityNeeded: ent.Comp.ToolQuality,
+            doAfterEv: new GatherDoAfterEvent());
+    }
+
+    private void OnDoAfter(Entity<ToolGatherableComponent> ent, ref GatherDoAfterEvent args)
+    {
+        Gather(ent, args.User);
+    }
+
+    protected virtual void Gather(Entity<ToolGatherableComponent> ent, EntityUid user)
+    {
+        // client can definitely predict the audio so do that
+        // do not use GatherSoundComponent as well or it will double play
+        _audio.PlayPredicted(ent.Comp.Sound, Transform(ent).Coordinates, user);
+    }
+}
+
+[Serializable, NetSerializable]
+public sealed partial class GatherDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Goobstation.Shared/Gatherable/SharedToolGatherableSystem.cs
+++ b/Content.Goobstation.Shared/Gatherable/SharedToolGatherableSystem.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Goobstation.Shared/Gatherable/ToolGatherableComponent.cs
+++ b/Content.Goobstation.Shared/Gatherable/ToolGatherableComponent.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Goobstation.Shared/Gatherable/ToolGatherableComponent.cs
+++ b/Content.Goobstation.Shared/Gatherable/ToolGatherableComponent.cs
@@ -1,0 +1,35 @@
+using Content.Shared.Tools;
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Goobstation.Shared.Gatherable;
+
+/// <summary>
+/// Requires <c>GatherableComponent</c> but cannot be used with <c>GatherableSoundComponent</c>.
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(SharedToolGatherableSystem))]
+public sealed partial class ToolGatherableComponent : Component
+{
+    /// <summary>
+    /// The tool quality to use for the gather doafter.
+    /// </summary>
+    [DataField]
+    public ProtoId<ToolQualityPrototype> ToolQuality = "Mining";
+
+    /// <summary>
+    /// How long it takes to gather using a tool.
+    /// </summary>
+    [DataField]
+    public TimeSpan GatherTime = TimeSpan.FromSeconds(4);
+
+    /// <summary>
+    /// Sound to play when gathering.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? Sound = new SoundPathSpecifier("/Audio/Effects/break_stone.ogg")
+    {
+        Params = AudioParams.Default
+            .WithVolume(-3f)
+    };
+}

--- a/Content.Goobstation.Shared/Gatherable/ToolGatherableComponent.cs
+++ b/Content.Goobstation.Shared/Gatherable/ToolGatherableComponent.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared.Tools;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;

--- a/Content.Goobstation.Shared/Tools/ItemToggleToolComponent.cs
+++ b/Content.Goobstation.Shared/Tools/ItemToggleToolComponent.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Goobstation.Shared/Tools/ItemToggleToolComponent.cs
+++ b/Content.Goobstation.Shared/Tools/ItemToggleToolComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Goobstation.Shared.Tools;
+
+/// <summary>
+/// Makes a tool with <c>ItemToggle</c> require being on to be used for its tool qualities.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ItemToggleToolComponent : Component;

--- a/Content.Goobstation.Shared/Tools/ItemToggleToolComponent.cs
+++ b/Content.Goobstation.Shared/Tools/ItemToggleToolComponent.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Robust.Shared.GameStates;
 
 namespace Content.Goobstation.Shared.Tools;

--- a/Content.Goobstation.Shared/Tools/ItemToggleToolSystem.cs
+++ b/Content.Goobstation.Shared/Tools/ItemToggleToolSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared.Item.ItemToggle;
 using Content.Shared.Popups;
 using Content.Shared.Tools.Components;

--- a/Content.Goobstation.Shared/Tools/ItemToggleToolSystem.cs
+++ b/Content.Goobstation.Shared/Tools/ItemToggleToolSystem.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Goobstation.Shared/Tools/ItemToggleToolSystem.cs
+++ b/Content.Goobstation.Shared/Tools/ItemToggleToolSystem.cs
@@ -1,0 +1,27 @@
+using Content.Shared.Item.ItemToggle;
+using Content.Shared.Popups;
+using Content.Shared.Tools.Components;
+
+namespace Content.Goobstation.Shared.Tools;
+
+public sealed class ItemToggleToolSystem : EntitySystem
+{
+    [Dependency] private readonly ItemToggleSystem _toggle = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ItemToggleToolComponent, ToolUseAttemptEvent>(OnToolUseAttempt);
+    }
+
+    private void OnToolUseAttempt(Entity<ItemToggleToolComponent> ent, ref ToolUseAttemptEvent args)
+    {
+        if (_toggle.IsActivated(ent.Owner))
+            return;
+
+        _popup.PopupClient(Loc.GetString("item-toggle-tool-turn-on", ("tool", ent)), ent, args.User);
+        args.Cancel();
+    }
+}

--- a/Content.Server/Gatherable/GatherableSystem.cs
+++ b/Content.Server/Gatherable/GatherableSystem.cs
@@ -16,6 +16,7 @@
 // SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 plykiya <plykiya@protonmail.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Server/Gatherable/GatherableSystem.cs
+++ b/Content.Server/Gatherable/GatherableSystem.cs
@@ -47,10 +47,11 @@ public sealed partial class GatherableSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<GatherableComponent, ActivateInWorldEvent>(OnActivate);
-        SubscribeLocalEvent<GatherableComponent, AttackedEvent>(OnAttacked);
+        //SubscribeLocalEvent<GatherableComponent, AttackedEvent>(OnAttacked); // Goobstation - handled by ToolGatherableSystem instead
         InitializeProjectile();
     }
 
+    /* Goobstation - handled by ToolGatherableSystem instead
     private void OnAttacked(Entity<GatherableComponent> gatherable, ref AttackedEvent args)
     {
         if (_whitelistSystem.IsWhitelistFailOrNull(gatherable.Comp.ToolWhitelist, args.Used))
@@ -58,6 +59,7 @@ public sealed partial class GatherableSystem : EntitySystem
 
         Gather(gatherable, args.User);
     }
+    */
 
     private void OnActivate(Entity<GatherableComponent> gatherable, ref ActivateInWorldEvent args)
     {

--- a/Content.Server/Gatherable/GatherableSystem.cs
+++ b/Content.Server/Gatherable/GatherableSystem.cs
@@ -16,6 +16,7 @@
 // SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 plykiya <plykiya@protonmail.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Locale/en-US/_Goobstation/tools/item-toggle-tool.ftl
+++ b/Resources/Locale/en-US/_Goobstation/tools/item-toggle-tool.ftl
@@ -1,0 +1,1 @@
+item-toggle-tool-turn-on = Turn on {THE($tool)} first!

--- a/Resources/Locale/en-US/_Goobstation/tools/tool-qualities.ftl
+++ b/Resources/Locale/en-US/_Goobstation/tools/tool-qualities.ftl
@@ -9,3 +9,6 @@ tool-quality-axing-tool-name = Fireaxe
 
 tool-quality-painting-name = Painting
 tool-quality-painting-tool-name = Spray Painter
+
+tool-quality-mining-name = Mining
+tool-quality-mining-tool-name = Pickaxe

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -97,7 +97,7 @@
 - type: damageModifierSet
   id: Rock
   coefficients:
-    Structural: 4
+    Structural: 0.25 # Goobstation
     Blunt: 0.5
     Slash: 0.25
     Piercing: 0.75

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -48,6 +48,7 @@
 # SPDX-FileCopyrightText: 2025 Aviu00 <aviu00@protonmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 # SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -118,6 +118,9 @@
     materialComposition:
       Steel: 250
       Wood: 125
+  - type: Tool # Goobstation - Mining tool quality
+    speedModifier: 1
+    qualities: [ Mining ]
 
 - type: entity
   name: mining drill
@@ -151,6 +154,9 @@
     materialComposition:
       Steel: 125
       Plastic: 25
+  - type: Tool # Goobstation - Mining tool quality
+    speedModifier: 1.666667 # 1 / 0.6
+    qualities: [ Mining ]
 
 - type: entity
   name: diamond tipped mining drill
@@ -180,6 +186,8 @@
       Plastic: 50
       Silver: 50
       Diamond: 25
+  - type: Tool # Goobstation - Mining tool quality
+    speedModifier: 5 # 1 / 0.2
 
 - type: entity
   abstract: true
@@ -257,6 +265,10 @@
       types:
         Blunt: 19
         Slash: 11
+  - type: Tool # Goobstation - Mining tool quality
+    speedModifier: 1.1428571428571 # not SS13 parity, just got from swing speed relative to pickaxe
+    qualities:
+    - Mining
 
 - type: entity
   parent: [ BaseKnife, BaseWeaponCrusher, BaseSecurityCargoContraband]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -56,7 +56,9 @@
 # SPDX-FileCopyrightText: 2025 Milon <plmilonpl@gmail.com>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 Pronana <66055347+Pronana@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 RedBookcase <crazykid1590@gmail.com>
 # SPDX-FileCopyrightText: 2025 Rouden <149893554+Roudenn@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Speebro <100388782+Speebr0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Speebro <speebro@notreal.com>

--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -51,7 +51,6 @@
 # SPDX-FileCopyrightText: 2024 Ghagliiarghii <68826635+Ghagliiarghii@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 HS <81934438+HolySSSS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 IProduceWidgets <107586145+IProduceWidgets@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Jeff <velcroboy333@hotmail.com>
 # SPDX-FileCopyrightText: 2024 K-Dynamic <20566341+K-Dynamic@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Kevin Zheng <kevinz5000@gmail.com>
@@ -101,6 +100,7 @@
 # SPDX-FileCopyrightText: 2025 FaDeOkno <143940725+FaDeOkno@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Firewars763 <35506916+Firewars763@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 # SPDX-FileCopyrightText: 2025 McBosserson <148172569+McBosserson@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Milon <plmilonpl@gmail.com>

--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -134,6 +134,11 @@
   - type: IconSmooth
     key: walls
     mode: NoSprite
+  - type: Gatherable # Goobstation - supercode has 2 different rock parents for no reason
+    toolWhitelist:
+      tags:
+      - Pickaxe
+  - type: ToolGatherable # Goobstation
   - type: SmoothEdge
   - type: Icon
     sprite: Structures/Walls/rock.rsi
@@ -162,11 +167,11 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
-      - !type:PlaySoundBehavior
-        sound:
-          path: /Audio/Effects/break_stone.ogg
-          params:
-            volume: -6
+      #- !type:PlaySoundBehavior # Goobstation - ToolGatherable plays a sound already
+      #  sound:
+      #    path: /Audio/Effects/break_stone.ogg
+      #    params:
+      #      volume: -6
   # Goobstation
   - type: Fixtures
     fixtures:
@@ -845,11 +850,12 @@
   components:
     - type: Transform
       noRot: true
-    - type: SoundOnGather
+    #- type: SoundOnGather # Goobstation - ToolGatherable plays predicted sound instead
     - type: Gatherable
       toolWhitelist:
-        tags: [] # Lavaland Change
-        #- Pickaxe
+        tags:
+        - Pickaxe
+    - type: ToolGatherable # Goobstation
     - type: Damageable
       damageContainer: StructuralInorganic
       damageModifierSet: Rock # Lavaland Change

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024 NULL882 <gost6865@yandex.ru>
 # SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
@@ -17,6 +17,10 @@
     tags:
     - Pickaxe
     - IndustrialMech
+  - type: Tool
+    speedModifier: 3 # better than handheld drill
+    qualities:
+    - Mining
   - type: MeleeWeapon
     canWideSwing: false
     autoAttack: true
@@ -44,6 +48,10 @@
     tags:
     - Pickaxe
     - IndustrialMech
+  - type: Tool
+    speedModifier: 6 # better than handheld diamond drill
+    qualities:
+    - Mining
   - type: MeleeWeapon
     canWideSwing: false
     autoAttack: true

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/Weapons/Melee/industrial.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024 NULL882 <gost6865@yandex.ru>
 # SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Goobstation/tool-qualities.yml
+++ b/Resources/Prototypes/_Goobstation/tool-qualities.yml
@@ -18,3 +18,10 @@
   toolName: tool-quality-painting-tool-name
   spawn: SprayPainter
   icon: { sprite: Objects/Tools/spray_painter.rsi, state: spray_painter }
+
+- type: tool
+  id: Mining
+  name: tool-quality-mining-name
+  toolName: tool-quality-mining-tool-name
+  spawn: Pickaxe
+  icon: { sprite: Objects/Weapons/Melee/pickaxe.rsi, state: pickaxe }

--- a/Resources/Prototypes/_Goobstation/tool-qualities.yml
+++ b/Resources/Prototypes/_Goobstation/tool-qualities.yml
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
+# SPDX-FileCopyrightText: 2025 LuciferMkshelter <154002422+LuciferEOS@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/e_pickaxe.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/e_pickaxe.yml
@@ -1,4 +1,6 @@
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 # SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/e_pickaxe.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Melee/e_pickaxe.yml
@@ -14,6 +14,12 @@
     activatedShape:
     - 0,0,2,0
     - 1,1,1,2
+  - type: Tool # Goobstation
+    speedModifier: 2
+    qualities:
+    - Ignition
+    - Mining
+  - type: ItemToggleTool # Goobstation - you can only mine when it's on
   - type: ItemToggleMeleeWeapon
     activatedDamage:
       groups:


### PR DESCRIPTION
## About the PR
mining is now a doafter from clicking ore like ss13 and i believe how it used to be like 5 years ago

better than old thing as its **actually predicted** which is important for drills as generally your lag would slow you down

rocks are now very hard to damage without mining because no more 4x structural damage

*due to mech shitcode, clarke drills can't mine anymore but they were shit anyway*
it would need mech interaction relay for tool usage to work, the yml is updated incase someone fixes that

## Why / Balance
ss13 parity and better for laggy players

now gamers click 5 rocks at a time like robust tg terry shaft miners

values are the same as tg except:
- crusher cant mine i think? so its just based off swing speed (14% faster than pickaxe)
- mech drills are just faster than normal drills
- energy pickaxe idk if its from ss13

## Technical details
disabled attack gathering for Gatherable
ToolGatherable does the doafter stuff
ItemToggleTool to prevent mining with a switched off e pickaxe

## Media

pka and normal tools all work

https://github.com/user-attachments/assets/dd42bbc0-b178-4ff7-b4c7-43ae3a11fd97



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Mining is now a do-after from using a mining tool. Click multiple rocks at once to go fast!