### PR TITLE
Tune down the nailguns damage output

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Engineering/nails.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Engineering/nails.yml
@@ -39,7 +39,7 @@
     onlyCollideWhenShot: true
     damage:
       types:
-        Piercing: 3
+        Piercing: 2
       armorPenetration: -1.75 # Very shitty against armor. Pro tip: target unarmored body parts
   - type: Fixtures
     fixtures:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Engineering/nails.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Engineering/nails.yml
@@ -39,7 +39,7 @@
     onlyCollideWhenShot: true
     damage:
       types:
-        Piercing: 5
+        Piercing: 3
       armorPenetration: -1.75 # Very shitty against armor. Pro tip: target unarmored body parts
   - type: Fixtures
     fixtures:
@@ -88,8 +88,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 4
-      armorPenetration: 0.75
+        Piercing: 3
+      armorPenetration: 0.65
   - type: ProjectileDamageWhitelist
     damage: # Slightly worse for repairs
       types:
@@ -111,7 +111,7 @@
       tags:
       - Nail
     proto: Nail
-    capacity: 100
+    capacity: 80
   - type: ContainerContainer
     containers:
       ballistic-ammo: !type:Container

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Engineering/nails.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Engineering/nails.yml
@@ -39,7 +39,7 @@
     onlyCollideWhenShot: true
     damage:
       types:
-        Piercing: 2
+        Piercing: 3
       armorPenetration: -1.75 # Very shitty against armor. Pro tip: target unarmored body parts
   - type: Fixtures
     fixtures:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/nailgun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/nailgun.yml
@@ -17,7 +17,7 @@
     whitelist:
       tags:
       - Nail
-    capacity: 50
+    capacity: 40
   - type: ContainerContainer
     containers:
       ballistic-ammo: !type:Container

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Nailgun/nailgun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Nailgun/nailgun.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 GMWQ <garethquaile@gmail.com>
+# SPDX-FileCopyrightText: 2025 Gareth Quaile <garethquaile@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Nailgun/nailgun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Nailgun/nailgun.yml
@@ -33,7 +33,7 @@
   - type: AmmoCounter
   - type: Gun
     projectileSpeed: 30
-    fireRate: 8
+    fireRate: 6
     selectedMode: FullAuto
     availableModes:
     - FullAuto

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Nailgun/nailgun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Nailgun/nailgun.yml
@@ -31,7 +31,7 @@
   - type: AmmoCounter
   - type: Gun
     projectileSpeed: 30
-    fireRate: 12
+    fireRate: 10
     selectedMode: FullAuto
     availableModes:
     - FullAuto

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Nailgun/nailgun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Nailgun/nailgun.yml
@@ -31,7 +31,7 @@
   - type: AmmoCounter
   - type: Gun
     projectileSpeed: 30
-    fireRate: 10
+    fireRate: 8
     selectedMode: FullAuto
     availableModes:
     - FullAuto


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
Tweaked Nailgun stats to make it a little bit more balanced

## Why / Balance
In it's current state, the nailgun has an incredibly high damage output and a very low TTK. Combined with no spread to shots and the nailgun is incredibly overtuned.

The following tables provide the damage statistics for a full magazine:

| - | Naked | Armor Vest Non-AP | Armor Vest AP |
| - | ------- | ---------------------- | ---------------- | 
| Current Values | 200 Pierce | 48 Pierce | 172 Pierce | 
| Reduced Values | 120 Pierce | 22.8 Pierce | 97.2 Pierce | 

The armor vest used to test was a standard issue armor vest with 45% Piercing resist
## Technical details

1. Magazine size: 50 -> 40
2. Nail box size: 100 -> 80
3. Fire Rate: 12 -> 8
4. Standard Nail Damage: 5 -> 3
5. AP Nail Damage: 4 -> 3
6. AP Nail Piercing: 0.75 -> 0.65

Lathe prices for producing these items have not been touched. 


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: You may now have a chance to survive getting attacked with a nailgun

