### PR TITLE
Add Sealed Doors

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/airlock.yml
@@ -101,6 +101,13 @@
       - material: ReinforcedGlass
         amount: 1
         doAfter: 2
+    - to: sealedElectronics # Goobstation - Sealed Doors
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 2
     - to: wired
       conditions:
       - !type:EntityAnchored {}
@@ -137,6 +144,112 @@
       steps:
       - tool: Prying
         doAfter: 5
+
+  - node: sealedElectronics # Goobstation - Sealed doors
+    entity: AirlockAssembly
+    edges:
+    - to: sealedAirlock
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - tool: Screwing
+        doAfter: 2.5
+    - to: sealedGlassAirlock
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - material: ReinforcedGlass
+        amount: 2
+        doAfter: 2
+      - tool: Screwing
+        doAfter: 4
+    - to: electronics
+      conditions:
+      - !type:EntityAnchored {}
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      steps:
+      - tool: Prying
+        doAfter: 5
+
+## Sealed Glass airlock
+  - node: sealedGlassAirlock # Goobstation - Sealed doors
+    entity: AirlockSealedGlass
+    doNotReplaceInheritingEntities: true
+    actions:
+    - !type:SetWiresPanelSecurity
+      wiresAccessible: true
+    edges:
+    - to: sealedElectronics
+      conditions:
+      - !type:EntityAnchored {}
+      - !type:DoorWelded {}
+      - !type:DoorBolted
+        value: false
+      - !type:WirePanel {}
+      - !type:AllWiresCut
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetRGlass1
+        amount: 2
+      steps:
+      - tool: Prying
+        doAfter: 2
+    - to: medSecurityUnfinished
+      conditions:
+      - !type:WirePanel {}
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 2
+    - to: highSecurityUnfinished
+      conditions:
+      - !type:WirePanel {}
+      steps:
+      - material: Plasteel
+        amount: 2
+        doAfter: 2
+
+## Sealed airlock
+  - node: sealedAirlock # Goobstation - Sealed doors
+    entity: AirlockSealed
+    doNotReplaceInheritingEntities: true
+    actions:
+    - !type:SetWiresPanelSecurity
+      wiresAccessible: true
+    edges:
+    - to: electronics
+      conditions:
+      - !type:EntityAnchored {}
+      - !type:DoorWelded {}
+      - !type:DoorBolted
+        value: false
+      - !type:WirePanel {}
+      - !type:AllWiresCut
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 2
+      steps:
+      - tool: Prying
+        doAfter: 2
+    - to: medSecurityUnfinished
+      conditions:
+      - !type:WirePanel {}
+      steps:
+      - material: Steel
+        amount: 2
+        doAfter: 2
+    - to: highSecurityUnfinished
+      conditions:
+      - !type:WirePanel {}
+      steps:
+      - material: Plasteel
+        amount: 2
+        doAfter: 2
+
 
 ## Glass airlock
   - node: glassAirlock
@@ -247,6 +360,32 @@
       examine: wires-panel-component-on-examine-security-level1
       wiresAccessible: false
     edges:
+    - to: sealedGlassAirlock # Goobstation - Sealed doors
+      completed:
+      - !type:GivePrototype
+        prototype: SheetSteel1
+        amount: 2
+      conditions:
+      - !type:WirePanel {}
+      - !type:HasTag
+        tag: SealedGlassAirlock
+      steps:
+      - tool: Prying
+        doAfter: 4
+
+    - to: sealedAirlock # Goobstation - Sealed doors
+      completed:
+      - !type:GivePrototype
+        prototype: SheetSteel1
+        amount: 2
+      conditions:
+      - !type:WirePanel {}
+      - !type:HasTag
+        tag: SealedAirlock
+      steps:
+      - tool: Prying
+        doAfter: 4
+
     - to: glassAirlock
       completed:
       - !type:GivePrototype
@@ -313,6 +452,32 @@
       examine: wires-panel-component-on-examine-security-level3
       wiresAccessible: false
     edges:
+    - to: sealedGlassAirlock # Goobstation - Sealed doors
+      completed:
+      - !type:GivePrototype
+        prototype: SheetPlasteel1
+        amount: 2
+      conditions:
+      - !type:WirePanel {}
+      - !type:HasTag
+        tag: SealedGlassAirlock
+      steps:
+      - tool: Prying
+        doAfter: 4
+
+    - to: sealedAirlock # Goobstation - Sealed doors
+      completed:
+      - !type:GivePrototype
+        prototype: SheetPlasteel1
+        amount: 2
+      conditions:
+      - !type:WirePanel {}
+      - !type:HasTag
+        tag: SealedAirlock
+      steps:
+      - tool: Prying
+        doAfter: 4
+
     - to: glassAirlock
       completed:
       - !type:GivePrototype

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -1419,6 +1419,40 @@
     - !type:TileNotBlocked
 
 - type: construction
+  name: sealed airlock
+  id: AirlockSealed
+  graph: Airlock
+  startNode: start
+  targetNode: sealedAirlock
+  category: construction-category-structures
+  description: It opens, it closes, and maybe crushes you. Now it stops little creatures too!
+  icon:
+    sprite: Structures/Doors/Airlocks/Standard/basic.rsi
+    state: assembly
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  name: sealed glass airlock
+  id: AirlockSealedGlass
+  graph: Airlock
+  startNode: start
+  targetNode: sealedGlassAirlock
+  category: construction-category-structures
+  description: It opens, it closes, and maybe crushes you. Now it stops little creatures too!
+  icon:
+    sprite: Structures/Doors/Airlocks/Glass/glass.rsi
+    state: assembly
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
   name: pinion airlock
   id: PinionAirlock
   graph: PinionAirlock

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -1,0 +1,65 @@
+
+
+- type: entity
+  id: AirlockSealed
+  parent: Airlock
+  name: sealed airlock
+  description: It opens, it closes, and maybe crushes you. Now it stops little creatures too!
+  suffix: DO NOT MAP
+  components:
+  - type: AnimationPlayer
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.49,-0.49,0.49,0.49" # don't want this colliding with walls or they won't close
+        density: 100
+        mask:
+        - FullTileMask
+        layer:
+        - WallLayer
+  - type: LayerChangeOnWeld # To undo the other.
+    unWeldedLayer: WallLayer
+    weldedLayer: WallLayer
+  - type: Construction
+    graph: Airlock
+    node: sealedAirlock
+  - type: PaintableAirlock
+    group: Standard
+  - type: Tag
+    tags:
+      - SealedAirlock
+      # This tag is used to nagivate the Airlock construction graph. It's needed because the construction graph is shared between Airlock, AirlockGlass, Sealed Variants, and HighSecDoor
+
+- type: entity
+  id: AirlockSealedGlass
+  parent: AirlockGlass
+  name: sealed glass airlock
+  description: It opens, it closes, and maybe crushes you. Now it stops little creatures too!
+  suffix: DO NOT MAP
+  components:
+  - type: AnimationPlayer
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.49,-0.49,0.49,0.49" # don't want this colliding with walls or they won't close
+        density: 100
+        mask:
+        - FullTileMask
+        layer:     #removed opaque from the layer, allowing lasers to pass through glass airlocks
+        - GlassLayer
+  - type: LayerChangeOnWeld # To undo the other
+    unWeldedLayer: GlassLayer
+    weldedLayer: GlassLayer
+  - type: Construction
+    graph: Airlock
+    node: sealedGlassAirlock
+  - type: PaintableAirlock
+    group: Glass
+  - type: Tag
+    tags:
+      - SealedGlassAirlock
+      # This tag is used to nagivate the Airlock construction graph. It's needed because the construction graph is shared between Airlock, AirlockGlass, and HighSecDoor

--- a/Resources/Prototypes/_Goobstation/tags.yml
+++ b/Resources/Prototypes/_Goobstation/tags.yml
@@ -101,7 +101,7 @@
 
 - type: Tag
   id: CannotSuicideAny
-  
+
 - type: Tag
   id: Chair
 
@@ -407,6 +407,12 @@
 
 - type: Tag
   id: Rosary
+
+- type: Tag
+  id: SealedAirlock
+
+- type: Tag
+  id: SealedGlassAirlock
 
 - type: Tag
   id: SecurityBreathMask


### PR DESCRIPTION
## About the PR
I've added Sealed Doors, a construction ghost for making a sealed variant of an airlock and a glass airlock. This has the construction ghost from the menu and just makes it so small creatures, i.e. mice and whatnot, cannot climb under the door.

## Why / Balance
This adds something for engineering to do, and is a baseline for potentially changing the structure of #2976 to match an offshoot of this to make those craft-able as well.

## Technical details
This configures the construction tree and the construction menu to allow for crafting and deconstructing the airlock doors.

## Media
https://youtu.be/EVIvOH7fytA

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Nothing breaks when I make changes. :3

**Changelog**
:cl:
- add: Added Sealed Airlocks and Sealed Glass Airlocks to the construction menu! Time to stop mice!