### PR TITLE
VIVA LA REVOLUTION! HEADS ARE NOT IMMUNE!

### DIFF
--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -226,8 +226,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
             !_mobState.IsAlive(ev.Target) ||
             HasComp<ZombieComponent>(ev.Target) ||
             HasComp<HereticComponent>(ev.Target) ||
-            HasComp<ChangelingComponent>(ev.Target) // goob edit - no more ling or heretic revs
-            || HasComp<CommandStaffComponent>(ev.Target)) // goob edit - rev no command flashing
+            HasComp<ChangelingComponent>(ev.Target)) // goob edit - no more ling or heretic revs
         {
             if(ev.User != null)
                 _popup.PopupEntity("The conversion failed!", ev.User.Value, ev.User.Value);
@@ -261,7 +260,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
 
         if (mind is { UserId: not null } && _player.TryGetSessionById(mind.UserId, out var session))
             _antag.SendBriefing(session, Loc.GetString("rev-role-greeting"), Color.Red, revComp.RevStartSound);
-        
+
         // Goobstation - Check lose if command was converted
         if (!TryComp<CommandStaffComponent>(ev.Target, out var commandComp))
             return;


### PR DESCRIPTION
## About the PR
Members of Command Staff are no longer completely immune from being converted by the Revolution.

## Why / Balance
Here are two perspectives, so hear me out:
1. Command Staff not being convertable just leads to a fight where people die or they inevitably try to break out of cuffs all the time when they are cuffed.
2. Cosmic Cultists can convert people by removing mindshields (prior to tier 3) and reapply the mindshield afterwards. This just makes Cosmic Cult a better revolution because they have powers and magic.

## Technical details
I simply removed the component check when converting someone in the rules system.

## Media
[Big File Moment](https://youtu.be/eP0-c2JQBYo)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Nothing breaks when I remove content, surely. :clueless:

**Changelog**
:cl:
- tweak: Heads of Staff (Command Staff) can be converted. No longer shall we kill, when we can truly take over the station as one.
