### PR TITLE
secret+ adjustments

### DIFF
--- a/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusComponent.cs
+++ b/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusComponent.cs
@@ -23,13 +23,13 @@ public sealed partial class SecretPlusComponent : Component
     ///   Minimum interval between events
     /// </summary>
     [DataField]
-    public TimeSpan EventIntervalMin = TimeSpan.FromMinutes(2);
+    public TimeSpan EventIntervalMin = TimeSpan.FromMinutes(1.5);
 
     /// <summary>
     ///   Maximum interval between events
     /// </summary>
     [DataField]
-    public TimeSpan EventIntervalMax = TimeSpan.FromMinutes(6);
+    public TimeSpan EventIntervalMax = TimeSpan.FromMinutes(5);
 
     /// <summary>
     ///   The current chaos score
@@ -55,13 +55,13 @@ public sealed partial class SecretPlusComponent : Component
     ///   How much to change chaos per second per living person
     /// </summary>
     [DataField]
-    public float LivingChaosChange = -0.008f;
+    public float LivingChaosChange = -0.014f;
 
     /// <summary>
     ///   How much to change chaos per second per dead person
     /// </summary>
     [DataField]
-    public float DeadChaosChange = 0.02f;
+    public float DeadChaosChange = 0.03f;
 
     /// <summary>
     ///   How much to offset chaos of events away from 0 when picking events

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -28,21 +28,21 @@
     BlobGameMode: 0.05
     Wizard: 0.007
 
+# admeme preset - nerf when it's voteable
 - type: entity
   id: SecretPlusHigh
   parent: SecretPlusMid
   categories: [ HideSpawnMenu ]
   components:
   - type: GameRule
-    minPlayers: 40
   - type: SecretPlus
-    livingChaosChange: -0.014
+    livingChaosChange: -0.03
     deadChaosChange: 0.03
     chaosExponent: 1.1 # five billion loneops
-    eventIntervalMin: 90
-    eventIntervalMax: 270
-    minStartingChaos: 15
-    maxStartingChaos: 30 # ling-blob-nukeops is fun
+    eventIntervalMin: 60
+    eventIntervalMax: 240 # hell
+    minStartingChaos: 20
+    maxStartingChaos: 40 # ling-blob-nukeops is fun
 
 - type: entity
   id: SecretPlusMid
@@ -50,9 +50,8 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: GameRule
-    minPlayers: 10 # it scales with playercount anyway
   - type: SecretPlus
-  # default config
+    # default config
   - type: SelectedGameRules
     scheduledGameRules: !type:NestedSelector
       tableId: SecretPlusTable
@@ -63,14 +62,13 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: GameRule
-    minPlayers: 0
   - type: SecretPlus
     noRoundstartAntags: true
-    livingChaosChange: -0.006
-    deadChaosChange: 0.015
+    livingChaosChange: -0.008
+    deadChaosChange: 0.02
     chaosExponent: 1.3 # nothing ever happens
-    eventIntervalMin: 180
-    eventIntervalMax: 540
+    eventIntervalMin: 120
+    eventIntervalMax: 450
 
 - type: entity
   id: SecretPlusDebug # do not use this in real games

--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -200,7 +200,6 @@
   name: secretplus-low-title
   description: secretplus-low-description
   showInVote: true
-  minPlayers: 0
   rules:
     - SecretPlusLow
     - LavalandStormScheduler
@@ -214,7 +213,6 @@
   name: secretplus-mid-title
   description: secretplus-mid-description
   showInVote: true
-  minPlayers: 10
   rules:
     - SecretPlusMid
     - LavalandStormScheduler
@@ -227,8 +225,7 @@
     - chaos
   name: secretplus-high-title
   description: secretplus-high-description
-  showInVote: true
-  minPlayers: 40
+  showInVote: false # 1984
   rules:
     - SecretPlusHigh
     - LavalandStormScheduler


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
see CL

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Chaos is no longer voteable.
- tweak: Secret+ should have more midround events.
