### PR TITLE
fix clownshot

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/lawbringer.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/lawbringer.yml
@@ -44,8 +44,8 @@
      components:
       - Clumsy
   - type: ProjectileThrowOnHit
-    distance: 10
-    speed: 10
+    distance: 20
+    speed: 50
 
 - type: entity
   id: BulletPulse


### PR DESCRIPTION

## Why / Balance
Clownshot launches clowns far and into walls as entended

:cl: Armok
- tweak: Restore clownshot to its former glory.

