### PR TITLE
Fix syndie reinforcement objectives

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -98,7 +98,7 @@
     description: ghost-role-information-syndicate-reinforcement-spy-description
     rules: ghost-role-information-syndicate-reinforcement-rules
     mindRoles:
-    - MindRoleGhostRoleTeamAntagonist
+    - MindRoleGhostRoleFamiliar
     raffle:
       settings: default
     requirements: # Goobstation - ghost roles requirements
@@ -141,7 +141,7 @@
     description: ghost-role-information-syndicate-monkey-reinforcement-description
     rules: ghost-role-information-syndicate-reinforcement-rules
     mindRoles:
-    - MindRoleGhostRoleTeamAntagonist
+    - MindRoleGhostRoleFamiliar
     raffle:
       settings: default
     requirements: # Goobstation - ghost roles requirements
@@ -173,7 +173,7 @@
     description: ghost-role-information-SyndiCat-description
     rules: ghost-role-information-syndicate-reinforcement-rules
     mindRoles:
-    - MindRoleGhostRoleTeamAntagonist
+    - MindRoleGhostRoleFamiliar
     raffle:
       settings: default
     requirements: # Goobstation - ghost roles requirements

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -64,6 +64,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Errant <35878406+Errant-4@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Theodore Lukin <66275205+pheenty@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>

--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -64,6 +64,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Errant <35878406+Errant-4@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Theodore Lukin <66275205+pheenty@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 #

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -331,6 +331,29 @@
     - groups: TraitorObjectiveGroups
     maxDifficulty: 5
 
+# Goobstation - order swapped since admin verbs use .Last() for some reason
+# TODO: Fix that 
+- type: entity
+  id: TraitorReinforcement
+  parent: BaseTraitorRuleNoObjectives # Goobstation
+  components:
+  - type: TraitorRule
+    giveUplink: false
+    giveCodewords: false # It would actually give them a different set of codewords than the regular traitors, anyway
+    giveBriefing: false
+  - type: AntagSelection
+    selectionTime: PostPlayerSpawn # Goobstation
+    definitions:
+    - prefRoles: [ Traitor ]
+      mindRoles:
+      - MindRoleTraitorReinforcement
+  - type: AntagRandomObjectives # goob - support objective
+    maxDifficulty: 1
+    sets:
+    - maxPicks: 1
+      minPicks: 1
+      groups: TraitorReinforcementObjectiveGroup
+
 - type: entity
   parent: BaseTraitorRule
   id: Traitor
@@ -350,21 +373,6 @@
       lateJoinAdditional: true
       mindRoles:
       - MindRoleTraitor
-
-- type: entity
-  id: TraitorReinforcement
-  parent: BaseTraitorRuleNoObjectives # Goobstation
-  components:
-  - type: TraitorRule
-    giveUplink: false
-    giveCodewords: false # It would actually give them a different set of codewords than the regular traitors, anyway
-    giveBriefing: false
-  - type: AntagSelection
-    selectionTime: PostPlayerSpawn # Goobstation
-    definitions:
-    - prefRoles: [ Traitor ]
-      mindRoles:
-      - MindRoleTraitorReinforcement
 
 - type: entity
   id: Revolutionary

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -347,12 +347,6 @@
     - prefRoles: [ Traitor ]
       mindRoles:
       - MindRoleTraitorReinforcement
-  - type: AntagRandomObjectives # goob - support objective
-    maxDifficulty: 1
-    sets:
-    - maxPicks: 1
-      minPicks: 1
-      groups: TraitorReinforcementObjectiveGroup
 
 - type: entity
   parent: BaseTraitorRule

--- a/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
@@ -4,8 +4,11 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Errant <35878406+Errant-4@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 keronshb <54602815+keronshb@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/Roles/MindRoles/mind_roles.yml
@@ -263,8 +263,7 @@
   name: Syndicate Reinforcement Role
   components:
   - type: MindRole
-    roleType: TeamAntagonist
-    antagPrototype: GenericTeamAntagonist
+    roleType: Familiar
 
 # Zombie Squad
 - type: entity

--- a/Resources/Prototypes/_Goobstation/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_Goobstation/Objectives/objectiveGroups.yml
@@ -32,13 +32,3 @@
   weights:
     LingKillRandomHeadObjective: 3
     ChangelingAbsorbOtherObjective: 1 # absorb another changeling
-
-- type: weightedRandom
-  id: TraitorReinforcementObjectiveGroup
-  weights:
-    TraitorReinforcementObjectiveGroupSupport: 1
-
-- type: weightedRandom
-  id: TraitorReinforcementObjectiveGroupSupport
-  weights:
-    TraitorReinforcementObjectiveSupport: 1

--- a/Resources/Prototypes/_Goobstation/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_Goobstation/Objectives/objectiveGroups.yml
@@ -32,3 +32,13 @@
   weights:
     LingKillRandomHeadObjective: 3
     ChangelingAbsorbOtherObjective: 1 # absorb another changeling
+
+- type: weightedRandom
+  id: TraitorReinforcementObjectiveGroup
+  weights:
+    TraitorReinforcementObjectiveGroupSupport: 1
+
+- type: weightedRandom
+  id: TraitorReinforcementObjectiveGroupSupport
+  weights:
+    TraitorReinforcementObjectiveSupport: 1

--- a/Resources/Prototypes/_Goobstation/Objectives/traitor.yml
+++ b/Resources/Prototypes/_Goobstation/Objectives/traitor.yml
@@ -100,16 +100,3 @@
     stealGroup: RapidSyringeGun
   - type: Objective
     difficulty: 3 # Slightly more than normal as it does not fit into storage implant
-
-- type: entity
-  parent: BaseTraitorObjective
-  id: TraitorReinforcementObjectiveSupport
-  name: Support.
-  description: Attempt to accomplish objectives of your superior.
-  components:
-  - type: Objective
-    icon:
-      sprite: Objects/Misc/Handy_Flags/syndie_handy_flag.rsi
-      state: icon
-    difficulty: 0
-  - type: RoleplayObjective

--- a/Resources/Prototypes/_Goobstation/Objectives/traitor.yml
+++ b/Resources/Prototypes/_Goobstation/Objectives/traitor.yml
@@ -100,3 +100,16 @@
     stealGroup: RapidSyringeGun
   - type: Objective
     difficulty: 3 # Slightly more than normal as it does not fit into storage implant
+
+- type: entity
+  parent: BaseTraitorObjective
+  id: TraitorReinforcementObjectiveSupport
+  name: Support.
+  description: Attempt to accomplish objectives of your superior.
+  components:
+  - type: Objective
+    icon:
+      sprite: Objects/Misc/Handy_Flags/syndie_handy_flag.rsi
+      state: icon
+    difficulty: 0
+  - type: RoleplayObjective


### PR DESCRIPTION
## About the PR
Earlier removal of syndie objectives from traitor led to this very "fun" issue of no objectives as antag, which means DADG. This rectifies it by making reinforcements familiars.

## Why / Balance
Basically very problematic without it lmao. Also fixes admin "make antag" verb.

## Technical details
The entire system is hilariously garbage, this is a stand-in solution while a cleaner version might be created in the future.
- Make antag verb uses `.Last()`, which is why the `TraitorReinforcement` is being moved above `Traitor` (this makes makeantagverb give objectives)

## Media


https://github.com/user-attachments/assets/0d174895-9892-4a9c-8160-122fd13a3697



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Syndicate reinforcement is now a familiar
