### PR TITLE
decrease cooldowns on the contractor baton (bounty)

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/contractor_baton.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/contractor_baton.yml
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: 2024 Remuchi <72476615+Remuchi@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 VMSolidus <evilexecutive@gmail.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Marcus F <199992874+thebiggestbruh@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/contractor_baton.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/contractor_baton.yml
@@ -27,7 +27,7 @@
       default:
         length: 1
       telebaton:
-        length: 2.5
+        length: 0.5
   - type: ItemToggle
     soundActivate:
       path: /Audio/_Goobstation/Weapons/Baton/contractorbatonextend.ogg
@@ -44,6 +44,7 @@
         Ion: 35
   - type: MeleeWeapon
     bluntStaminaDamageFactor: 0
+    attackRate: 1.25
   - type: StaminaDamageOnHit
     damage: 85
   - type: StunBorgsOnHit

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/contractor_baton.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/contractor_baton.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2024 Remuchi <72476615+Remuchi@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 VMSolidus <evilexecutive@gmail.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Marcus F <199992874+thebiggestbruh@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 #


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
title

## Why / Balance

<img width="1794" height="276" alt="image" src="https://github.com/user-attachments/assets/77b2fd5a-b9fd-49cc-b596-709e8e2d2ff9" />

## Technical details
yaml

## Media

https://github.com/user-attachments/assets/b93638e3-bc0b-4015-a7d8-62ea94e09732

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: the biggest bruh
- tweak: Contractor baton attack rate increased (1 -> 1.25) and the use delay when active has been decreased (2.5 -> 0.5)
