### PR TITLE
remove borg mindshield hud

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -474,7 +474,6 @@
   - type: AccessReader
     access: [["Command"], ["Research"]]
   - type: ShowJobIcons
-  - type: ShowMindShieldIcons
   - type: StationAiVision # Goobstation - AI can see through NT silicon
     range: 3
   - type: InteractionPopup


### PR DESCRIPTION
Was lost when upstreaming at some point
There's no reason why borgs need to see mindshields except if we get security borg, and it can get this component separately

:cl: ScarKy0
- fix: Borgs can no longer see mindshield status.