### PR TITLE
fix acids and contact topicals

### DIFF
--- a/Content.Server/EntityEffects/Effects/HealthChange.cs
+++ b/Content.Server/EntityEffects/Effects/HealthChange.cs
@@ -49,6 +49,7 @@
 // SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 // SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
+// SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Server/EntityEffects/Effects/HealthChange.cs
+++ b/Content.Server/EntityEffects/Effects/HealthChange.cs
@@ -94,10 +94,6 @@ namespace Content.Server.EntityEffects.Effects
         [JsonPropertyName("scaleByQuantity")]
         public bool ScaleByQuantity;
 
-        [DataField]
-        [JsonPropertyName("scaleByQuantityCap")]
-        public FixedPoint2 ScaleByQuantityCap = FixedPoint2.New(2.5);
-
         /// <summary>
         ///     Scales the effect based on the temperature of the entity.
         /// </summary>
@@ -229,10 +225,7 @@ namespace Content.Server.EntityEffects.Effects
             var damageSpec = new DamageSpecifier(Damage);
 
             if (args is EntityEffectReagentArgs reagentArgs)
-            {
                 scale = ScaleByQuantity ? reagentArgs.Quantity * reagentArgs.Scale : reagentArgs.Scale;
-                scale = FixedPoint2.Min(scale, ScaleByQuantityCap);
-            }
 
             if (ScaleByTemperature.HasValue)
             {

--- a/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
@@ -9,8 +9,10 @@
 # SPDX-FileCopyrightText: 2024 whateverusername0 <whateveremail>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
@@ -50,6 +50,7 @@
     groups:
       Flammable: [ Touch ]
       Extinguish: [ Touch ]
+      Acidic: [Touch, Ingestion, Eyes] # Goobstation
     reactions:
     - reagents: [ Water, SpaceCleaner ]
       methods: [ Touch ]

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -115,6 +115,7 @@
     groups:
       Flammable: [ Touch ]
       Extinguish: [ Touch ]
+      Acidic: [ Touch, Ingestion ]
     reactions:
     - reagents: [ Water, SpaceCleaner ]
       methods: [ Touch ]
@@ -130,8 +131,8 @@
         scaleByQuantity: true
         damage:
           groups:
-            Burn: -2 # healing obviously up to discussion
-            Brute: -1.5 # these groups are the only 2 possible ways to damage a skeleton
+            Burn: -4 # healing obviously up to discussion # Shitmed value
+            Brute: -3 # these groups are the only 2 possible ways to damage a skeleton # Shitmed value
       - !type:PopupMessage
         type: Local
         visualType: Large

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -33,10 +33,12 @@
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 LuciferMkshelter <154002422+LuciferEOS@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 pacable <77161122+pxc1984@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 pacable <igor.mamaev1@gmail.com>
+# SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -57,6 +57,7 @@
 # SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -148,6 +148,7 @@
     groups:
       Flammable: [ Touch ]
       Extinguish: [ Touch ]
+      Acidic: [Touch, Ingestion, Eyes] # Goobstation
     reactions:
     - reagents: [ Water, SpaceCleaner ]
       methods: [ Touch ]

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/felinid.yml
@@ -5,6 +5,7 @@
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/felinid.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2024 Aidenkrz <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2024 Rank #1 Jonestown partygoer <mary@thughunt.ing>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/felinid.yml
@@ -32,6 +32,7 @@
     groups:
       Flammable: [ Touch ]
       Extinguish: [ Touch ]
+      Acidic: [Touch, Ingestion, Eyes] # Goobstation
     reactions:
     - reagents: [ Water, SpaceCleaner ]
       methods: [ Touch ]

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/tajaran.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/tajaran.yml
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/tajaran.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/tajaran.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/tajaran.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/tajaran.yml
@@ -70,6 +70,7 @@
     groups:
       Flammable: [ Touch ]
       Extinguish: [ Touch ]
+      Acidic: [Touch, Ingestion, Eyes] # Goobstation
     reactions:
     - reagents: [ Water, SpaceCleaner ]
       methods: [ Touch ]


### PR DESCRIPTION
gingerbreads, slimes, skeletons and most importantly cats can now be sprayed with acids, also affects styptic powder
also buffed milk because long ago aviu removed skeleton damagemodifier so at least they have good healing now, one milk splash (20u) can heal 15 damage, wow
also removed the contact topical cap, because well, it was made for styptic and sulfudiazine which are absolutely fine after the chemical splitting fix so why nerf them (them being blocked by wounds is already a huge nerf by alone), moreover it also affects the said milk making it absolutely useless, also slimes cannot be water bombed now etc, it's a bad thing to have. 
it's also hyper goida because it's hardcoded to all chemicals, if it's really needed it should be done another way, but i don't see why would you want it at all

:cl:
- fix: All species can now be affected by contact chemicals such as acids.
- tweak: Removed cap on how much damage can a contact chemical heal.
- tweak: Milk heals more damage in skeletons now.