### PR TITLE
Cull uplink weapons

### DIFF
--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -350,6 +350,9 @@
     Telecrystal: 50
   categories:
   - UplinkWeaponry
+  conditions:
+  - !type:BuyerJobCondition
+    whitelist: []
 
 - type: listing
   id: UplinkSyndicateDisabler
@@ -397,17 +400,9 @@
     Telecrystal: 65 # fire
   categories:
   - UplinkWeaponry
-
-- type: listing
-  id: UplinkWeaponRifleBurner
-  name: uplink-weapon-burner-name
-  description: uplink-weapon-burner-desc
-  icon: { sprite: /Textures/_Goobstation/Objects/Weapons/Guns/Rifles/burner.rsi, state: icon }
-  productEntity: WeaponRifleBurner
-  cost:
-    Telecrystal: 100 # don't kill me piras
-  categories:
-  - UplinkWeaponry
+  conditions:
+  - !type:BuyerJobCondition
+    whitelist: []
 
 - type: listing
   id: UplinkWeaponShotgunHeavy
@@ -419,6 +414,9 @@
     Telecrystal: 200
   categories:
   - UplinkWeaponry
+  conditions:
+  - !type:BuyerJobCondition
+    whitelist: []
 
 - type: listing
   id: UplinkBowHardlight
@@ -456,6 +454,9 @@
     Telecrystal: 38 # This + esword = 75 TC
   categories:
   - UplinkWeaponry
+  conditions:
+  - !type:BuyerJobCondition
+    whitelist: []
 
 - type: listing
   id: UplinkBulkMosin
@@ -466,37 +467,6 @@
     Telecrystal: 25
   categories:
     - UplinkWeaponry
-
-- type: listing
-  id: UplinkWeaponM7S
-  name: uplink-m7s-name
-  description: uplink-m7s-desc
-  productEntity: WeaponSubMachineGunM7S
-  cost:
-    Telecrystal: 60
-  categories:
-    -  UplinkWeaponry
-
-- type: listing
-  id: UplinkWeaponHE1SG8
-  name: uplink-he1sg8-bundle-name
-  description: uplink-he1sg8-bundle-desc
-  icon: { sprite: _Goobstation/Objects/Weapons/Guns/Snipers/heavensgate.rsi, state: base }
-  productEntity: ClothingBackpackDuffelSyndicateFilledHE1SG8
-  cost:
-    Telecrystal: 130
-  categories:
-    - UplinkWeaponry
-
-- type: listing
-  id: UplinkWeaponCombatShotgun
-  name: uplink-combat-shotgun-name
-  description: uplink-combat-shotgun-desc
-  productEntity: WeaponShotgunCombat
-  cost:
-    Telecrystal: 50
-  categories:
-    -  UplinkWeaponry
 
 # Wearables
 
@@ -1064,6 +1034,9 @@
     Telecrystal: 8
   categories:
   - UplinkAmmo
+  conditions:
+  - !type:BuyerJobCondition
+    whitelist: []
 
 - type: listing
   id: UplinkMagazineHighCaliberExplosive
@@ -1075,6 +1048,9 @@
     Telecrystal: 12
   categories:
   - UplinkAmmo
+  conditions:
+  - !type:BuyerJobCondition
+    whitelist: []
 
 #- type: listing # A box, really? Why not like... mags?
 #  id: UplinkHighCaliberBox
@@ -1097,6 +1073,9 @@
     Telecrystal: 30
   categories:
   - UplinkAmmo
+  conditions:
+  - !type:BuyerJobCondition
+    whitelist: [ ]
 
 - type: listing
   id: UplinkMagazineShotgunHeavySlug
@@ -1108,6 +1087,9 @@
     Telecrystal: 40
   categories:
   - UplinkAmmo
+  conditions:
+  - !type:BuyerJobCondition
+    whitelist: []
 
 # 弾薬
 - type: listing
@@ -1131,6 +1113,9 @@
     Telecrystal: 8 # Much more damage than C20 or M90 (780, 98 dmg per TC), but hollow-point
   categories:
   - UplinkAmmo
+  conditions:
+  - !type:BuyerJobCondition
+    whitelist: [ ]
 
 - type: listing
   id: UplinkHighCapacityMagazinePistol
@@ -1180,80 +1165,6 @@
   categories:
   - UplinkAmmo
 
-- type: listing
-  id: UplinkMagazineM7S
-  name: uplink-m7s-mag-name
-  description: uplink-m7s-mag-desc
-  icon: { sprite: _Goobstation/Objects/Weapons/Guns/Ammunition/Magazine/M7S_magazine.rsi, state: icon }
-  productEntity: MagazineLowCaliberM7S
-  cost:
-    Telecrystal: 5 # 105 dmg per TC which seems huge, but you're missing half of your shots
-  categories:
-  - UplinkAmmo
-
-- type: listing
-  id: UplinkCartridgeG8Demolishing
-  name: uplink-cartridge-G8-demolishing-name
-  description: uplink-cartridge-G8-demolishing-desc
-  productEntity:  CartridgeG8Demolishing
-  cost:
-    Telecrystal: 6 # 12% cheaper than the bundle, coherency with china
-  categories:
-  - UplinkAmmo
-
-- type: listing
-  id: UplinkCartridgeG8Hypercharged
-  name: uplink-cartridge-G8-hypercharged-name
-  description: uplink-cartridge-G8-hypercharged-desc
-  productEntity: CartridgeG8Hypercharged
-  cost:
-    Telecrystal: 6 # 12% cheaper than the bundle, coherency with china
-  categories:
-  - UplinkAmmo
-
-- type: listing
-  id: UplinkBox8Gauge
-  name: uplink-high-caliber-shotgun-box-name
-  description: uplink-high-caliber-shotgun-box-desc
-  icon: { sprite: Objects/Weapons/Guns/Ammunition/Boxes/shotgun.rsi, state: icon-lethal }
-  productEntity: MagazineBoxShotgunHighCaliber
-  cost:
-    Telecrystal: 10
-  categories:
-  - UplinkAmmo
-
-- type: listing
-  id: UplinkBox8GaugeSlug
-  name: uplink-high-caliber-shotgun-box-slug-name
-  description: uplink-high-caliber-shotgun-box-slug-desc
-  icon: { sprite: Objects/Weapons/Guns/Ammunition/Boxes/shotgun.rsi, state: icon-slug }
-  productEntity: MagazineBoxShotgunSlugHighCaliber
-  cost:
-    Telecrystal: 8
-  categories:
-  - UplinkAmmo
-
-- type: listing
-  id: UplinkBox8GaugeFlash
-  name: uplink-high-caliber-shotgun-box-flash-slug-name
-  description: uplink-high-caliber-shotgun-box-flash-slug-desc
-  icon: { sprite: Objects/Weapons/Guns/Ammunition/Boxes/shotgun.rsi, state: icon-incendiary }
-  productEntity: MagazineBoxShotgunHighCaliberFlash
-  cost:
-    Telecrystal: 1
-  categories:
-  - UplinkAmmo
-
-- type: listing
-  id: UplinkBox8GaugeSarin
-  name: uplink-high-caliber-shotgun-box-sarin-name
-  description: uplink-high-caliber-shotgun-box-sarin-desc
-  icon: { sprite: Objects/Weapons/Guns/Ammunition/Boxes/shotgun.rsi, state: icon-sarin }
-  productEntity: MagazineBoxShotgunHighCaliberSarin
-  cost:
-    Telecrystal: 12
-  categories:
-  - UplinkAmmo
 
 # Mechs
 
@@ -1355,22 +1266,6 @@
       tags:
       - NukeOpsUplink
 
-- type: listing
-  id: UplinkRPOA
-  name: uplink-RPOA-name
-  description: uplink-RPOA-desc
-  productEntity: WeaponLauncherRocketDisposableThermobaric
-  icon: { sprite: _Goobstation/Objects/Weapons/Guns/Launchers/shmel.rsi, state: icon }
-  cost:
-    Telecrystal: 6 # one and a half incendiary grenades, takes up the same space as three
-  categories:
-  - UplinkExplosives
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - NukeOpsUplink
-
 # Misc
 - type: listing
   id: UplinkDimensionPot
@@ -1429,6 +1324,8 @@
   - !type:BuyerSpeciesCondition
     whitelist:
     - Dwarf # Rock and stone
+  - !type:BuyerJobCondition
+    whitelist: []
 
 - type: listing
   id: UplinkBloodredCasette


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Removed half of the guns from uplink or moved them to surplus only.

Criteria:
* Not upstream
* Invalidates a different weapon
* Copies an existing weapon
* Exclusive caliber

Changes:
* Energy pickaxe - Surplus, meme gimmick of trading damage for structural and being exclusive for dwarves is weird.
* Anaconda - Surplus, ballistic cap laser.
* Bojevic - Nuked, invalidates bulldog and station shotguns
* M-90 - Surplus
* Ventilator - Nuked, gimmicky
* WSPR - Surplus
* Burner - Nuked, "better cl"
* HE1S - Nuked, unique caliber, invalidates hristov
* Heavy shotgun - Surplus, gimmick
* Shmel - Nuked, cheap, invalidates cl
* M172 - Kept as is. Largely pointless as of testing.


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://discord.com/channels/310555209753690112/770682801607278632/1133922131076448356
![image](https://github.com/user-attachments/assets/70dbc23b-32f9-4233-a07d-6ee6395c3667)

**Changelog**
:cl: 
- tweak: Moved some weapons into surplus only and removed others from uplink entirely
