### PR TITLE
Fix insta stun + tweak batons

### DIFF
--- a/Content.Shared/_Shitcode/Heretic/Components/DisgustComponent.cs
+++ b/Content.Shared/_Shitcode/Heretic/Components/DisgustComponent.cs
@@ -12,16 +12,16 @@ public sealed partial class DisgustComponent : Component
     public float CurrentLevel = 5f;
 
     [DataField]
-    public float PassiveReduction = 0.5f;
+    public float PassiveReduction = 5f;
 
     [DataField]
-    public float NegativeEffectProb = 0.05f;
+    public float NegativeEffectProb = 0.025f;
 
     [DataField]
-    public float BadNegativeEffectProb = 0.13f;
+    public float BadNegativeEffectProb = 0.10f;
 
     [DataField]
-    public float ModifierPerUpdate = 5f;
+    public float ModifierPerUpdate = 2.5f;
 
     [DataField]
     public TimeSpan NegativeTime = TimeSpan.FromSeconds(2);

--- a/Content.Shared/_Shitcode/Heretic/Components/DisgustComponent.cs
+++ b/Content.Shared/_Shitcode/Heretic/Components/DisgustComponent.cs
@@ -12,16 +12,16 @@ public sealed partial class DisgustComponent : Component
     public float CurrentLevel = 5f;
 
     [DataField]
-    public float PassiveReduction = 5f;
+    public float PassiveReduction = 0.5f;
 
     [DataField]
-    public float NegativeEffectProb = 0.025f;
+    public float NegativeEffectProb = 0.05f;
 
     [DataField]
-    public float BadNegativeEffectProb = 0.10f;
+    public float BadNegativeEffectProb = 0.13f;
 
     [DataField]
-    public float ModifierPerUpdate = 2.5f;
+    public float ModifierPerUpdate = 5f;
 
     [DataField]
     public TimeSpan NegativeTime = TimeSpan.FromSeconds(2);

--- a/Content.Shared/_Shitcode/Heretic/Components/DisgustComponent.cs
+++ b/Content.Shared/_Shitcode/Heretic/Components/DisgustComponent.cs
@@ -1,9 +1,3 @@
-// SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._Shitcode.Heretic.Components;

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -64,14 +64,9 @@
     animation: WeaponArcThrust
   # it was ~35 now it's 55 so it's a buff ig
   - type: StaminaDamageOnHit # goob edited
-    damage: 15
-    overtime: 40
-    lightAttackDamageMultiplier: 5
-    lightAttackOvertimeDamageMultiplier: 0
-    sound: /Audio/Weapons/egloves.ogg
-  - type: StaminaDamageOnCollide # goob edited
-    damage: 15
-    overtime: 40
+    damage: 5
+    overtime: 1
+    lightAttackOvertimeDamageMultiplier: 40
     sound: /Audio/Weapons/egloves.ogg
   - type: DelayedKnockdownOnHit # Goobstation
     useDelay: stunbaton

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -15,9 +15,11 @@
 # SPDX-FileCopyrightText: 2024 whateverusername0 <whateveremail>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <aviu00@protonmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -104,4 +104,4 @@
     price: 100
   - type: Construction
     graph: makeshiftstunprod
-    node: msstunprod
+    node: stunprod

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -96,7 +96,6 @@
 # SPDX-FileCopyrightText: 2024 foboscheshir <156405958+foboscheshir@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 metalgearsloth <comedian_vs_clown@hotmail.com>
 # SPDX-FileCopyrightText: 2024 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 plykiya <plykiya@protonmail.com>
@@ -114,6 +113,7 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <aviu00@protonmail.com>
 # SPDX-FileCopyrightText: 2025 BramvanZijp <56019239+BramvanZijp@users.noreply.github.com>
@@ -124,10 +124,13 @@
 # SPDX-FileCopyrightText: 2025 Killerqu00 <47712032+Killerqu00@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Lincoln McQueen <lincoln.mcqueen@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+# SPDX-FileCopyrightText: 2025 Token <56667933+TokenStyle@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 VMSolidus <evilexecutive@gmail.com>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
+# SPDX-FileCopyrightText: 2025 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 vanx <61917534+Vaaankas@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -239,7 +239,6 @@
   - type: GuideHelp
     guides:
     - Security
-    - Antagonists
   - type: MartialArtBlocked # Goobstation - Martial Arts
     form: CorporateJudo # Goobstation - Martial Arts
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -180,21 +180,16 @@
     animation: WeaponArcThrust
   # it was ~35 now it's 55 so it's a buff ig
   - type: StaminaDamageOnHit # goob edited
-    damage: 15
-    overtime: 40
-    lightAttackDamageMultiplier: 5
-    lightAttackOvertimeDamageMultiplier: 0
-    sound: /Audio/Weapons/egloves.ogg
-  - type: StaminaDamageOnCollide # goob edited
-    damage: 15
-    overtime: 40
+    damage: 5
+    overtime: 1
+    lightAttackOvertimeDamageMultiplier: 50
     sound: /Audio/Weapons/egloves.ogg
   - type: DelayedKnockdownOnHit # Goobstation
     useDelay: stunbaton
   - type: UseDelayBlockMelee # Goobstation
     delays:
     - stunbaton
-  - type: LandAtCursor # it deals stamina damage when thrown
+  - type: LandAtCursor
   - type: Battery
     maxCharge: 1000
     startingCharge: 1000

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/blueshield.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/blueshield.yml
@@ -69,14 +69,9 @@
     soundHit:
       path: /Audio/_Goobstation/Weapons/Effects/metalcrush.ogg
   - type: StaminaDamageOnHit
-    damage: 40
-    overtime: 40
-    lightAttackDamageMultiplier: 2
-    lightAttackOvertimeDamageMultiplier: 0.5
-    sound: /Audio/Weapons/egloves.ogg
-  - type: StaminaDamageOnCollide
-    damage: 15
-    overtime: 40
+    damage: 5
+    overtime: 1
+    lightAttackOvertimeDamageMultiplier: 50
     sound: /Audio/Weapons/egloves.ogg
   - type: LandAtCursor
   - type: Battery

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/blueshield.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/blueshield.yml
@@ -15,6 +15,7 @@
 # SPDX-FileCopyrightText: 2024 whateverusername0 <whateveremail>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2025 Armok <155400926+ARMOKS@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>


### PR DESCRIPTION
Batons could insta stun by hitting, throwing, and disarming. No longer. Should keep time to stun values about the same.
:cl: Armok
- remove: Insta stun abuse
- tweak: Tweak stun batons to require sprite clicking to be effective

