### PR TITLE
The Great Glove Contra-ing

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -415,7 +415,7 @@
 # Insulated Gloves (Yellow Gloves)
 # Currently can not be greyscaled without looking like shit.
 - type: entity
-  parent: ClothingHandsBase
+  parent: [ClothingHandsBase, BaseEngineeringContraband]
   id: ClothingHandsGlovesColorYellow
   name: insulated gloves
   description: These gloves will protect the wearer from electric shocks.

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -393,7 +393,7 @@
       - type: CriminalRecordsHacker
 
 - type: entity
-  parent: ClothingHandsGlovesColorBlack # goobstation - no longer sec/engi contra its just reskinned insuls i can order this shit on amazon for 50 bucks
+  parent: [ClothingHandsGlovesColorBlack, BaseSecurityEngineeringContraband]
   id: ClothingHandsGlovesCombat
   name: combat gloves
   description: These tactical gloves are fireproof and shock resistant.

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Hands/gloves.yml
@@ -241,7 +241,7 @@
   - type: Unremoveable
 
 - type: entity
-  parent: ClothingHandsGlovesColorYellow
+  parent: [ClothingHandsGlovesColorYellow, BaseEngineeringContraband]
   id: ClothingHandsGlovesAtmosInsulated
   name: insulated atmos gloves
   description: Like normal insulated gloves, but simply better by virtue of being from the Atmospherics department.


### PR DESCRIPTION
## About the PR
Every round starts with both tiders and security officers rushing to areas they don't belong in to grab insuls which they shouldn't have. This will hopefully cull this a bit, especially with the powergaming secoffs.  Just adds engineering contra tags to regular and atmos insuls, and security+engineering contra tag to combat gloves. 

## Why / Balance
Powergaming bad. 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
- Adds Contra tags to insuls, atmos insuls, and combat gloves.
