### PR TITLE
Fixes Holographic.SWSL Compatibility Mode Crash...

### DIFF
--- a/Resources/Textures/Nyanotrasen/Shaders/holographic.swsl
+++ b/Resources/Textures/Nyanotrasen/Shaders/holographic.swsl
@@ -2,7 +2,6 @@ light_mode unshaded;
 
 uniform highp float hue;
 uniform highp float textureHeight;
-uniform highp float pixel_scale = 12.0;
 
 //
 // Description : Array and textureless GLSL 2D/3D/4D simplex
@@ -213,6 +212,7 @@ highp float pingpong(highp float value)
 
 void fragment()
 {
+    const highp float pixel_scale = 12.0;
     const highp float TIME_OFFSET1 = 138.11;
     const highp float TIME_OFFSET2 = 517.43;
     const highp float TIME_OFFSET3 = 1298.67;


### PR DESCRIPTION
## Why
Compatibility mode doesn't like uniform values being set outside of fragment.

## Technical details
Literally just moved the hard-coded uniform value into to the fragment as a constant.

## Media
![image](https://github.com/user-attachments/assets/479079ff-15ca-406b-b3c9-621c6a45e526)

**Changelog**
:cl: Rubin
- fix: Compatibility mode crashing due to Holographic shader.
