### PR TITLE
Minor changeling absorb and DNA extract changes

### DIFF
--- a/Content.Goobstation.Shared/Changeling/Components/PartialAbsorbableComponent.cs
+++ b/Content.Goobstation.Shared/Changeling/Components/PartialAbsorbableComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Goobstation.Shared.Changeling.Components;
+
+/// <summary>
+///     Component that indicates that a person can be absorbed by a changeling, but will not give any objective progress or evolution points.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class PartialAbsorbableComponent : Component
+{
+
+}

--- a/Resources/Locale/en-US/_Goobstation/Changeling/abilities/changeling.ftl
+++ b/Resources/Locale/en-US/_Goobstation/Changeling/abilities/changeling.ftl
@@ -20,6 +20,7 @@ changeling-absorb-fail-absorbed = They've already been absorbed.
 changeling-absorb-fail-unabsorbable = The target is not absorbable.
 changeling-absorb-end-self = The organism was absorbed. We are evolving.
 changeling-absorb-end-self-ling = Another changeling was absorbed. Our body is filled with immense vigor as our cells rapidly evolve.
+changeling-absorb-end-partial = The organism was absorbed. We were unable to extract anything to aid in our evolution.
 changeling-absorb-onexamine = [color=red]The body feels hollow.[/color]
 changeling-absorb-fail-nograb = We aren't grabbing hard enough.
 changeling-absorb-fail-onfire = The target is on fire, put them out first!

--- a/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
@@ -52,6 +52,7 @@
   - type: NpcFactionMember
     factions:
     - NanoTrasen
+  - type: PartialAbsorbable # Goobstation - changelings
 
 - type: entity
   name: salvager
@@ -69,6 +70,7 @@
     - type: HTN
       rootTask:
         task: SimpleHumanoidHostileCompound
+    - type: PartialAbsorbable # Goobstation - changelings
 
 - type: entity
   name: spirate
@@ -87,6 +89,7 @@
   - type: HTN
     rootTask:
       task: SimpleHumanoidHostileCompound
+  - type: PartialAbsorbable # Goobstation - changelings
 
 - type: entity
   name: syndicate footsoldier
@@ -104,6 +107,7 @@
     - type: HTN
       rootTask:
         task: SimpleHumanoidHostileCompound
+    - type: PartialAbsorbable # Goobstation - changelings
 
 - type: entity
   name: syndicate shuttle pilot
@@ -129,6 +133,7 @@
         Blunt: 19
   - type: Inventory
     templateId: corpse
+  - type: PartialAbsorbable # Goobstation - changelings
 
 - type: entity
   parent: MobHuman


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
changelings will no longer get evolution points or objective progress from absorbing (or DNA stinging) unidentified corpses, syndi shuttle pilots ect.
also absorbing will now ignore genetic damage resistances (lol)

## Why / Balance
how it feels to cheese by absorbing the 20 random unidentified corpses in delta maints or space

## Technical details
made PartialAbsorbableComponent and gave it to the aforementioned entities
bit of c# bit of yml

## Media

1998 resolution but who gaf

https://github.com/user-attachments/assets/65f8dc3f-82b3-42c4-9556-c22ca0a1e295

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: the_biggestbruh
- tweak: Changelings will no longer gain evolution points or objective progress from absorbing (or DNA stinging) unidentified corpses and the like.
- tweak: Changeling absorb should ignore resistances now
