### PR TITLE
port+tweak: https://github.com/DeltaV-Station/Delta-v/pull/3462

### DIFF
--- a/Content.Shared/_DV/Holosign/ChargeHolosignProjectorComponent.cs
+++ b/Content.Shared/_DV/Holosign/ChargeHolosignProjectorComponent.cs
@@ -1,0 +1,37 @@
+using Robust.Shared.Containers;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._DV.Holosign;
+
+/// <summary>
+/// A holosign projector that uses <c>LimitedCharges</c> instead of a power cell slot.
+/// If there is already a sign on the clicked tile it reclaims it for a charge instead of stacking it.
+/// Currently there is no spawning prediction so signs are spawned once in a container and moved out to allow prediction.
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(ChargeHolosignSystem))]
+public sealed partial class ChargeHolosignProjectorComponent : Component
+{
+    /// <summary>
+    /// The entity to spawn.
+    /// </summary>
+    [DataField(required: true)]
+    public EntProtoId SignProto;
+
+    /// <summary>
+    /// Component on <see cref="SignProto"/> to check for duplicates.
+    /// </summary>
+    [DataField(required: true)]
+    public string SignComponentName;
+
+    public Type SignComponent = default!;
+
+    /// <summary>
+    /// Container to store sign entities in before they are "spawned" on use.
+    /// </summary>
+    [DataField]
+    public string ContainerId = "signs";
+
+    [ViewVariables]
+    public Container Container = default!;
+}

--- a/Content.Shared/_DV/Holosign/ChargeHolosignProjectorComponent.cs
+++ b/Content.Shared/_DV/Holosign/ChargeHolosignProjectorComponent.cs
@@ -9,7 +9,7 @@ namespace Content.Shared._DV.Holosign;
 /// If there is already a sign on the clicked tile it reclaims it for a charge instead of stacking it.
 /// Currently there is no spawning prediction so signs are spawned once in a container and moved out to allow prediction.
 /// </summary>
-[RegisterComponent, NetworkedComponent, Access(typeof(ChargeHolosignSystem))]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(fieldDeltas: true), Access(typeof(ChargeHolosignSystem))]
 public sealed partial class ChargeHolosignProjectorComponent : Component
 {
     /// <summary>
@@ -31,6 +31,12 @@ public sealed partial class ChargeHolosignProjectorComponent : Component
     /// </summary>
     [DataField]
     public string ContainerId = "signs";
+
+    /// <summary>
+    /// Holosigns we "own".
+    /// </summary>
+    [ViewVariables, AutoNetworkedField]
+    public List<EntityUid> Signs = new();
 
     [ViewVariables]
     public Container Container = default!;

--- a/Content.Shared/_DV/Holosign/ChargeHolosignSystem.cs
+++ b/Content.Shared/_DV/Holosign/ChargeHolosignSystem.cs
@@ -3,10 +3,13 @@ using Content.Shared.Charges.Systems;
 using Content.Shared.Coordinates.Helpers;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Popups;
 using Content.Shared.Storage;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
+using Robust.Shared.Network;
+using Robust.Shared.Timing;
 using System.Linq;
 
 namespace Content.Shared._DV.Holosign;
@@ -14,6 +17,8 @@ namespace Content.Shared._DV.Holosign;
 public sealed class ChargeHolosignSystem : EntitySystem
 {
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedChargesSystem _charges = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -28,6 +33,7 @@ public sealed class ChargeHolosignSystem : EntitySystem
         SubscribeLocalEvent<ChargeHolosignProjectorComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<ChargeHolosignProjectorComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<ChargeHolosignProjectorComponent, BeforeRangedInteractEvent>(OnBeforeInteract);
+        SubscribeLocalEvent<ChargeHolosignProjectorComponent, UseInHandEvent>(OnUseInHand);
     }
 
     private void OnInit(Entity<ChargeHolosignProjectorComponent> ent, ref ComponentInit args)
@@ -48,17 +54,22 @@ public sealed class ChargeHolosignSystem : EntitySystem
         var containers = Comp<ContainerManagerComponent>(ent);
         for (var i = 0; i < charges.MaxCharges; i++)
         {
-            if (!TrySpawnInContainer(ent.Comp.SignProto, ent, ent.Comp.ContainerId, out _))
+            if (!TrySpawnInContainer(ent.Comp.SignProto, ent, ent.Comp.ContainerId, out var signUid))
             {
                 Log.Error($"Failed to spawn sign {ent.Comp.SignProto} for {ToPrettyString(ent)}!");
                 return;
             }
+
+            ent.Comp.Signs.Add(signUid.Value);
         }
+
+        DirtyField(ent, ent.Comp, nameof(ChargeHolosignProjectorComponent.Signs));
     }
 
     private void OnBeforeInteract(Entity<ChargeHolosignProjectorComponent> ent, ref BeforeRangedInteractEvent args)
     {
-        if (args.Handled || !args.CanReach ||
+        if (!_timing.IsFirstTimePredicted ||
+            args.Handled || !args.CanReach ||
             HasComp<StorageComponent>(args.Target) || // if it's a storage component like a bag, we ignore usage so it can be stored
             !TryComp<LimitedChargesComponent>(ent, out var charges))
             return;
@@ -76,8 +87,61 @@ public sealed class ChargeHolosignSystem : EntitySystem
         args.Handled = true;
     }
 
-    public bool TryPlaceSign(Entity<ChargeHolosignProjectorComponent, LimitedChargesComponent> ent, EntityCoordinates coords, EntityUid user)
+    private void OnUseInHand(Entity<ChargeHolosignProjectorComponent> ent, ref UseInHandEvent args)
     {
+        if (!_timing.IsFirstTimePredicted || !TryComp<LimitedChargesComponent>(ent, out var charges))
+            return;
+
+        // count how many holosigns we actually managed to recall
+        var count = 0;
+        var remQueue = new List<EntityUid>();
+
+        // recall all holosigns we can
+        foreach (var signUid in ent.Comp.Signs)
+        {
+            if (TerminatingOrDeleted(signUid))
+            {
+                remQueue.Add(signUid);
+                continue;
+            }
+
+            if (ent.Comp.Container.Contains(signUid) || TryRemoveSign((ent, ent.Comp, charges), signUid, args.User, false))
+            {
+                count++;
+            }
+            else
+            {
+                // delete it if we can't recall it
+                if (_net.IsServer)
+                    QueueDel(signUid);
+                remQueue.Add(signUid);
+            }
+        }
+
+        foreach (var signUid in remQueue)
+            ent.Comp.Signs.Remove(signUid);
+
+        // spawn replacements for holosigns we couldn't recall
+        for (var i = count; i < charges.MaxCharges; i++)
+        {
+            if (!TrySpawnInContainer(ent.Comp.SignProto, ent, ent.Comp.ContainerId, out var signUid))
+            {
+                Log.Error($"Failed to spawn sign {ent.Comp.SignProto} for {ToPrettyString(ent)}!");
+                break;
+            }
+
+            _charges.AddCharges((ent, charges), 1);
+            ent.Comp.Signs.Add(signUid.Value);
+        }
+
+        DirtyField(ent, ent.Comp, nameof(ChargeHolosignProjectorComponent.Signs));
+    }
+
+    public bool TryPlaceSign(Entity<ChargeHolosignProjectorComponent?, LimitedChargesComponent?> ent, EntityCoordinates coords, EntityUid user)
+    {
+        if (!Resolve(ent, ref ent.Comp1, ref ent.Comp2))
+            return false;
+
         var container = ent.Comp1.Container;
         if (container.Count == 0 || !_charges.TryUseCharge((ent, ent.Comp2)))
         {
@@ -91,10 +155,13 @@ public sealed class ChargeHolosignSystem : EntitySystem
         return true;
     }
 
-    public bool TryRemoveSign(Entity<ChargeHolosignProjectorComponent, LimitedChargesComponent> ent, EntityUid sign, EntityUid user)
+    public bool TryRemoveSign(Entity<ChargeHolosignProjectorComponent?, LimitedChargesComponent?> ent, EntityUid sign, EntityUid user, bool showIdentity = true)
     {
+        if (!Resolve(ent, ref ent.Comp1, ref ent.Comp2))
+            return false;
+
         // don't overfill
-        if (ent.Comp2.Charges >= ent.Comp2.MaxCharges)
+        if (_charges.GetCurrentCharges((ent, ent.Comp2)) >= ent.Comp2.MaxCharges)
         {
             _popup.PopupClient(Loc.GetString("charge-holoprojector-charges-full", ("item", ent)), sign, user);
             return false;
@@ -106,12 +173,13 @@ public sealed class ChargeHolosignSystem : EntitySystem
             return false;
         }
 
-        _charges.AddCharges(ent, 1, ent);
+        _charges.AddCharges((ent, ent.Comp2), 1);
 
-        var userIdentity = Identity.Name(user, EntityManager);
+        var othersStr = showIdentity ? Loc.GetString("charge-holoprojector-reclaim-others", ("sign", sign), ("user", Identity.Name(user, EntityManager)))
+                                     : Loc.GetString("charge-holoprojector-recall-others", ("sign", sign));
         _popup.PopupPredicted(
             Loc.GetString("charge-holoprojector-reclaim", ("sign", sign)),
-            Loc.GetString("charge-holoprojector-reclaim-others", ("sign", sign), ("user", userIdentity)),
+            othersStr,
             ent,
             user);
         return true;

--- a/Content.Shared/_DV/Holosign/ChargeHolosignSystem.cs
+++ b/Content.Shared/_DV/Holosign/ChargeHolosignSystem.cs
@@ -1,0 +1,119 @@
+using Content.Shared.Charges.Components;
+using Content.Shared.Charges.Systems;
+using Content.Shared.Coordinates.Helpers;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Interaction;
+using Content.Shared.Popups;
+using Content.Shared.Storage;
+using Robust.Shared.Containers;
+using Robust.Shared.Map;
+using System.Linq;
+
+namespace Content.Shared._DV.Holosign;
+
+public sealed class ChargeHolosignSystem : EntitySystem
+{
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly SharedChargesSystem _charges = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private HashSet<Entity<IComponent>> _signs = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ChargeHolosignProjectorComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<ChargeHolosignProjectorComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<ChargeHolosignProjectorComponent, BeforeRangedInteractEvent>(OnBeforeInteract);
+    }
+
+    private void OnInit(Entity<ChargeHolosignProjectorComponent> ent, ref ComponentInit args)
+    {
+        // its required, funny test is still funny
+        if (string.IsNullOrEmpty(ent.Comp.SignComponentName))
+            return;
+
+        ent.Comp.Container = _container.EnsureContainer<Container>(ent, ent.Comp.ContainerId);
+        ent.Comp.SignComponent = EntityManager.ComponentFactory.GetRegistration(ent.Comp.SignComponentName).Type;
+    }
+
+    private void OnMapInit(Entity<ChargeHolosignProjectorComponent> ent, ref MapInitEvent args)
+    {
+        if (!TryComp<LimitedChargesComponent>(ent, out var charges))
+            return;
+
+        var containers = Comp<ContainerManagerComponent>(ent);
+        for (var i = 0; i < charges.MaxCharges; i++)
+        {
+            if (!TrySpawnInContainer(ent.Comp.SignProto, ent, ent.Comp.ContainerId, out _))
+            {
+                Log.Error($"Failed to spawn sign {ent.Comp.SignProto} for {ToPrettyString(ent)}!");
+                return;
+            }
+        }
+    }
+
+    private void OnBeforeInteract(Entity<ChargeHolosignProjectorComponent> ent, ref BeforeRangedInteractEvent args)
+    {
+        if (args.Handled || !args.CanReach ||
+            HasComp<StorageComponent>(args.Target) || // if it's a storage component like a bag, we ignore usage so it can be stored
+            !TryComp<LimitedChargesComponent>(ent, out var charges))
+            return;
+
+        // first check if there's any existing holofans to clear
+        var coords = args.ClickLocation.SnapToGrid(EntityManager);
+        var mapCoords = _transform.ToMapCoordinates(coords);
+        _signs.Clear();
+        _lookup.GetEntitiesInRange(ent.Comp.SignComponent, mapCoords, 0.25f, _signs);
+        if (_signs.Count == 0)
+            TryPlaceSign((ent, ent, charges), coords, args.User);
+        else
+            TryRemoveSign((ent, ent, charges), _signs.First(), args.User);
+
+        args.Handled = true;
+    }
+
+    public bool TryPlaceSign(Entity<ChargeHolosignProjectorComponent, LimitedChargesComponent> ent, EntityCoordinates coords, EntityUid user)
+    {
+        var container = ent.Comp1.Container;
+        if (container.Count == 0 || !_charges.TryUseCharge((ent, ent.Comp2)))
+        {
+            _popup.PopupClient(Loc.GetString("charge-holoprojector-no-charges", ("item", ent)), ent, user);
+            return false;
+        }
+
+        var placed = container.ContainedEntities.First(); // checked Count beforehand so this won't fail
+        _transform.SetCoordinates(placed, coords);
+        _transform.AnchorEntity(placed);
+        return true;
+    }
+
+    public bool TryRemoveSign(Entity<ChargeHolosignProjectorComponent, LimitedChargesComponent> ent, EntityUid sign, EntityUid user)
+    {
+        // don't overfill
+        if (ent.Comp2.Charges >= ent.Comp2.MaxCharges)
+        {
+            _popup.PopupClient(Loc.GetString("charge-holoprojector-charges-full", ("item", ent)), sign, user);
+            return false;
+        }
+
+        if (!_container.Insert(sign, ent.Comp1.Container, force: true))
+        {
+            Log.Error($"Failed to insert holosign {ToPrettyString(sign)} back into {ToPrettyString(ent)}!");
+            return false;
+        }
+
+        _charges.AddCharges(ent, 1, ent);
+
+        var userIdentity = Identity.Name(user, EntityManager);
+        _popup.PopupPredicted(
+            Loc.GetString("charge-holoprojector-reclaim", ("sign", sign)),
+            Loc.GetString("charge-holoprojector-reclaim-others", ("sign", sign), ("user", userIdentity)),
+            ent,
+            user);
+        return true;
+    }
+}

--- a/Content.Shared/_DV/Whitelist/HolofanComponent.cs
+++ b/Content.Shared/_DV/Whitelist/HolofanComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._DV.Whitelist;
+
+/// <summary>
+/// Marker component for holofans, used for reclaiming charges of the projector.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class HolofanComponent : Component;

--- a/Resources/Locale/en-US/_DV/tools/charge-holoprojector.ftl
+++ b/Resources/Locale/en-US/_DV/tools/charge-holoprojector.ftl
@@ -1,0 +1,4 @@
+charge-holoprojector-no-charges = {CAPITALIZE(THE($item))} is empty, reclaim an old holosign first!
+charge-holoprojector-charges-full = {CAPITALIZE(THE($item))} is full, it can't reclaim more charges!
+charge-holoprojector-reclaim = You stop projecting {THE($sign)}.
+charge-holoprojector-reclaim-others = {CAPITALIZE($user)} stops projecting {THE($sign)}.

--- a/Resources/Locale/en-US/_DV/tools/charge-holoprojector.ftl
+++ b/Resources/Locale/en-US/_DV/tools/charge-holoprojector.ftl
@@ -2,3 +2,4 @@ charge-holoprojector-no-charges = {CAPITALIZE(THE($item))} is empty, reclaim an 
 charge-holoprojector-charges-full = {CAPITALIZE(THE($item))} is full, it can't reclaim more charges!
 charge-holoprojector-reclaim = You stop projecting {THE($sign)}.
 charge-holoprojector-reclaim-others = {CAPITALIZE($user)} stops projecting {THE($sign)}.
+charge-holoprojector-recall-others = {CAPITALIZE(THE($sign))} stops being projected.

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -79,17 +79,28 @@
         swap: false
 
 - type: entity
-  parent: Holoprojector
+  parent: BaseItem # DeltaV - remove powercell requirement
   id: HolofanProjector
   name: holofan projector
   description: Stop suicidal passengers from killing everyone during atmos emergencies.
   components:
-  - type: HolosignProjector
+  - type: ChargeHolosignProjector # DeltaV - different implementation using charges
     signProto: HoloFan
-    chargeUse: 120
+    signComponentName: Holofan # DeltaV
+    #chargeUse: 120 # DeltaV
   - type: Sprite
     sprite: Objects/Devices/Holoprojectors/atmos.rsi
     state: icon
+  # Begin DeltaV Additions
+  - type: Item
+    storedRotation: -90
+  - type: LimitedCharges
+    maxCharges: 6 # same as it was on a medium cell
+    charges: 6
+  - type: ContainerContainer
+    containers:
+      signs: !type:Container
+  # End DeltaV Additions
   - type: Tag
     tags:
       - HolofanProjector
@@ -109,12 +120,13 @@
 - type: entity
   parent: HolofanProjector
   id: HolofanProjectorEmpty
+  categories: [ HideSpawnMenu ] # DeltaV - this is identical to the normal one
   suffix: Empty
-  components:
-  - type: ItemSlots
-    slots:
-      cell_slot:
-        name: power-cell-slot-component-slot-name-default
+  #components: # DeltaV - no cell slot for empty one
+  #- type: ItemSlots
+  #  slots:
+  #    cell_slot:
+  #      name: power-cell-slot-component-slot-name-default
 
 - type: entity
   parent: HolofanProjector

--- a/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
@@ -47,7 +47,7 @@
 
 - type: entity
   id: HoloFan
-  parent: HolosignWetFloor
+  parent: BaseHolosign # DeltaV - don't include TimedDespawn
   name: holofan
   description: A barrier of hard light that blocks air, but nothing else.
   components:
@@ -60,10 +60,13 @@
         shape:
           !type:PhysShapeAabb
             bounds: "-0.5,-0.5,0.5,0.5"
-  - type: TimedDespawn
-    lifetime: 180
+  #- type: TimedDespawn # DeltaV - no despawning for holofans
+  #  lifetime: 180
+  - type: Transform # DeltaV
+    noRot: true
   - type: Airtight
     noAirWhenFullyAirBlocked: false
+  - type: Holofan # DeltaV - for whitelisting
 
 - type: entity
   id: HolosignSecurity

--- a/Resources/Prototypes/_DV/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Holographic/projections.yml
@@ -1,0 +1,23 @@
+# like HolosignWetFloor but no sprite or crucially, TimedDespawn
+# this is so holofans can never run out
+- type: entity
+  abstract: true
+  id: BaseHolosign
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: Transform
+    anchored: true
+  - type: Physics
+    bodyType: Static
+    canCollide: false
+  - type: Damageable
+    damageContainer: Inorganic
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 30
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
- ports https://github.com/DeltaV-Station/Delta-v/pull/3462
- adds using it in hand to recall all holofans and restore charges
- adds firsttimepredicted checks because why did it not have those

## Why / Balance
good

## Media
tested pretty extensively
it's shared so tested with 400ms fake lag for no orphan entities and no other trollage

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: deltanedas & Ilya246
- tweak: Holofans now work like in SS13, you can place up to 6 at once with charges reclaimed by removing unused holofans.
- tweak: You can also recall and restore all holofans by using the projector in hand.
- remove: Removed the battery requirement from holofan projectors.