### PR TITLE
betterify secret+ light

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/game-ticking/secretplus.ftl
+++ b/Resources/Locale/en-US/_Goobstation/game-ticking/secretplus.ftl
@@ -9,3 +9,6 @@ secretplus-admeme-description = If it can happen, it will.
 
 survivalplus-title = Survival+
 survivalplus-description = Starts pretty calm. Ends up not quite.
+
+secretplus-calm-title = Secret+ Calm
+secretplus-calm-description = Very calm, even if not entirely.

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -98,20 +98,35 @@
     ignoreIncompatible: true
     ignoreTimings: true # would run out of events otherwise
 
+# calmer preset - intended for calmer MRP servers or similar
 - type: entity
   id: SecretPlusLow
   parent: SecretPlusMid
   categories: [ HideSpawnMenu ]
   components:
   - type: SecretPlus
+    minStartingChaos: 6
+    maxStartingChaos: 14
+    livingChaosChange: -0.008
+    deadChaosChange: 0.016
+    chaosExponent: 1.2
+    eventIntervalMin: 120
+    eventIntervalMax: 400
+
+# very calm preset
+- type: entity
+  id: SecretPlusCalm
+  parent: SecretPlusLow
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SecretPlus
     minStartingChaos: 0
     maxStartingChaos: 0
     noRoundstartAntags: true
-    livingChaosChange: -0.006
-    deadChaosChange: 0.015
-    chaosExponent: 1.2
-    eventIntervalMin: 120
-    eventIntervalMax: 450
+    livingChaosChange: -0.005
+    deadChaosChange: 0.02
+    eventIntervalMin: 150
+    eventIntervalMax: 600
 
 # survival+
 - type: entity

--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -191,6 +191,7 @@
     - IonStormScheduler
     - SpaceTrafficControlEventScheduler
 
+# intended for MRP servers or similar
 - type: gamePreset
   id: SecretPlusLow
   alias:
@@ -242,4 +243,18 @@
   showInVote: true
   rules:
     - SecretPlusRampingMid
+    - LavalandStormScheduler
+
+# essentially not 100% calm alternative to greenshift gamemode
+- type: gamePreset
+  id: SecretPlusCalm
+  alias:
+    - secretpluschud
+    - secretpluschudshift
+    - secretpluscalm
+  name: secretplus-calm-title
+  description: secretplus-calm-description
+  showInVote: false # nobody will vote this ever anyway
+  rules:
+    - SecretPlusCalm
     - LavalandStormScheduler

--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -254,7 +254,7 @@
     - secretpluscalm
   name: secretplus-calm-title
   description: secretplus-calm-description
-  showInVote: false # nobody will vote this ever anyway
+  showInVote: true # if people for some reason want greenshift
   rules:
     - SecretPlusCalm
     - LavalandStormScheduler


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
makes secret+ light be about 2/3 of mid instead of chudshift
adds secret+ calm as an alternative to extended/greenshift, is votable because why not

## Why / Balance
according to rouge MRP servers turned out to be too unrobust to handle secret+ mid or survival+ as-is and light is currently absolute chudshift so this is needed 
now secret+ light is more of a proper gamemode
also adds secret+ calm to replace what secret+ light was

## Media
untested, what would i even test

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Secret+ light is now just calmer and not greenshift.
