### PR TITLE
Changes the Borg maints panel back to using a screwdriver

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -285,7 +285,7 @@
       components:
       - RoboticsConsole
   - type: WiresPanel
-    openingTool: Screwing
+    openingTool: Screwing #Goob Edit
   - type: ActivatableUIRequiresPanel
   - type: NameIdentifier
     group: Silicon

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -285,7 +285,7 @@
       components:
       - RoboticsConsole
   - type: WiresPanel
-    openingTool: Prying
+    openingTool: Screwing
   - type: ActivatableUIRequiresPanel
   - type: NameIdentifier
     group: Silicon

--- a/Resources/Prototypes/_Goobstation/MisandryBox/JobObjectives.yml
+++ b/Resources/Prototypes/_Goobstation/MisandryBox/JobObjectives.yml
@@ -1,4 +1,10 @@
-﻿- type: entity
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
+# SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: entity
   abstract: true
   parent: BaseObjective
   id: BaseBlueshieldObjective
@@ -18,7 +24,7 @@
   - type: Objective
     difficulty: 2
     icon:
-      sprite: Objects/Misc/bureaucracy.rsi
+      sprite: Objects/Misc/folders.rsi
       state: folder-white
   - type: TargetObjective
     title: objective-condition-other-head-alive-title


### PR DESCRIPTION
## About the PR
This very simple pr is to change the action needed to open and close the borg maints panel to a screw driver instead of a crowbar

## Why / Balance
I feel as if this is better in line will all other maints panels in the game which use the screwdriver the borg also did before recent changes 

## Technical details
Not much to say here this is one line of code change in yml 

## Requirements
I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
 I have added media to this PR or it does not require an ingame showcase.


**Changelog**

:cl:
- tweak: Borg maint panel using a screwdriver to open and close once again 


