### PR TITLE
Making PTL not useless (Draft) 

### DIFF
--- a/Content.Goobstation.Server/Power/PTL/PTLSystem.cs
+++ b/Content.Goobstation.Server/Power/PTL/PTLSystem.cs
@@ -96,7 +96,7 @@ public sealed partial class PTLSystem : EntitySystem
 
         var charge = ent.Comp2.CurrentCharge / megajoule;
         // some random formula i found in bounty thread i popped it into desmos i think it looks good
-        var spesos = (int) (charge * 144.9 / (Math.Log(charge * 2) + 1));
+        var spesos = (int) (charge * 144.9 / (Math.Log(charge * 2) + 1)); // Updated formula that equates to around 4333 spesos per shot at 100% at 250MJ you're still looking at 5-10min per max shot
 
         if (charge <= 0 || !double.IsFinite(spesos) || spesos < 0) return;
 

--- a/Content.Goobstation.Server/Power/PTL/PTLSystem.cs
+++ b/Content.Goobstation.Server/Power/PTL/PTLSystem.cs
@@ -96,7 +96,7 @@ public sealed partial class PTLSystem : EntitySystem
 
         var charge = ent.Comp2.CurrentCharge / megajoule;
         // some random formula i found in bounty thread i popped it into desmos i think it looks good
-        var spesos = (int) (charge / (Math.Log(charge * 2) + 1));
+        var spesos = (int) (charge * 144.9 / (Math.Log(charge * 2) + 1));
 
         if (charge <= 0 || !double.IsFinite(spesos) || spesos < 0) return;
 

--- a/Content.Goobstation.Shared/Power/PTL/PTLComponent.cs
+++ b/Content.Goobstation.Shared/Power/PTL/PTLComponent.cs
@@ -17,11 +17,11 @@ public sealed partial class PTLComponent : Component
 
     [DataField, AutoNetworkedField] public double SpesosHeld = 0f;
 
-    [DataField] public double MinShootPower = 1e6; // 1 MJ
-    [DataField] public double MaxEnergyPerShot = 1e9; // 1 GJ
+    [DataField] public double MinShootPower = 1e6; // 1 MJ 
+    [DataField] public double MaxEnergyPerShot = 2.5e8; // 250 MJ which can be achieved at 4-8min with a standard powernet
 
-    [DataField, AutoNetworkedField] public float ShootDelay = 10f;
-    [DataField, AutoNetworkedField] public MinMax ShootDelayThreshold = new MinMax(2, 10);
+    [DataField, AutoNetworkedField] public float ShootDelay = 30f; //So Laser can build a charge
+    [DataField, AutoNetworkedField] public MinMax ShootDelayThreshold = new MinMax(60, 120);
     [DataField, AutoNetworkedField] public bool ReversedFiring = false;
     [ViewVariables(VVAccess.ReadOnly)] public TimeSpan NextShotAt = TimeSpan.Zero;
 
@@ -30,5 +30,5 @@ public sealed partial class PTLComponent : Component
     /// <summary>
     ///     Amount of power required to start emitting radiation and blinding people that come nearby
     /// </summary>
-    [DataField] public double PowerEvilThreshold = 50; // 50 MJ;
+    [DataField] public double PowerEvilThreshold = 50e6; // 50 MJ Chudstation had this at 50J thats why it kept irradiating people
 }


### PR DESCRIPTION
## About the PR
Tweaks PTL so it has some better use in the current power gen system SS14 uses. It will still eat up most of the powernet if not careful, but now it only requires 1/4th of the power for a 100% shot. The speso formula was also changed to assume for 250MJ on a 400kw powernet to shoot at 100% once every 4-10mins for 4333 spesos at 100% charge of 250MW vs the current 1GW for only 230. It's still a FAR cry from what you could do in the 13, but it is a good start. Suggestions are welcome.

This PR is more of a hotfix until a permanent solution arrives further down the line.

## Why / Balance
<PTL is currently a griefing tool that just nukes the powernet and has no discernable benefit to even use. Now the PTL can make a good amount of cash while also still needing engineers to babysit it, but at a lesser degree than before. The extra money helps out cargo/station order more items they normally wouldnt be able to out of a lack of income or cargo bounties being completed.

## Technical details
Implements a hard limit on the PTL of 250MW at 100% instead of 1GW, Changes speso earnings multiplier to compensate for the lower charge value needed.  Increases cooldown between each shot to let the battery build up a little bit. 

## Media
TODO-


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
no

**Changelog**

:cl:
- tweak: changed PTL charge/income values. Order even more Tesla crates from cargo now!
