### PR TITLE
Revert "Fire no longer instakills moths"

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -89,7 +89,6 @@
 # SPDX-FileCopyrightText: 2024 Арт <123451459+JustArt1m@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <aviu00@protonmail.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
@@ -163,7 +162,7 @@
   - type: Flammable
     damage:
       types:
-        Heat: 1.5 # moths burn more easily
+        Heat: 4.5 # moths burn more easily
   - type: Temperature # Moths hate the heat and thrive in the cold.
     heatDamageThreshold: 320
     coldDamageThreshold: 230


### PR DESCRIPTION
it was part of moth uniqueness + they're already a pretty good specie with their dash + no goob comment in upstream content + review not adressed + made for a bounty that was intended to give them another downside but that was never done + goidamerged + 
![image](https://github.com/user-attachments/assets/10735cfb-eaff-4034-98e5-649ddc43ef32)

Reverts Goob-Station/Goob-Station#3116

