### PR TITLE
Nuclear GambaOps 2: Electric Boogaloo

### DIFF
--- a/Content.Goobstation.Server/NukeOps/NukieBundleComponent.cs
+++ b/Content.Goobstation.Server/NukeOps/NukieBundleComponent.cs
@@ -1,0 +1,11 @@
+
+namespace Content.Goobstation.Server.NukeOps.NukieBundle;
+
+
+[RegisterComponent]
+public sealed partial class NukieBundleComponent : Component
+{
+
+    [DataField]
+    public int TotalPrice = 250;
+}

--- a/Content.Goobstation.Server/NukeOps/NukieBundleSystem.cs
+++ b/Content.Goobstation.Server/NukeOps/NukieBundleSystem.cs
@@ -1,0 +1,78 @@
+using System.Linq;
+using Content.Goobstation.Server.NukeOps.NukieBundle;
+using Content.Server.Storage.EntitySystems;
+using Content.Server.Store.Systems;
+using Content.Goobstation.Maths.FixedPoint;
+using Content.Shared.Store;
+using Content.Shared.Store.Components;
+using Robust.Shared.Random;
+
+
+namespace Content.Goobstation.Server.Nukeops;
+
+public sealed class NukieSystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly EntityStorageSystem _entityStorage = default!;
+    [Dependency] private readonly StoreSystem _store = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<NukieBundleComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(EntityUid uid, NukieBundleComponent component, MapInitEvent args)
+    {
+        if (!TryComp<StoreComponent>(uid, out var store))
+            return;
+
+        FillStorage((uid, component, store));
+    }
+
+    private void FillStorage(Entity<NukieBundleComponent, StoreComponent> ent)
+    {
+        var cords = Transform(ent).Coordinates;
+        var content = GetRandomContent(ent);
+        foreach (var item in content)
+        {
+            var dode = Spawn(item.ProductEntity, cords);
+            _entityStorage.Insert(dode, ent);
+        }
+    }
+
+    private List<ListingData> GetRandomContent(Entity<NukieBundleComponent, StoreComponent> ent)
+    {
+        var ret = new List<ListingData>();
+
+        var listings = _store.GetAvailableListings(ent.Owner, ent.Owner, ent.Comp2)   // Basically turns the Bundle into the buyer, which allows it's tag to filter
+            .OrderBy(p => p.Cost.Values.Sum())
+            .ToList();
+
+        if (listings.Count == 0)
+            return ret;
+
+        var totalCost = FixedPoint2.Zero;
+        var index = 0;
+        while (totalCost < ent.Comp1.TotalPrice)
+        {
+            var remainingBudget = ent.Comp1.TotalPrice - totalCost;
+            while (listings[index].Cost.Values.Sum() > remainingBudget)
+            {
+                index++;
+                if (index >= listings.Count)
+                {
+
+                    return ret;
+                }
+            }
+            var randomIndex = _random.Next(index, listings.Count);
+            var randomItem = listings[randomIndex];
+            ret.Add(randomItem);
+            totalCost += randomItem.Cost.Values.Sum();
+        }
+
+        return ret;
+    }
+}

--- a/Resources/Locale/en-US/_Goobstation/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Goobstation/store/uplink-catalog.ftl
@@ -278,3 +278,6 @@ uplink-undetermined-bundle-desc = This crate comes with three random bundles and
 
 uplink-energy-pickaxe-name = Energy Pickaxe
 uplink-energy-pickaxe-desc = A holographic mining tool with blades comprised of hard light that also serves a deadly melee weapon. Rock and stone!
+
+uplink-nukie-bundle-name = Nuclear Operative Crate
+uplink-nukie-bundle-desc = Your bosses would be upset with you. Luckily they don't care as long as the job gets done, but they limit it only to one per Agent.

--- a/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
@@ -47,3 +47,15 @@
   components:
     - type: SurplusBundle
       totalPrice: 625
+
+- type: entity #Gooooooooooooooob editin - NukeOps specific Surplus
+  id: CrateNukieBundle
+  parent: [ CrateSyndicate, StorePresetUplink, BaseSyndicateContraband ]
+  name: Nuclear Operative Crate
+  description: Contains 250 telecrystals worth of completely random Nuclear Operative items. You should be ashamed of yourself, but we know you aren't.
+  components:
+    - type: NukieBundle
+      totalPrice: 250
+    - type: Tag
+      tags:
+      - NukeOpsUplink

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -192,6 +192,7 @@
   categories:
   - UplinkWeaponry
 
+
 - type: listing
   id: UplinkRevolverPython
   name: uplink-revolver-python-name
@@ -469,6 +470,7 @@
     blacklist:
       components:
       - SurplusBundle
+      - NukieBundle #Goob - NukeOps Surplus
 
 
 - type: listing
@@ -1140,7 +1142,7 @@
       blacklist:
         components:
           - SurplusBundle
-
+          - NukieBundle #Goob - NukeOps Surplus
 
 - type: listing
   id: UplinkAntimovCircuitBoard
@@ -2025,7 +2027,10 @@
   - !type:BuyerJobCondition
     whitelist:
     - Botanist
-
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - NukieBundle #Goob - NukeOps Surplus
 
 - type: listing
   id: uplinkRiggedBoxingGlovesPassenger # Remove when contractor baton gets added- and yes, i'm working on that - Goobstation, Fenn :3
@@ -2040,7 +2045,10 @@
     - !type:BuyerJobCondition
       whitelist:
         - Passenger
-
+    - !type:BuyerWhitelistCondition
+      blacklist:
+        components:
+        - NukieBundle #Goob - NukeOps Surplus
 
 - type: listing
   id: uplinkRiggedBoxingGlovesBoxer
@@ -2055,7 +2063,10 @@
     - !type:BuyerJobCondition
       whitelist:
         - Boxer
-
+    - !type:BuyerWhitelistCondition
+      blacklist:
+        components:
+        - NukieBundle #Goob - NukeOps Surplus
 
 - type: listing
   id: uplinkNecronomicon
@@ -2074,7 +2085,7 @@
     blacklist:
       components:
       - SurplusBundle
-
+      - NukieBundle #Goob - NukeOps Surplus
 
 - type: listing
   id: uplinkHolyHandGrenade
@@ -2089,7 +2100,10 @@
   - !type:BuyerJobCondition
     whitelist:
     - Chaplain
-
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - NukieBundle #Goob - NukeOps Surplus
 
 - type: listing
   id: uplinkRevolverCapGunFake
@@ -2105,7 +2119,10 @@
     whitelist:
     - Mime
     - Clown
-
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - NukieBundle #Goob - NukeOps Surplus
 
 - type: listing
   id: uplinkBananaPeelExplosive
@@ -2121,7 +2138,10 @@
   - !type:BuyerJobCondition
     whitelist:
     - Clown
-
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - NukieBundle #Goob - NukeOps Surplus
 
 - type: listing
   id: UplinkClusterBananaPeel
@@ -2136,7 +2156,10 @@
   - !type:BuyerJobCondition
     whitelist:
     - Clown
-
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+       - NukieBundle #Goob - NukeOps Surplus
 
 - type: listing
   id: UplinkHoloclownKit
@@ -2152,7 +2175,10 @@
   - !type:BuyerJobCondition
     whitelist:
     - Clown
-
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - NukieBundle #Goob - NukeOps Surplus
 
 - type: listing
   id: uplinkHotPotato
@@ -2170,7 +2196,10 @@
     - Botanist
     - Clown
     - Mime
-
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - NukieBundle #Goob - NukeOps Surplus
 
 - type: listing
   id: UplinkChimpUpgradeKit
@@ -2185,7 +2214,10 @@
     - !type:BuyerDepartmentCondition
       whitelist:
       - Science
-
+    - !type:BuyerWhitelistCondition
+      blacklist:
+        components:
+        - NukieBundle #Goob - NukeOps Surplus
 
 - type: listing
   id: uplinkProximityMine
@@ -2204,7 +2236,7 @@
     blacklist:
       components:
       - SurplusBundle
-
+      - NukieBundle #Goob - NukeOps Surplus
 
 - type: listing
   id: UplinkSyndicateSpongeBox
@@ -2223,7 +2255,10 @@
     - Scientist
     - ResearchDirector
     - Chef
-
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - NukieBundle #Goob - NukeOps Surplus
 
 - type: listing
   id: UplinkCaneBlade
@@ -2239,11 +2274,11 @@
   - !type:BuyerJobCondition
     whitelist:
     - Librarian
-  #- !type:BuyerWhitelistCondition
-  #  blacklist:
-  #    components:
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
   #    - SurplusBundle
-
+      - NukieBundle #Goob - NukeOps Surplus
 
 - type: listing
   id: UplinkCombatBakery
@@ -2260,6 +2295,10 @@
     whitelist:
     - Chef
     - Mime
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - NukieBundle #Goob - NukeOps Surplus
 
 - type: listing
   id: UplinkSmugglerSatchel

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -512,11 +512,16 @@
     Telecrystal: 20
   categories:
   - UplinkWearables
-  #conditions: # Blacklist this from nukies if dreadsuits abuse it too much.
-  #- !type:StoreWhitelistCondition
+  conditions:
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - NukieBundle #Blacklisted due to possibility of using a large chunk of your crate on something for a set species.
+  #- !type:StoreWhitelistCondition # Blacklist this from nukies if dreadsuits abuse it too much.
   #  blacklist:
   #    tags:
   #    - NukeOpsUplink
+
 
 - type: listing
   id: UplinkHardsuitSyndieMedic
@@ -593,6 +598,9 @@
   - !type:BuyerJobCondition
     whitelist:
     - Clown
+  - !type:BuyerWhitelistCondition
+    blacklist:
+    - NukieBundle
 
 - type: listing
   id: UplinkSyndicateWhimsyBundle
@@ -607,7 +615,9 @@
   - !type:BuyerJobCondition
     whitelist:
     - Clown
-
+  - !type:BuyerWhitelistCondition
+    blacklist:
+    - NukieBundle
 
 - type: listing
   id: UplinkLubeGrenade
@@ -623,7 +633,9 @@
     whitelist:
     - Clown
     - Mime
-
+  - !type:BuyerWhitelistCondition
+    blacklist:
+    - NukieBundle
 
 - type: listing
   id: UplinkGlueGrenade
@@ -639,6 +651,9 @@
     whitelist:
     - Clown
     - Mime
+  - !type:BuyerWhitelistCondition
+    blacklist:
+    - NukieBundle
 
 - type: listing
   id: UplinkClowncar
@@ -654,6 +669,9 @@
   - !type:BuyerJobCondition
     whitelist:
     - Clown
+  - !type:BuyerWhitelistCondition
+    blacklist:
+    - NukieBundle
 
 - type: listing
   id: UplinkMobRoachMicrobomb
@@ -680,6 +698,9 @@
     whitelist:
     - Botanist
     - Zookeeper
+  - !type:BuyerWhitelistCondition
+    blacklist:
+    - NukieBundle
 
 - type: listing
   id: UplinkDartGun
@@ -694,6 +715,9 @@
   - !type:BuyerDepartmentCondition
     whitelist:
     - Medical
+  - !type:BuyerWhitelistCondition
+    blacklist:
+    - NukieBundle
 
 # chemicals
 
@@ -987,6 +1011,7 @@
     blacklist:
       components:
       - SurplusBundle
+      - NukieBundle
 
 - type: listing
   id: UplinkSyndicateWeaponModuleAdvanced
@@ -1226,3 +1251,25 @@
   - !type:BuyerSpeciesCondition
     whitelist:
     - Dwarf # Rock and stone
+
+- type: listing
+  id: UplinkNukieBundle
+  name: uplink-nukie-bundle-name
+  description: uplink-nukie-bundle-desc
+  productEntity: CrateNukieBundle
+  cost:
+    Telecrystal: 100
+  categories:
+  - UplinkDisruption
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
+      - ContravendUplink
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - NukieBundle
+  - !type:ListingLimitedStockCondition
+    stock: 1


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Nukies got their own surplus crate that respects what they're able to buy.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
People liked having surplus on Nukies. This new crate follows NukeOpsUplink blacklists/whitelists, and is only buyable once per person for balance purposes.

## Technical details
<!-- Summary of code changes for easier review. -->
New Component and System are a fairly copy of the Surplus Crate. I used the new system to make it respect the tags on the crate itself to decide what to buy, in this instance NukeOpsUplink, as it's now the buying entity. Blacklists for job items were required as Armok's shop change isn't respected due to it having no mind.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
**Telecrystal amount was at 3000 only for testing and media purposes. They are 250 TC same as normal crates.**
Job Blacklists for the couple job items seen in the video were added afterwards.

https://github.com/user-attachments/assets/027f7728-13b3-4b38-8215-09dc74aa4576



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Gamba Ops are back. Nukie surplus crates are here, with correct items. One purchase per Nukie only.


