### PR TITLE
changes to ling absorb (again), minor change to dna obj, and some other stuff

### DIFF
--- a/Content.Goobstation.Server/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingSystem.Abilities.cs
@@ -31,16 +31,19 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Goobstation.Common.Changeling;
+using Content.Goobstation.Maths.FixedPoint;
+using Content.Goobstation.Server.Changeling.Objectives.Components;
 using Content.Goobstation.Shared.Atmos.Components;
 using Content.Goobstation.Shared.Body.Components;
-using Content.Goobstation.Common.Changeling;
-using Content.Goobstation.Server.Changeling.Objectives.Components;
 using Content.Goobstation.Shared.Changeling.Actions;
 using Content.Goobstation.Shared.Changeling.Components;
 using Content.Goobstation.Shared.Temperature.Components;
 using Content.Server.Light.Components;
 using Content.Server.Nutrition.Components;
 using Content.Shared._Goobstation.Weapons.AmmoSelector;
+using Content.Shared._Starlight.CollectiveMind;
+using Content.Shared._Shitmed.Targeting; // Shitmed Change
 using Content.Shared.Actions;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
@@ -52,22 +55,20 @@ using Content.Shared.Damage.Prototypes;
 using Content.Shared.DoAfter;
 using Content.Shared.Ensnaring;
 using Content.Shared.Ensnaring.Components;
-using Content.Goobstation.Maths.FixedPoint;
+using Content.Shared.Eye.Blinding.Components;
+using Content.Shared.Humanoid;
+using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Mobs;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Popups;
-using Content.Shared._Starlight.CollectiveMind;
+using Content.Shared.Rejuvenate;
 using Content.Shared.Stealth.Components;
 using Content.Shared.Store.Components;
-using Content.Shared.Tag;
-using Content.Shared.Traits.Assorted;
 using Content.Shared.StatusEffect;
-using Content.Shared.Eye.Blinding.Components;
+using Content.Shared.Traits.Assorted;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
-using Content.Shared._Shitmed.Targeting; // Shitmed Change
-using Content.Shared.Rejuvenate;
 
 namespace Content.Goobstation.Server.Changeling;
 
@@ -191,15 +192,21 @@ public sealed partial class ChangelingSystem
         EnsureComp<AbsorbedComponent>(target);
         EnsureComp<UnrevivableComponent>(target);
 
-        var popup = Loc.GetString("changeling-absorb-end-self-ling");
+        var popup = string.Empty;
         var bonusChemicals = 0f;
         var bonusEvolutionPoints = 0f;
         var bonusChangelingAbsorbs = 0;
+
         if (TryComp<ChangelingIdentityComponent>(target, out var targetComp))
         {
+            popup = Loc.GetString("changeling-absorb-end-self-ling");
             bonusChemicals += targetComp.MaxChemicals / 2;
             bonusEvolutionPoints += targetComp.TotalEvolutionPoints / 2;
             bonusChangelingAbsorbs += targetComp.TotalChangelingsAbsorbed + 1;
+
+            if (!TryComp<HumanoidAppearanceComponent>(target, out var targetForm)
+                || targetForm.Species == "Monkey") // if they are a headslug or in monkey form
+                popup = Loc.GetString("changeling-absorb-end-self-ling-incompatible");
         }
         else
         {
@@ -318,7 +325,6 @@ public sealed partial class ChangelingSystem
         var target = args.Target;
         if (!TryStealDNA(uid, target, comp, true))
         {
-            _popup.PopupEntity(Loc.GetString("changeling-sting-extract-fail"), uid, uid);
             // royal cashback
             comp.Chemicals += Comp<ChangelingActionComponent>(args.Action).ChemicalCost;
         }
@@ -617,11 +623,32 @@ public sealed partial class ChangelingSystem
 
         var target = args.Target;
         var fakeArmblade = EntityManager.SpawnEntity(FakeArmbladePrototype, Transform(target).Coordinates);
-        if (!_hands.TryPickupAnyHand(target, fakeArmblade))
+
+        var handsValid = _hands.TryForcePickupAnyHand(target, fakeArmblade);
+
+        if (TryComp<HandsComponent>(target, out var handComp)
+            && handsValid)
+        {
+            var weaponCount = 0;
+
+            foreach (var hand in handComp.Hands.Values)
+            {
+                if (hand.HeldEntity != null
+                    && HasComp<ChangelingFakeWeaponComponent>(hand.HeldEntity.Value))
+                {
+                    weaponCount++;
+                }
+            }
+
+            handsValid = (weaponCount <= 1);
+
+        }
+
+        if (!handsValid)
         {
             QueueDel(fakeArmblade);
             comp.Chemicals += Comp<ChangelingActionComponent>(args.Action).ChemicalCost;
-            _popup.PopupEntity(Loc.GetString("changeling-sting-fail-simplemob"), uid, uid);
+            _popup.PopupEntity(Loc.GetString("changeling-sting-fail-fakeweapon"), uid, uid);
             return;
         }
 
@@ -842,7 +869,7 @@ public sealed partial class ChangelingSystem
         }
 
         _explosionSystem.QueueExplosion(
-            (EntityUid) newUid,
+            (EntityUid) newUid, 
             typeId: "Default",
             totalIntensity: 1,
             slope: 4,
@@ -865,6 +892,9 @@ public sealed partial class ChangelingSystem
             comp.Chemicals += Comp<ChangelingActionComponent>(args.Action).ChemicalCost;
             return;
         }
+
+        EnsureComp<AbsorbableComponent>((EntityUid) newUid); // allow other changelings to absorb them (monkeys dont have this by default)
+
         PlayMeatySound((EntityUid) newUid, comp);
     }
     public ProtoId<CollectiveMindPrototype> HivemindProto = "Lingmind";

--- a/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
@@ -36,6 +36,7 @@ using System.Numerics;
 using Content.Goobstation.Common.Actions;
 using Content.Goobstation.Common.Changeling;
 using Content.Goobstation.Common.MartialArts;
+using Content.Goobstation.Maths.FixedPoint;
 using Content.Goobstation.Server.Changeling.Objectives.Components;
 using Content.Goobstation.Server.Changeling.GameTicking.Rules;
 using Content.Goobstation.Shared.Flashbang;
@@ -73,7 +74,6 @@ using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Eye.Blinding.Components;
-using Content.Goobstation.Maths.FixedPoint;
 using Content.Shared.Fluids;
 using Content.Shared.Forensics.Components;
 using Content.Shared.Hands.EntitySystems;
@@ -81,6 +81,7 @@ using Content.Shared.Heretic;
 using Content.Shared.Humanoid;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Inventory;
+using Content.Shared.Medical;
 using Content.Shared.Mind;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -92,6 +93,7 @@ using Content.Shared.Nutrition.Components;
 using Content.Shared.Polymorph;
 using Content.Shared.Popups;
 using Content.Shared.Projectiles;
+using Content.Shared.Rejuvenate;
 using Content.Shared.Revolutionary.Components;
 using Content.Shared.Store.Components;
 using Content.Shared.Tag;
@@ -103,8 +105,6 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Serialization.Manager;
 using Robust.Shared.Timing;
-using Content.Shared.Medical;
-using Content.Shared.Rejuvenate;
 
 namespace Content.Goobstation.Server.Changeling;
 
@@ -453,10 +453,10 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
     {
         var target = action.Target;
 
-        // can't get his dna if he doesn't have it!
-        if (!HasComp<AbsorbableComponent>(target) || HasComp<AbsorbedComponent>(target))
+        // can't sting a dried out husk
+        if (HasComp<AbsorbedComponent>(target))
         {
-            _popup.PopupEntity(Loc.GetString("changeling-sting-fail"), uid, uid);
+            _popup.PopupEntity(Loc.GetString("changeling-sting-fail-hollow"), uid, uid);
             return false;
         }
 
@@ -576,12 +576,18 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
         || !TryComp<MetaDataComponent>(target, out var metadata)
         || !TryComp<DnaComponent>(target, out var dna)
         || !TryComp<FingerprintComponent>(target, out var fingerprint))
-            return false;
-
-        foreach (var storedDNA in comp.AbsorbedDNA)
         {
-            if (storedDNA.DNA != null && storedDNA.DNA == dna.DNA)
+            _popup.PopupEntity(Loc.GetString("changeling-sting-extract-fail-lesser"), uid, uid);
+            return false;
+        }
+
+        foreach (var storedDNA in comp.AbsorbedHistory)
+        {
+            if (storedDNA.DNA != null && storedDNA.DNA == dna.DNA) // the dna NEEDS to be unique
+            {
+                _popup.PopupEntity(Loc.GetString("changeling-sting-extract-fail-duplicate"), uid, uid);
                 return false;
+            }
         }
 
         var data = new TransformData
@@ -606,6 +612,8 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
             _popup.PopupEntity(Loc.GetString("changeling-sting-extract-max"), uid, uid);
         else
         {
+            comp.AbsorbedHistory.Add(data); // so we can't just come back and sting them again 
+
             comp.AbsorbedDNA.Add(data);
             comp.TotalStolenDNA++;
         }
@@ -616,6 +624,7 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
     private ChangelingIdentityComponent? CopyChangelingComponent(EntityUid target, ChangelingIdentityComponent comp)
     {
         var newComp = EnsureComp<ChangelingIdentityComponent>(target);
+        newComp.AbsorbedHistory = comp.AbsorbedHistory;
         newComp.AbsorbedDNA = comp.AbsorbedDNA;
         newComp.AbsorbedDNAIndex = comp.AbsorbedDNAIndex;
 

--- a/Content.Goobstation.Shared/Changeling/Components/ChangelingFakeWeaponComponent.cs
+++ b/Content.Goobstation.Shared/Changeling/Components/ChangelingFakeWeaponComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Goobstation.Shared.Changeling.Components;
+
+/// <summary>
+///     Marks an entity that currently has a fake changeling weapon.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ChangelingFakeWeaponComponent : Component
+{
+
+}

--- a/Content.Goobstation.Shared/Changeling/Components/ChangelingIdentityComponent.cs
+++ b/Content.Goobstation.Shared/Changeling/Components/ChangelingIdentityComponent.cs
@@ -147,8 +147,18 @@ public sealed partial class ChangelingIdentityComponent : Component
     public TimeSpan UpdateTimer = TimeSpan.Zero;
     public float UpdateCooldown = 1f;
 
+    /// <summary>
+    ///     All of the DNA that the changeling had extracted in their lifetime.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public List<TransformData> AbsorbedHistory = new();
+
+    /// <summary>
+    ///     The DNA that the changeling has stored up.
+    /// </summary>
     [ViewVariables(VVAccess.ReadOnly)]
     public List<TransformData> AbsorbedDNA = new();
+
     /// <summary>
     ///     Index of <see cref="AbsorbedDNA"/>. Used for switching forms.
     /// </summary>

--- a/Content.Server/Objectives/Components/PickRandomPersonComponent.cs
+++ b/Content.Server/Objectives/Components/PickRandomPersonComponent.cs
@@ -17,4 +17,7 @@ public sealed partial class PickRandomPersonComponent : Component
 {
     [DataField]
     public bool NeedsOrganic; // Goobstation: Only pick non-silicon players.
+
+    [DataField]
+    public bool ExcludeChangeling; // Goobstation: Determine if you can get changelings as an objective
 }

--- a/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
+++ b/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
@@ -73,7 +73,8 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
         if (target.Target != null)
             return;
 
-        var allHumans = _mind.GetAliveHumans(args.MindId);
+        var allHumans = _mind.GetAliveHumans(args.MindId,
+            ent.Comp.NeedsOrganic, ent.Comp.ExcludeChangeling); // Goob edit - exclude IPCs and/or changelings
 
         // Can't have multiple objectives to kill the same person
         foreach (var objective in args.Mind.Objectives)

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -53,6 +53,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Content.Goobstation.Common.Changeling; // Goobstation
 using Content.Shared._EinsteinEngines.Silicon.Components; // Goobstation
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
@@ -652,7 +653,8 @@ public abstract partial class SharedMindSystem : EntitySystem
     /// <summary>
     /// Returns a list of every living humanoid player's minds, except for a single one which is exluded.
     /// </summary>
-    public HashSet<Entity<MindComponent>> GetAliveHumans(EntityUid? exclude = null, bool excludeSilicon = false)
+    public HashSet<Entity<MindComponent>> GetAliveHumans(EntityUid? exclude = null,
+        bool excludeSilicon = false, bool excludeChangeling = false) // Goob edit - exclude certain groups of entities
     {
         var allHumans = new HashSet<Entity<MindComponent>>();
         // HumanoidAppearanceComponent is used to prevent mice, pAIs, etc from being chosen
@@ -666,6 +668,10 @@ public abstract partial class SharedMindSystem : EntitySystem
 
             // Goobstation: Skip IPCs from selections
             if (excludeSilicon && HasComp<SiliconComponent>(uid))
+                continue;
+
+            // Goobstation: Skip changelings from selections
+            if (excludeChangeling && HasComp<ChangelingComponent>(uid))
                 continue;
 
             allHumans.Add(new Entity<MindComponent>(mind, mindComp));

--- a/Resources/Locale/en-US/_Goobstation/Changeling/abilities/changeling.ftl
+++ b/Resources/Locale/en-US/_Goobstation/Changeling/abilities/changeling.ftl
@@ -20,6 +20,7 @@ changeling-absorb-fail-absorbed = They've already been absorbed.
 changeling-absorb-fail-unabsorbable = The target is not absorbable.
 changeling-absorb-end-self = The organism was absorbed. We are evolving.
 changeling-absorb-end-self-ling = Another changeling was absorbed. Our body is filled with immense vigor as our cells rapidly evolve.
+changeling-absorb-end-self-ling-incompatible = Another changeling was absorbed. However, their current form prevented us from extracting their DNA sequence.
 changeling-absorb-onexamine = [color=red]The body feels hollow.[/color]
 changeling-absorb-fail-nograb = We aren't grabbing hard enough.
 changeling-absorb-fail-onfire = The target is on fire, put them out first!
@@ -36,12 +37,14 @@ changeling-transform-fail-choose = We did not choose a form to transform into!
 changeling-transform-fail-absorbed = We can't transform a husk!
 changeling-transform-finish = We are now {$target}.
 
+changeling-sting = We silently sting {CAPITALIZE(THE($target))}
 changeling-sting-fail-self = We tried to sting {CAPITALIZE(THE($target))}, but something stopped us from doing it!
 changeling-sting-fail-ling = Someone just tried to silently sting us!
+changeling-sting-fail-fakeweapon = They will be unable to sustain a faux weapon.
+changeling-sting-fail-hollow = We are unable to sting a hollow organism.
 
-changeling-sting = We silently sting {CAPITALIZE(THE($target))}
-changeling-sting-fail-simplemob = We can't sting a lesser creature!
-changeling-sting-extract-fail = Unable to extract DNA
+changeling-sting-extract-fail-duplicate = We have already extracted this DNA in the past.
+changeling-sting-extract-fail-lesser = We can't extract DNA from a lesser creature!
 changeling-sting-extract-max = Need to get rid of the stored DNA beforehand
 
 changeling-dartgun-no-stings = We don't have any reagent stings evolved!

--- a/Resources/Locale/en-US/_Goobstation/Changeling/objectives/changeling.ftl
+++ b/Resources/Locale/en-US/_Goobstation/Changeling/objectives/changeling.ftl
@@ -13,7 +13,7 @@ objective-condition-absorb-description = We must absorb {$count} humanoids. It i
 objective-condition-absorb-other-title = Absorb {$count} other changeling(s).
 objective-condition-absorb-other-description = In order to attain true power, we must absorb changelings. {$count} will suffice.
 
-objective-condition-stealdna-title = Extract {$count} compatible genomes.
+objective-condition-stealdna-title = Extract {$count} compatible, unique genomes.
 objective-condition-stealdna-description = We must extract {$count} unique genomes.
 
 objective-condition-escape-identity-title = Escape on the evacuation shuttle alive and unrestrained while being {$targetName}, {CAPITALIZE($job)}.

--- a/Resources/Prototypes/_Goobstation/Changeling/Actions/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Actions/changeling.yml
@@ -393,7 +393,7 @@
 - type: entity
   id: ActionStingLethargic
   name: Lethargic Sting
-  description: Silently inject a cocktail of anesthetics into the target. Costs 25 chemicals.
+  description: Silently inject a cocktail of anesthetics into the target. Costs 30 chemicals.
   categories: [ HideSpawnMenu ]
   components:
   - type: EntityTargetAction
@@ -443,7 +443,7 @@
 - type: entity
   id: ActionStingFakeArmblade
   name: Fake Armblade Sting
-  description: Silently sting your target, making them grow a dull armblade for a short time. Costs 50 chemicals.
+  description: Silently sting your target, making them grow a dull armblade for a short time. Costs 30 chemicals.
   categories: [ HideSpawnMenu ]
   components:
   - type: EntityTargetAction
@@ -459,7 +459,7 @@
       state: sting_armblade
     event: !type:StingFakeArmbladeEvent {}
   - type: ChangelingAction
-    chemicalCost: 50
+    chemicalCost: 30
     useInLesserForm: true
 
 - type: entity

--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
@@ -42,6 +42,7 @@
     thresholds:
       0: Alive
       50: Dead
+  - type: Absorbable
   - type: NightVision # Goobstation - Nigthvision
     color: "#808080"
     activateSound: null

--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Objects/Weapons/Melee/changeling_armblade.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Objects/Weapons/Melee/changeling_armblade.yml
@@ -55,6 +55,7 @@
   parent: ArmBladeChangeling
   id: FakeArmBladeChangeling
   components:
+  - type: ChangelingFakeWeapon
   - type: MeleeWeapon
     damage:
       types:

--- a/Resources/Prototypes/_Goobstation/Changeling/Objectives/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Objectives/changeling.yml
@@ -101,6 +101,7 @@
     title: objective-condition-escape-identity-title
   - type: PickRandomPerson
     needsOrganic: true # Don't pick IPCs.
+    excludeChangeling: true # if they swap identities its a guarantee fail
 
 - type: entity
   parent: [BaseChangelingSyndicateObjective, BaseStealObjective]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
changelings can now absorb headslugs and lesser form (monkey) changelings
changelings will be able to sting simplemobs now (DNA extract will still not work)
dna extract objective now actually needs UNIQUE dna (everything must be different now)
fake armblade sting cost reduced to 30 and received a very minor refactor
lethargic sting description shouldn't lie to you now and actually says it takes 30 chems
some changes to the ftl's used and fixed some of them having weird ones (fake armblade sting had the one for... lesser form)
reorganised the usings (who cares tho)
reorganised like a tiny bit of the absorb method
pickrandomperson component should now actually have its fields used in pickobjectivetarget system
getalivehumans (method used for getting obj targets) now has the option to exclude changelings
changeling's "escape as x" objective should no longer picks changeling targets (instant unavoidable fail if they swap identities)

the other stuff that uses pickrandomperson will probably get a pr later (someone else can probably do it, its unimaginably easy)

## Why / Balance
how it feels to cuck a changeling out of their progression by turning into a monkey or headslug
how it feels to cuck a changeling out of their greentext by just swapping identities

dna extract was too easy (transform and sting the guy you just got the DNA from over and over)
nobody uses armblade sting (for now...........) so a lower price doesnt seem to be allat bad
changelings could sometimes very rarely get ipcs as their escape objective (a hunnet percent not because of upstream merge :trollface: )

everything else is self explanatory

## Technical details
added ChangelingFakeWeaponComponent and gave it to the fake armblade
outside of being used to count the fake armblades someone has (and prevent more from being given) it serves no real big purpose (FOR NOW............)

everything else is uhh c# slop
and a little bit of yaml

## Media

absorbing the headslug and unreal monkey

https://github.com/user-attachments/assets/69993de8-0441-4f6c-b692-f30cfb2261fb

dna extract and the other stinging stuff

https://github.com/user-attachments/assets/d2f7fc43-c37e-4289-abd4-a6af1b3e5dba

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Added a few new text popups for changeling stings.
- tweak: Changelings now need to extract UNIQUE genomes for the DNA extraction objective (a person cannot give you objective progress if you had previously extracted their DNA during the round).
- tweak: Changelings should no longer roll other changelings as their "escape as x's identity" target (if they swap identities its a guaranteed fail).
- tweak: Changelings are now able to absorb headslugs and other changelings who entered lesser (monkey) form.
- tweak: Fake armblade sting chem cost reduced to 30.
- tweak: Fake armblade sting will now force the target to drop an item in their hand if both are full (provided that the item can actually be dropped in the first place)
- tweak: Changeling stings (except for DNA extract) will now be able to work on simplemobs (monkeys, carp, pets ect).
- fix: Fake armblade sting should no longer tell you that you can't inject a monkey when the target's hands are full (the fact that nobody pointed this out earlier shows that literally nobody uses it).
- fix: Lethargic sting description now correctly display its chem cost of 30 (from 25).
- fix: Changelings should no longer be able to roll IPCs as their "escape with x's identity" target.
