### PR TITLE
SurgeryIgnoreClothing fix

### DIFF
--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -24,7 +24,6 @@ using Content.Shared.Bed.Sleep;
 using Content.Shared.Body.Part;
 using Content.Shared.Body.Organ;
 using Content.Shared._Shitmed.BodyEffects;
-using Content.Shared._Shitmed.Body.Events;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Damage;
@@ -48,7 +47,6 @@ using Content.Shared.Popups;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using System.Linq;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Content.Shared._Shitmed.Medical.Surgery;
 
@@ -124,8 +122,6 @@ public abstract partial class SharedSurgerySystem
         if (TryToolOrganCheck(ent.Comp.AddOrganOnAdd, args.Part)
             || TryToolOrganCheck(ent.Comp.RemoveOrganOnAdd, args.Part, checkMissing: false))
             args.Cancelled = true;
-
-
     }
 
     private void OnToolCanPerform(Entity<SurgeryStepComponent> ent, ref SurgeryCanPerformStepEvent args)
@@ -140,11 +136,10 @@ public abstract partial class SharedSurgerySystem
             }
         }
 
-        if (_inventory.TryGetContainerSlotEnumerator(args.Body, out var containerSlotEnumerator, args.TargetSlots))
+        if (!HasComp<SurgeryIgnoreClothingComponent>(args.User)
+            && !HasComp<SurgeryIgnoreClothingComponent>(args.Tool)
+            && _inventory.TryGetContainerSlotEnumerator(args.Body, out var containerSlotEnumerator, args.TargetSlots))
         {
-            if (HasComp<SurgeryIgnoreClothingComponent>(args.User))
-                return;
-
             while (containerSlotEnumerator.MoveNext(out var containerSlot))
             {
                 if (!containerSlot.ContainedEntity.HasValue)
@@ -161,24 +156,24 @@ public abstract partial class SharedSurgerySystem
         if (args.Invalid != StepInvalidReason.None)
             return;
 
-        if (ent.Comp.Tool != null)
+        if (ent.Comp.Tool == null)
+            return;
+
+        args.ValidTools ??= new Dictionary<EntityUid, float>();
+
+        foreach (var reg in ent.Comp.Tool.Values)
         {
-            args.ValidTools ??= new Dictionary<EntityUid, float>();
-
-            foreach (var reg in ent.Comp.Tool.Values)
+            if (!HasSurgeryComp(args.Tool, reg.Component, out var speed))
             {
-                if (!AnyHaveComp(args.Tools, reg.Component, out var tool, out var speed))
-                {
-                    args.Invalid = StepInvalidReason.MissingTool;
+                args.Invalid = StepInvalidReason.MissingTool;
 
-                    if (reg.Component is ISurgeryToolComponent required)
-                        args.Popup = $"You need {required.ToolName} to perform this step!";
+                if (reg.Component is ISurgeryToolComponent required)
+                    args.Popup = $"You need {required.ToolName} to perform this step!";
 
-                    return;
-                }
-
-                args.ValidTools[tool] = speed;
+                return;
             }
+
+            args.ValidTools[args.Tool] = speed;
         }
     }
 
@@ -269,23 +264,18 @@ public abstract partial class SharedSurgerySystem
 
     private void OnAddPartStep(Entity<SurgeryAddPartStepComponent> ent, ref SurgeryStepEvent args)
     {
-        if (!TryComp(args.Surgery, out SurgeryPartRemovedConditionComponent? removedComp))
+        if (!TryComp(args.Surgery, out SurgeryPartRemovedConditionComponent? removedComp)
+            || !TryComp(args.Tool, out BodyPartComponent? partComp)
+            || partComp.PartType != removedComp.Part
+            || removedComp.Symmetry != null && partComp.Symmetry != removedComp.Symmetry)
             return;
 
-        foreach (var tool in args.Tools)
-        {
-            if (TryComp(tool, out BodyPartComponent? partComp)
-                && partComp.PartType == removedComp.Part
-                && (removedComp.Symmetry == null || partComp.Symmetry == removedComp.Symmetry))
-            {
-                var slotName = removedComp.Symmetry != null
-                    ? $"{removedComp.Symmetry?.ToString().ToLower()} {removedComp.Part.ToString().ToLower()}"
-                    : removedComp.Part.ToString().ToLower();
-                _body.TryCreatePartSlot(args.Part, slotName, partComp.PartType, partComp.Symmetry, out var _);
-                _body.AttachPart(args.Part, slotName, tool);
-                EnsureComp<BodyPartReattachedComponent>(tool);
-            }
-        }
+        var slotName = removedComp.Symmetry != null
+                ? $"{removedComp.Symmetry?.ToString().ToLower()} {removedComp.Part.ToString().ToLower()}"
+                : removedComp.Part.ToString().ToLower();
+            _body.TryCreatePartSlot(args.Part, slotName, partComp.PartType, partComp.Symmetry, out var _);
+            _body.AttachPart(args.Part, slotName, args.Tool);
+            EnsureComp<BodyPartReattachedComponent>(args.Tool);
     }
 
     private void OnAddOrganSlotStep(Entity<SurgeryAddOrganSlotStepComponent> ent, ref SurgeryStepEvent args)
@@ -371,23 +361,20 @@ public abstract partial class SharedSurgerySystem
         if (firstOrgan == default)
             return;
 
-        foreach (var tool in args.Tools)
-        {
-            if (HasComp(tool, firstOrgan.Component.GetType())
-                && TryComp<OrganComponent>(tool, out var insertedOrgan)
-                && _body.InsertOrgan(args.Part, tool, insertedOrgan.SlotId, partComp, insertedOrgan))
-            {
-                EnsureComp<OrganReattachedComponent>(tool);
-                if (_body.TrySetOrganUsed(tool, true, insertedOrgan)
-                    && insertedOrgan.OriginalBody != args.Body)
-                {
-                    var ev = new SurgeryStepDamageChangeEvent(args.User, args.Body, args.Part, ent);
-                    RaiseLocalEvent(ent, ref ev);
-                    args.Complete = true;
-                }
-                break;
-            }
-        }
+        if (!HasComp(args.Tool, firstOrgan.Component.GetType())
+            || !TryComp<OrganComponent>(args.Tool, out var insertedOrgan)
+            || !_body.InsertOrgan(args.Part, args.Tool, insertedOrgan.SlotId, partComp, insertedOrgan))
+            return;
+
+        EnsureComp<OrganReattachedComponent>(args.Tool);
+
+        if (!_body.TrySetOrganUsed(args.Tool, true, insertedOrgan)
+            || insertedOrgan.OriginalBody == args.Body)
+            return;
+
+        var ev = new SurgeryStepDamageChangeEvent(args.User, args.Body, args.Part, ent);
+            RaiseLocalEvent(ent, ref ev);
+            args.Complete = true;
     }
 
     private void OnAddOrganCheck(Entity<SurgeryAddOrganStepComponent> ent, ref SurgeryStepCompleteCheckEvent args)
@@ -473,7 +460,6 @@ public abstract partial class SharedSurgerySystem
         foreach (var reg in organComp.Organ.Values)
         {
             if (_body.TryGetBodyPartOrgans(args.Part, reg.Component.GetType(), out var organs)
-                && organs != null
                 && organs.Count > 0)
             {
                 args.Cancelled = true;
@@ -494,29 +480,25 @@ public abstract partial class SharedSurgerySystem
             return;
 
         var markingCategory = MarkingCategoriesConversion.FromHumanoidVisualLayers(ent.Comp.MarkingCategory);
-        foreach (var tool in args.Tools)
+
+        if (!TryComp(args.Tool, out MarkingContainerComponent? markingComp)
+            || !HasComp(args.Tool, organType.Component.GetType())
+            || !bodyAppearance.MarkingSet.Markings.TryGetValue(markingCategory, out var markingList)
+            || markingList.Any(marking => marking.MarkingId.Contains(ent.Comp.MatchString)))
+            return;
+
+        EnsureComp<BodyPartAppearanceComponent>(args.Part);
+        _body.ModifyMarkings(args.Body, args.Part, bodyAppearance, ent.Comp.MarkingCategory, markingComp.Marking);
+
+        if (ent.Comp.Accent != null
+            && ent.Comp.Accent.Values.FirstOrDefault() is { } accent)
         {
-            if (TryComp(tool, out MarkingContainerComponent? markingComp)
-                && HasComp(tool, organType.Component.GetType()))
-            {
-                if (!bodyAppearance.MarkingSet.Markings.TryGetValue(markingCategory, out var markingList)
-                    || !markingList.Any(marking => marking.MarkingId.Contains(ent.Comp.MatchString)))
-                {
-                    EnsureComp<BodyPartAppearanceComponent>(args.Part);
-                    _body.ModifyMarkings(args.Body, args.Part, bodyAppearance, ent.Comp.MarkingCategory, markingComp.Marking);
-
-                    if (ent.Comp.Accent != null
-                        && ent.Comp.Accent.Values.FirstOrDefault() is { } accent)
-                    {
-                        var compType = accent.Component.GetType();
-                        if (!HasComp(args.Body, compType))
-                            AddComp(args.Body, _compFactory.GetComponent(compType));
-                    }
-
-                    QueueDel(tool); // Again since this isnt actually being inserted we just delete it lol.
-                }
-            }
+            var compType = accent.Component.GetType();
+            if (!HasComp(args.Body, compType))
+                AddComp(args.Body, _compFactory.GetComponent(compType));
         }
+
+        QueueDel(args.Tool); // Again since this isnt actually being inserted we just delete it lol.
 
     }
 
@@ -727,14 +709,14 @@ public abstract partial class SharedSurgerySystem
             return true;
         foreach (var reg in ent.Comp.Tool.Values)
         {
-            if (!AnyHaveComp(args.Tools, reg.Component, out var tool, out _))
+            if (!HasSurgeryComp(args.Tool, reg.Component, out _))
                 return false;
 
             if (_net.IsServer &&
-                TryComp(tool, out SurgeryToolComponent? toolComp) &&
+                TryComp(args.Tool, out SurgeryToolComponent? toolComp) &&
                 toolComp.EndSound != null)
             {
-                _audio.PlayPvs(toolComp.EndSound, tool);
+                _audio.PlayPvs(toolComp.EndSound, args.Tool);
             }
         }
 
@@ -800,7 +782,7 @@ public abstract partial class SharedSurgerySystem
         if (components == null)
             return false;
 
-        foreach (var (key,entry) in components)
+        foreach (var (_, entry) in components)
         {
             var hasComponent = HasComp(target, entry.Component.GetType());
             if (checkMissing != hasComponent)
@@ -892,8 +874,7 @@ public abstract partial class SharedSurgerySystem
         // TODO: Move 2 seconds to a field of SurgeryStepComponent
         var duration = GetSurgeryDuration(step, user, body, speed);
 
-        if (TryComp(user, out SurgerySpeedModifierComponent? surgerySpeedMod)
-            && surgerySpeedMod is not null)
+        if (TryComp(user, out SurgerySpeedModifierComponent? surgerySpeedMod))
             duration = duration / surgerySpeedMod.SpeedModifier;
 
         var doAfter = new DoAfterArgs(EntityManager, user, TimeSpan.FromSeconds(duration), ev, body, part)
@@ -1018,7 +999,7 @@ public abstract partial class SharedSurgerySystem
             _ => SlotFlags.NONE
         };
 
-        var check = new SurgeryCanPerformStepEvent(user, body, GetTools(user), slot);
+        var check = new SurgeryCanPerformStepEvent(user, body, _hands.GetActiveItemOrSelf(user), slot);
         RaiseLocalEvent(step, ref check);
         popup = check.Popup;
         validTools = check.ValidTools;
@@ -1051,19 +1032,14 @@ public abstract partial class SharedSurgerySystem
         return !ev.Cancelled;
     }
 
-    private bool AnyHaveComp(List<EntityUid> tools, IComponent component, out EntityUid withComp, out float speed)
+    private bool HasSurgeryComp(EntityUid tool, IComponent component, out float speed)
     {
-        foreach (var tool in tools)
+        if (EntityManager.TryGetComponent(tool, component.GetType(), out var found) && found is ISurgeryToolComponent toolComp)
         {
-            if (EntityManager.TryGetComponent(tool, component.GetType(), out var found) && found is ISurgeryToolComponent toolComp)
-            {
-                withComp = tool;
-                speed = toolComp.Speed;
-                return true;
-            }
+            speed = toolComp.Speed;
+            return true;
         }
 
-        withComp = EntityUid.Invalid;
         speed = 1f;
         return false;
     }

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
@@ -22,7 +22,6 @@ using Content.Shared._Shitmed.Medical.Surgery.Steps;
 using Content.Shared._Shitmed.Medical.Surgery.Steps.Parts;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds.Systems;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds.Components;
-using Content.Shared._Shitmed.Medical.Surgery.Traumas.Components;
 using Content.Shared._Shitmed.Medical.Surgery.Traumas.Systems;
 //using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Buckle.Components;
@@ -30,7 +29,6 @@ using Content.Shared.Body.Components;
 using Content.Shared.Body.Part;
 using Content.Shared.Body.Systems;
 using Content.Shared.Containers.ItemSlots;
-using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.GameTicking;
@@ -47,7 +45,6 @@ using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
-using Robust.Shared.Utility;
 
 namespace Content.Shared._Shitmed.Medical.Surgery;
 
@@ -169,7 +166,7 @@ public abstract partial class SharedSurgerySystem : EntitySystem
 
         var complete = IsStepComplete(ent, part, args.Step, surgery);
         args.Repeat = HasComp<SurgeryRepeatableStepComponent>(step) && !complete;
-        var ev = new SurgeryStepEvent(args.User, ent, part, GetTools(args.User), surgery, step, complete);
+        var ev = new SurgeryStepEvent(args.User, ent, part, _hands.GetActiveItemOrSelf(args.User), surgery, step, complete);
         RaiseLocalEvent(step, ref ev);
         RaiseLocalEvent(args.User, ref ev);
         RefreshUI(ent);
@@ -448,11 +445,6 @@ public abstract partial class SharedSurgerySystem : EntitySystem
         }
 
         return ent;
-    }
-
-    private List<EntityUid> GetTools(EntityUid surgeon)
-    {
-        return _hands.EnumerateHeld(surgeon).ToList();
     }
 
     public bool IsLyingDown(EntityUid entity, EntityUid user)

--- a/Content.Shared/_Shitmed/Surgery/Steps/SurgeryCanPerformStepEvent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Steps/SurgeryCanPerformStepEvent.cs
@@ -13,7 +13,7 @@ namespace Content.Shared._Shitmed.Medical.Surgery.Steps;
 public record struct SurgeryCanPerformStepEvent(
     EntityUid User,
     EntityUid Body,
-    List<EntityUid> Tools,
+    EntityUid Tool,
     SlotFlags TargetSlots,
     string? Popup = null,
     StepInvalidReason Invalid = StepInvalidReason.None,

--- a/Content.Shared/_Shitmed/Surgery/SurgeryStepEvent.cs
+++ b/Content.Shared/_Shitmed/Surgery/SurgeryStepEvent.cs
@@ -13,7 +13,7 @@ namespace Content.Shared._Shitmed.Medical.Surgery;
 ///     Raised on the step entity and the user after doing a step.
 /// </summary>
 [ByRefEvent]
-public record struct SurgeryStepEvent(EntityUid User, EntityUid Body, EntityUid Part, List<EntityUid> Tools, EntityUid Surgery, EntityUid Step, bool Complete);
+public record struct SurgeryStepEvent(EntityUid User, EntityUid Body, EntityUid Part, EntityUid Tool, EntityUid Surgery, EntityUid Step, bool Complete);
 
 /// <summary>
 /// Raised on the user after failing to do a step for any reason.

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -693,9 +693,7 @@
   - type: Item
     size: Small
     heldPrefix: evil
-  - type: HeldGrantComponent
-    components:
-    - type: SurgeryIgnoreClothing
+  - type: SurgeryIgnoreClothing
 
 - type: entity
   id: OmnimedToolDebug
@@ -725,6 +723,3 @@
     speed: 10
   - type: Stitches
     speed: 10
-  - type: HeldGrantComponent
-    components:
-    - type: SurgeryIgnoreClothing

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/yowie.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Species/yowie.yml
@@ -60,6 +60,8 @@
     damage:
       types:
         Blunt: 4
+  - type: SurgeryTarget
+    sepsisImmune: true
   - type: Fixtures
     fixtures: # TODO: This needs a second fixture just for mob collisions.
       fix1:


### PR DESCRIPTION
Removes some goida from surgery code, adds some to compensate.
Surgery now only uses the active hand (makes sense)
Fixes SurgeryIgnoreClothing users not getting speed bonuses from tools, not playing surgery sounds and trying to start surgery even with a wrong tool
Oh and you can apply it to surgery tools itself now not only to users, so nukie agent (and inherently admeme) omnitools are no longer use goidafied HeldGrantComponent

Also random specie in dev lobby W, apparently yowies took poison damage from surgery, it's two yaml lines fix

## Media
Tested, works

:cl:
- tweak: Surgery now requires to hold the tool in the active hand.
- fix: Performing surgery through clothes now applies speed modifiers and plays sounds.
- fix: Yowies are not affected by poison damage from surgery anymore.