### PR TITLE
secret+ fix

### DIFF
--- a/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusComponent.cs
+++ b/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusComponent.cs
@@ -113,6 +113,13 @@ public sealed partial class SecretPlusComponent : Component
     [ViewVariables]
     public List<SelectedEvent> SelectedEvents = new();
 
+
+    /// <summary>
+    /// Weight table for primary roundstart antags.
+    /// </summary>
+    [DataField]
+    public ProtoId<WeightedRandomPrototype> PrimaryAntagsWeightTable = "SecretPlusPrimary";
+
     /// <summary>
     /// Weight table for roundstart antags.
     /// </summary>

--- a/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
+++ b/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
@@ -208,7 +208,8 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
         if (scheduler.NoRoundstartAntags)
             return;
 
-        // Spawn antags based on SecretPlusComponent
+        // Spawn antags based on SecretPlusComponentvar weightList = _prototypeManager.Index(scheduler.RoundStartAntagsWeightTable);
+        var primaryWeightList = _prototypeManager.Index(scheduler.PrimaryAntagsWeightTable);
         var weightList = _prototypeManager.Index(scheduler.RoundStartAntagsWeightTable);
 
 #if DEBUG
@@ -219,13 +220,16 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
         LogMessage($"Trying to run roundstart rules, total player count: {count}", false);
 
         var weights = weightList.Weights.ToDictionary();
+        var primaryWeights = primaryWeightList.Weights.ToDictionary();
         int maxIters = 50, i = 0;
         while (scheduler.ChaosScore < 0 && i < maxIters)
         {
             i++;
 
-            var pick = _random.Pick(weights);
+            // on first iter pick a primary antag
+            var pick = _random.Pick(i == 1 ? primaryWeights : weights);
 
+            // on lowpop this may still go no likey even for the ptimary antag pick and pick thief or something, intended
             GameRuleComponent? ruleComp = null;
             if (_prototypeManager.TryIndex(pick, out var entProto) &&
                 entProto.TryGetComponent<GameRuleComponent>(out ruleComp, _factory) &&

--- a/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
+++ b/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
@@ -208,7 +208,7 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
         if (scheduler.NoRoundstartAntags)
             return;
 
-        // Spawn antags based on SecretPlusComponentvar weightList = _prototypeManager.Index(scheduler.RoundStartAntagsWeightTable);
+        // Spawn antags based on SecretPlusComponent
         var primaryWeightList = _prototypeManager.Index(scheduler.PrimaryAntagsWeightTable);
         var weightList = _prototypeManager.Index(scheduler.RoundStartAntagsWeightTable);
 

--- a/Content.Shared/GameTicking/Components/GameRuleComponent.cs
+++ b/Content.Shared/GameTicking/Components/GameRuleComponent.cs
@@ -56,7 +56,7 @@ public sealed partial class GameRuleComponent : Component
     /// <summary>
     ///  Used by SecretPlus to rate which event should be fired.
     /// </summary>
-    [DataField]
+    [DataField(required: true)]
     public float ChaosScore = 100f;
 }
 

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -463,6 +463,7 @@
     delay:
       min: 600
       max: 900
+    chaosScore: 1400
   - type: ZombieRule
   - type: AntagSelection
     definitions:

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -13,20 +13,27 @@
       - !type:NestedSelector
         tableId: BasicGameRulesTable
 
-# note that secret plus will pick up to several roundstart antags to achieve its chaos goal
+# extras to pick if primary didn't spend our chaos budget
 - type: weightedRandom
   id: SecretPlus
   weights:
     # subgamemodes
     Thief: 0.2
     Devil: 0.1
-    # primary
+    # normal
     Traitor: 0.25
     Changeling: 0.10
+    Heretic: 0.11
+
+- type: weightedRandom
+  id: SecretPlusPrimary
+  weights:
+    Traitor: 0.25
+    Changeling: 0.10
+    Heretic: 0.11
     Nukeops: 0.05
     Revolutionary: 0.05
     Zombie: 0.04
-    Heretic: 0.11
     BlobGameMode: 0.05
     Wizard: 0.025
     CosmicCult: 0.12


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
makes secret+ spawn certain antags only ever as the first
fixes zeds having no chaos score

this entire PR is a webedit since i have no access to any sane device right now

## Media
i have not tested this and i will still have no ability to test it for a while

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Secret+ should now pick more sane roundstart antag combinations.
