### PR TITLE
Fix mech oversights

### DIFF
--- a/Resources/Changelog/GoobChangelog.yml
+++ b/Resources/Changelog/GoobChangelog.yml
@@ -10571,3 +10571,13 @@ Entries:
         to control them.
   id: 1164
   time: '2025-06-02T08:49:17.0000000+00:00'
+- author: Rouden
+  changes:
+    - type: Tweak
+      message: >-
+        Hierophant damaging tiles are now easier to dodge, and deal damage
+        correctly.
+    - type: Fix
+      message: Fixed Hierophant second fight making only Teleportation attacks.
+  id: 1165
+  time: '2025-06-03T07:38:09.0000000+00:00'

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -859,10 +859,10 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
-    maxIntensity: 2 # max 30 per tile
-    intensitySlope: 1
-    totalIntensity: 4 # 60 total damage to distribute over tiles
-    maxTileBreak: 1
+    maxIntensity: 2 # Goob edit
+    intensitySlope: 5
+    totalIntensity: 12 # Goob edit
+    maxTileBreak: 0
   - type: PointLight
     radius: 3.5
     color: orange

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -639,8 +639,7 @@
     emagDynamicPacks:
     - MechWeaponsSalvage
     - MechWeaponsSecurityLight
-    - MechWeaponsSecurityStatic
-    - MechWeaponsSecurityHeavysd
+    - MechWeaponsSecurityHeavy
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -639,6 +639,8 @@
     emagDynamicPacks:
     - MechWeaponsSalvage
     - MechWeaponsSecurityLight
+    - MechWeaponsSecurityStatic
+    - MechWeaponsSecurityHeavysd
   - type: MaterialStorage
     whitelist:
       tags:


### PR DESCRIPTION
Mech emag recipes were not working
Mech mini explosion from small rocket was not working
both are now

:cl: Armok
- fix: Emag interaction now properly works with exofab, allowing the creation of weapons.
