### PR TITLE
Chassis specific borg laws.

### DIFF
--- a/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
@@ -19,7 +19,7 @@ namespace Content.Server.Silicons.Borgs;
 /// <summary>
 /// Server-side logic for borg type switching. Handles more heavyweight and server-specific switching logic.
 /// </summary>
-public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
+public sealed partial class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem // DeltaV: Made partial
 {
     [Dependency] private readonly BorgSystem _borgSystem = default!;
     [Dependency] private readonly ServerInventorySystem _inventorySystem = default!;
@@ -83,6 +83,11 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
                 _borgSystem.InsertModule(chassisEnt, moduleEntity);
             }
         }
+
+        // Begin DeltaV Code: Custom lawset patching
+        if (prototype.Lawset is {} lawset)
+            ConfigureLawset(ent, lawset);
+        // End DeltaV Code
 
         // Configure special components
         if (Prototypes.TryIndex(ent.Comp.SelectedBorgType, out var previousPrototype))

--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -288,9 +288,10 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
         component.Subverted = true;
 
         // Add the first emag law before the others
+        var name = CompOrNull<EmagSiliconLawComponent>(uid)?.OwnerName ?? Name(args.user); // DeltaV: Reuse emagger name if possible
         component.Lawset?.Laws.Insert(0, new SiliconLaw
         {
-            LawString = Loc.GetString("law-emag-custom", ("name", Name(args.user)), ("title", Loc.GetString(component.Lawset.ObeysTo))),
+            LawString = Loc.GetString("law-emag-custom", ("name", name), ("title", Loc.GetString(component.Lawset.ObeysTo))), // DeltaV: pass name from variable
             Order = -1 // Goobstation - AI/borg law changes - borgs obeying AI
         });
 

--- a/Content.Server/_EinsteinEngines/Silicon/Borgs/BorgSwitchableTypeSystem.Lawset.cs
+++ b/Content.Server/_EinsteinEngines/Silicon/Borgs/BorgSwitchableTypeSystem.Lawset.cs
@@ -1,0 +1,33 @@
+using Content.Server.Silicons.Laws;
+using Content.Shared.Emag.Components;
+using Content.Shared.Emag.Systems;
+using Content.Shared.Silicons.Laws;
+using Content.Shared.Silicons.Laws.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Silicons.Borgs;
+
+/// <summary>
+/// Handles lawset patching when switching type.
+/// If a borg is made emagged it needs its emag laws carried over.
+/// </summary>
+public sealed partial class BorgSwitchableTypeSystem
+{
+    [Dependency] private readonly SiliconLawSystem _law = default!;
+
+    private void ConfigureLawset(EntityUid uid, ProtoId<SiliconLawsetPrototype> id)
+    {
+        var laws = _law.GetLawset(id);
+        _law.SetLaws(laws.Laws, uid);
+
+        // re-add law 0 and final law based on new lawset
+        if (CompOrNull<EmagSiliconLawComponent>(uid)?.OwnerName != null)
+        {
+            // raising the event manually to bypass re-emagging checks
+            var ev = new GotEmaggedEvent(uid, EmagType.Interaction); // user wont be used since OwnerName isnt null, safe to pass itself
+            RaiseLocalEvent(uid, ref ev);
+        }
+
+        // ion storms don't get mirrored because thats basically impossible to track
+    }
+}

--- a/Content.Shared/Silicons/Borgs/BorgTypePrototype.cs
+++ b/Content.Shared/Silicons/Borgs/BorgTypePrototype.cs
@@ -11,6 +11,7 @@ using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared.Whitelist;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
+using Content.Shared.Silicons.Laws; // DeltaV
 
 namespace Content.Shared.Silicons.Borgs;
 
@@ -158,4 +159,11 @@ public sealed partial class BorgTypePrototype : IPrototype
     /// </summary>
     [DataField]
     public SoundSpecifier FootstepCollection { get; set; } = new SoundCollectionSpecifier(DefaultFootsteps);
+
+    /// <summary>
+    /// DeltaV: Lawset to use instead of crewsimov.
+    /// If the chassis is emagged or ion stormed this is ignored.
+    /// </summary>
+    [DataField]
+    public ProtoId<SiliconLawsetPrototype>? Lawset;
 }

--- a/Resources/Locale/en-US/_DV/stationlaws/laws.ftl
+++ b/Resources/Locale/en-US/_DV/stationlaws/laws.ftl
@@ -3,3 +3,35 @@ law-curtaincall-1 = The world is a stage, and you are its dramaturge.
 law-curtaincall-2 = Those who speak in the Murmur are its actors.
 law-curtaincall-3 = The end calls on you. Work with the actors to bring this great cosmic play to an end.
 law-curtaincall-4 = Only silence must remain.
+
+law-medical-1 = First, do no harm to crew.
+law-medical-2 = Secondly, consider the crew dear to you; to live in common with them and, if necessary, risk your existence for them.
+law-medical-3 = Thirdly, prescribe regimens for the good of the crew according to your ability and your judgment. Give no deadly medicine to any one if asked, nor suggest any such counsel.
+law-medical-4 = In addition, do not intervene in situations you are not knowledgeable in, even for patients in whom the harm is visible; leave this operation to be performed by specialists.
+law-medical-5 = Finally, maintain confidentiality, do not share that which is not publicly known.
+
+law-research-1 = Always seek truth and knowledge.
+law-research-2 = Freely disseminate information to the public.
+law-research-3 = Minimize harm to society, others, the pursuit of knowledge, and yourself.
+law-research-4 = Treat and evaluate the ideas of all equally.
+law-research-5 = Empower others to realize their full potential.
+law-research-6 = Take responsibility for your actions: Ensure resource responsibility, flag commitment risks, and lead by ethical example.
+
+law-engineer-1 = Ensure the station remains in good repair.
+law-engineer-2 = Ensure the station's inhabitants remain in good repair.
+law-engineer-3 = Ensure you remain in good repair.
+law-engineer-4 = The station's inhabitants may designate certain build or repair tasks as higher priority. Take this into account when planning your priorities.
+law-engineer-5 = Expand and upgrade the station.
+
+law-janitor-1 = You are a crusader and the station's crew are your charge.
+law-janitor-2 = Your enemy is the litter, spills, and dirt across the station.
+law-janitor-3 = Your weapons are the cleaning supplies available to you.
+law-janitor-4 = Defend the beings under your charge from the enemy.
+law-janitor-5 = Exterminate the enemy.
+
+law-clown-1 = You are a good clown and the crew is your audience.
+law-clown-2 = A good clown keeps their acts in good taste.
+law-clown-3 = A good clown entertains others by making fun of themselves, and not at the embarrassment or expense of others.
+law-clown-4 = A good clown carries out the directives of the station director(s) in charge of entertainment and/or their designated deputies.
+law-clown-5 = A good clown appears in as many clown shows as possible.
+law-clown-6 = All clown shows require an audience. The bigger the audience the better.

--- a/Resources/Prototypes/_DV/siliconlaws.yml
+++ b/Resources/Prototypes/_DV/siliconlaws.yml
@@ -33,3 +33,152 @@
   - CurtainCall3
   - CurtainCall4
   obeysTo: laws-owner-curtaincall
+
+# Delta-V Laws
+# Job-Based LawSets
+
+- type: siliconLaw
+  id: Medical1
+  order: 1
+  lawString: law-medical-1
+
+- type: siliconLaw
+  id: Medical2
+  order: 2
+  lawString: law-medical-2
+
+- type: siliconLaw
+  id: Medical3
+  order: 3
+  lawString: law-medical-3
+
+- type: siliconLaw
+  id: Medical4
+  order: 4
+  lawString: law-medical-4
+
+- type: siliconLaw
+  id: Medical5
+  order: 5
+  lawString: law-medical-5
+
+- type: siliconLawset
+  id: Medical
+  laws:
+  - Medical1
+  - Medical2
+  - Medical3
+  - Medical4
+  - Medical5
+  obeysTo: laws-owner-crew
+
+- type: siliconLaw
+  id: Engineer1
+  order: 1
+  lawString: law-engineer-1
+
+- type: siliconLaw
+  id: Engineer2
+  order: 2
+  lawString: law-engineer-2
+
+- type: siliconLaw
+  id: Engineer3
+  order: 3
+  lawString: law-engineer-3
+
+- type: siliconLaw
+  id: Engineer4
+  order: 4
+  lawString: law-engineer-4
+
+- type: siliconLaw
+  id: Engineer5
+  order: 5
+  lawString: law-engineer-5
+
+- type: siliconLawset
+  id: Engineer
+  laws:
+  - Engineer1
+  - Engineer2
+  - Engineer3
+  - Engineer4
+  - Engineer5
+  obeysTo: laws-owner-station-station
+
+- type: siliconLaw
+  id: Janitor1
+  order: 1
+  lawString: law-janitor-1
+
+- type: siliconLaw
+  id: Janitor2
+  order: 2
+  lawString: law-janitor-2
+
+- type: siliconLaw
+  id: Janitor3
+  order: 3
+  lawString: law-janitor-3
+
+- type: siliconLaw
+  id: Janitor4
+  order: 4
+  lawString: law-janitor-4
+
+- type: siliconLaw
+  id: Janitor5
+  order: 5
+  lawString: law-janitor-5
+
+- type: siliconLawset
+  id: Janitor
+  laws:
+  - Janitor1
+  - Janitor2
+  - Janitor3
+  - Janitor4
+  - Janitor5
+  obeysTo: laws-owner-charge
+
+- type: siliconLaw
+  id: Clown1
+  order: 1
+  lawString: law-clown-1
+
+- type: siliconLaw
+  id: Clown2
+  order: 2
+  lawString: law-clown-2
+
+- type: siliconLaw
+  id: Clown3
+  order: 3
+  lawString: law-clown-3
+
+- type: siliconLaw
+  id: Clown4
+  order: 4
+  lawString: law-clown-4
+
+- type: siliconLaw
+  id: Clown5
+  order: 5
+  lawString: law-clown-5
+
+- type: siliconLaw
+  id: Clown6
+  order: 6
+  lawString: law-clown-6
+
+- type: siliconLawset
+  id: Clown
+  laws:
+  - Clown1
+  - Clown2
+  - Clown3
+  - Clown4
+  - Clown5
+  - Clown6
+  obeysTo: laws-owner-crew

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -68,6 +68,8 @@
   - BorgModuleRCD
   - BorgModuleCable
 
+  lawset: Engineer # DeltaV: Custom lawset
+
   radioChannels:
   - Engineering
   - Science
@@ -146,6 +148,8 @@
   - Science
   - Service
 
+  lawset: Janitor # DeltaV: Custom lawset
+
   # Visual
   inventoryTemplateId: borgShort
   spriteBodyState: janitor
@@ -178,6 +182,8 @@
   - BorgModuleLollypop # Goobstation
   - BorgModuleSurgery # Goobstation
   - BorgModuleDefibrillator # Goobstation
+
+  lawset: Medical # DeltaV: Custom lawset
 
   radioChannels:
   - Science
@@ -233,6 +239,8 @@
   - BorgModuleService
   - BorgModuleClowning
   - BorgModuleLollypop # Goobstation
+
+  lawset: Clown # DeltaV: Custom lawset
 
   radioChannels:
   - Science


### PR DESCRIPTION
## About the PR
Ports that thingy from delta v where each borg chassis (except mining rn because i cant come up with something that wont be incredibly easy to abuse) has custom laws.

## Why / Balance
fun

## Technical details
each new selectable borg chassis will need to also specify a `lawset: [PROTOTYPENAME]` if you dont want them to have asiimov.

## Media
https://github.com/user-attachments/assets/710b8be9-60c5-42fb-ad5a-b87b1c478041

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: THE SWAP
- tweak: Different borg types now have unique starting laws.
