### PR TITLE
Edit lollychop

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/lollychop.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/lollychop.yml
@@ -22,7 +22,7 @@
     heavyStaminaCost: 15
     wideAnimationRotation: 135
     swingLeft: true
-    attackRate: 2
+    attackRate: 1
     damage:
       types:
         Blunt: 5

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/lollychop.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/lollychop.yml
@@ -22,10 +22,10 @@
     heavyStaminaCost: 15
     wideAnimationRotation: 135
     swingLeft: true
-    attackRate: 0.75
+    attackRate: 2
     damage:
       types:
-        Blunt: 10
+        Blunt: 5
         Slash: 5
         Structural: 10
     soundHit:
@@ -34,7 +34,6 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 10
         Structural: 40
   - type: Item
     size: Huge
@@ -63,13 +62,13 @@
   - type: SolutionContainerManager
     solutions:
       melee:
-        maxVol: 30
+        maxVol: 300
   - type: SolutionRegeneration
     solution: melee
     generated:
       reagents:
-      - ReagentId: Amatoxin
-        Quantity: 5
+      - ReagentId: Honk
+        Quantity: 15
   - type: MeleeChemicalInjector
-    transferAmount: 5
+    transferAmount: 15
     solution: melee

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/lollychop.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/lollychop.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/lollychop.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/lollychop.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
It did 90 damage per hit before this 

:cl: Armok
- tweak: Lollychop turns people into bananamen instead of killing them

