### PR TITLE
survival+, more secret+ adjustments

### DIFF
--- a/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
+++ b/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
@@ -286,6 +286,22 @@ public sealed partial class GoobCVars
 
     #endregion
 
+    #region Station Events
+
+    /// <summary>
+    /// Makes station event schedulers behave as if time is sped up by this much.
+    /// Supported for secret, secret+, and game director.
+    /// </summary>
+    public static readonly CVarDef<float> StationEventSpeedup =
+        CVarDef.Create("stationevents.debug_speedup", 1f, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Makes station event schedulers consider the server to have this many extra living players.
+    /// Supported for secret+ and game director.
+    /// </summary>
+    public static readonly CVarDef<int> StationEventPlayerBias =
+        CVarDef.Create("stationevents.debug_player_bias", 0, CVar.SERVERONLY);
+
     #region Game Director
 
     // also used by secret+
@@ -296,14 +312,6 @@ public sealed partial class GoobCVars
         CVarDef.Create("gamedirector.debug_player_count", 80, CVar.SERVERONLY);
 
     #endregion
-
-    #region Secret+
-
-    /// <summary>
-    /// Makes secret+ consider the server to have this many extra living players, for debug.
-    /// </summary>
-    public static readonly CVarDef<int> SecretPlusPlayerBias =
-        CVarDef.Create("secretplus.debug_player_bias", 0, CVar.SERVERONLY);
 
     #endregion
 

--- a/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
+++ b/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
@@ -19,6 +19,7 @@
 // SPDX-FileCopyrightText: 2025 Poips <Hanakohashbrown@gmail.com>
 // SPDX-FileCopyrightText: 2025 PuroSlavKing <103608145+PuroSlavKing@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 // SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 // SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
 // SPDX-FileCopyrightText: 2025 Steve <marlumpy@gmail.com>

--- a/Content.Goobstation.Server/StationEvents/GameDirectorSystem.cs
+++ b/Content.Goobstation.Server/StationEvents/GameDirectorSystem.cs
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
+// SPDX-FileCopyrightText: 2025 Milon <milonpl.git@proton.me>
 // SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
 // SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 // SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>

--- a/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusComponent.cs
+++ b/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusComponent.cs
@@ -65,6 +65,31 @@ public sealed partial class SecretPlusComponent : Component
     public float DeadChaosChange;
 
     /// <summary>
+    ///   Chaos change multiplier we're using
+    /// </summary>
+    [ViewVariables]
+    public float ChaosChangeVariation = 1f;
+
+    /// <summary>
+    ///   Minimum multiplier of chaos-over-time to generate at the start
+    /// </summary>
+    [DataField]
+    public float ChaosChangeVariationMin = 1f;
+
+    /// <summary>
+    ///   Maximum multiplier of chaos-over-time to generate at the start
+    /// </summary>
+    [DataField]
+    public float ChaosChangeVariationMax = 1f;
+
+    /// <summary>
+    ///   How much to bias the chaos change variation multiplier towards generating closer to 1
+    ///   Higher values mean more bias, values below 1 mean bias away from 1
+    /// </summary>
+    [DataField]
+    public float ChaosChangeVariationExponent = 2f;
+
+    /// <summary>
     ///   How much to offset chaos of events away from 0 when picking events
     ///   Higher values make low-chaos events have more equal chances to be picked
     /// </summary>

--- a/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusComponent.cs
+++ b/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusComponent.cs
@@ -75,20 +75,28 @@ public sealed partial class SecretPlusComponent : Component
     ///   Higher values make high-chaos events more uncommon.
     /// </summary>
     [DataField]
-    public float ChaosExponent = 1.2f;
+    public float ChaosExponent = 1.1f;
 
     /// <summary>
     ///   Lower values make the game director be more picky with events.
     /// </summary>
     [DataField]
-    public float ChaosMatching = 2f;
+    public float ChaosMatching = 1.8f;
 
     /// <summary>
     ///   "Base" chaos value to use for event weighting.
     ///   Matters for how much having negative weight affects probability.
     /// </summary>
     [DataField]
-    public float ChaosThreshold = 10f;
+    public float ChaosThreshold = 20f;
+
+    /// <summary>
+    ///   How much to ramp itself up per second.
+    ///   Turns the scheduler into essentially the survival gamemode.
+    ///   Linearly scales chaos point generation, event frequency, and reduces reoccurence delays.
+    /// </summary>
+    [DataField]
+    public float SpeedRamping = 0f;
 
     /// <summary>
     /// Does this round start with antags at all?

--- a/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
+++ b/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
+// SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: 2022 Moony <moonheart08@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Aidenkrz <aiden@djkraz.com>
-// SPDX-FileCopyrightText: 2024 IProduceWidgets <107586145+IProduceWidgets@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Kara <lunarautomaton6@gmail.com>
 // SPDX-FileCopyrightText: 2024 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 IProduceWidgets <107586145+IProduceWidgets@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
@@ -67,7 +67,7 @@ namespace Content.Server.StationEvents
 
                 if (eventScheduler.TimeUntilNextEvent > 0)
                 {
-                    eventScheduler.TimeUntilNextEvent -= frameTime;
+                    eventScheduler.TimeUntilNextEvent -= frameTime * _event.EventSpeedup; // Goobstation
                     continue;
                 }
 

--- a/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 IProduceWidgets <107586145+IProduceWidgets@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 //

--- a/Content.Server/StationEvents/EventManagerSystem.cs
+++ b/Content.Server/StationEvents/EventManagerSystem.cs
@@ -14,9 +14,7 @@
 // SPDX-FileCopyrightText: 2024 Errant <35878406+Errant-4@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Flareguy <78941145+Flareguy@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Hrosts <35345601+Hrosts@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 IProduceWidgets <107586145+IProduceWidgets@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Ian <ignaz.k@live.de>
-// SPDX-FileCopyrightText: 2024 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Joel Zimmerman <JoelZimmerman@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 JustCone <141039037+JustCone14@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Kara <lunarautomaton6@gmail.com>
@@ -75,6 +73,8 @@
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 IProduceWidgets <107586145+IProduceWidgets@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 // SPDX-FileCopyrightText: 2025 Winkarst <74284083+Winkarst-cpu@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>

--- a/Resources/Locale/en-US/_Goobstation/game-ticking/secretplus.ftl
+++ b/Resources/Locale/en-US/_Goobstation/game-ticking/secretplus.ftl
@@ -1,11 +1,11 @@
-secretplus-low-title = Turbulence
+secretplus-low-title = Secret+ Light
 secretplus-low-description = Relatively calm. But not always.
 
-secretplus-mid-title = Entropy
-secretplus-mid-description = Not too much time to relax. Anything can happen.
+secretplus-mid-title = Secret+ Medium
+secretplus-mid-description = Handle unknown but balanced threats.
 
-secretplus-high-title = Chaos
-secretplus-high-description = If it can happen, it will.
+secretplus-admeme-title = Secret+ Chaos
+secretplus-admeme-description = If it can happen, it will.
 
-survivalplus-title = Descent
+survivalplus-title = Survival+
 survivalplus-description = Starts pretty calm. Ends up not quite.

--- a/Resources/Locale/en-US/_Goobstation/game-ticking/secretplus.ftl
+++ b/Resources/Locale/en-US/_Goobstation/game-ticking/secretplus.ftl
@@ -6,3 +6,6 @@ secretplus-mid-description = Not too much time to relax. Anything can happen.
 
 secretplus-high-title = Chaos
 secretplus-high-description = If it can happen, it will.
+
+survivalplus-title = Descent
+survivalplus-description = Starts pretty calm. Ends up not quite.

--- a/Resources/Prototypes/DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/DeltaV/GameRules/events.yml
@@ -12,13 +12,13 @@
     startAnnouncement: station-event-xeno-vent-start-announcement
     startAudio:
       path: /Audio/Announcements/aliens.ogg
-    earliestStart: 45
+    earliestStart: 20
     minimumPlayers: 20
-    weight: 1
+    weight: 3
     duration: 30
     eventType: HostilesSpawn
   - type: GameRule
-    chaosScore: 360
+    chaosScore: 300
  #- type: PrecognitionResult
  #  message: psionic-power-precognition-xeno-vents-result-message
   - type: VentCrittersRule
@@ -52,7 +52,7 @@
     duration: 30
     eventType: Neutral
   - type: GameRule
-    chaosScore: 80
+    chaosScore: 40
  #- type: PrecognitionResult
  #  message: psionic-power-precognition-mothroach-spawn-result-message
   - type: VentCrittersRule

--- a/Resources/Prototypes/DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/DeltaV/GameRules/events.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -171,6 +171,7 @@
     - id: TidemindDevelop # Goobstation - Tidemind
     - id: MothroachSpawn # DeltaV
     - id: XenoVents # DeltaV
+    - id: DerelictCyborgSyndicateSpawn # Goobstation - usually calm
 
 - type: entityTable
   id: BasicAntagEventsTable
@@ -505,7 +506,7 @@
     eventType: HostilesSpawn # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 280
+    chaosScore: 450
   - type: RandomSpawnRule
     prototype: MobRevenant
 
@@ -593,7 +594,7 @@
     eventType: Maintenance # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 40
+    chaosScore: 80
   - type: KudzuGrowthRule
 
 - type: entity
@@ -688,7 +689,7 @@
     eventType: HostilesSpawn # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 360
+    chaosScore: 200
   - type: VentCrittersRule
     table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
       children:
@@ -714,7 +715,7 @@
     eventType: HostilesSpawn # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 360
+    chaosScore: 240
   - type: VentCrittersRule
     table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
       children:
@@ -740,7 +741,7 @@
     eventType: HostilesSpawn # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 360
+    chaosScore: 240
   - type: VentCrittersRule
     table: # DeltaV: EntityTable instead of spawn entries
       id: MobGiantSpiderAngry
@@ -763,7 +764,7 @@
     eventType: HostilesSpawn # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 360
+    chaosScore: 240
   - type: VentCrittersRule
     playerRatio: 20 # DeltaV: Clown spiders are very robust
     table: # DeltaV: EntityTable instead of spawn entries
@@ -879,7 +880,7 @@
     eventType: HostilesSpawn # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 550
+    chaosScore: 500
   - type: AlertLevelInterceptionRule
   - type: AntagSelection
     definitions:

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -126,8 +126,10 @@
 # SPDX-FileCopyrightText: 2025 MilenVolf <63782763+MilenVolf@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 PunishedJoe <PunishedJoeseph@proton.me>
+# SPDX-FileCopyrightText: 2025 Rouden <149893554+Roudenn@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Roudenn <romabond091@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tayrtahn <tayrtahn@gmail.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -160,7 +160,7 @@
     eventType: Chaotic # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 40
+    chaosScore: 30
   - type: VentCrittersRule
     table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
       children:

--- a/Resources/Prototypes/_Goobstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/events.yml
@@ -29,6 +29,8 @@
   parent: BaseGameRule
   id: DerelictCyborgSyndicateSpawn
   components:
+  - type: GameRule
+    chaosScore: 150
   - type: StationEvent
     weight: 6 # Rare, but not AS rare
     earliestStart: 15

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -70,7 +70,6 @@
     maxStartingChaos: 20
     livingChaosChange: -0.012
     deadChaosChange: 0.024
-    chaosExponent: 1.1
     # often fires chud events so relatively low
     eventIntervalMin: 90
     eventIntervalMax: 300
@@ -103,21 +102,23 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: SecretPlus
+    minStartingChaos: 0
+    maxStartingChaos: 0
     noRoundstartAntags: true
-    livingChaosChange: -0.008
-    deadChaosChange: 0.02
+    livingChaosChange: -0.006
+    deadChaosChange: 0.015
     chaosExponent: 1.2
     eventIntervalMin: 120
     eventIntervalMax: 450
 
-# testing rule
+# "survival+"
 - type: entity
-  id: SecretPlusDebug
+  id: SecretPlusRampingMid
   parent: SecretPlusMid
   categories: [ HideSpawnMenu ]
   components:
   - type: SecretPlus
-    eventIntervalMin: 3
-    eventIntervalMax: 10
-    livingChaosChange: -21.6
-    ignoreTimings: true
+    minStartingChaos: 0
+    maxStartingChaos: 0
+    noRoundstartAntags: true
+    speedRamping: 0.0003 # ramps to 2x in about an hour, to 3x in ~2

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -70,6 +70,9 @@
     maxStartingChaos: 20
     livingChaosChange: -0.012
     deadChaosChange: 0.024
+    # chance for greenshift as well as evilshift
+    chaosChangeVariationMin: 0.65
+    chaosChangeVariationMax: 1.3
     # often fires chud events so relatively low
     eventIntervalMin: 90
     eventIntervalMax: 300
@@ -110,7 +113,7 @@
     eventIntervalMin: 120
     eventIntervalMax: 450
 
-# "survival+"
+# survival+
 - type: entity
   id: SecretPlusRampingMid
   parent: SecretPlusMid

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -78,9 +78,8 @@
     scheduledGameRules: !type:NestedSelector
       tableId: SecretPlusTable
 
-# admeme preset - nerf when it's voteable
 - type: entity
-  id: SecretPlusHigh
+  id: SecretPlusAdmeme
   parent: SecretPlusMid
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -229,3 +229,16 @@
   rules:
     - SecretPlusHigh
     - LavalandStormScheduler
+
+- type: gamePreset
+  id: SurvivalPlusMid
+  alias:
+    - survivalplus
+    - newsurvival
+    - survivalnew
+  name: survivalplus-title
+  description: survivalplus-description
+  showInVote: true
+  rules:
+    - SecretPlusRampingMid
+    - LavalandStormScheduler

--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -218,16 +218,17 @@
     - LavalandStormScheduler
 
 - type: gamePreset
-  id: SecretPlusHigh
+  id: SecretPlusAdmeme
   alias:
-    - secretplushigh
+    - secretplusadmeme
     - secretplusevil
+    - secretplushigh
     - chaos
-  name: secretplus-high-title
-  description: secretplus-high-description
+  name: secretplus-admeme-title
+  description: secretplus-admeme-description
   showInVote: false # 1984
   rules:
-    - SecretPlusHigh
+    - SecretPlusAdmeme
     - LavalandStormScheduler
 
 - type: gamePreset


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
- adds survival+: secret+ but no roundstart antags and it ramps up over time
- adds new debug cvars to try out secret+ event rolls in localhost
- tweaks a few chaos score values
- tweaks secret+ event-picking values since it was struggling to regulate its chaos budget
- minor fix in secret+ event picking logic
- adds chaos change variation: secret+ can now pick to generate more or less chaos for this round, but will still tend to pick closer-to-1 multipliers

## Why / Balance
more gamemodes more variety
if people don't want it they won't vote it anyway
should make entropy feel better

considering the new debug cvars now exist you can actually check out examples of event rolls ingame yourself by spoofing 60 players (minus some from 80 since dead players decrease chaos score) and 40x speedup or so

## Media
tested all of it ingame
![image](https://github.com/user-attachments/assets/2378a715-d798-4e24-8079-c53cd417f4b4)
kept chaos score in acceptable values 5 minutes in on 20x speedup before i stopped testing

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added survival+: play it by voting the new Descent gamemode.
- tweak: Secret+ should now pick events less randomly.
- tweak: Renamed secret+ gamemodes to be more clear.
- tweak: Secret+ now may randomly infrequently decide for the shift to be calm or less calm.
- fix: Derelict assault borg should now spawn.
