### PR TITLE
Tc miner tweaks

### DIFF
--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -294,9 +294,6 @@
     Telecrystal: 100
   categories:
     - UplinkDisruption
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
 
 # Weaponry
 

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -51,6 +51,7 @@
 # SPDX-FileCopyrightText: 2025 fishbait <gnesse@gmail.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
+# SPDX-FileCopyrightText: 2025 loltart <lo1tartyt@gmail.com>
 # SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 # SPDX-FileCopyrightText: 2025 terminatorbo <kovalevb059@gmail.com>
 #

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/tcprinter.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/tcprinter.yml
@@ -13,7 +13,7 @@
   description: A very loud machine that uses bluespace blockchain technology to generate telecrystals every 30 seconds when powered.
   components:
   - type: ApcPowerReceiver
-    powerLoad: 20000
+    powerLoad: 10000
   - type: TelecrystalMiner
     announceAt: 40
     locationAt: 100 # breakeven

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/tcprinter.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/tcprinter.yml
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 # SPDX-FileCopyrightText: 2025 IrisTheAmped <iristheamped@gmail.com>
 # SPDX-FileCopyrightText: 2025 LuciferMkshelter <stepanteliatnik2022@gmail.com>
+# SPDX-FileCopyrightText: 2025 loltart <lo1tartyt@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Changed the power draw to 10k and removed the uplink limit
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
After the nerfs the tc miners are in a good spot balance wise. I have only seen them snowball twice (both of which was Jack Pierson who has thousands of hours in this game) since the nerfs. The reason for these changes is to make it viable for Nukies again, as that was one of the main draws of tcminers as a concept. With the limit of 1 per uplink / them using 20k power, it was pretty much unfeasible to do anything like that, even for a lone op. Previously they would snowball quite easily due to the amount of chaos in a round with 20 antags and the audio breaking making it incredibly difficult to find in maints. Both of these were fixed so this shouldn't be a problem now.
## Technical details
<!-- Summary of code changes for easier review. -->
Yaml
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- tweak: Bitcoin-ops enjoyers rejoice! The limit of one TC miner per uplink has been removed.
- tweak: TC miners now draw 10k instead of 20k.

