### PR TITLE
PKA rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
@@ -54,8 +54,6 @@
     lightActionPrototype: ActionTogglePKALight
   - type: PressureDamageChange
     applyToMelee: false
-  - type: Multishot
-    missChance: 0.3
   - type: UpgradeableGun
     whitelist:
       tags:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -103,6 +103,7 @@
 # SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
 # SPDX-FileCopyrightText: 2025 keronshb <54602815+keronshb@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 metalgearsloth <comedian_vs_clown@hotmail.com>
+# SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 # SPDX-FileCopyrightText: 2025 thebiggestbruh <marcus2008stoke@gmail.com>
 # SPDX-FileCopyrightText: 2025 username <113782077+whateverusername0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 whateverusername0 <whateveremail>
@@ -606,12 +607,14 @@
     sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
     layers:
     - state: buster
-  - type: PointLight
-    radius: 3.5
-    color: orange
-    energy: 0.5
   - type: SinguloFood
     energy: -500
+  - type: Explosive # Goob
+    explosionType: Electrical
+    maxIntensity: 10
+    intensitySlope: 3
+    totalIntensity: 150
+    maxTileBreak: 1
 
 - type: entity
   id: BulletCharge

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -563,9 +563,7 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 40 # Lavaland Change - TOTAL PKA VICTORY
-#        Structural: 30 Lavaland Change - No easy break-ins :)
-  # Short lifespan
+        Blunt: 20
   - type: TimedDespawn
     lifetime: 0.2 # Lavaland Change
   - type: GatheringProjectile

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Basic/pka.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Basic/pka.yml
@@ -50,11 +50,13 @@
     capacity: 1
     count: 1
   - type: UpgradeableGun
-    maxUpgradeCapacity: 70
+    maxUpgradeCapacity: 100
     whitelist:
       tags:
       - PKAUpgrade
   - type: GunRequiresWield
+  - type: Gun
+    fireRate: 0.4 #goobstation
   - type: Item
     shape:
     - 0,0,4,0
@@ -97,7 +99,7 @@
     capacity: 3
     count: 3
   - type: UpgradeableGun
-    maxUpgradeCapacity: 70
+    maxUpgradeCapacity: 100
     whitelist:
       tags:
       - PKAUpgrade
@@ -133,7 +135,7 @@
     capacity: 1
     count: 1
   - type: UpgradeableGun
-    maxUpgradeCapacity: 200
+    maxUpgradeCapacity: 70
     whitelist:
       tags:
       - PKAUpgrade

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Basic/pka.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Basic/pka.yml
@@ -146,6 +146,8 @@
     shape:
     - 0,0,1,0
     - 0,1,0,1
+  - type: Multishot
+    missChance: 0.3
 
 # Lavaland Change
 - type: entity

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aineias1 <dmitri.s.kiselev@gmail.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 FaDeOkno <143940725+FaDeOkno@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 McBosserson <148172569+McBosserson@users.noreply.github.com>

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -31,7 +31,7 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 24
+        Blunt: 12
 
 - type: entity
   id: WeakBulletKinetic
@@ -51,6 +51,11 @@
   components:
   - type: GatheringProjectile
     probability: 0.5
+  - type: Projectile
+    impactEffect: BulletImpactEffectKinetic
+    damage:
+      types:
+        Blunt: 8
 
 - type: entity
   id: PelletKineticSpread
@@ -59,5 +64,5 @@
   components:
   - type: ProjectileSpread
     proto: PelletKinetic
-    count: 6
-    spread: 30
+    count: 4
+    spread: 20

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/pka_upgrade.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/pka_upgrade.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aineias1 <dmitri.s.kiselev@gmail.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 FaDeOkno <143940725+FaDeOkno@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 McBosserson <148172569+McBosserson@users.noreply.github.com>

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/pka_upgrade.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/pka_upgrade.yml
@@ -53,13 +53,15 @@
     - state: overlay-3
       color: "#eb4c13"
   - type: GunUpgrade
-    capacityCost: 40
+    capacityCost: 35
     tags: [ GunUpgradeDamage ]
     examineText: gun-upgrade-examine-text-damage
   - type: GunUpgradeDamage
     damage:
       types:
-        Blunt: 10
+        Blunt: 5
+  - type: GunUpgradeFireRate
+    coefficient: 0.9
 
 - type: entity
   id: PKAUpgradeRange


### PR DESCRIPTION
## Why / Balance
Salv is absurd, some build can one shot people before this change

:cl: Armok
- tweak: Only PKA pistols are duel wieldable 
- tweak: Standardize PKA md capacity to 100, pistol has 70
- tweak: Most PKA weapons tweaked to full their niches better without being insane
- tweak: PKA mods changed to not be as insane.
- tweak: No more roundstart 80DPS standard PKA


