### PR TITLE
fix stamres

### DIFF
--- a/Content.Goobstation.Server/Weapons/DelayedKnockdown/DelayedKnockdownOnHitSystem.cs
+++ b/Content.Goobstation.Server/Weapons/DelayedKnockdown/DelayedKnockdownOnHitSystem.cs
@@ -14,6 +14,7 @@ using Content.Server.Heretic.Components.PathSpecific;
 using Content.Server.Heretic.EntitySystems.PathSpecific;
 using Content.Server.Stunnable;
 using Content.Shared._Goobstation.Heretic.Components;
+using Content.Shared._Shitcode.Weapons.Misc;
 using Content.Shared.Armor;
 using Content.Shared.Damage.Events;
 using Content.Shared.Inventory;

--- a/Content.Goobstation.Server/Weapons/DelayedKnockdown/DelayedKnockdownOnHitSystem.cs
+++ b/Content.Goobstation.Server/Weapons/DelayedKnockdown/DelayedKnockdownOnHitSystem.cs
@@ -5,6 +5,7 @@
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
 // SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
+// SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Goobstation.Shared/Inventory/GoobInventorySystem.Relays.cs
+++ b/Content.Goobstation.Shared/Inventory/GoobInventorySystem.Relays.cs
@@ -14,11 +14,9 @@ using Content.Goobstation.Shared.Flashbang;
 using Content.Goobstation.Shared.Stunnable;
 using Content.Shared._Goobstation.Wizard.Chuuni;
 using Content.Shared._White.Standing;
-using Content.Shared.Damage.Events;
 using Content.Shared.Heretic;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
-using Content.Shared.Mobs;
 
 namespace Content.Goobstation.Shared.Inventory;
 
@@ -41,7 +39,6 @@ public partial class GoobInventorySystem
         SubscribeLocalEvent<InventoryComponent, ModifyStunTimeEvent>(RefRelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, IsEyesCoveredCheckEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, RefreshEquipmentHudEvent<Overlays.NightVisionComponent>>(RefRelayInventoryEvent);
-        SubscribeLocalEvent<InventoryComponent, TakeStaminaDamageEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, RefreshEquipmentHudEvent<Overlays.ThermalVisionComponent>>(RefRelayInventoryEvent);
     }
 

--- a/Content.Goobstation.Shared/Inventory/GoobInventorySystem.Relays.cs
+++ b/Content.Goobstation.Shared/Inventory/GoobInventorySystem.Relays.cs
@@ -4,6 +4,7 @@
 // SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 // SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
 // SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
+// SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.CorporateJudo.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.CorporateJudo.cs
@@ -17,7 +17,6 @@ using Content.Goobstation.Shared.MartialArts.Components;
 using Content.Goobstation.Shared.MartialArts.Events;
 using Content.Shared.Clothing;
 using Content.Shared.Damage;
-using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Events;
 using Content.Shared.Eye.Blinding.Components;
 using Content.Goobstation.Maths.FixedPoint;
@@ -136,16 +135,10 @@ public partial class SharedMartialArtsSystem
 
         var knockdownTime = TimeSpan.FromSeconds(proto.ParalyzeTime);
 
-        if (TryComp<StaminaComponent>(target, out var stamina))
-        {
-            var ev = new TakeStaminaDamageEvent((target, stamina));
-            RaiseLocalEvent(target, ev);
+        var ev = new BeforeStaminaDamageEvent(1f);
+        RaiseLocalEvent(target, ref ev);
 
-            if (ev.Handled)
-                return;
-
-            knockdownTime *= ev.Multiplier;
-        }
+        knockdownTime *= ev.Value;
 
         _stun.TryKnockdown(target, knockdownTime, true, proto.DropHeldItemsBehavior);
 
@@ -169,16 +162,10 @@ public partial class SharedMartialArtsSystem
 
         var knockdownTime = TimeSpan.FromSeconds(proto.ParalyzeTime);
 
-        if (TryComp<StaminaComponent>(target, out var stamina))
-        {
-            var ev = new TakeStaminaDamageEvent((target, stamina));
-            RaiseLocalEvent(target, ev);
+        var ev = new BeforeStaminaDamageEvent(1f);
+        RaiseLocalEvent(target, ref ev);
 
-            if (ev.Handled)
-                return;
-
-            knockdownTime *= ev.Multiplier;
-        }
+        knockdownTime *= ev.Value;
 
         if (!HasComp<ArmbarredComponent>(target))
         {

--- a/Content.Server/_Shitcode/Heretic/EntitySystems/PathSpecific/ChampionStanceSystem.cs
+++ b/Content.Server/_Shitcode/Heretic/EntitySystems/PathSpecific/ChampionStanceSystem.cs
@@ -13,7 +13,6 @@
 
 using Content.Goobstation.Common.Bloodstream;
 using Content.Server.Heretic.Components.PathSpecific;
-using Content.Shared._Shitmed.Body.Events;
 using Content.Shared.Body.Part;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Events;
@@ -34,7 +33,7 @@ public sealed class ChampionStanceSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<ChampionStanceComponent, DamageModifyEvent>(OnDamageModify);
-        SubscribeLocalEvent<ChampionStanceComponent, TakeStaminaDamageEvent>(OnTakeStaminaDamage);
+        SubscribeLocalEvent<ChampionStanceComponent, BeforeStaminaDamageEvent>(OnBeforeStaminaDamage);
         SubscribeLocalEvent<ChampionStanceComponent, GetBloodlossDamageMultiplierEvent>(OnGetBloodlossMultiplier);
         SubscribeLocalEvent<ChampionStanceComponent, ComponentStartup>(OnChampionStartup);
         SubscribeLocalEvent<ChampionStanceComponent, ComponentShutdown>(OnChampionShutdown);
@@ -89,12 +88,12 @@ public sealed class ChampionStanceSystem : EntitySystem
         args.Damage = args.OriginalDamage / 2f;
     }
 
-    private void OnTakeStaminaDamage(Entity<ChampionStanceComponent> ent, ref TakeStaminaDamageEvent args)
+    private void OnBeforeStaminaDamage(Entity<ChampionStanceComponent> ent, ref BeforeStaminaDamageEvent args)
     {
         if (!Condition(ent))
             return;
 
-        args.Multiplier /= 2.5f;
+        args.Value *= 0.4f;
     }
 
     private void OnBodyPartAdded(Entity<ChampionStanceComponent> ent, ref BodyPartAddedEvent args)

--- a/Content.Server/_Shitcode/Heretic/EntitySystems/PathSpecific/ChampionStanceSystem.cs
+++ b/Content.Server/_Shitcode/Heretic/EntitySystems/PathSpecific/ChampionStanceSystem.cs
@@ -7,7 +7,9 @@
 // SPDX-FileCopyrightText: 2025 Aviu00 <aviu00@protonmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
+// SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
+// SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
@@ -15,7 +15,6 @@
 // SPDX-FileCopyrightText: 2023 Vordenburg <114301317+Vordenburg@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
-// SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Adeinitas <147965189+adeinitas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Callmore <22885888+Callmore@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Dakamakat <52600490+dakamakat@users.noreply.github.com>
@@ -36,12 +35,19 @@
 // SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aviu00 <aviu00@protonmail.com>
+// SPDX-FileCopyrightText: 2025 BramvanZijp <56019239+BramvanZijp@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Eagle <lincoln.mcqueen@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Lincoln McQueen <lincoln.mcqueen@gmail.com>
 // SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
+// SPDX-FileCopyrightText: 2025 Princess Cheeseballs <66055347+Pronana@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
+// SPDX-FileCopyrightText: 2025 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 VMSolidus <evilexecutive@gmail.com>
 // SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
+// SPDX-FileCopyrightText: 2025 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 nikitosych <boriszyn@gmail.com>
 // SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 // SPDX-FileCopyrightText: 2025 vanx <61917534+Vaaankas@users.noreply.github.com>
 //

--- a/Content.Shared/_Shitcode/Weapons/Misc/TakeStaminaDamageEvent.cs
+++ b/Content.Shared/_Shitcode/Weapons/Misc/TakeStaminaDamageEvent.cs
@@ -11,36 +11,8 @@
 
 using System.Numerics;
 using Content.Shared.Damage.Components;
-using Content.Shared.Inventory;
 
-namespace Content.Shared.Damage.Events;
-
-/// <summary>
-/// The entity is going to be hit,
-/// give opportunities to change the damage or other stuff.
-/// </summary>
-// goobstation - stun resistance. try not to modify this event allat much
-public sealed class TakeStaminaDamageEvent : HandledEntityEventArgs, IInventoryRelayEvent
-{
-    public SlotFlags TargetSlots { get; } = SlotFlags.WITHOUT_POCKET;
-
-    public Entity<StaminaComponent>? Target;
-
-    /// <summary>
-    /// The multiplier. Generally, try to use *= or /= instead of overwriting.
-    /// </summary>
-    public float Multiplier = 1;
-
-    /// <summary>
-    /// The flat modifier. Generally, try to use += or -= instead of overwriting.
-    /// </summary>
-    public float FlatModifier = 0;
-
-    public TakeStaminaDamageEvent(Entity<StaminaComponent> target)
-    {
-        Target = target;
-    }
-}
+namespace Content.Shared._Shitcode.Weapons.Misc;
 
 public sealed class StaminaDamageMeleeHitEvent(List<(EntityUid Entity, StaminaComponent Component)> hitEntities, Vector2? direction) : EntityEventArgs
 {


### PR DESCRIPTION
stamres wasn't working, upstream merge seemingly broke smth because of wizden stamina resistances
before (vid from goob discord):

https://github.com/user-attachments/assets/2c4a0039-77d3-46db-8926-706a1e08f6b0

after the fix:

https://github.com/user-attachments/assets/a9b95db0-c7bc-46ca-ba9b-cde752037bfa

yeah getting total stam res via the event of "what happens BEFORE taking exactly 1 stamina damage" is not really its correct use but hey it works as before, cant be fucked to unshitcode it
also why the fuck did we have completely unmarked goob files in core namespace, well im not goobmodding it

:cl:
- fix: Stamina resistances work once again.