### PR TITLE
Morphchems sillies :3

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/flavors/flavor-profiles.ftl
+++ b/Resources/Locale/en-US/_Goobstation/flavors/flavor-profiles.ftl
@@ -19,4 +19,6 @@ flavor-base-alienblood = alien
 flavor-base-old = old
 flavor-base-robust = robust
 flavor-complex-unicorntears = like unicorn tears
-
+flavor-stupid = stupid
+flavor-complex-mothsweetnsour = chaotically sweet and sour
+flavor-complex-inkyvoid = like an inky void

--- a/Resources/Locale/en-US/_Goobstation/reagents/meta/fun.ftl
+++ b/Resources/Locale/en-US/_Goobstation/reagents/meta/fun.ftl
@@ -52,3 +52,18 @@ reagent-desc-nostalgia = Why is this here?
 
 reagent-name-tilenol = tilenol
 reagent-desc-tilenol = You can feel yourself becoming more robust just by holding this.
+
+reagent-name-birdflu = bird flu 
+reagent-desc-birdflu = The bird flu? Yeah...they tend to do that.
+
+reagent-name-moffaine = moffaine
+reagent-desc-moffaine = This reagent chitters at you... odd. CRACK MOFFA-
+
+reagent-name-cacaphonium = cacaphonium
+reagent-desc-cacaphonium = By mimicking the process used by an infamous researcher, this compound can temporarily and agressively emulate the process that was used to create squackroaches.
+
+reagent-name-chitterzine = chitterzine
+reagent-desc-chitterzine = A half-succesful experiment done by a deranged mothperson cult. The created concotion is capable of forcefully, agressively, although temporarily, morph someone or something into a mothroach.
+
+reagent-name-marotine = marotine
+reagent-desc-marotine = The purified form of species struggles.

--- a/Resources/Locale/en-US/_Goobstation/reagents/meta/physical-desc.ftl
+++ b/Resources/Locale/en-US/_Goobstation/reagents/meta/physical-desc.ftl
@@ -14,3 +14,6 @@ reagent-physical-desc-sigma = sigma
 reagent-physical-desc-ling = living
 reagent-physical-desc-comforting = comforting
 reagent-physical-desc-alien = alien
+reagent-physical-desc-feathery = feathery
+reagent-physical-desc-chaoticallyfuzzy = chaotically fuzzy
+reagent-physical-desc-headacheinducing = headache inducing

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -24,6 +24,7 @@
 # SPDX-FileCopyrightText: 2024 potato1234_x <79580518+potato1234x@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Pon <pongozdalski@gmail.com>
 # SPDX-FileCopyrightText: 2025 Princess Cheeseballs <66055347+Pronana@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -24,8 +24,12 @@
 # SPDX-FileCopyrightText: 2024 potato1234_x <79580518+potato1234x@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Pon <pongozdalski@gmail.com>
+# SPDX-FileCopyrightText: 2025 Princess Cheeseballs <66055347+Pronana@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 UpAndLeaves <92269094+Alpha-Two@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Velken <8467292+Velken@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 āda <ss.adasts@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -431,3 +431,125 @@
         conditions:
         - !type:ReagentThreshold
           min: 50
+
+- type: reagent
+  id: BirdFlu
+  name: reagent-name-birdflu
+  group: Toxins
+  desc: reagent-desc-birdflu
+  physicalDesc: reagent-physical-desc-feathery
+  flavor: stupid
+  color: "#58DCA8"
+  metabolisms:
+    Poison:
+      metabolismRate: 0.25
+      effects:
+      - !type:Polymorph
+        prototype: PolymorphHarpy
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+      - !type:AdjustReagent
+        reagent: BirdFlu
+        amount: -40 # Prevents the bug that keeps demorphing and morphing a person keeping them in place when injected with way over the threshold for morphing, once demorphed by knocking into crit.
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+
+- type: reagent
+  id: Moffaine
+  name: reagent-name-moffaine
+  group: Toxins
+  desc: reagent-desc-moffaine
+  physicalDesc: reagent-physical-desc-chaoticallyfuzzy
+  flavor: mothsweetnsour
+  color: "#a592db"
+  metabolisms:
+    Poison:
+      metabolismRate: 0.25
+      effects:
+      - !type:Jitter
+      - !type:Polymorph
+        prototype: PolymorphMoth
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+      - !type:AdjustReagent
+        reagent: Moffaine
+        amount: -40 # Prevents the bug that keeps demorphing and morphing a person keeping them in place when injected with way over the threshold for morphing, once demorphed by knocking into crit.
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+
+- type: reagent
+  id: Cacaphonium
+  name: reagent-name-cacaphonium
+  group: Toxins
+  desc: reagent-desc-cacaphonium
+  physicalDesc: reagent-physical-desc-feathery
+  flavor: stupid
+  color: "#84dcb9"
+  metabolisms:
+    Poison:
+      metabolismRate: 0.25
+      effects:
+      - !type:Polymorph
+        prototype: PolymorphSquackroach
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+      - !type:AdjustReagent
+        reagent: Cacaphonium
+        amount: -40 # Prevents the bug that keeps demorphing and morphing a person keeping them in place when injected with way over the threshold for morphing, once demorphed by knocking into crit.
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+
+- type: reagent
+  id: Chitterzine
+  name: reagent-name-chitterzine
+  group: Toxins
+  desc: reagent-desc-chitterzine
+  physicalDesc: reagent-physical-desc-chaoticallyfuzzy
+  flavor: mothsweetnsour
+  color: "#baaedb"
+  metabolisms:
+    Poison:
+      metabolismRate: 0.25
+      effects:
+      - !type:Jitter
+      - !type:Polymorph
+        prototype: PolymorphMothroach
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+      - !type:AdjustReagent
+        reagent: Chitterzine
+        amount: -40 # Prevents the bug that keeps demorphing and morphing a person keeping them in place when injected with way over the threshold for morphing, once demorphed by knocking into crit.
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+
+- type: reagent
+  id: Marotine
+  name: reagent-name-marotine
+  group: Toxins
+  desc: reagent-desc-marotine
+  physicalDesc: reagent-physical-desc-headacheinducing
+  flavor: inkyvoid
+  color: "#3065b0"
+  metabolisms:
+    Poison:
+      metabolismRate: 0.25
+      effects:
+      - !type:Polymorph
+        prototype: PolymorphShadowkin
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
+      - !type:AdjustReagent
+        reagent: Marotine
+        amount: -40 # Prevents the bug that keeps demorphing and morphing a person keeping them in place when injected with way over the threshold for morphing, once demorphed by knocking into crit.
+        conditions:
+        - !type:ReagentThreshold
+          min: 50

--- a/Resources/Prototypes/_Goobstation/Flavors/flavors.yml
+++ b/Resources/Prototypes/_Goobstation/Flavors/flavors.yml
@@ -56,6 +56,8 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 Pon <pongozdalski@gmail.com>
+# SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 #

--- a/Resources/Prototypes/_Goobstation/Flavors/flavors.yml
+++ b/Resources/Prototypes/_Goobstation/Flavors/flavors.yml
@@ -110,3 +110,18 @@
   id: robust
   flavorType: Base
   description: flavor-base-robust
+
+- type: flavor
+  id: stupid
+  flavorType: Base
+  description: flavor-stupid
+
+- type: flavor
+  id: mothsweetnsour
+  flavorType: Complex
+  description: flavor-complex-mothsweetnsour
+
+- type: flavor
+  id: inkyvoid
+  flavorType: Complex
+  description: flavor-complex-inkyvoid

--- a/Resources/Prototypes/_Goobstation/Flavors/flavors.yml
+++ b/Resources/Prototypes/_Goobstation/Flavors/flavors.yml
@@ -56,6 +56,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Pon <pongozdalski@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>

--- a/Resources/Prototypes/_Goobstation/Polymorphs/polymorph.yml
+++ b/Resources/Prototypes/_Goobstation/Polymorphs/polymorph.yml
@@ -113,3 +113,58 @@
     forced: true
     duration: 180
     attachToGridOrMap: true
+
+- type: polymorph 
+  id: PolymorphHarpy
+  configuration:
+    entity: MobHarpyRandom
+    forced: true
+    inventory: Transfer
+    transferName: true
+    transferDamage: true
+    revertOnDeath: true
+    revertOnCrit: true
+
+- type: polymorph 
+  id: PolymorphMoth
+  configuration:
+    entity: MobMothRandom
+    forced: true
+    inventory: Transfer
+    transferName: true
+    transferDamage: true
+    revertOnDeath: true
+    revertOnCrit: true
+
+- type: polymorph
+  id: PolymorphSquackroach
+  configuration:
+    entity: MobSquackroach
+    forced: true
+    inventory: None
+    transferName: true
+    transferDamage: true
+    revertOnDeath: true
+    revertOnCrit: true
+
+- type: polymorph
+  id: PolymorphMothroach
+  configuration:
+    entity: MobMothroach
+    forced: true
+    inventory: None
+    transferName: true
+    transferDamage: true
+    revertOnDeath: true
+    revertOnCrit: true
+
+- type: polymorph
+  id: PolymorphShadowkin
+  configuration:
+    entity: MobShadowkinRandom
+    forced: true
+    inventory: Transfer
+    transferName: true
+    transferDamage: true
+    revertOnDeath: true
+    revertOnCrit: true

--- a/Resources/Prototypes/_Goobstation/Polymorphs/polymorph.yml
+++ b/Resources/Prototypes/_Goobstation/Polymorphs/polymorph.yml
@@ -6,6 +6,7 @@
 # SPDX-FileCopyrightText: 2025 Fishbait <Fishbait@git.ml>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
+# SPDX-FileCopyrightText: 2025 Pon <pongozdalski@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>

--- a/Resources/Prototypes/_Goobstation/Reagents/narcotics.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/narcotics.yml
@@ -378,7 +378,12 @@
         visualType: Medium
         messages: [ "mousebites-effects-vexes", "mousebites-effects-stupid", "mousebites-effects-metoo" ]
         probability: 0.10
-
+      - !type:AdjustReagent
+        reagent: MouseBites
+        amount: -20 # # added because of the bug that keeps demorphing and morphing a person keeping them in place when injected with way over the threshold for morphing, once demorphed by knocking into crit.
+        conditions:
+        - !type:ReagentThreshold
+          min: 50
 
 - type: reagent
   id: OleoresinCapsaicin

--- a/Resources/Prototypes/_Goobstation/Reagents/narcotics.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/narcotics.yml
@@ -8,8 +8,10 @@
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Pon <pongozdalski@gmail.com>
 # SPDX-FileCopyrightText: 2025 PunishedJoe <PunishedJoeseph@proton.me>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>

--- a/Resources/Prototypes/_Goobstation/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Reactions/fun.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Pon <pongozdalski@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>

--- a/Resources/Prototypes/_Goobstation/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Reactions/fun.yml
@@ -2,7 +2,9 @@
 # SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 Pon <pongozdalski@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>

--- a/Resources/Prototypes/_Goobstation/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Reactions/fun.yml
@@ -110,3 +110,71 @@
       amount: 4
   products:
     Tilenol: 1
+
+- type: reaction
+  id: BirdFlu
+  reactants:
+    Egg:
+      amount: 6
+    Impedrezene:
+      amount: 6
+    Ephedrine:
+      amount: 6
+  products:
+    BirdFlu: 20
+  
+- type: reaction
+  id: Moffaine
+  reactants:
+    Fiber: 
+      amount: 6
+    Sugar:
+      amount: 2
+    InsectBlood:
+      amount: 3
+    Phlogiston:
+      amount: 1
+  products:
+    Moffaine: 12
+
+- type: reaction
+  id: Cacaphonium
+  reactants:
+    BirdFlu: 
+      amount: 6 
+    SpaceDrugs:
+      amount: 1
+    Sugar:
+      amount: 1
+    InsectBlood:
+      amount: 2
+  products:
+    Cacaphonium: 10
+
+- type: reaction
+  id: Chitterzine
+  reactants:
+    Moffaine:
+      amount: 6
+    SpaceDrugs:
+      amount: 1
+    Ash: 
+      amount: 1
+    EnergyDrink:
+      amount: 2
+  products:
+    Chitterzine: 10
+
+- type: reaction
+  id: Marotine
+  reactants:
+    BlackBlood:
+      amount: 3
+    NorepinephricAcid:
+      amount: 5
+    MindbreakerToxin:
+      amount: 3
+    JuiceCarrot:
+      amount: 1
+  products:
+    Marotine: 12


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
This PR adds five (5) new chems into the game, as well as slightly changing mouse bites to fix a bug that causes them to demorph and morph getting the person to be stuck in place, once you demorph them by critting them. (this only happened if you injected them with waaay over the threshold limit of the chem)
Polymorphs required for the chems to function have also been added. 
The chems are:
Bird flu (harpy), moffaine (mothperson), marotine (shadowkin), cacaphonium (squackroach), chitterzine (mothroach).
They all morph the person or thing injected with them into something, if the threshold is reached. They all have a 50 unit threshold, and they all revert on crit/death. 
They also remove 40 units of themselves from the metabolizers system upon reaching the morph threshold (50u), to prevent the same bug I fixed for mouse bites.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A part of this is technically a bounty (Cyg wanted bird flu and cacaphonium) and the rest were mostly made due to the public in mrp expressing that they want these. (mostly about mothroach, and a bunch also said yes to shadowkin when I asked if anyone would want such a thing)
Besides, they're really silly chems that I think will make for some funny interactions and/or situations in game. Don't see any harm that they could do.
## Technical details
<!-- Summary of code changes for easier review. -->
Mostly yaml :3 
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/cb5dddca-eb7c-4961-99a3-ddfc1cd147b4


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added five (5) new chemicals, Bird Flu, Moffaine, Cacaphonium, Chitterzine and Marotine! Each of these morphs the metabolizer into a different entity upon reaching 50 units, those being either a harpy, mothperson, squackroach, mothroach, or shadowkin! Reverts upon crit or death.
- fix: Fixed a bug with mousebites that caused them to constantly demorph and morph the metabolizer, upon being demorphed by hitting them into crit. This happened when there were way more mouse bites in the metabolizers system than the threshold of 50 units is.

