### PR TITLE
attempt to fix nukeops heisenbug

### DIFF
--- a/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
+++ b/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
+++ b/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
@@ -38,12 +38,14 @@ public sealed class SelectedEvent
     ///   The station event prototype
     /// </summary>
     public readonly EntityPrototype Proto;
-    public readonly StationEventComponent Comp;
+    public readonly GameRuleComponent RuleComp;
+    public readonly StationEventComponent? EvComp;
 
-    public SelectedEvent(EntityPrototype proto, StationEventComponent comp)
+    public SelectedEvent(EntityPrototype proto, GameRuleComponent ruleComp, StationEventComponent? evComp = null)
     {
         Proto = proto;
-        Comp = comp;
+        RuleComp = ruleComp;
+        EvComp = evComp;
     }
 }
 public sealed class PlayerCount
@@ -119,13 +121,15 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
     {
         foreach (var proto in GameTicker.GetAllGameRulePrototypes())
         {
-            if (!proto.TryGetComponent<StationEventComponent>(out var stationEvent, _factory))
+            if (!proto.TryGetComponent<GameRuleComponent>(out var gameRule, _factory) ||
+                !proto.TryGetComponent<StationEventComponent>(out var stationEvent, _factory)
+            )
                 continue;
 
             if (scheduler.DisallowedEvents.Contains(stationEvent.EventType) || (!scheduler.IgnoreTimings && !_event.CanRun(proto, stationEvent, count.Players, _timing.CurTime)))
                 continue;
 
-            scheduler.SelectedEvents.Add(new SelectedEvent(proto, stationEvent));
+            scheduler.SelectedEvents.Add(new SelectedEvent(proto, gameRule, stationEvent));
         }
     }
 
@@ -141,11 +145,13 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
         {
             var proto = entry.Key;
             var stationEvent = entry.Value;
+            if (!proto.TryGetComponent<GameRuleComponent>(out var gameRule, _factory))
+                continue;
 
             if (scheduler.DisallowedEvents.Contains(stationEvent.EventType) || (!scheduler.IgnoreTimings && !_event.CanRun(proto, stationEvent, count.Players, _timing.CurTime)))
                 continue;
 
-            scheduler.SelectedEvents.Add(new SelectedEvent(proto, stationEvent));
+            scheduler.SelectedEvents.Add(new SelectedEvent(proto, gameRule, stationEvent));
         }
     }
 
@@ -185,7 +191,7 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
         if (selectedEvent != null)
         {
             _event.RunNamedEvent(selectedEvent.Proto.ID);
-            scheduler.ChaosScore += selectedEvent.Comp.ChaosScore;
+            scheduler.ChaosScore += selectedEvent.RuleComp.ChaosScore;
         }
         else {
             LogMessage($"No runnable events");
@@ -219,35 +225,34 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
 
             var pick = _random.Pick(weights);
 
-            StationEventComponent? stationEvent = null;
+            GameRuleComponent? ruleComp = null;
             if (_prototypeManager.TryIndex(pick, out var entProto) &&
-                entProto.TryGetComponent<StationEventComponent>(out stationEvent, _factory) &&
-                _random.Prob(1 - -scheduler.ChaosScore / stationEvent.ChaosScore)) // have a chance to re-pick if we have low chaos budget left compared to this
+                entProto.TryGetComponent<GameRuleComponent>(out ruleComp, _factory) &&
+                _random.Prob(1 - -scheduler.ChaosScore / ruleComp.ChaosScore)) // have a chance to re-pick if we have low chaos budget left compared to this
                 continue;
 
             weights.Remove(pick);
             if (_prototypeManager.TryIndex(pick, out IncompatibleGameModesPrototype? incompModes))
                 weights = weights.Where(w => !incompModes.Modes.Contains(w.Key)).ToDictionary();
 
-            IndexAndStartGameMode(pick, entProto, stationEvent);
+            IndexAndStartGameMode(pick, entProto, ruleComp);
             if (weights.Count == 0)
                 return;
         }
 
         return;
 
-        void IndexAndStartGameMode(string pick, EntityPrototype? pickProto, StationEventComponent? evComp)
+        void IndexAndStartGameMode(string pick, EntityPrototype? pickProto, GameRuleComponent? ruleComp)
         {
             if(pickProto == null ||
-               evComp == null ||
-               !pickProto.TryGetComponent<GameRuleComponent>(out var pickGameRule, _factory) ||
-               pickGameRule.MinPlayers > count)
+               ruleComp == null ||
+               ruleComp.MinPlayers > count)
             {
                 return;
             }
             LogMessage($"Roundstart rule chosen: {pick}");
             GameTicker.AddGameRule(pick);
-            scheduler.ChaosScore += evComp.ChaosScore;
+            scheduler.ChaosScore += ruleComp.ChaosScore;
         }
     }
 
@@ -302,7 +307,9 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
 
         foreach (var ev in possible)
         {
-            var weight = ev.Comp.ChaosScore;
+            if (ev.EvComp == null)
+                continue;
+            var weight = ev.RuleComp.ChaosScore;
             bool negative = weight < 0f;
             weight = MathF.Abs(weight);
             weight = MathF.Pow(weight, scheduler.ChaosExponent);
@@ -310,7 +317,7 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
             weight += scheduler.ChaosOffset; // offset negative-chaos events upwards too else they never happen
             weight += weight < 0f ? -scheduler.ChaosThreshold : scheduler.ChaosThreshold; // make sure it's not in (-1, 1) to not get absurdly low event probabilities
             var delta = ChaosDelta(-scheduler.ChaosScore, weight, scheduler.ChaosMatching, scheduler.ChaosThreshold);
-            weights[ev] = ev.Comp.Weight / (delta + 1f);
+            weights[ev] = ev.EvComp.Weight / (delta + 1f);
         }
 
         return weights.Count == 0 ? null : _random.Pick(weights);

--- a/Content.Server/StationEvents/Components/StationEventComponent.cs
+++ b/Content.Server/StationEvents/Components/StationEventComponent.cs
@@ -18,7 +18,6 @@
 // SPDX-FileCopyrightText: 2024 Hrosts <35345601+Hrosts@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 IProduceWidgets <107586145+IProduceWidgets@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Ian <ignaz.k@live.de>
-// SPDX-FileCopyrightText: 2024 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Joel Zimmerman <JoelZimmerman@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 JustCone <141039037+JustCone14@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Kara <lunarautomaton6@gmail.com>
@@ -77,6 +76,7 @@
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 // SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
 // SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>

--- a/Content.Server/StationEvents/Components/StationEventComponent.cs
+++ b/Content.Server/StationEvents/Components/StationEventComponent.cs
@@ -198,11 +198,5 @@ public sealed partial class StationEventComponent : Component
     /// </summary>
     [DataField]
     public ProtoId<EventTypePrototype> EventType = "Neutral";
-
-    /// <summary>
-    ///  Used by SecretPlus to rate which event should be fired.
-    /// </summary>
-    [DataField]
-    public float ChaosScore = 100f;
     // Goobstation end
 }

--- a/Content.Shared/GameTicking/Components/GameRuleComponent.cs
+++ b/Content.Shared/GameTicking/Components/GameRuleComponent.cs
@@ -49,6 +49,13 @@ public sealed partial class GameRuleComponent : Component
     /// </summary>
     [DataField]
     public MinMax? Delay;
+
+    // Goobstation
+    /// <summary>
+    ///  Used by SecretPlus to rate which event should be fired.
+    /// </summary>
+    [DataField]
+    public float ChaosScore = 100f;
 }
 
 /// <summary>

--- a/Content.Shared/GameTicking/Components/GameRuleComponent.cs
+++ b/Content.Shared/GameTicking/Components/GameRuleComponent.cs
@@ -9,6 +9,7 @@
 // SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Shared/GameTicking/Components/GameRuleComponent.cs
+++ b/Content.Shared/GameTicking/Components/GameRuleComponent.cs
@@ -9,6 +9,7 @@
 // SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -9,6 +9,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 # SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
 #

--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -59,8 +59,10 @@
     chaos: # Goobstation
       Hunger: -80
       Thirst: -40
-    chaosScore: -15 # Goobstation
     eventType: FreeStuff # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: -15
   - type: CargoGiftsRule
     description: cargo-gift-pizza-small
     dest: cargo-gift-dest-bar
@@ -82,8 +84,10 @@
     chaos: # Goobstation
       Hunger: -300
       Thirst: -120
-    chaosScore: -30 # Goobstation
     eventType: FreeStuff # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: -30
   - type: CargoGiftsRule
     description: cargo-gift-pizza-large
     dest: cargo-gift-dest-bar
@@ -104,8 +108,10 @@
     chaos: # Goobstation
       Atmos: -300
       Power: -100
-    chaosScore: -40 # Goobstation
     eventType: FreeStuffUseful # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: -40
   - type: CargoGiftsRule
     description: cargo-gift-eng
     dest: cargo-gift-dest-eng
@@ -129,8 +135,10 @@
     chaos: # Goobstation
       Hunger: -100
       Thirst: -100
-    chaosScore: -20 # Goobstation
     eventType: FreeStuff # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: -20
   - type: CargoGiftsRule
     description: cargo-gift-vending
     dest: cargo-gift-dest-supp
@@ -153,8 +161,10 @@
     earliestStart: 20
     chaos: # Goobstation
       Mess: -200
-    chaosScore: -20 # Goobstation
     eventType: FreeStuff # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: -20
   - type: CargoGiftsRule
     description: cargo-gift-cleaning
     dest: cargo-gift-dest-janitor
@@ -175,8 +185,10 @@
     chaos: #Goobstation
       Medical: -200
       Friend: 10
-    chaosScore: -40 # Goobstation
     eventType: FreeStuffUseful # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: -40
   - type: CargoGiftsRule
     description: cargo-gift-medical-supply
     dest: cargo-gift-dest-med
@@ -198,8 +210,10 @@
     minimumPlayers: 40
     chaos: # Goobstation
       Atmos: -300
-    chaosScore: -40 # Goobstation
     eventType: FreeStuffUseful # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: -40
   - type: CargoGiftsRule
     description: cargo-gift-space-protection
     dest: cargo-gift-dest-supp
@@ -221,8 +235,10 @@
     minimumPlayers: 40
     chaos: # Goobstation
       Atmos: -200
-    chaosScore: -35 # Goobstation
     eventType: FreeStuffUseful # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: -35
   - type: CargoGiftsRule
     description: cargo-gift-fire-protection
     dest: cargo-gift-dest-supp
@@ -243,8 +259,10 @@
     chaos: # Goobstation
       Hostile: -100
       Combat: -100
-    chaosScore: -90 # Goobstation
     eventType: FreeStuffUseful # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: -90
   - type: CargoGiftsRule
     description: cargo-gift-security-guns
     dest: cargo-gift-dest-sec
@@ -266,8 +284,10 @@
     chaos: # Goobstation
       Hostile: -30
       Combat: -30
-    chaosScore: -80 # Goobstation
     eventType: FreeStuffUseful # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: -80
   - type: CargoGiftsRule
     description: cargo-gift-security-riot
     dest: cargo-gift-dest-sec

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -229,8 +229,10 @@
     duration: 35
     chaos: # Goobstation
       Anomaly: 100
-    chaosScore: 70 # Goobstation
     eventType: Chaotic # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 70
   - type: AnomalySpawnRule
 
 - type: entity
@@ -241,6 +243,7 @@
     delay:
       min:  30
       max:  30
+    chaosScore: 40 # Goobstation
   - type: StationEvent
     startAnnouncementColor: "#18abf5"
     startAudio:
@@ -249,7 +252,6 @@
     duration: 35
     chaos: # Goobstation
       Anomaly: 40
-    chaosScore: 40 # Goobstation
     eventType: Chaotic # Goobstation
   - type: BluespaceArtifactRule
 
@@ -264,8 +266,10 @@
     duration: 1
     chaos: # Goobstation
       Anomaly: 40
-    chaosScore: 40 # Goobstation
     eventType: Neutral # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 40
   - type: BluespaceLockerRule
 
 - type: entity
@@ -278,8 +282,10 @@
     minimumPlayers: 15
     chaos: # Goobstation
       Power: 100
-    chaosScore: 60 # Goobstation
     eventType: Maintenance # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 60
   - type: BreakerFlipRule
 
 - type: entity
@@ -291,8 +297,10 @@
     minimumPlayers: 25
     weight: 3
     duration: 1
-    chaosScore: 50 # Goobstation
     eventType: Neutral # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 50
   - type: BureaucraticErrorRule
     ignoredJobs:
     - StationAi
@@ -306,8 +314,10 @@
     minimumPlayers: 15
     weight: 5
     duration: 1
-    chaosScore: 30 # Goobstation
     eventType: Chaotic # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 30
   - type: ClericalErrorRule
 
 - type: entity
@@ -318,8 +328,10 @@
     weight: 5
     duration: 1
     minimumPlayers: 10
-    chaosScore: 60 # Goobstation
     eventType: Chaotic # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 60
   - type: RandomEntityStorageSpawnRule
     prototype: MobSkeletonCloset
 
@@ -339,8 +351,10 @@
       Combat: 40
       Death: 100
       Medical: 100
-    chaosScore: 600 # Goobstation
     eventType: HostilesSpawn # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 600
   - type: SpaceSpawnRule
     spawnDistance: 0
   - type: AntagSpawner
@@ -376,8 +390,10 @@
       Combat: 40
       Death: 40
       Medical: 40
-    chaosScore: 300 # Goobstation
     eventType: HostilesSpawn # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 300
   - type: SpaceSpawnRule
   - type: AntagLoadProfileRule
     # Goobstation start
@@ -437,8 +453,10 @@
     earliestStart: 20
     reoccurrenceDelay: 20
     minimumPlayers: 15
-    chaosScore: 80 # Goobstation
     eventType: Chaotic # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 80
   - type: ParadoxCloneRule
     objectiveBlacklist:
       tags:
@@ -480,8 +498,10 @@
       Combat: 40
       Death: 100
       Medical: 100
-    chaosScore: 280 # Goobstation
     eventType: HostilesSpawn # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 280
   - type: RandomSpawnRule
     prototype: MobRevenant
 
@@ -564,8 +584,10 @@
       Hostile: 20
       Friend: 20
       Medical: 100
-    chaosScore: 40 # Goobstation
     eventType: Maintenance # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 40
   - type: KudzuGrowthRule
 
 - type: entity
@@ -582,8 +604,10 @@
         volume: -4
     duration: 60
     maxDuration: 120
-    chaosScore: 80 # Goobstation
     eventType: Interference # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 80
   - type: PowerGridCheckRule
 
 - type: entity
@@ -600,8 +624,10 @@
     maxDuration: 240
     chaos: # Goobstation
       Friend: 20
-    chaosScore: 60 # Goobstation
     eventType: Interference # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 60
   - type: SolarFlareRule
     onlyJamHeadsets: true
     affectedChannels:
@@ -632,8 +658,10 @@
     duration: 60
     chaos: # Goobstation
       Mess: 200
-    chaosScore: 70 # Goobstation
     eventType: Interference # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 70
   - type: VentClogRule
 
 - type: entity
@@ -651,8 +679,10 @@
     chaos: # Goobstation
       Hostile: 20
       Medical: 50
-    chaosScore: 240 # Goobstation
     eventType: HostilesSpawn # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 240
   - type: VentCrittersRule
     entries:
     - id: MobAdultSlimesBlueAngry
@@ -677,8 +707,10 @@
     chaos: # Goobstation
       Hostile: 20
       Medical: 50
-    chaosScore: 240 # Goobstation
     eventType: HostilesSpawn # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 240
   - type: VentCrittersRule
     entries:
     - id: MobPurpleSnake
@@ -703,8 +735,10 @@
     chaos: # Goobstation
       Hostile: 20
       Medical: 50
-    chaosScore: 240 # Goobstation
     eventType: HostilesSpawn # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 240
   - type: VentCrittersRule
     entries:
     - id: MobGiantSpiderAngry
@@ -725,8 +759,10 @@
     chaos: # Goobstation
       Hostile: 20
       Medical: 50
-    chaosScore: 240 # Goobstation
     eventType: HostilesSpawn # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 240
   - type: VentCrittersRule
     playerRatio: 35 # DeltaV: Clown spiders are very robust
     entries:
@@ -746,8 +782,10 @@
       Hostile: 100
       Medical: 200
       Death: 200
-    chaosScore: 1400 # Goobstation
     eventType: HostilesSpawn # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 1400
   - type: ZombieRule
   - type: AntagSelection
     definitions:
@@ -786,8 +824,10 @@
       Hostile: 60
       Medical: 75
       Death: 100
-    chaosScore: 700 # Goobstation
     eventType: HostilesSpawn # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 700
   - type: RuleGrids
   - type: LoadMapRule
     gridPath: /Maps/Shuttles/ShuttleEvent/striker.yml
@@ -836,8 +876,10 @@
       path: /Audio/Announcements/intercept.ogg
     duration: null # the rule has to last the whole round not 1 second
     occursDuringRoundEnd: false
-    chaosScore: 550 # Goobstation
     eventType: HostilesSpawn # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 550
   - type: AlertLevelInterceptionRule
   - type: AntagSelection
     definitions:
@@ -863,8 +905,10 @@
     reoccurrenceDelay: 30
     chaos: # Goobstation
       Friend: 20
-    chaosScore: 30 # Goobstation
     eventType: Chaotic # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 30
   - type: MassHallucinationsRule
     minTimeBetweenIncidents: 0.1
     maxTimeBetweenIncidents: 300
@@ -884,8 +928,10 @@
       Hostile: 10
       Friend: 20
       Mess: 30
-    chaosScore: 150 # Goobstation
     eventType: Chaotic # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 150
   - type: IonStormRule
 
 - type: entity
@@ -901,8 +947,10 @@
       Hostile: 20 # for when they're actually properly hostile
       Hunger: 10
       Thirst: 10
-    chaosScore: 20 # Goobstation
     eventType: Neutral # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 20
   - type: MobReplacementRule
 
 - type: entity
@@ -918,8 +966,10 @@
     chaos: # Goobstation
       Atmos: 15
       Mess: 30
-    chaosScore: 160 # Goobstation
     eventType: Maintenance # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 160
   - type: GreytideVirusRule
     accessGroups:
     - Cargo
@@ -958,8 +1008,10 @@
       # can be both hostile and friendly
       Hostile: 10
       Friend: -10
-    chaosScore: 80 # Goobstation
     eventType: Chaotic # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 80
   - type: SpaceSpawnRule
     spawnDistance: 0
   - type: AntagSpawner

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -567,8 +567,10 @@
     chaos:
       Atmos: 100
       Medical: 50
-    chaosScore: 80 # Goobstation # most of the time scrubbers just clean it
     eventType: Maintenance # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 80 # most of the time scrubbers just clean it
   - type: GasLeakRule
 
 - type: entity

--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -33,9 +33,8 @@
     objectives:
     - EscapeThiefShuttleObjective
   # Goobstation
-  - type: StationEvent
+  - type: GameRule
     chaosScore: 300
-    eventType: HostilesSpawn
   - type: AntagRandomObjectives
     sets:
     - groups: ThiefBigObjectiveGroups

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -40,8 +40,10 @@
     duration: 30 # DeltaV: was 50, used as a delay now
     chaos: # Goobstation
       Mess: 10 # there's 15 morbillion mice usually and they're easy to kill
-    chaosScore: 20 # Goobstation
     eventType: Neutral # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 20
   - type: VentCrittersRule
     entries:
     - id: MobMouse
@@ -69,8 +71,10 @@
     chaos: # Goobstation
       Mess: 10
       Hostile: 1 # low chance to spawn rat king
-    chaosScore: 25 # Goobstation
     eventType: HostilesSpawn # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 25
   - type: VentCrittersRule
     entries:
     - id: MobMouse
@@ -100,8 +104,10 @@
     chaos: # Goobstation
       Mess: 15
       Hostile: 2
-    chaosScore: 20 # Goobstation
     eventType: Neutral # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 20
   - type: VentCrittersRule
     entries:
     - id: MobCockroach
@@ -124,8 +130,10 @@
     chaos: # Goobstation
       Friend: -5
       Mess: 5
-    chaosScore: 20 # Goobstation
     eventType: Neutral # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 20
   - type: VentCrittersRule
     entries:
     - id: MobSnail
@@ -150,8 +158,10 @@
     chaos: # Goobstation
       Mess: 5
       Hostile: 1 # the very low gib snail prob
-    chaosScore: 40 # Goobstation
     eventType: Chaotic # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 40
   - type: VentCrittersRule
     entries:
     - id: MobSnail

--- a/Resources/Prototypes/GameRules/random_sentience.yml
+++ b/Resources/Prototypes/GameRules/random_sentience.yml
@@ -19,8 +19,10 @@
     chaos: # Goobstation
       Mess: 5
       Friend: -5
-    chaosScore: 20 # Goobstation
     eventType: Neutral # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 20
   - type: RandomSentienceRule
     minSentiences: 2
     maxSentiences: 5

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -224,9 +224,9 @@
   - type: NukeopsRule
   - type: RuleGrids
   - type: AntagSelection
-  - type: StationEvent # Goobstation
+  # Goobstation
+  - type: GameRule
     chaosScore: 1200
-    eventType: Roundstart
   - type: AntagLoadProfileRule
     speciesOverride: Human
     speciesOverrideBlacklist:
@@ -312,9 +312,9 @@
   id: BaseTraitorRule
   components:
   - type: TraitorRule
-  - type: StationEvent # Goobstation
+  # Goobstation
+  - type: GameRule
     chaosScore: 700
-    eventType: Roundstart
   # TODO: codewords in yml
   # TODO: uplink in yml
   - type: AntagRandomObjectives
@@ -365,9 +365,7 @@
   components:
   - type: GameRule
     minPlayers: 15
-  - type: StationEvent # Goobstation
-    chaosScore: 800
-    eventType: Roundstart
+    chaosScore: 800 # Goobstation
   - type: RevolutionaryRule
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn # Goobstation

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -74,8 +74,10 @@
     chaos: # Goobstation
       Friend: -20
       Power: -10 # can be salvaged for power
-    chaosScore: -70 # Goobstation
     eventType: FriendlySpawn # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: -70
   - type: RuleGrids
   - type: LoadMapRule
 
@@ -119,8 +121,10 @@
     chaos: # Goobstation
       Friend: -10
       Mess: 20
-    chaosScore: -40 # Goobstation
     eventType: Chaotic # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: -40
   - type: LoadMapRule
     preloadedGrid: Honki
 
@@ -156,8 +160,10 @@
     weight: 2 # Its just a big ship, so it needs to be rarer to be interesting.
     chaos: # Goobstation
       Friend: -60
-    chaosScore: -180 # Goobstation
     eventType: FriendlySpawn # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: -180
   - type: LoadMapRule
     preloadedGrid: Cruiser
 
@@ -188,8 +194,10 @@
     chaos: # Goobstation
       Friend: -20
       Medical: -20
-    chaosScore: -140 # Goobstation
     eventType: FriendlySpawn # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: -140
   - type: LoadMapRule
     preloadedGrid: Flatline
 
@@ -213,8 +221,10 @@
     earliestStart: 45 # late to hopefully have enough ghosts to fill all roles quickly. (5-6)
     chaos: # Goobstation
       Friend: -50
-    chaosScore: -150 # Goobstation
     eventType: FriendlySpawn # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: -150
   - type: LoadMapRule
     preloadedGrid: NTIncorporation
 
@@ -231,8 +241,10 @@
       Hostile: 80
       Death: 100
       Medical: 100
-    chaosScore: 900 # Goobstation
     eventType: HostilesSpawn # Goobstation
+  # Goobstation
+  - type: GameRule
+    chaosScore: 900
   - type: LoadMapRule
     preloadedGrid: Instigator
 

--- a/Resources/Prototypes/_Goobstation/GameRules/bingleEvent.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/bingleEvent.yml
@@ -26,7 +26,8 @@
       Combat: 100
       Death: 100
       Medical: 100
-    chaosScore: 400 # easily defeated by turning off grav
     eventType: HostilesSpawn
+  - type: GameRule
+    chaosScore: 400
   - type: RandomSpawnRule
     prototype: SpawnPointGhostBinglePrime

--- a/Resources/Prototypes/_Goobstation/GameRules/event_types.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/event_types.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Goobstation/GameRules/event_types.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/event_types.yml
@@ -34,7 +34,3 @@
 # self-explanatory
 - type: eventType
   id: FreeStuffUseful
-
-# self-explanatory
-- type: eventType
-  id: Roundstart

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -27,8 +27,9 @@
       Hostile: 100
       Medical: 100
       Death: 100
-    chaosScore: 250
     eventType: HostilesSpawn
+  - type: GameRule
+    chaosScore: 250
   - type: AlertLevelInterceptionRule
   - type: AntagSelection
     selectionTime: PostPlayerSpawn
@@ -64,8 +65,9 @@
       Hostile: 150
       Medical: 150
       Death: 150
-    chaosScore: 300
     eventType: HostilesSpawn
+  - type: GameRule
+    chaosScore: 300
   - type: AlertLevelInterceptionRule
   - type: AntagSelection
     selectionTime: PostPlayerSpawn
@@ -84,6 +86,7 @@
   - type: Tag
     tags:
       - MidroundAntag
+
 # Midround Heretics
 - type: entity
   parent: Heretic
@@ -102,8 +105,9 @@
       Hostile: 200
       Medical: 150
       Death: 200
-    chaosScore: 300
     eventType: HostilesSpawn
+  - type: GameRule
+    chaosScore: 300
   - type: AlertLevelInterceptionRule
   - type: AntagSelection
     selectionTime: PostPlayerSpawn
@@ -123,6 +127,7 @@
   - type: Tag
     tags:
       - MidroundAntag
+
 # Midround Revolutionaries
 - type: entity
   parent: Revolutionary
@@ -139,8 +144,9 @@
       Hostile: 250
       Medical: 250
       Death: 250
-    chaosScore: 800
     eventType: HostilesSpawn
+  - type: GameRule
+    chaosScore: 800
   - type: AntagSelection
     selectionTime: PostPlayerSpawn
     definitions:
@@ -164,6 +170,7 @@
   - type: Tag
     tags:
       - MidroundAntag
+
 # Skeleton Spawn
 - type: entity
   parent: BaseGameRule
@@ -177,13 +184,15 @@
       Hostile: 40
       Medical: 40
       Death: 40
-    chaosScore: 90
     eventType: Chaotic
+  - type: GameRule
+    chaosScore: 90
   - type: RandomEntityStorageSpawnRule
     prototype: MobSkeletonCloset
   - type: Tag
     tags:
       - MidroundAntag
+
 # Blob Midround
 - type: entity
   parent: BaseGameRule
@@ -199,8 +208,9 @@
       Hostile: 300
       Medical: 300
       Death: 300
-    chaosScore: 800
     eventType: HostilesSpawn
+  - type: GameRule
+    chaosScore: 800
   - type: BlobSpawnRule
     carrierBlobProtos:
     - SpawnPointGhostBlobRat

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -34,9 +34,7 @@
   - type: ChangelingRule
   - type: GameRule
     minPlayers: 15
-  - type: StationEvent
     chaosScore: 600
-    eventType: Roundstart
   - type: AntagRandomObjectives
     sets:
     - groups: ChangelingObjectiveGroups
@@ -68,9 +66,7 @@
   components:
   - type: GameRule
     minPlayers: 30
-  - type: StationEvent
     chaosScore: 700
-    eventType: Roundstart
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
     definitions:
@@ -94,9 +90,7 @@
   components:
   - type: GameRule
     minPlayers: 30
-  - type: StationEvent
     chaosScore: 450
-    eventType: Roundstart
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
     agentName: changeling-roundend-name
@@ -117,9 +111,7 @@
   components:
   - type: GameRule
     minPlayers: 30
-  - type: StationEvent
     chaosScore: 1000
-    eventType: Roundstart
   - type: LoadMapRule
     mapPath: /Maps/_Goobstation/Nonstations/nukieplanet.yml
   - type: AntagSelection
@@ -189,9 +181,7 @@
   components:
   - type: GameRule
     minPlayers: 30
-  - type: StationEvent
     chaosScore: 700
-    eventType: Roundstart
   - type: RevolutionaryRule
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
@@ -219,9 +209,8 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: BlobRule
-  - type: StationEvent
+  - type: GameRule
     chaosScore: 900
-    eventType: Roundstart
 
 - type: entity
   id: BlobGameMode
@@ -231,9 +220,7 @@
   - type: BlobRule
   - type: GameRule
     minPlayers: 15
-  - type: StationEvent
     chaosScore: 900
-    eventType: Roundstart
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
     definitions:
@@ -266,6 +253,7 @@
       Death: 300
       Medical: 200
     eventType: HostilesSpawn
+  - type: GameRule
     chaosScore: 900
   - type: BlobSpawnRule
     carrierBlobProtos:
@@ -353,10 +341,8 @@
   id: Devil
   components:
   - type: DevilRule
-  - type: StationEvent
-    eventType: Roundstart
-    chaosScore: 250 # low since they tend to revive people and stuff
   - type: GameRule
+    chaosScore: 250 # low since they tend to revive people and stuff
     minPlayers: 15
   - type: AntagObjectives
     objectives:

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -37,7 +37,6 @@
   parent: SecretPlusMid
   categories: [ HideSpawnMenu ]
   components:
-  - type: GameRule
   - type: SecretPlus
     livingChaosChange: -0.03
     deadChaosChange: 0.03
@@ -52,7 +51,6 @@
   parent: BaseGameRule
   categories: [ HideSpawnMenu ]
   components:
-  - type: GameRule
   - type: SecretPlus
     # default config
   - type: SelectedGameRules
@@ -64,7 +62,6 @@
   parent: SecretPlusMid
   categories: [ HideSpawnMenu ]
   components:
-  - type: GameRule
   - type: SecretPlus
     noRoundstartAntags: true
     livingChaosChange: -0.008

--- a/Resources/Prototypes/_Goobstation/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/unknown_shuttles.yml
@@ -24,9 +24,10 @@
   - type: StationEvent
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
     weight: 4
-    chaos: # Goobstation
+    chaos:
       Friend: -20
-    chaosScore: -80 # Goobstation
-    eventType: FriendlySpawn # Goobstation
+    eventType: FriendlySpawn
+  - type: GameRule
+    chaosScore: -80
   - type: LoadMapRule
     preloadedGrid: AlienTourist

--- a/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
@@ -21,9 +21,7 @@
   - type: WizardRule
   - type: GameRule
     minPlayers: 30
-  - type: StationEvent
     chaosScore: 900
-    eventType: HostilesSpawn
   - type: AntagObjectives
     objectives:
     - WizardSurviveObjective
@@ -68,9 +66,6 @@
 - type: entity
   parent: BaseWizardRule
   id: Wizard
-  components:
-  - type: StationEvent
-    eventType: Roundstart
 
 - type: entity
   parent: BaseWizardRule

--- a/Resources/Prototypes/_Goobstation/_Pirates/game_ticking.yml
+++ b/Resources/Prototypes/_Goobstation/_Pirates/game_ticking.yml
@@ -25,8 +25,9 @@
       Hostile: 50
       Medical: 50
       Death: 25
-    chaosScore: 500 # Goobstation
-    eventType: HostilesSpawn # Goobstation
+    eventType: HostilesSpawn
+  - type: GameRule
+    chaosScore: 500
   - type: PendingPirateRule
     ransomPrototype: BikeHornRansom
   - type: Tag

--- a/Resources/Prototypes/_Shitmed/GameRules/events.yml
+++ b/Resources/Prototypes/_Shitmed/GameRules/events.yml
@@ -22,11 +22,12 @@
     weight: 7.5
     minimumPlayers: 10
     duration: 1
-    chaos: # Goobstation
+    chaos:
       Hostile: 75
       Medical: 75
-    chaosScore: 300 # Goobstation
-    eventType: HostilesSpawn # Goobstation
+    eventType: HostilesSpawn
+  - type: GameRule
+    chaosScore: 300
   - type: RuleGrids
   - type: LoadMapRule
     mapPath: /Maps/_Shitmed/Shuttles/ShuttleEvent/abductor_shuttle.yml
@@ -120,11 +121,12 @@
     weight: 7.5
     minimumPlayers: 20
     duration: 1
-    chaos: # Goobstation
+    chaos:
       Hostile: 150
       Medical: 150
-    chaosScore: 450 # Goobstation
-    eventType: HostilesSpawn # Goobstation
+    eventType: HostilesSpawn
+  - type: GameRule
+    chaosScore: 450
   - type: RuleGrids
   - type: LoadMapRule
     mapPath: /Maps/_Shitmed/Shuttles/ShuttleEvent/duo_abductor_shuttle.yml


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
attempts to fix bug where nukeops fails to choose anyone
moves ChaosScore to GameRuleComponent from StationEventComponent so we don't have to add `- type: StationEvent` to roundstart events
i used a regex to migrate the yml field but seems like it didn't troll
i suspect the nukeops bug is caused by the gamerule getting killed due to being a station event (1s duration by default), but this doesn't happen in localhost since it loads fast enough

## Media
heisenbug, has to be tested in production

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Possibly fixed nukeops.
