### PR TITLE
changes to ling stasis + ling damage cap gone + mobstate evil shit fix

### DIFF
--- a/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
@@ -123,6 +123,7 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly DoAfterSystem _doAfter = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly DamageableSystem _damage = default!;
     [Dependency] private readonly BloodstreamSystem _blood = default!;
@@ -171,6 +172,7 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
 
         SubscribeLocalEvent<ChangelingIdentityComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<ChangelingIdentityComponent, MobStateChangedEvent>(OnMobStateChange);
+        SubscribeLocalEvent<ChangelingIdentityComponent, UpdateMobStateEvent>(OnUpdateMobState);
         SubscribeLocalEvent<ChangelingIdentityComponent, DamageChangedEvent>(OnDamageChange);
         SubscribeLocalEvent<ChangelingIdentityComponent, ComponentRemove>(OnComponentRemove);
         SubscribeLocalEvent<ChangelingIdentityComponent, TargetBeforeDefibrillatorZapsEvent>(OnDefibZap);
@@ -833,18 +835,29 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
             RemoveAllChangelingEquipment(uid, comp);
     }
 
+    private void OnUpdateMobState(Entity<ChangelingIdentityComponent> ent, ref UpdateMobStateEvent args)
+    {
+        if (ent.Comp.IsInStasis)
+        {
+            args.State = MobState.Dead;
+        }
+    }
+
     private void OnDamageChange(Entity<ChangelingIdentityComponent> ent, ref DamageChangedEvent args)
     {
-        var target = args.Damageable;
+        if (!TryComp<MobThresholdsComponent>(ent, out var thresholds)
+            || !_mobThreshold.TryGetThresholdForState(ent, MobState.Dead, out var maxThreshold))
+            return;
 
         if (!ent.Comp.IsInStasis)
         {
-            var lowestStasisTime = ent.Comp.DefaultStasisTime;
-            var highestStasisTime = ent.Comp.MaxStasisTime; // 1.5 minutes
-            var catastrophicStasisTime = ent.Comp.CatastrophicStasisTime; // 2 minutes
-            var catastrophicDamage = 200f; // 100% dead
+            var lowestStasisTime = ent.Comp.DefaultStasisTime; // 15 sec
+            var highestStasisTime = ent.Comp.MaxStasisTime; // 45 sec
+            var catastrophicStasisTime = ent.Comp.CatastrophicStasisTime; // 1 min
+            var catastrophicDamage = maxThreshold; // enough damage to be dead
 
-            var damageTaken = float.Round(target.TotalDamage.Float()) / 2;
+            var damage = args.Damageable;
+            var damageTaken = float.Round(damage.TotalDamage.Float()) / 2;
             var damageToTime = MathF.Min(damageTaken, highestStasisTime);
 
             var newStasisTime = MathF.Max(lowestStasisTime, damageToTime);
@@ -854,17 +867,6 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
             else
                 ent.Comp.StasisTime = catastrophicStasisTime;
         }
-
-        if (!TryComp<MobStateComponent>(ent, out var mobState))
-            return;
-
-        if (mobState.CurrentState != MobState.Dead)
-            return;
-
-        if (!args.DamageIncreased)
-            return;
-
-        target.Damage.ClampMax(200); // we never die. UNLESS??
     }
 
     private void OnComponentRemove(Entity<ChangelingIdentityComponent> ent, ref ComponentRemove args)
@@ -888,6 +890,8 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
         {
             ent.Comp.IsInStasis = false;
             ent.Comp.StasisTime = ent.Comp.DefaultStasisTime;
+
+            _mobState.UpdateMobState(ent);
         }
         else
         {

--- a/Content.Goobstation.Shared/Changeling/Components/ChangelingIdentityComponent.cs
+++ b/Content.Goobstation.Shared/Changeling/Components/ChangelingIdentityComponent.cs
@@ -94,17 +94,17 @@ public sealed partial class ChangelingIdentityComponent : Component
     /// <summary>
     ///     The default stasis time (in s).
     /// </summary>
-    public readonly int DefaultStasisTime = 30;
+    public readonly int DefaultStasisTime = 15;
 
     /// <summary>
     ///     The typical longest time that stasis can last (in s).
     /// </summary>
-    public readonly int MaxStasisTime = 90;
+    public readonly int MaxStasisTime = 45;
 
     /// <summary>
     ///     The time a changeling must stay in stasis upon taking catastrophic damage (in s).
     /// </summary>
-    public readonly int CatastrophicStasisTime = 120;
+    public readonly int CatastrophicStasisTime = 60;
 
     /// <summary>
     ///     Time in seconds the changeling must spend in stasis.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
lowest stasis time halved (30s -> 15s)
highest stasis time halved (90s -> 45s)
dead stasis time halved (120s -> 60s)

also fixed a bug with mobstate shit where you could kick a changeling out of stasis and revive them by dealing damage to them (provided they had enough health to not be dead)

## Why / Balance
damage capped remove because its not necessary now (lings don't need a head anymore + gibbing is pretty hard anyways)
stasis time reduced for the reason above and also because they were kinda overtuned

## Technical details
c# slop

## Media

before:

https://github.com/user-attachments/assets/cf463463-2966-4222-9fc4-4a26b735c767

after (the split second standing up is unavoidable as far as im aware):

https://github.com/user-attachments/assets/31862f15-174a-48fb-934d-fc038c207155

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: the biggest bruh
- remove: Removed damage cap from Changelings (it is possible to gib them now!)
- tweak: The damage-time scaling caps for changelings' stasis were halved. (Lowest 30s -> 15s, Highest 90s -> 45s, Dead 120s -> 60s)
- fix: You should no longer be able to kick a Changeling out of their stasis and revive them by dealing damage to them. bruh.