### PR TITLE
(Hot)fix shove prediction

### DIFF
--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -1055,9 +1055,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
         if (Deleted(target)
             || user == target)
-        {
             return false;
-        }
 
         EntityUid? inTargetHand = null;
 
@@ -1065,9 +1063,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             return false;
 
         if (!InRange(user, target, component.Range, session))
-        {
             return false;
-        }
 
         PhysicalShove(user, target);
         Interaction.DoContactInteraction(user, target);

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -1110,7 +1110,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         var chance = CalculateDisarmChance(user, target, inTargetHand, combatMode);
 
         _audio.PlayPredicted(combatMode.DisarmSuccessSound,
-            user, null,
+            user, user,
             AudioParams.Default.WithVariation(0.025f).WithVolume(5f));
         AdminLogger.Add(LogType.DisarmedAction,
             $"{ToPrettyString(user):user} used disarm on {ToPrettyString(target):target}");

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -1053,8 +1053,8 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
         var target = GetEntity(ev.Target.Value);
 
-        if (Deleted(target) ||
-            user == target)
+        if (Deleted(target)
+            || user == target)
         {
             return false;
         }

--- a/Resources/Changelog/GoobChangelog.yml
+++ b/Resources/Changelog/GoobChangelog.yml
@@ -10901,3 +10901,9 @@ Entries:
       message: Lathes queues can now be cleared by pressing the "Reset Queue" button.
   id: 1200
   time: '2025-06-14T20:53:38.0000000+00:00'
+- author: RedMush1
+  changes:
+    - type: Tweak
+      message: Hyperzine takes more time to metabolize.
+  id: 1201
+  time: '2025-06-14T20:59:19.0000000+00:00'


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Shoves mispredicted before and had infinite range, no more.
This also fixes the lag, since the prediction didn't guarantee for objects to be properly set (so it spammed server console)

## Why / Balance
Bug

## Technical details
Slipped by when testing after moving to shared

## Media

https://github.com/user-attachments/assets/118258e6-db62-4665-b83c-1a1bdecdbf04

Double audio was fixed in the second commit of this PR, didn't re-record.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Fixed shove prediction/range checks
-->
