### PR TITLE
Nerfs grilles

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -102,8 +102,8 @@
           path:
             "/Audio/Weapons/grille_hit.ogg"
     - type: RCDDeconstructable
-      cost: 2 # Goobstation
-      delay: 4
+      cost: 4 # Goobstation
+      delay: 2 # Goobstation
       fx: EffectRCDDeconstruct4
     - type: CanBuildWindowOnTop
     - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -102,7 +102,7 @@
           path:
             "/Audio/Weapons/grille_hit.ogg"
     - type: RCDDeconstructable
-      cost: 6
+      cost: 2 # Goobstation
       delay: 4
       fx: EffectRCDDeconstruct4
     - type: CanBuildWindowOnTop
@@ -157,13 +157,13 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 130 #excess damage (nuke?). avoid computational cost of spawning entities.
+            damage: 60 # Goobstation. excess damage (nuke?). avoid computational cost of spawning entities.
           behaviors:
             - !type:DoActsBehavior
               acts: ["Destruction"]
         - trigger:
             !type:DamageTrigger
-            damage: 100
+            damage: 30 # Goobstation
           behaviors:
             - !type:ChangeConstructionNodeBehavior
               node: grilleBroken


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Grilles now have 30 health down from 100
Grilles now cost 4 RCD ammo to build down from 6 (a wall is 6 but a directional window is 4)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A flimsy framework of iron rods my ass this thing was stronger than a person
The damn grille shouldn't have more health than the window over it
Window health: 50
Reinforced window health: 75
GRILLE HEALTH: 100
## Technical details
<!-- Summary of code changes for easier review. -->
RCD INFO
-Before
      cost: 6
      delay: 4
-After
      cost:
      delay: 2

HEALTH INFO
-Before
            damage: 100
-After
            damage: 30
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: JoeHammad
- tweak: Grille health nerfed to 30 from 100
