### PR TITLE
[Port] Add Item Rendering to Weapon Recharger

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -156,6 +156,7 @@ using Robust.Shared.ContentPack;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Replays;
 using Robust.Shared.Timing;
+using Content.Client._White.ItemSlotRenderer;
 
 namespace Content.Client.Entry
 {
@@ -283,6 +284,7 @@ namespace Content.Client.Entry
 
             _overlayManager.AddOverlay(new SingularityOverlay());
             _overlayManager.AddOverlay(new RadiationPulseOverlay());
+            _overlayManager.AddOverlay(new SpriteToLayerBullshitOverlay()); // WD EDIT
             _chatManager.Initialize();
             _clientPreferencesManager.Initialize();
             _euiManager.Initialize();

--- a/Content.Client/PowerCell/PowerChargerVisualizerSystem.cs
+++ b/Content.Client/PowerCell/PowerChargerVisualizerSystem.cs
@@ -45,4 +45,5 @@ public enum PowerChargerVisualLayers : byte
 {
     Base,
     Light,
+    ItemDisplay,
 }

--- a/Content.Client/PowerCell/PowerChargerVisualizerSystem.cs
+++ b/Content.Client/PowerCell/PowerChargerVisualizerSystem.cs
@@ -45,5 +45,5 @@ public enum PowerChargerVisualLayers : byte
 {
     Base,
     Light,
-    ItemDisplay,
+    ItemDisplay, // WWDP
 }

--- a/Content.Client/_White/ItemSlotRenderer/ItemSlotRendererComponent.cs
+++ b/Content.Client/_White/ItemSlotRenderer/ItemSlotRendererComponent.cs
@@ -1,0 +1,35 @@
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Content.Client._White.ItemSlotRenderer;
+
+[RegisterComponent]
+public sealed partial class ItemSlotRendererComponent : Component
+{
+    // [slotId] = layer mapping (in string form)
+    [DataField("mapping")]
+    public Dictionary<string, string> PrototypeLayerMappings = new();
+
+    // [mapkey] = slotId
+    [ViewVariables(VVAccess.ReadWrite)]
+    public List<(object, string)> LayerMappings = new();
+
+    // [slotId] = entity uid
+    [ViewVariables(VVAccess.ReadOnly)]
+    public Dictionary<string, EntityUid?> CachedEntities = new();
+
+    // [slotId] = IRenderTexture
+    [ViewVariables(VVAccess.ReadOnly)]
+    public Dictionary<string, IRenderTexture> CachedRT = new();
+
+    [DataField]
+    public bool ErrorOnMissing = true;
+
+    [DataField]
+    public Vector2i RenderTargetSize = new Vector2i(32, 32);
+}

--- a/Content.Client/_White/ItemSlotRenderer/ItemSlotRendererSystem.cs
+++ b/Content.Client/_White/ItemSlotRenderer/ItemSlotRendererSystem.cs
@@ -1,0 +1,143 @@
+using Content.Client.Hands;
+using Content.Shared.Containers.ItemSlots;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.Input;
+using Robust.Shared.Containers;
+using Robust.Shared.Enums;
+using Robust.Shared.Graphics;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+using Robust.Shared.Reflection;
+using Robust.Shared.Timing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Content.Client._White.ItemSlotRenderer;
+
+/// <summary>
+/// I can feel my grip on reality slowly slipping.
+/// </summary>
+public sealed class ItemSlotRendererSystem : EntitySystem
+{
+    [Dependency] private readonly IReflectionManager _reflection = default!;
+    [Dependency] private readonly ItemSlotsSystem _slot = default!;
+    [Dependency] private readonly IClyde _clyde = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ItemSlotRendererComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<ItemSlotRendererComponent, ComponentRemove>(OnRemove);
+        SubscribeLocalEvent<ItemSlotRendererComponent, EntInsertedIntoContainerMessage>(OnInsertIntoContainer);
+        SubscribeLocalEvent<ItemSlotRendererComponent, EntRemovedFromContainerMessage>(OnRemoveFromContainer);
+
+    }
+    private void OnInsertIntoContainer(EntityUid uid, ItemSlotRendererComponent comp, EntInsertedIntoContainerMessage args)
+    {
+        if (args.Container is not ContainerSlot || !_timing.IsFirstTimePredicted)
+            return;
+
+        comp.CachedEntities[args.Container.ID] = args.Entity;
+    }
+
+    private void OnRemoveFromContainer(EntityUid uid, ItemSlotRendererComponent comp, EntRemovedFromContainerMessage args)
+    {
+        if (args.Container is not ContainerSlot || !_timing.IsFirstTimePredicted)
+            return;
+
+        comp.CachedEntities[args.Container.ID] = null;
+    }
+
+    private void OnRemove(EntityUid uid, ItemSlotRendererComponent comp, ComponentRemove args)
+    {
+        foreach (var (_, renderTexture) in comp.CachedRT)
+            renderTexture.Dispose();
+    }
+
+    private void OnStartup(EntityUid uid, ItemSlotRendererComponent comp, ComponentStartup args)
+    {
+        if(!TryComp<SpriteComponent>(uid, out var sprite))
+        {
+            Log.Error($"ItemSlotRendererCompontn requires SpriteComponent to work, but {ToPrettyString(uid)} did not have one. Removing ItemSlotRenderer.");
+            RemComp<ItemSlotRendererComponent>(uid);
+            return;
+        }
+
+        foreach (var kvp in comp.PrototypeLayerMappings)
+        {
+
+            (string slotId, object mapKey) = kvp;
+            bool isEnum = false;
+            if (_reflection.TryParseEnumReference((string)mapKey, out var e))
+            {
+                mapKey = e;
+                isEnum = true;
+            }
+            if (!sprite.LayerMapTryGet(mapKey, out _) && comp.ErrorOnMissing)
+            {
+                Log.Warning($"ItemSlotRenderer: Tried to add a missing layer under the {(isEnum ? "enum" : "string")} key {mapKey}. Skipping missing layer. If this is unwanted, set component's ErrorOnMissing to false.");
+                continue;
+            }
+
+            if(_slot.TryGetSlot(uid, slotId, out var slot))
+                comp.CachedEntities[slotId] = slot.Item;
+
+            comp.LayerMappings.Add((mapKey, slotId));
+
+            comp.CachedRT.Add(slotId, _clyde.CreateRenderTarget(comp.RenderTargetSize, new RenderTargetFormatParameters(RenderTargetColorFormat.Rgba8Srgb), new TextureSampleParameters { Filter = false }, $"{slotId}-itemrender-rendertarget"));
+        }
+    }
+}
+
+/// <summary>
+/// Doesn't actually render anything by itself. I'd place this code in a system's FrameUpdate,
+/// but I need to somehow acquire a draw handle to draw an entity to a texture.
+/// </summary>
+public sealed class SpriteToLayerBullshitOverlay : Overlay
+{
+    [Dependency] private readonly EntityManager _entMan = default!;
+
+    public override OverlaySpace Space => OverlaySpace.ScreenSpaceBelowWorld;
+
+    public SpriteToLayerBullshitOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        var handle = args.ScreenHandle;
+        var query = _entMan.EntityQueryEnumerator<ItemSlotRendererComponent, SpriteComponent>();
+        while (query.MoveNext(out var uid, out var comp, out var sprite))
+        {
+            for (int i = 0; i < comp.LayerMappings.Count; i++)
+            {
+                var (layerKey, slotId) = comp.LayerMappings[i];
+                if (!sprite.LayerMapTryGet(layerKey, out int layerIndex) ||
+                    !sprite.TryGetLayer(layerIndex, out var layer)) // verify that the layer actually exists
+                    continue;
+
+                // if for some reason we can't render the item to a texture (or there is no item to render),
+                // assign an "empty" texture to the layer
+                if (!comp.CachedEntities.TryGetValue(slotId, out var _item) || _item is not EntityUid item ||
+                    !comp.CachedRT.TryGetValue(slotId, out var renderTarget))
+                {
+                    if (layer.Texture != Texture.Transparent)
+                        sprite.LayerSetTexture(layerIndex, Texture.Transparent);
+                    continue;
+                }
+
+                handle.RenderInRenderTarget(renderTarget, () =>
+                {
+                    handle.DrawEntity(item, renderTarget.Size / 2, Vector2.One, 0); // If this throws due to a missing spritecomp, it's your fault.
+                }, Color.Transparent);
+                sprite.LayerSetTexture(layerIndex, renderTarget.Texture);
+            }
+        }
+    }
+}

--- a/Content.Server/Entry/IgnoredComponents.cs
+++ b/Content.Server/Entry/IgnoredComponents.cs
@@ -82,6 +82,7 @@ namespace Content.Server.Entry
             "OptionsVisualizer",
             "ToggleableLightWieldable", // Goobstation
             "HideClothingLayerClothing", // Goobstation
+            "ItemSlotRenderer", // WWDP EDIT
         };
     }
 }

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -198,6 +198,17 @@
   components:
   - type: Sprite
     sprite: Structures/Power/recharger.rsi
+    layers:
+    - map: ["enum.PowerChargerVisualLayers.Base"]
+      state: "empty"
+    - map: ["enum.PowerChargerVisualLayers.Light"]
+      state: "light-off"
+      shader: "unshaded"
+    - map: ["enum.PowerChargerVisualLayers.ItemDisplay"]
+      shader: "FlickerHologram"
+      color: "#ffffffaa"
+      offset: 0,0.45
+      scale: 0.5,0.5
   - type: Machine
     board: WeaponCapacitorRechargerCircuitboard
   # no powercellslot since stun baton etc arent powercells
@@ -218,6 +229,10 @@
           - WizardWand
           components:
           - MaterialEnergy
+
+  - type: ItemSlotRenderer
+    mapping:
+      charger_slot: enum.PowerChargerVisualLayers.ItemDisplay
 
 - type: entity
   parent: BaseItemRecharger

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -199,6 +199,7 @@
   - type: Sprite
     sprite: Structures/Power/recharger.rsi
     layers:
+    # WWDP Edit begin
     - map: ["enum.PowerChargerVisualLayers.Base"]
       state: "empty"
     - map: ["enum.PowerChargerVisualLayers.Light"]
@@ -209,6 +210,7 @@
       color: "#ffffffaa"
       offset: 0,0.45
       scale: 0.5,0.5
+    # WWDP Edit end
   - type: Machine
     board: WeaponCapacitorRechargerCircuitboard
   # no powercellslot since stun baton etc arent powercells
@@ -229,8 +231,7 @@
           - WizardWand
           components:
           - MaterialEnergy
-
-  - type: ItemSlotRenderer
+  - type: ItemSlotRenderer # WWDP
     mapping:
       charger_slot: enum.PowerChargerVisualLayers.ItemDisplay
 
@@ -242,6 +243,19 @@
   components:
   - type: Sprite
     sprite: Structures/Power/turbo_recharger.rsi
+    layers:
+    # WWDP Edit begin
+    - map: ["enum.PowerChargerVisualLayers.Base"]
+      state: "empty"
+    - map: ["enum.PowerChargerVisualLayers.Light"]
+      state: "light-off"
+      shader: "unshaded"
+    - map: ["enum.PowerChargerVisualLayers.ItemDisplay"]
+      shader: "FlickerHologram"
+      color: "#ffffffaa"
+      offset: 0,0.45
+      scale: 0.5,0.5
+    # WWDP Edit end
   - type: Machine
     board: TurboItemRechargerCircuitboard
   - type: Charger
@@ -262,6 +276,9 @@
           - WizardWand # Goobstation
           components:  # Goobstation
           - MaterialEnergy
+  - type: ItemSlotRenderer # WWDP
+    mapping:
+      charger_slot: enum.PowerChargerVisualLayers.ItemDisplay
 
 - type: entity
   parent: BaseItemRecharger
@@ -276,6 +293,13 @@
     - map: ["enum.PowerChargerVisualLayers.Light"]
       state: "light-off"
       shader: "unshaded"
+      # WWDP Edit begin
+    - map: ["enum.PowerChargerVisualLayers.ItemDisplay"]
+      shader: "FlickerHologram"
+      color: "#ffffffaa"
+      offset: 0,0.45
+      scale: 0.5,0.5
+      # WWDP Edit end
   - type: WallMount
   - type: Charger
     chargeRate: 25
@@ -291,6 +315,9 @@
         blacklist:  # Goobstation
           tags:
           - WizardWand
+  - type: ItemSlotRenderer # WWDP
+    mapping:
+      charger_slot: enum.PowerChargerVisualLayers.ItemDisplay
 
 - type: entity
   parent: BaseRecharger

--- a/Resources/Prototypes/_White/Shaders/shaders.yml
+++ b/Resources/Prototypes/_White/Shaders/shaders.yml
@@ -8,3 +8,25 @@
   id: NightVision
   kind: source
   path: "/Textures/_White/Shaders/nightvision.swsl"
+
+- type: shader
+  id: FlickerHologram
+  kind: source
+  path: "/Textures/_White/Shaders/flickerhologram.swsl"
+  light_mode: unshaded
+  params:
+    jitter: 0.5
+    colorJitter: 0.4
+    alphaJitter: 0.5
+    hue: 0.48
+
+- type: shader
+  id: FlickerHologramGlitch
+  kind: source
+  path: "/Textures/_White/Shaders/flickerhologram.swsl"
+  light_mode: unshaded
+  params:
+    jitter: 5
+    colorJitter: 0.8
+    alphaJitter: 1
+    hue: 0.48

--- a/Resources/Textures/_White/Shaders/flickerhologram.swsl
+++ b/Resources/Textures/_White/Shaders/flickerhologram.swsl
@@ -1,0 +1,67 @@
+//
+// https://gamedev.stackexchange.com/a/59808
+//
+//   Author: sam hocevar
+// Answered: Jul 27, 2013 at 13:33
+//  License: CC BY-SA 3.0
+//
+
+uniform highp float jitter;
+uniform highp float colorJitter;
+uniform highp float alphaJitter;
+uniform highp float hue;
+
+highp vec3 rgb2hsv(highp vec3 c)
+{
+    highp vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+    highp vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+    highp vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+
+    highp float d = q.x - min(q.w, q.y);
+    /* float e = 1.0e-10; */
+    highp float e = 0.0000000001;
+    return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+}
+
+highp vec3 hsv2rgb(highp vec3 c)
+{
+    highp vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+    highp vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+    return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+}
+
+highp float rng(highp vec2 co){
+    return fract(sin(dot(co.xy ,vec2(12.9898,78.233))) * 43758.5453);
+}
+
+highp vec3 blend(highp vec3 base, highp vec3 color, highp float factor){
+	return base+(color-base)*factor;
+}
+
+// quick and simple okay-ish looking shader because i don't like the deltaV one.
+void fragment() {
+
+
+	highp float hue2 = hue-0.01;
+
+	// introduces random noise in the X coord of the UV, seeded by Y
+	// produces scanline-like effect, with each line of pixels being randomly displaced left or right
+	// makes the item jitter a bit
+	highp float dispfloat = rng(vec2(UV.y*TIME, 0)) * jitter;
+
+    highp vec4 tex = zTexture(UV + vec2(dispfloat*TEXTURE_PIXEL_SIZE.x*0.5, 0));
+	highp vec3 col = rgb2hsv(tex.rgb);
+	col.x = hue;
+	col.z = (log(col.z) + 4.0) / 4.0; // increase the value in hsv color, helps with highlighting detail
+
+	// this produces a color which randomly flashes from hue2 (at max value) to white
+	// mixed in with sprite color down below
+	highp vec3 col2 = hsv2rgb(vec3(hue2, rng(vec2(TIME*0.001, 0)) * colorJitter + (1.0 - colorJitter), 1.0));
+	col = hsv2rgb(col);
+
+	COLOR = vec4(mix(col, col2, 0.3), max(tex.w*(sin(TIME * sin(TIME)))*0.25, 0.0)+0.45*tex.w);
+	// another scanline-like effect, but with transparensy this time
+	// "*=" instead of proper construction because it's an afterthought
+	COLOR.w *= rng(vec2(0, 1.09248882*TIME*UV.y)) * alphaJitter + (1.0 - alphaJitter);
+	lightSample = vec3(1.0);
+}


### PR DESCRIPTION
## About the PR
This ports the Item Hologram Renderer from Einstein Engines from this PR: https://github.com/Simple-Station/Einstein-Engines/pull/2480. This adds a hologram icon of the item placed into the recharger, and I expanded it to the Turbo Recharger and the Wall-Mounted Recharger.

## Why / Balance
![image](https://github.com/user-attachments/assets/3a6fce15-feb6-4ec2-a50c-454da6870780)

## Technical details
This adds shaders from the WWDP and creates a new system for rendering icons and mapping them to the item. This is shown in the PR referenced.

## Media
![image](https://github.com/user-attachments/assets/a33d048f-9da0-4297-8757-0195ed94d1c5)
![image](https://github.com/user-attachments/assets/2a1546b3-febd-4459-b8a8-124263793220)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
There are none that I know of.

**Changelog**
:cl: CerberusWolfie, Erisfiregamer1
- add: Added an Item Renderer Hologram to the Recharger, Turbo Recharger, and Wall-Mounted Recharger. You can now see what you are recharging in the form of a little hologram!