### PR TITLE
critter fax slipthrough

### DIFF
--- a/Content.Goobstation.Server/Fax/FaxSlipComponent.cs
+++ b/Content.Goobstation.Server/Fax/FaxSlipComponent.cs
@@ -1,0 +1,22 @@
+namespace Content.Goobstation.Server.Fax;
+
+/// <summary>
+/// Causes items to, instead of their normal fax behavior, have a chance to teleport to the fax destination instead.
+/// Can have a separate chance for lubed items.
+/// </summary>
+[RegisterComponent]
+public sealed partial class FaxSlipComponent : Component
+{
+    /// <summary>
+    /// Chance we get teleported to destination instead of normal behavior.
+    /// </summary>
+    [DataField]
+    public float SlipChance = 0.3f;
+
+    /// <summary>
+    /// If not null, chance override for lubed items.
+    /// Also will also allow insertion of this item into faxes even if lubed.
+    /// </summary>
+    [DataField]
+    public float? LubedChance = 1f;
+}

--- a/Content.Goobstation.Server/Fax/FaxSlipSystem.cs
+++ b/Content.Goobstation.Server/Fax/FaxSlipSystem.cs
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Goobstation.Shared.Fax;
+using Content.Goobstation.Shared.Lube;
+using Content.Server.DeviceNetwork.Systems;
+using Content.Server.Fax;
+using Content.Shared.Administration.Logs;
+using Content.Shared.Database;
+using Content.Shared.DeviceNetwork;
+using Content.Shared.Fax.Components;
+using Content.Shared.Lube;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Random;
+
+namespace Content.Goobstation.Server.Fax;
+
+public sealed class FaxSlipSystem : EntitySystem
+{
+    [Dependency] private readonly DeviceNetworkSystem _deviceNetwork = default!;
+    [Dependency] private readonly IRobustRandom _gambling = default!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<FaxSlipComponent, GettingFaxedSentEvent>(OnGettingFaxedSent);
+        SubscribeLocalEvent<FaxSlipComponent, CanLubedInsertEvent>(OnCanLubedInsert);
+    }
+
+    private void OnGettingFaxedSent(Entity<FaxSlipComponent> ent, ref GettingFaxedSentEvent args)
+    {
+        var chance = HasComp<LubedComponent>(ent) && ent.Comp.LubedChance != null ? ent.Comp.LubedChance.Value : ent.Comp.SlipChance;
+        var shouldSlip = _gambling.Prob(chance);
+
+        // FaxSystem wasn't really intended to do this so this copypastes logic from Send()
+        // justifiable since other listeners to GettingFaxedSentEvent() might want to do different logic
+        if (shouldSlip)
+        {
+            // stop normal faxing behaviors
+            args.Handled = true;
+
+            // FaxSystem should probably be changed to handle this by itself
+            if (args.Fax.Comp.SendTimeoutRemaining > 0)
+                return;
+
+            var sendEntity = args.Fax.Comp.PaperSlot.Item;
+            if (sendEntity == null)
+                return;
+
+            if (args.Fax.Comp.DestinationFaxAddress == null)
+                return;
+
+            if (!args.Fax.Comp.KnownFaxes.TryGetValue(args.Fax.Comp.DestinationFaxAddress, out var faxName))
+                return;
+
+            var payload = new NetworkPayload()
+            {
+                { DeviceNetworkConstants.Command, FaxConstants.FaxSendEntityCommand },
+                { FaxConstants.FaxEntitySentData, args.Fax.Comp.PaperSlot.Item }
+            };
+
+            _deviceNetwork.QueuePacket(args.Fax, args.Fax.Comp.DestinationFaxAddress, payload);
+
+            var actor = args.Args.Actor;
+            if (actor.IsValid())
+            _adminLogger.Add(LogType.Action,
+                LogImpact.Low,
+                $"{ToPrettyString(actor):actor} " +
+                $"sent entity {ToPrettyString(sendEntity)} from \"{args.Fax.Comp.FaxName}\" {ToPrettyString(args.Fax):tool} " +
+                $"to \"{faxName}\" ({args.Fax.Comp.DestinationFaxAddress}) ");
+
+            args.Fax.Comp.SendTimeoutRemaining += args.Fax.Comp.SendTimeout;
+
+            _audio.PlayPvs(args.Fax.Comp.SendSound, args.Fax);
+        }
+    }
+
+    private void OnCanLubedInsert(Entity<FaxSlipComponent> ent, ref CanLubedInsertEvent args)
+    {
+        args.CanInsert |= ent.Comp.LubedChance != null && HasComp<FaxMachineComponent>(args.Into.Owner);
+    }
+}

--- a/Content.Goobstation.Shared/Fax/GettingFaxedSentEvent.cs
+++ b/Content.Goobstation.Shared/Fax/GettingFaxedSentEvent.cs
@@ -1,0 +1,11 @@
+using Content.Shared.Fax;
+using Content.Shared.Fax.Components;
+
+namespace Content.Goobstation.Shared.Fax;
+
+/// <summary>
+/// Raised on an entity when it's getting sent with a fax.
+/// Set Handled to true to cancel normal fax behavior.
+/// </summary>
+[ByRefEvent]
+public record struct GettingFaxedSentEvent(Entity<FaxMachineComponent> Fax, ref readonly FaxSendMessage Args, bool Handled = false);

--- a/Content.Goobstation.Shared/Lube/CanLubedInsertEvent.cs
+++ b/Content.Goobstation.Shared/Lube/CanLubedInsertEvent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.Containers;
+
+namespace Content.Goobstation.Shared.Lube;
+
+/// <Goobstation>
+/// Raised on a lubed entity when there's an attempt to insert it into a container.
+/// Set CanInsert to true to allow it to be inserted.
+/// </Goobstation>
+[ByRefEvent]
+public record struct CanLubedInsertEvent(ref readonly BaseContainer Into, bool CanInsert = false);

--- a/Content.Server/Fax/FaxConstants.cs
+++ b/Content.Server/Fax/FaxConstants.cs
@@ -29,6 +29,12 @@ public static class FaxConstants
      */
     public const string FaxPrintCommand = "fax_print";
 
+    // Goobstation
+    /**
+     * Used when fax sending entity to destination fax
+     */
+    public const string FaxSendEntityCommand = "fax_send_entity";
+
     // Data
 
     public const string FaxNameData = "fax_data_name";
@@ -40,4 +46,7 @@ public static class FaxConstants
     public const string FaxPaperStampedByData = "fax_data_stamped_by";
     public const string FaxSyndicateData = "fax_data_i_am_syndicate";
     public const string FaxPaperLockedData = "fax_data_locked";
+
+    // Goobstation
+    public const string FaxEntitySentData = "fax_entity_sent";
 }

--- a/Content.Server/Lube/LubedSystem.cs
+++ b/Content.Server/Lube/LubedSystem.cs
@@ -6,6 +6,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Goobstation.Shared.Lube; // Goobstation
 using Content.Shared.IdentityManagement;
 using Content.Shared.Lube;
 using Content.Shared.NameModifier.EntitySystems;
@@ -40,6 +41,14 @@ public sealed class LubedSystem : EntitySystem
 
     private void OnHandPickUp(EntityUid uid, LubedComponent component, ContainerGettingInsertedAttemptEvent args)
     {
+        // <Goobstation>
+        var ev = new CanLubedInsertEvent(args.Container);
+        RaiseLocalEvent(uid, ref ev);
+
+        if (ev.CanInsert)
+            return;
+        // </Goobstation>
+
         if (component.SlipsLeft <= 0)
         {
             RemComp<LubedComponent>(uid);

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -783,6 +783,9 @@
     allowedEmotes: ['Chitter', 'Squeak', 'Flap'] #flap is from goob
   - type: FaxableObject
     insertingState: inserting_mothroach
+  # Goobstation
+  - type: FaxSlip
+    slipChance: 0.3
   - type: MothAccent
   - type: Sprite
     sprite: Mobs/Animals/mothroach/mothroach.rsi
@@ -2205,6 +2208,8 @@
     defaultChannel: Mousemind
     channels:
     - Mousemind
+  - type: FaxSlip
+    slipChance: 0.3
   # </Goobstation>
   - type: Destructible # Shitmed Change
     thresholds:
@@ -3718,6 +3723,9 @@
   - type: Physics
   - type: FaxableObject
     insertingState: inserting_hamster
+  # Goobstation
+  - type: FaxSlip
+    slipChance: 0.3
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -751,6 +751,9 @@
     flavors:
     - meaty
     - sadness
+  # Goobstation - hamlet is unique so higher chance to actually get faxed
+  - type: FaxSlip
+    slipChance: 0.5
 
 - type: entity
   name: Shiva


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
30% chance for mice/mothroaches/hamsters to actually get sent if faxed
50% for hamlet since he's unique
100% chance if lubed (have to lube while in hand then insert)
also allows insertion of them into faxes even if lubed

## Why / Balance
fun
send mice to the ntr
i contemplated letting people send any tiny item but too much trolling

## Media
![image](https://github.com/user-attachments/assets/f3fa607a-6dbb-4cf4-938c-d498b0ebfe7c)
tested lubed and unlubed mice

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Faxing critters now sometimes succeeds. Always if lubed.