### PR TITLE
Moving CQC's Parrying into Bso's Kung Fu

### DIFF
--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.cs
@@ -481,11 +481,6 @@ public abstract partial class SharedMartialArtsSystem : EntitySystem
         {
             case MartialArtsForms.KungFuDragon:
                 EnsureComp<DragonKungFuTimerComponent>(user);
-                break;
-            case MartialArtsForms.Ninjutsu:
-                EnsureComp<NinjutsuSneakAttackComponent>(user);
-                break;
-            case MartialArtsForms.CloseQuartersCombat:
                 var riposte = EnsureComp<RiposteeComponent>(user);
                 riposte.Data.TryAdd("CQC",
                     new(0.1f,
@@ -500,6 +495,25 @@ public abstract partial class SharedMartialArtsSystem : EntitySystem
                     null,
                     null,
                     new CanDoCQCEvent()));
+                break;
+            case MartialArtsForms.Ninjutsu:
+                EnsureComp<NinjutsuSneakAttackComponent>(user);
+                break;
+            case MartialArtsForms.CloseQuartersCombat:
+                //var riposte = EnsureComp<RiposteeComponent>(user);
+                //riposte.Data.TryAdd("CQC",
+                //    new(0.1f,
+                //    false,
+                //    null,
+                //    true,
+                //    new SoundPathSpecifier("/Audio/Weapons/genhit1.ogg"),
+                //    TimeSpan.Zero,
+                //    TimeSpan.FromSeconds(4),
+                //    false,
+                //    0.75f,
+                //    null,
+                //    null,
+                //    new CanDoCQCEvent()));
                 break;
         }
 

--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.cs
@@ -499,7 +499,6 @@ public abstract partial class SharedMartialArtsSystem : EntitySystem
                     null,
                     null,
                     null));
-                    
                 break;
             case MartialArtsForms.Ninjutsu:
                 EnsureComp<NinjutsuSneakAttackComponent>(user);

--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.cs
@@ -493,8 +493,8 @@ public abstract partial class SharedMartialArtsSystem : EntitySystem
                     false,
                     0.75f,
                     null,
-                    null
-                    ));
+                    null,
+                    null));
                     
                 break;
             case MartialArtsForms.Ninjutsu:

--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.cs
@@ -482,7 +482,7 @@ public abstract partial class SharedMartialArtsSystem : EntitySystem
             case MartialArtsForms.KungFuDragon:
                 EnsureComp<DragonKungFuTimerComponent>(user);
                 var riposte = EnsureComp<RiposteeComponent>(user);
-                riposte.Data.TryAdd("CQC",
+                riposte.Data.TryAdd("KungFuDragon",
                     new(0.1f,
                     false,
                     null,
@@ -493,8 +493,9 @@ public abstract partial class SharedMartialArtsSystem : EntitySystem
                     false,
                     0.75f,
                     null,
-                    null,
-                    new CanDoCQCEvent()));
+                    null
+                    ));
+                    
                 break;
             case MartialArtsForms.Ninjutsu:
                 EnsureComp<NinjutsuSneakAttackComponent>(user);

--- a/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/CQC.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/CQC.xml
@@ -18,11 +18,6 @@
 
   CQC users are better at Disarm intent, as their shoves will deal extra stamina damage to the opponent.
 
-  ### Riposte
-
-  With lightning reflexes, a CQC master has a chance to parry any incoming melee attack. In that brief moment, the attacker is left vulnerable,
-  so the CQC master strikes back and stuns them automatically, unless they are also a CQC master. A calculated, deadly response to any assault.
-
   ### Neck Snap
 
   There is no escape from a choke grab of a CQC master. With a single Harm action to the head, the victim's neck breaks,

--- a/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/DragonKungFu.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/MartialArts/DragonKungFu.xml
@@ -12,6 +12,11 @@
 
   ## Special abilities
 
+  ### Riposte
+
+  With lightning reflexes, a Dragon Kung Fu master has a chance to parry any incoming melee attack. In that brief moment, the attacker is left vulnerable,
+  Leaving an opening for the Dragon Kung Fu to Strike back and stun them automatically, unless they are also a Dragon Kung Fu Master. A Magestic response to any assault, Imitating the Wings of a Dragon.
+
   ### Dragon Power
 
   <Box>


### PR DESCRIPTION



## About the PR
Making Kung FU actually defensive

## Why / Balance
Fixing the Genius idea of giving the most agressive martial art the best defense against Meeles
## Technical details
moved riposte code from cqc to kung fu

## Media

https://github.com/user-attachments/assets/bdb9acbe-4918-4688-b862-e128b8f3a080



## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.




**Changelog**

:cl:
- tweak: Dragon Kung Fu now posseses the riposte ability instead of CQC


