### PR TITLE
Completely removes Gorlex Hypospray cooldown

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -183,8 +183,6 @@
     solution: hypospray
   - type: Hypospray
     onlyAffectsMobs: false
-  - type: UseDelay
-    delay: 0.5
   - type: Appearance
   - type: SolutionContainerVisuals
     maxFillLevels: 4


### PR DESCRIPTION
<!-- What did you change? -->
deleted two lines of code

## Why / Balance
The majority of the time spent healing is in actually moving your mouse between the chems in your bag and to the person you're trying to heal. Removing the cooldown on the actual injection part makes healing people feel a lot smoother, as you can spam it without the very slight delay. It's so minor I can't see it affecting any balancing, as the time spent actually injecting stuff has been reduced by like, half a second. It just feels better this way.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

:cl:
- tweak: The Gorlex Hypospray no longer has a cooldown between injections. Heal to your heart's content.
-->
