### PR TITLE
nuclear blast mining

### DIFF
--- a/Content.Goobstation.Server/Atmos/EntitySystems/LavalandTankRangeSystem.cs
+++ b/Content.Goobstation.Server/Atmos/EntitySystems/LavalandTankRangeSystem.cs
@@ -1,0 +1,27 @@
+using Content.Goobstation.Shared.Atmos.Events;
+using Content.Server._Lavaland.Procedural.Components;
+
+namespace Content.Goobstation.Server.Atmos.Systems;
+
+/// <summary>
+/// System to make atmos bombs have uncapped range on lavaland.
+/// </summary>
+public sealed class LavalandTankRangeSystem : EntitySystem
+{
+    private EntityQuery<LavalandMapComponent> _lavalandQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _lavalandQuery = GetEntityQuery<LavalandMapComponent>();
+
+        SubscribeLocalEvent<TransformComponent, GasTankGetRangeEvent>(OnGetRange);
+    }
+
+    private void OnGetRange(Entity<TransformComponent> ent, ref GasTankGetRangeEvent args)
+    {
+        if (_lavalandQuery.HasComponent(ent.Comp.MapUid))
+            args.MaxRange = float.MaxValue;
+    }
+}

--- a/Content.Goobstation.Shared/Atmos/Events/GasTankGetRangeEvent.cs
+++ b/Content.Goobstation.Shared/Atmos/Events/GasTankGetRangeEvent.cs
@@ -1,0 +1,4 @@
+namespace Content.Goobstation.Shared.Atmos.Events;
+
+[ByRefEvent]
+public record struct GasTankGetRangeEvent(float MaxRange);

--- a/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTankSystem.cs
@@ -37,6 +37,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Goobstation.Shared.Atmos.Events;
 using Content.Server.Atmos.Components;
 using Content.Server.Body.Components;
 using Content.Server.Body.Systems;
@@ -202,7 +203,13 @@ namespace Content.Server.Atmos.EntitySystems
 
             var pressure = component.Air.Pressure;
 
-            if (pressure > component.TankFragmentPressure && _maxExplosionRange > 0)
+            // <Goobstation>
+            var rangeEv = new GasTankGetRangeEvent(component.MaxExplosionRange ?? _maxExplosionRange);
+            RaiseLocalEvent(ent, ref rangeEv);
+            var maxRange = rangeEv.MaxRange;
+            // </Goobstation>
+                                                             // Goobstation
+            if (pressure > component.TankFragmentPressure && maxRange > 0)
             {
                 // Give the gas a chance to build up more pressure.
                 for (var i = 0; i < 3; i++)
@@ -215,7 +222,7 @@ namespace Content.Server.Atmos.EntitySystems
 
                 // Let's cap the explosion, yeah?
                 // !1984
-                range = Math.Min(Math.Min(range, GasTankComponent.MaxExplosionRange), _maxExplosionRange);
+                range = Math.Min(range, maxRange); // Goobstation
 
                 _explosions.TriggerExplosive(owner, radius: range);
 

--- a/Content.Shared/Atmos/Components/GasTankComponent.cs
+++ b/Content.Shared/Atmos/Components/GasTankComponent.cs
@@ -7,12 +7,14 @@ namespace Content.Shared.Atmos.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
 public sealed partial class GasTankComponent : Component, IGasMixtureHolder
 {
-    public const float MaxExplosionRange = 26f;
     private const float DefaultLowPressure = 0f;
     private const float DefaultOutputPressure = Atmospherics.OneAtmosphere;
 
     public int Integrity = 3;
     public bool IsLowPressure => Air.Pressure <= TankLowPressure;
+
+    [DataField]
+    public float? MaxExplosionRange; // Goobstation - If null, use the atmos explosion range cvar, otherwise, use this value
 
     [DataField]
     public SoundSpecifier RuptureSound = new SoundPathSpecifier("/Audio/Effects/spray.ogg");


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
- fixes/reintroduces #1511 since upstream merge broke it i think
- makes maxcaps ignore max range if map is lavaland

## Why / Balance
nuclear blast mining
mine literally all of lavaland
doesn't affect antaggery since why would an antag maxcap lavaland
and even if you would maxcap lavaland maxcaps large enough to bump into cap are impractical for antaggery

## Media
tested, works
cap on non-lavaland still applies normally

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Atmos bomb range is now uncapped on lavaland.
