### PR TITLE
[BOUNTY] Captain Suit Selector

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/set-selector/selectable-sets.ftl
+++ b/Resources/Locale/en-US/_Goobstation/set-selector/selectable-sets.ftl
@@ -204,3 +204,13 @@ selectable-set-engineering-modsuit-desc =
     A modular hardsuit with increased blast plating and the large vulnerable visor
     replaced with external cameras to better protect against explosions
     and other external threats.
+
+selectable-set-captain-voidsuit-name = Captain's voidsuit
+selectable-set-captain-voidsuit-desc =
+    Captain's light voidsuit for the average shift leading the station.
+
+selectable-set-captain-modsuit-name = Captain's 'Magnate' hardsuit
+selectable-set-captain-modsuit-desc =
+    A modular hardsuit perfectly shined, adorned, and armored to fit the best of the best,
+    fitted with custom plating, cooling fluid, and fitting to make even the toughest of
+    times leading seem like nothing to you.

--- a/Resources/Locale/en-US/_Goobstation/set-selector/selectable-sets.ftl
+++ b/Resources/Locale/en-US/_Goobstation/set-selector/selectable-sets.ftl
@@ -207,10 +207,12 @@ selectable-set-engineering-modsuit-desc =
 
 selectable-set-captain-voidsuit-name = Captain's voidsuit
 selectable-set-captain-voidsuit-desc =
-    Captain's light voidsuit for the average shift leading the station.
+    Captain's light voidsuit made custom fitted for formal occasions, lightly
+    armored to protect during the average shift, all while still retaining
+    common spacewalking capabilities.
 
 selectable-set-captain-modsuit-name = Captain's 'Magnate' hardsuit
 selectable-set-captain-modsuit-desc =
-    A modular hardsuit perfectly shined, adorned, and armored to fit the best of the best,
-    fitted with custom plating, cooling fluid, and fitting to make even the toughest of
-    times leading seem like nothing to you.
+    A modular hardsuit perfectly shined, adorned, and armored to fit the best of
+    the best, fitted with custom plating, cooling fluid, and diamonds to
+    make even the toughest of times leading seem like nothing to you.

--- a/Resources/Locale/en-US/_Goobstation/set-selector/selectable-sets.ftl
+++ b/Resources/Locale/en-US/_Goobstation/set-selector/selectable-sets.ftl
@@ -213,6 +213,6 @@ selectable-set-captain-voidsuit-desc =
 
 selectable-set-captain-modsuit-name = Captain's 'Magnate' hardsuit
 selectable-set-captain-modsuit-desc =
-    A modular hardsuit perfectly shined, adorned, and armored to fit the best of
+    A modular hardsuit perfectly shined, adorned, and armored for the best of
     the best, fitted with custom plating, cooling fluid, and diamonds to
     make even the toughest of times leading seem like nothing to you.

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -213,7 +213,7 @@
   id: FillCaptainHardsuit
   table: !type:AllSelector
     children:
-    - id: ClothingOuterHardsuitCap
+    - id: UndeterminedVoidsuitCaptain # Goobstation - Modsuit Update
     - id: ClothingMaskGasCaptain
     - id: JetpackCaptainFilled
     - id: OxygenTankFilled

--- a/Resources/Prototypes/_Goobstation/Catalog/selectable_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/selectable_sets.yml
@@ -558,3 +558,25 @@
     state: icon
   content:
   - ClothingBackpackDuffelHosFilledUtility
+
+# Captain
+
+- type: selectableSet
+  id: VoidsuitSelectorCaptainVoidsuit
+  name: selectable-set-captain-voidsuit-name
+  description: selectable-set-captain-voidsuit-desc
+  sprite:
+    sprite: Clothing/OuterClothing/Hardsuits/capspace.rsi
+    state: icon
+  content:
+  - ClothingOuterHardsuitCap
+
+- type: selectableSet
+  id: VoidsuitSelectorCaptainHardsuit
+  name: selectable-set-captain-modsuit-name
+  description: selectable-set-captain-modsuit-desc
+  sprite:
+    sprite: _Goobstation/Clothing/Back/Modsuits/captain.rsi
+    state: control
+  content:
+  - ClothingModsuitCaptainPowerCell

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Misc/voidsuitselectors.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Misc/voidsuitselectors.yml
@@ -62,3 +62,18 @@
     possibleSets:
     - VoidsuitSelectorEngineerVoidsuit
     - VoidsuitSelectorEngineerHardsuit
+
+# Cappy Suit
+- type: entity
+  id: UndeterminedVoidsuitCaptain
+  name: captain voidsuit selector
+  description: A small remote utilizing bluespace technology to drop in a voidsuit or hardsuit of your choosing.
+  parent: [ BaseItem, BaseSetSelector, BaseCommandContraband ]
+  components:
+  - type: Sprite
+    sprite: _Goobstation/Objects/Devices/unique_teleporters.rsi
+    state: standard
+  - type: SetSelector
+    possibleSets:
+    - VoidsuitSelectorCaptainVoidsuit
+    - VoidsuitSelectorCaptainHardsuit


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Changed Cap storage's suit to a selector, adding both the base suit and the added modsuit as selections.
Did my best to give them descriptions fit for a king based off the suit descriptions.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bounty: https://discord.com/channels/1202734573247795300/1375791374707982437/1375791374707982437

Tldr; Cap's modsuit existed but wasn't added anywhere. This does nothing but add it in as a choice for caps to use.

## Technical details
<!-- Summary of code changes for easier review. -->
New selector for cap, replacement of the suit in storage with a selector similar to other departments and jobs.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/30d5d301-0cae-42b3-ad24-89dd2e47e958

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Captain suit selector. Captain's expensive af modsuit is now selectable.

