### PR TITLE
fix goliath cloak and remove its armor

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
@@ -301,14 +301,6 @@
   - type: HideLayerClothing
     slots:
     - Hair
-  - type: Armor
-    coverage:
-    - Head
-    modifiers:
-      coefficients:
-        Blunt: 0.85
-        Slash: 0.85
-        Piercing: 0.85
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -203,20 +203,10 @@
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/goliathcloak.rsi
   - type: ToggleableClothing # Goobstation - Modsuits change
+    requiredSlot:
+    - neck
     clothingPrototypes:
-      neck: ClothingHeadHatHoodGoliathCloak
-  - type: Armor
-    coverage:
-    - Chest
-    - Groin
-    - Tail
-    - Arm
-    - Leg
-    modifiers:
-     coefficients:
-      Blunt: 0.8
-      Slash: 0.8
-      Piercing: 0.8
+      head: ClothingHeadHatHoodGoliathCloak
   - type: Construction
     graph: GoliathCloak
     node: cloak

--- a/Resources/Prototypes/_Goobstation/Recipes/Construction/Graphs/clothing/goliath_cloak.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Construction/Graphs/clothing/goliath_cloak.yml
@@ -15,7 +15,7 @@
     - to: cloak
       steps:
       - material: GoliathHide
-        amount: 4
+        amount: 1
         doAfter: 2
   - node: cloak
     entity: ClothingNeckCloakGoliathCloak


### PR DESCRIPTION
fixed goliath cloak hood not working
also removed its armor because salvager suits already have a shit ton of armor and neck items are supposed to be cosmetic

- tweak: Goliath cloak no longer provides armor.