### PR TITLE
HTN fixes round 3

### DIFF
--- a/Content.Server/NPC/Components/NPCSteeringComponent.cs
+++ b/Content.Server/NPC/Components/NPCSteeringComponent.cs
@@ -110,6 +110,12 @@ public sealed partial class NPCSteeringComponent : Component
 
     // Goobstation
     /// <summary>
+    /// Whether to ignore pathing and just move directly to target.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)] public bool DirectMove = false;
+
+    // Goobstation
+    /// <summary>
     /// Up to how fast can we be going before being considered in range, if not null.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)] public float? InRangeMaxSpeed = null;

--- a/Content.Server/NPC/Components/NPCSteeringComponent.cs
+++ b/Content.Server/NPC/Components/NPCSteeringComponent.cs
@@ -4,7 +4,9 @@
 // SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
+// SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 //
 // SPDX-License-Identifier: MIT
 

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
@@ -82,6 +82,13 @@ public sealed partial class MoveToOperator : HTNOperator, IHtnConditionalShutdow
     [DataField]
     public float? BrakeMaxVelocity = 0.03f;
 
+    // Goobstation
+    /// <summary>
+    /// If either we or the target are offgrid, gets assigned to make us just move directly to target.
+    /// </summary>
+    [DataField]
+    public string DirectMoveTargetKey = "DirectMoveTarget";
+
     private const string MovementCancelToken = "MovementCancelToken";
 
     public override void Initialize(IEntitySystemManager sysManager)
@@ -106,11 +113,9 @@ public sealed partial class MoveToOperator : HTNOperator, IHtnConditionalShutdow
             !_entManager.TryGetComponent<PhysicsComponent>(owner, out var body))
             return (false, null);
 
-        if (!_entManager.TryGetComponent<MapGridComponent>(xform.GridUid, out var ownerGrid) ||
-            !_entManager.TryGetComponent<MapGridComponent>(_transform.GetGrid(targetCoordinates), out var targetGrid))
-        {
-            return (false, null);
-        }
+        // Goobstation - check if we or target are offgrid
+        var offGrid = !_entManager.TryGetComponent<MapGridComponent>(xform.GridUid, out var ownerGrid) ||
+                      !_entManager.TryGetComponent<MapGridComponent>(_transform.GetGrid(targetCoordinates), out var targetGrid);
 
         var range = blackboard.GetValueOrDefault<float>(RangeKey, _entManager);
 
@@ -131,25 +136,37 @@ public sealed partial class MoveToOperator : HTNOperator, IHtnConditionalShutdow
             });
         }
 
-        var path = await _pathfind.GetPath(
-            blackboard.GetValue<EntityUid>(NPCBlackboard.Owner),
-            xform.Coordinates,
-                targetCoordinates,
-            range,
-            cancelToken,
-            _pathfind.GetFlags(blackboard));
-
-        if (path.Result != PathResult.Path)
+        // Goobstation - if we're not offgrid, just try to pathfind
+        if (!offGrid)
         {
-            return (false, null);
+            var path = await _pathfind.GetPath(
+                blackboard.GetValue<EntityUid>(NPCBlackboard.Owner),
+                xform.Coordinates,
+                    targetCoordinates,
+                range,
+                cancelToken,
+                _pathfind.GetFlags(blackboard));
+
+            if (path.Result != PathResult.Path)
+            {
+                return (false, null);
+            }
+
+            return (true, new Dictionary<string, object>()
+            {
+                {NPCBlackboard.OwnerCoordinates, targetCoordinates},
+                {PathfindKey, path}
+            });
         }
-
-        return (true, new Dictionary<string, object>()
+        // Goobstation - else try move directly to target
+        else
         {
-            {NPCBlackboard.OwnerCoordinates, targetCoordinates},
-            {PathfindKey, path}
-        });
-
+            return (true, new Dictionary<string, object>()
+            {
+                {NPCBlackboard.OwnerCoordinates, targetCoordinates},
+                {DirectMoveTargetKey, true}
+            });
+        }
     }
 
     // Given steering is complicated we'll hand it off to a dedicated system rather than this singleton operator.
@@ -172,7 +189,13 @@ public sealed partial class MoveToOperator : HTNOperator, IHtnConditionalShutdow
             comp.Range = range;
         }
 
-        if (blackboard.TryGetValue<PathResultEvent>(PathfindKey, out var result, _entManager))
+        // Goobstation - see if we want to just move directly first
+        if (blackboard.TryGetValue<bool>(DirectMoveTargetKey, out var doDirectMove, _entManager) && doDirectMove)
+        {
+            comp.Coordinates = targetCoordinates;
+            comp.DirectMove = true;
+        }
+        else if (blackboard.TryGetValue<PathResultEvent>(PathfindKey, out var result, _entManager))
         {
             if (blackboard.TryGetValue<EntityCoordinates>(NPCBlackboard.OwnerCoordinates, out var coordinates, _entManager))
             {
@@ -218,6 +241,8 @@ public sealed partial class MoveToOperator : HTNOperator, IHtnConditionalShutdow
 
         // OwnerCoordinates is only used in planning so dump it.
         blackboard.Remove<PathResultEvent>(PathfindKey);
+        // Goobstation - also clear direct move
+        blackboard.Remove<bool>(DirectMoveTargetKey);
 
         if (RemoveKeyOnFinish)
         {

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
@@ -198,18 +198,9 @@ public sealed partial class MoveToOperator : HTNOperator, IHtnConditionalShutdow
             return HTNOperatorStatus.Finished;
         }
 
-        // Goobstation
-        var inRangeStatus = HTNOperatorStatus.Continuing;
-        if (BrakeMaxVelocity == null ||
-            !_entManager.TryGetComponent<PhysicsComponent>(owner, out var physics) ||
-            physics.LinearVelocity.Length() < BrakeMaxVelocity.Value)
-        {
-            inRangeStatus = HTNOperatorStatus.Finished;
-        }
-
         return steering.Status switch
         {
-            SteeringStatus.InRange => inRangeStatus, // Goobstation
+            SteeringStatus.InRange => HTNOperatorStatus.Finished,
             SteeringStatus.NoPath => HTNOperatorStatus.Failed,
             SteeringStatus.Moving => HTNOperatorStatus.Continuing,
             _ => throw new ArgumentOutOfRangeException()

--- a/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/Operators/MoveToOperator.cs
@@ -197,6 +197,9 @@ public sealed partial class MoveToOperator : HTNOperator, IHtnConditionalShutdow
         }
         else if (blackboard.TryGetValue<PathResultEvent>(PathfindKey, out var result, _entManager))
         {
+            // Goobstation
+            comp.DirectMove = false;
+
             if (blackboard.TryGetValue<EntityCoordinates>(NPCBlackboard.OwnerCoordinates, out var coordinates, _entManager))
             {
                 var mapCoords = _transform.ToMapCoordinates(coordinates);

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -185,10 +185,11 @@ public sealed partial class NPCSteeringSystem
         }
 
         // Goobstation
+        var velLen = body.LinearVelocity.Length();
+
         var careAboutSpeed = steering.InRangeMaxSpeed != null;
         var finalInRange = ourCoordinates.TryDistance(EntityManager, destinationCoordinates, out var targetDistance) && inLos && targetDistance <= steering.Range;
-                           // ideally this would be careAboutSpeed but schizo C#
-        var velocityHigh = steering.InRangeMaxSpeed != null && body.LinearVelocity.LengthSquared() > steering.InRangeMaxSpeed.Value * steering.InRangeMaxSpeed.Value;
+        var velocityHigh = careAboutSpeed && velLen > steering.InRangeMaxSpeed!.Value;
         // if we're in range and we care about velocity, stop trying to move if we early return
         if (finalInRange && careAboutSpeed)
             moveMultiplier = 0f;
@@ -412,7 +413,6 @@ public sealed partial class NPCSteeringSystem
         var frameAccel = realAccel * frameTime;
 
         // check our tangential velocity
-        var velLen = body.LinearVelocity.Length();
         var normVel = direction * Vector2.Dot(body.LinearVelocity, direction) / direction.LengthSquared();
         var tgVel = body.LinearVelocity - normVel;
 
@@ -420,7 +420,6 @@ public sealed partial class NPCSteeringSystem
         if (haveToBrake)
         {
             // how much distance we'll pass before hitting our desired max speed
-                                                              // schizo C#
             var brakePath = (velLen - steering.InRangeMaxSpeed ?? 0f) / friction;
             var hardBrake = brakePath > MathF.Min(0.5f, steering.Range); // hard brake if it takes more than half a tile
 
@@ -446,9 +445,12 @@ public sealed partial class NPCSteeringSystem
             case MovementType.Braking:
                 if (velLen > 0f)
                 {
+                    // copy our velocity and apply friction to the copy
                     var cvel = body.LinearVelocity;
                     _mover.Friction(0f, frameTime, friction, ref cvel);
-                    // slow down our braking if we would overbrake in this frame
+                    // clamp our braking to what our post-friction velocity would be
+                    // otherwise we can overbrake in this frame and reverse movement direction
+                    // TODO: a way to tell calling code that we don't want to reverse movement direction to not have to do this
                     moveMultiplier = MapValue(cvel.Length(), 0f, frameAccel);
                                         // brake                                 // normalise
                     ApplySeek(interest, -offsetRot.RotateVec(body.LinearVelocity / velLen), 1f);

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -152,6 +152,9 @@ public sealed partial class NPCSteeringSystem
         var destinationCoordinates = steering.Coordinates;
         var inLos = true;
 
+        // Goobstation - makes us ignore all pathing logic and go straight to the target coordinates
+        var directMove = steering.DirectMove;
+
         // Check if we're in LOS if that's required.
         // TODO: Need something uhh better not sure on the interaction between these.
         if (!steering.ForceMove && steering.ArriveOnLineOfSight)
@@ -200,7 +203,8 @@ public sealed partial class NPCSteeringSystem
         }
 
         // Grab the target position, either the next path node or our end goal..
-        var targetCoordinates = GetTargetCoordinates(steering);
+        // Goobstation - add DirectMove
+        var targetCoordinates = steering.DirectMove ? steering.Coordinates : GetTargetCoordinates(steering);
 
         if (!targetCoordinates.IsValid(EntityManager))
         {
@@ -213,7 +217,8 @@ public sealed partial class NPCSteeringSystem
         // If the next node is invalid then get new ones
         if (!targetCoordinates.IsValid(EntityManager))
         {
-            if (steering.CurrentPath.TryPeek(out var poly) &&
+            // Goobstation - add DirectMove
+            if (!directMove && steering.CurrentPath.TryPeek(out var poly) &&
                 (poly.Data.Flags & PathfindingBreadcrumbFlag.Invalid) != 0x0)
             {
                 steering.CurrentPath.Dequeue();
@@ -262,7 +267,8 @@ public sealed partial class NPCSteeringSystem
         if (arrived)
         {
             // Node needs some kind of special handling like access or smashing.
-            if (steering.CurrentPath.TryPeek(out var node) && !IsFreeSpace(uid, steering, node))
+            // Goobstation - add DirectMove
+            if (!directMove && steering.CurrentPath.TryPeek(out var node) && !IsFreeSpace(uid, steering, node))
             {
                 // Ignore stuck while handling obstacles.
                 ResetStuck(steering, ourCoordinates);
@@ -301,7 +307,8 @@ public sealed partial class NPCSteeringSystem
 
             // Distance should already be handled above.
             // It was just a node, not the target, so grab the next destination (either the target or next node).
-            if (steering.CurrentPath.Count > 0)
+            // Goobstation - add DirectMove
+            if (!directMove && steering.CurrentPath.Count > 0)
             {
                 forceSteer = true;
                 steering.CurrentPath.Dequeue();
@@ -369,21 +376,26 @@ public sealed partial class NPCSteeringSystem
         }
 
         // If not in LOS and no path then get a new one fam.
-        if ((!inLos && steering.ArriveOnLineOfSight && steering.CurrentPath.Count == 0) ||
-            (!steering.ArriveOnLineOfSight && steering.CurrentPath.Count == 0))
+        // Goobstation - add DirectMove
+        if (!directMove &&
+            ((!inLos && steering.ArriveOnLineOfSight && steering.CurrentPath.Count == 0) ||
+             (!steering.ArriveOnLineOfSight && steering.CurrentPath.Count == 0)))
         {
             needsPath = true;
         }
 
         // TODO: Probably need partial planning support i.e. patch from the last node to where the target moved to.
-        CheckPath(uid, steering, xform, needsPath, targetDistance);
+        // Goobstation - add DirectMove
+        if (!directMove)
+            CheckPath(uid, steering, xform, needsPath, targetDistance);
 
         // Goobstation
         var haveToBrake = finalInRange && velocityHigh;
 
         // If we don't have a path yet then do nothing; this is to avoid stutter-stepping if it turns out there's no path
         // available but we assume there was.
-        if (steering is { Pathfind: true, CurrentPath.Count: 0 } && !haveToBrake)
+        // Goobstation - add DirectMove
+        if (!directMove && steering is { Pathfind: true, CurrentPath.Count: 0 } && !haveToBrake)
                                                                  // Goobstation
             return true;
 

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -182,8 +182,13 @@ public sealed partial class NPCSteeringSystem
         }
 
         // Goobstation
+        var careAboutSpeed = steering.InRangeMaxSpeed != null;
         var finalInRange = ourCoordinates.TryDistance(EntityManager, destinationCoordinates, out var targetDistance) && inLos && targetDistance <= steering.Range;
+                           // ideally this would be careAboutSpeed but schizo C#
         var velocityHigh = steering.InRangeMaxSpeed != null && body.LinearVelocity.LengthSquared() > steering.InRangeMaxSpeed.Value * steering.InRangeMaxSpeed.Value;
+        // if we're in range and we care about velocity, stop trying to move if we early return
+        if (finalInRange && careAboutSpeed)
+            moveMultiplier = 0f;
 
         // We've arrived, nothing else matters.
         // Goobstation - also check if our velocity is higher than desired
@@ -423,6 +428,7 @@ public sealed partial class NPCSteeringSystem
         switch (moveType)
         {
             case MovementType.MovingToTarget:
+                moveMultiplier = 1f;
                 ApplySeek(interest, offsetRot.RotateVec(direction.Normalized()), 1f);
                 break;
             case MovementType.Braking:

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -181,13 +181,13 @@ public sealed partial class NPCSteeringSystem
             steering.ForceMove = false;
         }
 
+        // Goobstation
+        var finalInRange = ourCoordinates.TryDistance(EntityManager, destinationCoordinates, out var targetDistance) && inLos && targetDistance <= steering.Range;
+        var velocityHigh = steering.InRangeMaxSpeed != null && body.LinearVelocity.LengthSquared() > steering.InRangeMaxSpeed.Value * steering.InRangeMaxSpeed.Value;
+
         // We've arrived, nothing else matters.
-        if (xform.Coordinates.TryDistance(EntityManager, destinationCoordinates, out var targetDistance) &&
-            inLos &&
-            targetDistance <= steering.Range &&
-            // Goobstation
-            (steering.InRangeMaxSpeed == null ||
-                body.LinearVelocity.LengthSquared() < steering.InRangeMaxSpeed.Value * steering.InRangeMaxSpeed.Value))
+        // Goobstation - also check if our velocity is higher than desired
+        if (finalInRange && !velocityHigh)
         {
             steering.Status = SteeringStatus.InRange;
             ResetStuck(steering, ourCoordinates);
@@ -374,12 +374,11 @@ public sealed partial class NPCSteeringSystem
         CheckPath(uid, steering, xform, needsPath, targetDistance);
 
         // Goobstation
-        var finalInRange = targetDistance != null && targetDistance < steering.Range;
-        var arrivedFinal = arrived && steering.CurrentPath.Count == 0 && finalInRange;
+        var haveToBrake = finalInRange && velocityHigh;
 
         // If we don't have a path yet then do nothing; this is to avoid stutter-stepping if it turns out there's no path
         // available but we assume there was.
-        if (steering is { Pathfind: true, CurrentPath.Count: 0 } && !arrivedFinal)
+        if (steering is { Pathfind: true, CurrentPath.Count: 0 } && !haveToBrake)
                                                                  // Goobstation
             return true;
 
@@ -401,10 +400,11 @@ public sealed partial class NPCSteeringSystem
         var tgVel = body.LinearVelocity - normVel;
 
         // we're near final node but haven't braked, do so
-        if (arrivedFinal && steering.InRangeMaxSpeed != null)
+        if (haveToBrake)
         {
             // how much distance we'll pass before hitting our desired max speed
-            var brakePath = (velLen - steering.InRangeMaxSpeed.Value) / friction;
+                                                              // schizo C#
+            var brakePath = (velLen - steering.InRangeMaxSpeed ?? 0f) / friction;
             var hardBrake = brakePath > MathF.Min(0.5f, steering.Range); // hard brake if it takes more than half a tile
 
             moveType = hardBrake ? MovementType.Braking : MovementType.Coasting;

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.cs
@@ -393,14 +393,17 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
         var agentRadius = steering.Radius;
         var worldPos = _transform.GetWorldPosition(xform);
         var (layer, mask) = _physics.GetHardCollision(uid);
-
         // Use rotation relative to parent to rotate our context vectors by.
         var offsetRot = -_mover.GetParentGridAngle(mover);
+
         _modifierQuery.TryGetComponent(uid, out var modifier);
-        var moveSpeed = GetSprintSpeed(uid, modifier);
-        var acceleration = GetAcceleration((uid, modifier, xform, null)); // Goobstation
-        var friction = GetFriction((uid, modifier, xform, null)); // Goobstation
         var body = _physicsQuery.GetComponent(uid);
+
+        var weightless = _gravity.IsWeightless(uid, body, xform);
+        var moveSpeed = GetSprintSpeed(uid, modifier);
+        var acceleration = GetAcceleration((uid, modifier), weightless);
+        var friction = GetFriction((uid, modifier), weightless);
+
         var dangerPoints = steering.DangerPoints;
         dangerPoints.Clear();
         Span<float> interest = stackalloc float[InterestDirections];
@@ -560,25 +563,20 @@ public sealed partial class NPCSteeringSystem : SharedNPCSteeringSystem
     }
 
     // <Goobstation>
-    private float GetAcceleration(Entity<MovementSpeedModifierComponent?, TransformComponent?, PhysicsComponent?> ent)
+    private float GetAcceleration(Entity<MovementSpeedModifierComponent?> ent, bool weightless)
     {
-        var weightless = _gravity.IsWeightless(ent, ent.Comp3, ent.Comp2);
-
-        if (!Resolve(ent, ref ent.Comp1, false))
+        if (!Resolve(ent, ref ent.Comp, false))
             return weightless ? MovementSpeedModifierComponent.DefaultWeightlessAcceleration : MovementSpeedModifierComponent.DefaultAcceleration;
 
-        return weightless ? ent.Comp1.WeightlessAcceleration : ent.Comp1.Acceleration;
+        return weightless ? ent.Comp.WeightlessAcceleration : ent.Comp.Acceleration;
     }
 
-    // TODO: make this upstream's problem since friction as-is is kinda scuffed to get properly
-    private float GetFriction(Entity<MovementSpeedModifierComponent?, TransformComponent?, PhysicsComponent?> ent)
+    private float GetFriction(Entity<MovementSpeedModifierComponent?> ent, bool weightless)
     {
-        var weightless = _gravity.IsWeightless(ent, ent.Comp3, ent.Comp2);
-
-        if (!Resolve(ent, ref ent.Comp1, false))
+        if (!Resolve(ent, ref ent.Comp, false))
             return weightless ? MovementSpeedModifierComponent.DefaultWeightlessFriction : MovementSpeedModifierComponent.DefaultFriction;
 
-        return weightless ? ent.Comp1.WeightlessFriction : ent.Comp1.Friction;
+        return weightless ? ent.Comp.WeightlessFriction : ent.Comp.Friction;
     }
     // </Goobstation>
 

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.cs
@@ -49,8 +49,10 @@
 // SPDX-FileCopyrightText: 2024 themias <89101928+themias@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 // SPDX-FileCopyrightText: 2025 J <billsmith116@gmail.com>
+// SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 // SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_EinsteinEngines/NPCs/fillbot.yml
+++ b/Resources/Prototypes/_EinsteinEngines/NPCs/fillbot.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
+# SPDX-FileCopyrightText: 2025 Rouden <149893554+Roudenn@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: htnCompound
   id: FillbotCompound
   branches:

--- a/Resources/Prototypes/_EinsteinEngines/NPCs/fillbot.yml
+++ b/Resources/Prototypes/_EinsteinEngines/NPCs/fillbot.yml
@@ -22,6 +22,7 @@
               key: NearbyFillableItem
           operator: !type:MoveToOperator
             pathfindInPlanning: false
+            brakeMaxVelocity: null # don't need to brake
         # Pick it up
         - !type:HTNPrimitiveTask
           preconditions:
@@ -44,6 +45,7 @@
               key: LinkedFillableMachine
           operator: !type:MoveToOperator
             pathfindInPlanning: false
+            brakeMaxVelocity: null
         # Insert the item
         - !type:HTNPrimitiveTask
           operator: !type:FillLinkedMachineOperator

--- a/Resources/Prototypes/_EinsteinEngines/NPCs/fillbot.yml
+++ b/Resources/Prototypes/_EinsteinEngines/NPCs/fillbot.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 # SPDX-FileCopyrightText: 2025 Rouden <149893554+Roudenn@users.noreply.github.com>
 #


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
- fixes jank stutter-movement observed under high server load
- potentially fixes more jank back-and-forth movement
- if you or the target coordinates are offgrid, NPCs will now attempt to move directly to you without pathfinding
- makes fillbot not brake because it doesn't need to

## Media
i have tested:
- space carp, offgrid and ongrid both target and source
- bunch of space carp jumping to attack me off a wreck
![image](https://github.com/user-attachments/assets/dfb6fa32-72a5-4368-8692-13a68323de18)
- spirates, offgrid and ongrid both target and source, with melee and with gun
- fillbot, ongrid, in grav and nograv
- approximately 400 mice strolling around on chloris (high server load test), jank that was before isn't there anymore
- space carp fighting spirate in melee in space
![image](https://github.com/user-attachments/assets/919e6f6b-0dee-4da0-a66a-e07ef14620fe)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed more NPC movement jank.
- fix: NPCs will now chase and attack you in space. Fear the fish.
