### PR TITLE
[Technically Bounty?] Bso balancing but actually trying

### DIFF
--- a/Content.Goobstation.Shared/SetSelector/SetSelectorSystem.cs
+++ b/Content.Goobstation.Shared/SetSelector/SetSelectorSystem.cs
@@ -14,6 +14,10 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Goobstation.Shared.SetSelector;
 
+/// <summary>
+/// <see cref="SetSelectorComponent"/>
+/// this system links the interface to the logic, and will spawn sets selected by the player in the interface
+/// </summary>
 public sealed class SetSelectorSystem : EntitySystem
 {
     [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -42,6 +46,7 @@ public sealed class SetSelectorSystem : EntitySystem
             return;
         }
 
+        // Randomize sets available for selection
         var sets = selector.Comp.PossibleSets.ToArray();
         new System.Random().Shuffle(sets);
         selector.Comp.AvailableSets = sets.Take(selector.Comp.SetsToSelect).ToList();
@@ -83,9 +88,12 @@ public sealed class SetSelectorSystem : EntitySystem
             }
         }
 
+        // Since we immediately delete the selector, the sound played on it would get deleted too,
+        // so we play the sound on coordinates of the selector instead.
         _audio.PlayPvs(selector.Comp.ApproveSound, Transform(selector.Owner).Coordinates);
         Del(selector);
 
+        // We do this after deleting the selector so the spawned storage does not collide with it
         if (storagePrototype != null && spawnedStorageContainer != null)
         {
             spawnedStorage = Spawn(storagePrototype, coordinates);
@@ -117,6 +125,7 @@ public sealed class SetSelectorSystem : EntitySystem
 
     private void OnChangeSet(Entity<SetSelectorComponent> selector, ref SetSelectorChangeSetMessage args)
     {
+        // Switch selecting set
         if (!selector.Comp.SelectedSets.Remove(args.SetNumber))
              selector.Comp.SelectedSets.Add(args.SetNumber);
 

--- a/Resources/Changelog/GoobChangelog.yml
+++ b/Resources/Changelog/GoobChangelog.yml
@@ -11319,3 +11319,9 @@ Entries:
       message: Polymorphs no longer spawn urists
   id: 1244
   time: '2025-06-16T09:11:35.0000000+00:00'
+- author: SX-7
+  changes:
+    - type: Fix
+      message: Traitors should get their uplinks now
+  id: 1245
+  time: '2025-06-16T13:16:56.0000000+00:00'

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -121,6 +121,6 @@
     damage:
       types:
         Blunt: 3
-        Heat: 15
+        Heat: 12
     soundHit:
       collection: MeatLaserImpact

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2024 Icepick <122653407+Icepicked@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 IrisTheAmped <iristheamped@gmail.com>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>

--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Belt/belts.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Belt/belts.yml
@@ -239,6 +239,7 @@
   - type: StorageFill
     contents:
     - id: EnergySpeedloaderLethal
+    - id: EnergySpeedloaderLethal
     - id: EnergySpeedloaderDisabler
 
 - type: entity

--- a/Resources/Prototypes/_Goobstation/Catalog/selectable_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/selectable_sets.yml
@@ -348,7 +348,7 @@
 
 - type: selectableSet
   id: BSOSyringeSet
-  name: selectable-set-blueshied-syringe-name
+  name: selectable-set-blueshield-syringe-name
   description: selectable-set-blueshield-syringe-description
   sprite:
     sprite: _Goobstation/Objects/Weapons/Melee/blueshield_knife.rsi

--- a/Resources/Prototypes/_Goobstation/Catalog/selectable_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/selectable_sets.yml
@@ -346,6 +346,16 @@
 #  tables:
 #  - ChesterRandomAmmoTable
 
+- type: selectableSet
+  id: BSOSyringeSet
+  name: selectable-set-blueshied-syringe-name
+  description: selectable-set-blueshield-syringe-description
+  sprite:
+    sprite: _Goobstation/Objects/Weapons/Melee/blueshield_knife.rsi
+    state: icon
+  content:
+    - BoxCombatInjector
+
 # Blueshield hardsuits
 
 - type: selectableSet

--- a/Resources/Prototypes/_Goobstation/Catalog/selectable_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/selectable_sets.yml
@@ -341,9 +341,10 @@
   - WeaponLeverChester
   - MagazineShotgunLeverRifleEmpty
   - MagazineShotgunLeverRifleEmpty
-  - MagazineBoxShotgunHighCaliber
-  tables:
-  - ChesterRandomAmmoTable
+  - MagazineBoxShotgunHighCaliberEmp
+  - MagazineBoxShotgunHighCaliberEnsnare
+#  tables:
+#  - ChesterRandomAmmoTable
 
 # Blueshield hardsuits
 

--- a/Resources/Prototypes/_Goobstation/Catalog/selectable_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/selectable_sets.yml
@@ -341,8 +341,8 @@
   - WeaponLeverChester
   - MagazineShotgunLeverRifleEmpty
   - MagazineShotgunLeverRifleEmpty
-  - MagazineBoxShotgunHighCaliberEmp
-  - MagazineBoxShotgunHighCaliberEnsnare
+  - MagazineBoxShotgunHighCaliberEMP
+  - MagazineBoxShotgunHighCaliberEnsnaring
 #  tables:
 #  - ChesterRandomAmmoTable
 

--- a/Resources/Prototypes/_Goobstation/Catalog/selectable_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/selectable_sets.yml
@@ -317,7 +317,7 @@
     sprite: _Goobstation/Objects/Weapons/Guns/Battery/erevolver.rsi
     state: icon
   content:
-    - ClothingBeltHolsterFilledBlueshield # Pistol, 1+2 lethal speedloaders and 2 disabler speedloaders
+    - ClothingBeltHolsterFilledBlueshield # Pistol, 1+2 lethal speedloaders and 1 disabler speedloader
 
 - type: selectableSet
   id: BSOCQCSet

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/CentralCommand/set_selectors.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/CentralCommand/set_selectors.yml
@@ -15,7 +15,7 @@
 
 - type: entity
   id: BlueshieldUndeterminedWeapon
-  name: blueshield weaponry pack
+  name: blueshield sets pack
   description: A small box utilizing bluespace technology to drop in a loadout directly to you. Choose wisely.
   parent: [ BaseItem, BaseSetSelector, BaseCentcommContraband ]
   components:
@@ -28,6 +28,7 @@
     - BSORevolverSet
     - BSOCQCSet
     - BSOChesterSet
+    - BSOSyringeSet
     maxSelectedSets: 2
 
 

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/CentralCommand/set_selectors.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/CentralCommand/set_selectors.yml
@@ -45,7 +45,7 @@
     possibleSets:
     - BSOHardsuitLightSet
     - BSOModsuitSet
-    maxSelectedSets: 2
+    maxSelectedSets: 1
 
 # ERT
 

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/CentralCommand/set_selectors.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/CentralCommand/set_selectors.yml
@@ -28,6 +28,20 @@
     - BSORevolverSet
     - BSOCQCSet
     - BSOChesterSet
+    maxSelectedSets: 2
+
+
+- type: entity
+  id: BlueshieldUndeterminedHardsuit
+  name: blueshield hardsuit pack
+  description: A small box utilizing bluespace technology to drop in a loadout directly to you. Choose wisely.
+  parent: [ BaseItem, BaseSetSelector, BaseCentcommContraband ]
+  components:
+  - type: Sprite
+    sprite: _Goobstation/Objects/Specific/Security/blueshieldundetermined.rsi
+    state: icon-alt
+  - type: SetSelector
+    possibleSets:
     - BSOHardsuitLightSet
     - BSOModsuitSet
     maxSelectedSets: 2


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
I was promised 1k more GC to make an actual balance PR like I thought would be better instead of the complete revert I was originally told to.

The entire point of BSO was to be strong in defending heads as you only have one life with forced lifeline. BSO 100% got away with having too much in terms of powercreep, but in it's current state is dead, considering rounds of 85+ people having no BSO.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Revolver got hit stupid hard by less speedloaders considering the pheenty nerf that makes them have a wait time on recharge. Readding a lethal speedloader allows you to follow original intent (skill swapping loaders for consistent dps) while recharge keeps you from infinite chaining. 3 damage was also removed to make one loader 90 from 108 damage so while this allows Revolver to keep holding fire it nerfs dps a bit to compensate.

Chester random ammo + lethal was removed in favor of giving BSO solely two utility ammos roundstart in addition to their single lethal mag. More lethals are always printable, but the previous change just guaranteed them roundstart anyways and Pheenty reduced fire rate, so it's more of a deterrent with utility to save Heads instead of the validhunting gun roundstart.

Syringe kit was added back because it was literally the one kit BSO got that didn't fuck other people up. Injectors are already dumb for chem healing and BSO gets one for free, this is just a light upgrade that keeps BSO in it's identity of saving heads. 

Selector set was renamed from weaponry pack to sets pack to reduce weird ass mald that syringe kit was "not a weapon in weapon pack"

CQC will be replaced with Dragon Kung Fu in #2462 which moves their martial arts to defensive from validhunt tool so it was untouched.

Comments were readded because why remove effectively the only documentation for the selector system?

## Technical details
<!-- Summary of code changes for easier review. -->
Yamlmaxxed
C# edits are just comments readded

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Readded Syringe Kit, heal mains rejoice.
- tweak: BSO kits have been unmerged.
- tweak: Chester no longer has randomed ammo but only guaranteed utility ammo. Friendly reminder printing lethals roundstart is powergaming.
- tweak: Revolver has regained a speedloader but deals a bit less now, back to skill-swapping barrages to do good damage.

