### PR TITLE
Secet+ is ass, let's make it at least tolerable ...webedit ops my beloved <3

### DIFF
--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -19,6 +19,7 @@
 # SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
+# SPDX-FileCopyrightText: 2025 SaffronFennec <firefoxwolf2020@protonmail.com>
 # SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 keronshb <54602815+keronshb@users.noreply.github.com>
 #

--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -48,8 +48,8 @@
     agentName: thief-round-end-agent-name
     definitions:
     - prefRoles: [ Thief ]
-      max: 3
-      playerRatio: 15
+      max: 4
+      playerRatio: 20
       lateJoinAdditional: true
       allowNonHumans: true
       multiAntagSetting: NotExclusive

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -363,7 +363,7 @@
     definitions:
     - prefRoles: [ Traitor ]
       max: 6
-      playerRatio: 15
+      playerRatio: 12 
       blacklist:
         components:
         - AntagImmune

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -115,9 +115,11 @@
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
+# SPDX-FileCopyrightText: 2025 SaffronFennec <firefoxwolf2020@protonmail.com>
 # SPDX-FileCopyrightText: 2025 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
+# SPDX-FileCopyrightText: 2025 Southbridge <7013162+southbridge-fur@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Tayrtahn <tayrtahn@gmail.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -228,7 +228,7 @@
   - type: AntagSelection
   # Goobstation
   - type: GameRule
-    chaosScore: 1500
+    chaosScore: 1200
   - type: AntagLoadProfileRule
     speciesOverride: Human
     speciesOverrideBlacklist:

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -228,7 +228,7 @@
   - type: AntagSelection
   # Goobstation
   - type: GameRule
-    chaosScore: 1200
+    chaosScore: 1500
   - type: AntagLoadProfileRule
     speciesOverride: Human
     speciesOverrideBlacklist:
@@ -317,7 +317,7 @@
   - type: TraitorRule
   # Goobstation
   - type: GameRule
-    chaosScore: 900
+    chaosScore: 800
   # TODO: codewords in yml
   # TODO: uplink in yml
   - type: AntagSelection
@@ -360,8 +360,8 @@
     selectionTime: IntraPlayerSpawn # Goobstation
     definitions:
     - prefRoles: [ Traitor ]
-      max: 8
-      playerRatio: 10
+      max: 6
+      playerRatio: 15
       blacklist:
         components:
         - AntagImmune
@@ -376,14 +376,14 @@
   components:
   - type: GameRule
     minPlayers: 15
-    chaosScore: 1000 # Goobstation
+    chaosScore: 1200 # Goobstation
   - type: RevolutionaryRule
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn # Goobstation
     definitions:
     - prefRoles: [ HeadRev ]
-      max: 3
-      playerRatio: 15
+      max: 4
+      playerRatio: 20
       briefing:
         text: head-rev-role-greeting
         color: CornflowerBlue

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -17,6 +17,7 @@
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
+# SPDX-FileCopyrightText: 2025 SaffronFennec <firefoxwolf2020@protonmail.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -52,7 +52,7 @@
     definitions:
     - prefRoles: [ Changeling ]
       max: 6
-      playerRatio: 15
+      playerRatio: 12
       jobBlacklist: [ Chaplain ] # GOOBSTATION
       lateJoinAdditional: true
       mindRoles:
@@ -73,7 +73,7 @@
     definitions:
     - prefRoles: [ Traitor ]
       max: 3
-      playerRatio: 30
+      playerRatio: 25
       blacklist:
         components:
         - AntagImmune
@@ -98,7 +98,7 @@
     definitions:
     - prefRoles: [ Changeling ]
       max: 3
-      playerRatio: 30
+      playerRatio: 25
       lateJoinAdditional: true
       mindRoles:
       - MindRoleChangeling
@@ -266,6 +266,8 @@
   parent: BaseNukeopsRule
   id: Honkops
   components:
+  - type: GameRule
+    chaosScore: 1000
   - type: RandomMetadata # this generates the random operation name cuz it's cool.
     nameSegments:
     - OperationPrefixHonkops

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -34,7 +34,7 @@
   - type: ChangelingRule
   - type: GameRule
     minPlayers: 15
-    chaosScore: 800
+    chaosScore: 1000
   - type: AntagRandomObjectives
     sets:
     - groups: ChangelingObjectiveGroups
@@ -50,8 +50,8 @@
     agentName: changeling-roundend-name
     definitions:
     - prefRoles: [ Changeling ]
-      max: 4
-      playerRatio: 12
+      max: 6
+      playerRatio: 15
       jobBlacklist: [ Chaplain ] # GOOBSTATION
       lateJoinAdditional: true
       mindRoles:
@@ -66,13 +66,13 @@
   components:
   - type: GameRule
     minPlayers: 30
-    chaosScore: 700
+    chaosScore: 450
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
     definitions:
     - prefRoles: [ Traitor ]
       max: 3
-      playerRatio: 15
+      playerRatio: 30
       blacklist:
         components:
         - AntagImmune
@@ -90,14 +90,14 @@
   components:
   - type: GameRule
     minPlayers: 30
-    chaosScore: 450
+    chaosScore: 600
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
     agentName: changeling-roundend-name
     definitions:
     - prefRoles: [ Changeling ]
-      max: 2
-      playerRatio: 15
+      max: 3
+      playerRatio: 30
       lateJoinAdditional: true
       mindRoles:
       - MindRoleTraitor
@@ -342,7 +342,7 @@
   components:
   - type: DevilRule
   - type: GameRule
-    chaosScore: 350 # low since they tend to revive people and stuff
+    chaosScore: 200 # low since they tend to revive people and stuff
     minPlayers: 15
   - type: AntagObjectives
     objectives:

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -101,7 +101,7 @@
       playerRatio: 30
       lateJoinAdditional: true
       mindRoles:
-      - MindRoleTraitor
+      - MindRoleChangeling
   - type: Tag
     tags:
       - CalmAntag

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -19,13 +19,16 @@
   weights: # Fun Fact: There's 0 reason to use decimals except for clean percentages, but chaos scores *also* change chances so it makes 0 sense to have it here and it makes new modes harder :shrug:
     # subgamemodes
     Thief: 3
-    Devil: 2
+    Devil: 3
     # normal
     Traitor: 5
     CalmTraitor: 3
-    Changeling: 2
+    Changeling: 3
     CalmLing: 2
-    Heretic: 3
+    Heretic: 4
+    # major solo
+    BlobGameMode: 1
+    Wizard: 1
 
 # important note: those (and above) weights aren't entirely accurate,
 # as secret+ can randomly decide it's not going to use this gamerule

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -16,14 +16,16 @@
 # extras to pick if primary didn't spend our chaos budget
 - type: weightedRandom
   id: SecretPlus
-  weights:
+  weights: # Fun Fact: There's 0 reason to use decimals except for clean percentages, but chaos scores *also* change chances so it makes 0 sense to have it here and it makes new modes harder :shrug:
     # subgamemodes
-    Thief: 0.2
-    Devil: 0.1
+    Thief: 3
+    Devil: 2
     # normal
-    Traitor: 0.25
-    Changeling: 0.10
-    Heretic: 0.11
+    Traitor: 5
+    CalmTraitor: 3
+    Changeling: 2
+    CalmLing: 2
+    Heretic: 3
 
 # important note: those (and above) weights aren't entirely accurate,
 # as secret+ can randomly decide it's not going to use this gamerule
@@ -32,32 +34,32 @@
 # however the amount of effective budget used is reduced for primary rule so this only matters on low/midpop
 - type: weightedRandom
   id: SecretPlusPrimary
-  weights:
-    Traitor: 0.25
-    Changeling: 0.10
-    Heretic: 0.11
-    Nukeops: 0.05
-    Revolutionary: 0.05
-    Zombie: 0.04 # in search of how to make a rule always run alone? just tag it with LoneRunRule like zombies are
-    BlobGameMode: 0.05
-    Wizard: 0.025
-    CosmicCult: 0.05
+  weights: # 
+    Traitor: 15
+    Changeling: 10
+    Heretic: 8
+    Nukeops: 4
+    Revolutionary: 4
+    Zombie: 1 #2% Chance pre score effects for example currently [zombies are ass]
+    BlobGameMode: 2
+    Wizard: 2
+    CosmicCult: 4
 
 # all antags
 - type: weightedRandom
   id: SecretPlusChaos
   weights:
-    Thief: 0.2
-    Devil: 0.1
-    Traitor: 0.25
-    Changeling: 0.10
-    Heretic: 0.11
-    Nukeops: 0.05
-    Revolutionary: 0.05
-    Zombie: 0.04
-    BlobGameMode: 0.05
-    Wizard: 0.025
-    CosmicCult: 0.05
+    Thief: 6
+    Devil: 4
+    Traitor: 15
+    Changeling: 10
+    Heretic: 8
+    Nukeops: 4
+    Revolutionary: 4
+    Zombie: 1
+    BlobGameMode: 2
+    Wizard: 2
+    CosmicCult: 4
 
 - type: entity
   id: SecretPlusMid
@@ -66,8 +68,8 @@
   components:
   - type: SecretPlus
     # if you've come here due to "too many antags", you probably want to raise playerRatio on the individual antag rules instead
-    minStartingChaos: 10 # scales per player
-    maxStartingChaos: 20
+    minStartingChaos: 15 # scales per player
+    maxStartingChaos: 30
     livingChaosChange: -0.012
     deadChaosChange: 0.024
     # chance for greenshift as well as evilshift
@@ -87,8 +89,8 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: SecretPlus
-    minStartingChaos: 40
-    maxStartingChaos: 40 # ling-blob-nukeops is fun
+    minStartingChaos: 60
+    maxStartingChaos: 60 # ling-blob-nukeops is fun - And apparently even 40 chaos creates almost average games pre-change. Even after some small changes / fixes it needs an increase
     livingChaosChange: -0.03
     deadChaosChange: 0.03
     chaosExponent: 1

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
+# SPDX-FileCopyrightText: 2025 SaffronFennec <firefoxwolf2020@protonmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -43,7 +43,8 @@
     Changeling: 10
     Heretic: 8
     Nukeops: 4
-    Revolutionary: 4
+    Honkops: 1
+    Revolutionary: 3
     Zombie: 1 #2% Chance pre score effects for example currently [zombies are ass]
     BlobGameMode: 2
     Wizard: 2
@@ -59,7 +60,8 @@
     Changeling: 10
     Heretic: 8
     Nukeops: 4
-    Revolutionary: 4
+    Honkops: 1
+    Revolutionary: 3
     Zombie: 1
     BlobGameMode: 2
     Wizard: 2

--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -20,8 +20,8 @@
   components:
   - type: HereticRule
   - type: GameRule
-    minPlayers: 15
-    chaosScore: 800
+    minPlayers: 20
+    chaosScore: 700
   - type: AntagObjectives
     objectives:
     - HereticKnowledgeObjective
@@ -32,8 +32,8 @@
     agentName: heretic-roundend-name
     definitions:
     - prefRoles: [ Heretic ]
-      max: 3
-      playerRatio: 15
+      max: 4
+      playerRatio: 20
       lateJoinAdditional: true
       jobBlacklist: [ Chaplain ] # GOOBSTATION
       mindRoles:

--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -7,8 +7,10 @@
 # SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
+# SPDX-FileCopyrightText: 2025 SaffronFennec <firefoxwolf2020@protonmail.com>
 # SPDX-FileCopyrightText: 2025 TheBorzoiMustConsume <197824988+TheBorzoiMustConsume@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
 #


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Secret+ as a concept immediately fails by how chaos scales. Less players already means less antags already, yet chaos still decreases. it's just a worse dynamic really. And even at high pop it generates games that are basically what "blueshift" means.

...Am i gonna fix that... yet? Fuckkk no, that's a PR for a different day. But i can bump up the chaos [even the admeme variant barely made the average secret ling shift amped up a bit and 2 sides], change around player ratios and make weights a little less ass, and replace those pesky decimals that make new antags less of a weight ass pain! <3


Basically a bandaid for this shit. Expect Secret++ eventually / dynamic 2.0 / The Guiding-er Guide one day. Dream of it girl, it will actually not be blatantly flawed, waow! [Thanks ilya anyways, you may of burnt it yet you still cooked!]

## Why / Balance
Chaos up by 50% - Even chaos mode barely generates an amped up secret shift, mayyybeee 2 major antags when lucky. Both Medium and Chaos have been amped up by 50% because of this. Hell they may even need a 2x but we'll see +50% first.

Balanced Player Ratios - Changeling max? 4. Traitor max? 8. what costs more...? Lings, apparently... - Both have been made 6, and their calm variants 3. 15/30 players per antag. Additionally thief, heretic and revs have been given 4 as a max but a higher ratio so they scale better. no more 3 of any at 45 /and/ 80, they'd now be 2 and 4 at each. Revs has been score-bumped to 1200 like the other major teams to compensate.

Calm Variants in Rotation - They already had chaos scores, why not use them? Helps when there's smaller chaos scores left, as they naturally have a higher chance to trigger and pad out the shift. Also helps prevent the primary being the only roll when chaos is low more, not a cure though.

Major Solos in Secondary - Generally makes them not stupidly rare as well as letting them roll with majors. Guide let this happen, so should secret+ - And either way it'd happen pretty rarely, maybe 1-1.5% of games at best.

The weight changes - Fun Fact: The decimal percentages aren't actually needed except for a clean way to tell the chance- problem: Secret+ changes chances if a score's too low. ...which happens literally every game currently as you'd need 120 players pre-score change to guarantee that a major had 100% chance. Even after the change it'll happen pretty often. Also, adding a new antag meant /everything/ had to change. imagine trying to cleanly fit 8 major antags into 30-35%... There's already 6 by the way.

New weights:
Primary - Traitor 15 [30%], Changeling 10 [20%], Heretic 8 [16%], Nuclear 4 [8%], Revs 3 [6% - Revs suck!!!], Cult 4 [8%], Blob 2 [4%], wizard 2 [4%], Zombies 1 [2%], Honkops 1 [2%] - 34% chance for a major antag at 1200+ score.
Secondary - Thief 3 [12%], Devil 3 [12%], Traitor 5 [20%], CalmTraitor 3 [12%], Lings 3 [12%], CalmLings 2 [8%], Heretic 4 [16%], Blob 1 [4%], wizard 1 [4%] - Swap the calm and normal, add calmheretic if secret+ still fucks up the secondary antag that often.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [<3] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [<3] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Secret+ still sucks... but sucks a little less now, having a higher chaos score scale, cleaner weights, more balanced ratios... etc. Most changes besides more antags, less crazy variation and higher chances of major antags aren't very noticable. Have fun! <3
- tweak: Honk operatives can now roll in secret+
