### PR TITLE
new vent critters event

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/human.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   parent: MobSyndicateFootsoldierPilot
   id: MobSyndicateFootsoldierVent

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/human.yml
@@ -1,0 +1,7 @@
+- type: entity
+  parent: MobSyndicateFootsoldierPilot
+  id: MobSyndicateFootsoldierVent
+  components:
+    - type: Loadout
+      prototypes:
+        - SyndicateFootsoldierGearVent

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/human.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Goobstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/events.yml
@@ -47,3 +47,22 @@
       min: 1
       max: 1
       pickPlayer: false
+
+- type: entity
+  id: VentSyndies
+  parent: BaseGameRule
+  components:
+  - type: StationEvent
+    earliestStart: 15
+    minimumPlayers: 20
+    weight: 2 # rare
+    duration: 30
+    eventType: HostilesSpawn
+  - type: GameRule
+    chaosScore: 250
+  - type: VentCrittersRule
+    playerRatio: 30
+    min: 1
+    max: 2
+    table:
+      id: MobSyndicateFootsoldierVent

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Fun/misc_startinggear.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: startingGear
   id: SyndicateFootsoldierGearVent
   equipment:

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Fun/misc_startinggear.yml
@@ -1,0 +1,16 @@
+- type: startingGear
+  id: SyndicateFootsoldierGearVent
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitAtmosSyndie
+    head: ClothingHeadHelmetSwatSyndicate
+    mask: ClothingMaskGasSyndicate
+    outerClothing: ClothingOuterArmorBasic
+    gloves: ClothingHandsGlovesCombat
+    back: ClothingBackpack
+    shoes: ClothingShoesBootsCombat
+    id: SyndiPDA
+  storage:
+    back:
+    - BoxSurvivalSlots
+  inhand:
+    - CombatKnife

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Fun/misc_startinggear.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
2kgc bounty
adds low-chance vent critters event that spawns syndicate shuttle pilot with combat knife and contortionist jumpsuit
NOT ghost role

## Why / Balance
peak
also it's rare so it's fine
crew will loot the jumpsuit but i think that's fine, i don't think it's bad for crew to have the contortionist with how rare this is, can lead to fun
otherwise if you wanna be 1984 i can also give them acidifiers

## Media
addgamerule'd in localhost, works
![image](https://github.com/user-attachments/assets/d224b962-43e3-4bcd-ad4d-02463b1fa0cb)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added rare vent critters event that spawns syndicate shuttle pilots.
