### PR TITLE
Revert "fix reinforcement objs"

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -306,11 +306,10 @@
       mindRoles:
       - MindRoleNukeops
 
-# Goobstation
 - type: entity
   abstract: true
   parent: BaseGameRule
-  id: BaseTraitorRuleNoObjectives
+  id: BaseTraitorRule
   components:
   - type: TraitorRule
   # Goobstation
@@ -318,18 +317,12 @@
     chaosScore: 700
   # TODO: codewords in yml
   # TODO: uplink in yml
-  - type: AntagSelection
-    agentName: traitor-round-end-agent-name
-
-- type: entity
-  abstract: true
-  parent: BaseTraitorRuleNoObjectives
-  id: BaseTraitorRule
-  components:
   - type: AntagRandomObjectives
     sets:
     - groups: TraitorObjectiveGroups
     maxDifficulty: 5
+  - type: AntagSelection
+    agentName: traitor-round-end-agent-name
 
 - type: entity
   parent: BaseTraitorRule
@@ -353,7 +346,7 @@
 
 - type: entity
   id: TraitorReinforcement
-  parent: BaseTraitorRuleNoObjectives # Goobstation
+  parent: BaseTraitorRule
   components:
   - type: TraitorRule
     giveUplink: false


### PR DESCRIPTION
Do it properly or don't touch it.

![brave_6Q6oADIAEu](https://github.com/user-attachments/assets/c6d849b8-8f80-485a-84e0-98d6fd5f041d)

Players know the rules around the concept of no-objectives. No, we're not handing DAGD out to every reinforcement or token used on players. 