### PR TITLE
Port walk-by-default option from EE

### DIFF
--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -154,6 +154,11 @@ namespace Content.Client.Options.UI.Tabs
 
             _deferCommands.Add(_inputManager.SaveToUserData);
         }
+        private void HandleDefaultWalk(BaseButton.ButtonToggledEventArgs args)
+        {
+            _cfg.SetCVar(CCVars.DefaultWalk, args.Pressed);
+            _cfg.SaveToFile();
+        }
 
         private void HandleStaticStorageUI(BaseButton.ButtonToggledEventArgs args)
         {
@@ -225,6 +230,7 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(EngineKeyFunctions.MoveRight);
             AddButton(EngineKeyFunctions.Walk);
             AddCheckBox("ui-options-hotkey-toggle-walk", _cfg.GetCVar(CCVars.ToggleWalk), HandleToggleWalk);
+            AddCheckBox("ui-options-hotkey-default-walk", _cfg.GetCVar(CCVars.DefaultWalk), HandleDefaultWalk);
             AddButton(ContentKeyFunctions.ToggleStanding);
             AddCheckBox("ui-options-function-auto-get-up", _cfg.GetCVar(GoobCVars.AutoGetUp), HandleToggleAutoGetUp); // WD EDIT
             InitToggleWalk();

--- a/Content.Client/Physics/Controllers/MoverController.cs
+++ b/Content.Client/Physics/Controllers/MoverController.cs
@@ -25,6 +25,7 @@
 using Content.Shared.Alert;
 using Content.Shared.CCVar;
 using Content.Shared.Movement.Components;
+using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Systems;
 using Robust.Client.Physics;
@@ -53,6 +54,8 @@ public sealed class MoverController : SharedMoverController
         SubscribeLocalEvent<InputMoverComponent, UpdateIsPredictedEvent>(OnUpdatePredicted);
         SubscribeLocalEvent<MovementRelayTargetComponent, UpdateIsPredictedEvent>(OnUpdateRelayTargetPredicted);
         SubscribeLocalEvent<PullableComponent, UpdateIsPredictedEvent>(OnUpdatePullablePredicted);
+
+        Subs.CVar(_cfg, CCVars.DefaultWalk, _ => RaiseNetworkEvent(new UpdateInputCVarsMessage()));
     }
 
     private void OnUpdatePredicted(Entity<InputMoverComponent> entity, ref UpdateIsPredictedEvent args)
@@ -142,7 +145,7 @@ public sealed class MoverController : SharedMoverController
         // Logger.Info($"[{_gameTiming.CurTick}/{subTick}] Sprint: {enabled}");
         base.SetSprinting(entity, subTick, walking);
 
-        if (walking && _cfg.GetCVar(CCVars.ToggleWalk))
+        if (_cfg.GetCVar(CCVars.ToggleWalk) && (walking && !_cfg.GetCVar(CCVars.DefaultWalk) || !walking && _cfg.GetCVar(CCVars.DefaultWalk)))
             _alerts.ShowAlert(entity, WalkingAlert, showCooldown: false, autoRemove: false);
         else
             _alerts.ClearAlert(entity, WalkingAlert);

--- a/Content.Shared/CCVar/CCVars.Interactions.cs
+++ b/Content.Shared/CCVar/CCVars.Interactions.cs
@@ -24,7 +24,13 @@ public sealed partial class CCVars
     ///     Toggles whether the walking key is a toggle or a held key.
     /// </summary>
     public static readonly CVarDef<bool> ToggleWalk =
-        CVarDef.Create("control.toggle_walk", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+        CVarDef.Create("control.toggle_walk", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Whether the player mob is walking by default instead of running.
+    /// </summary>
+    public static readonly CVarDef<bool> DefaultWalk =
+        CVarDef.Create("control.default_walk", false, CVar.CLIENT | CVar.REPLICATED | CVar.ARCHIVE);
 
     // The rationale behind the default limit is simply that I can easily get to 7 interactions per second by just
     // trying to spam toggle a light switch or lever (though the UseDelay component limits the actual effect of the

--- a/Content.Shared/Movement/Components/InputMoverComponent.cs
+++ b/Content.Shared/Movement/Components/InputMoverComponent.cs
@@ -76,7 +76,11 @@ namespace Content.Shared.Movement.Components
 
         public const float LerpTime = 1.0f;
 
-        public bool Sprinting => (HeldMoveButtons & MoveButtons.Walk) == 0x0;
+        public bool Sprinting => DefaultSprinting
+        ? (HeldMoveButtons & MoveButtons.Walk) != 0x0
+        : (HeldMoveButtons & MoveButtons.Walk) == 0x0;
+        
+        public bool DefaultSprinting = true;
 
         [ViewVariables(VVAccess.ReadWrite)]
         public bool CanMove = true;
@@ -90,6 +94,6 @@ namespace Content.Shared.Movement.Components
         public Angle TargetRelativeRotation;
         public Angle RelativeRotation;
         public TimeSpan LerpTarget;
-        public bool CanMove;
+        public bool CanMove, DefaultSprinting;
     }
 }

--- a/Content.Shared/Movement/Events/UpdateInputCVarsMessage.cs
+++ b/Content.Shared/Movement/Events/UpdateInputCVarsMessage.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Movement.Events;
+
+/// <summary>
+///     Raised from the client to the server to require the server to update the client's input CVars.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class UpdateInputCVarsMessage : EntityEventArgs { }

--- a/Content.Shared/Movement/Systems/SharedMoverController.CVars.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.CVars.cs
@@ -1,0 +1,44 @@
+using Content.Shared.CCVar;
+using Content.Shared.Mind.Components;
+using Content.Shared.Movement.Components;
+using Content.Shared.Movement.Events;
+using Robust.Shared.Configuration;
+using Robust.Shared.Player;
+
+namespace Content.Shared.Movement.Systems;
+
+public abstract partial class SharedMoverController
+{
+    [Dependency] private readonly INetConfigurationManager _netConfig = default!;
+    [Dependency] private readonly ISharedPlayerManager _player = default!;
+
+    private void InitializeCVars()
+    {
+        SubscribeLocalEvent<InputMoverComponent, MindAddedMessage>(OnMindAdded);
+        SubscribeLocalEvent<InputMoverComponent, MindRemovedMessage>(OnMindRemoved);
+        SubscribeNetworkEvent<UpdateInputCVarsMessage>(OnUpdateCVars);
+    }
+
+    private void OnMindAdded(Entity<InputMoverComponent> ent, ref MindAddedMessage args)
+    {
+        if (!_player.TryGetSessionById(args.Mind.Comp.UserId, out var session)) return;
+
+        if (session.Channel is not { } channel) return;
+
+        ent.Comp.DefaultSprinting = _netConfig.GetClientCVar(channel, CCVars.DefaultWalk);
+    }
+
+    private void OnMindRemoved(Entity<InputMoverComponent> ent, ref MindRemovedMessage args)
+    {
+        // If it's an ai-controlled mob, we probably want them sprinting by default.
+        ent.Comp.DefaultSprinting = true;
+    }
+
+    private void OnUpdateCVars(UpdateInputCVarsMessage msg, EntitySessionEventArgs args)
+    {
+        if (args.SenderSession.AttachedEntity is not { } uid || !TryComp<InputMoverComponent>(uid, out var mover))
+            return;
+
+        mover.DefaultSprinting = _netConfig.GetClientCVar(args.SenderSession.Channel, CCVars.DefaultWalk);
+    }
+}

--- a/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
@@ -152,6 +152,7 @@ namespace Content.Shared.Movement.Systems
             entity.Comp.TargetRelativeRotation = state.TargetRelativeRotation;
             entity.Comp.CanMove = state.CanMove;
             entity.Comp.RelativeEntity = EnsureEntity<InputMoverComponent>(state.RelativeEntity, entity.Owner);
+            entity.Comp.DefaultSprinting = state.DefaultSprinting;
 
             // Reset
             entity.Comp.LastInputTick = GameTick.Zero;
@@ -182,6 +183,7 @@ namespace Content.Shared.Movement.Systems
                 HeldMoveButtons = entity.Comp.HeldMoveButtons,
                 RelativeRotation = entity.Comp.RelativeRotation,
                 TargetRelativeRotation = entity.Comp.TargetRelativeRotation,
+                DefaultSprinting = entity.Comp.DefaultSprinting
             };
         }
 

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -209,6 +209,7 @@ public abstract partial class SharedMoverController : VirtualController
 
         InitializeInput();
         InitializeRelay();
+        InitializeCVars();
         Subs.CVar(_configManager, CCVars.RelativeMovement, value => _relativeMovement = value, true);
         Subs.CVar(_configManager, CCVars.MinFriction, value => _minDamping = value, true);
         Subs.CVar(_configManager, CCVars.AirFriction, value => _airDamping = value, true);

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -181,6 +181,7 @@ ui-options-header-general = General
 
 ui-options-hotkey-keymap = Use US QWERTY Keys
 ui-options-hotkey-toggle-walk = Toggle Walk
+ui-options-hotkey-default-walk = Walk by default
 
 ui-options-function-move-up = Move Up
 ui-options-function-move-left = Move Left


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
This PR ports the "Walk by default" option from the old EE-based Goob MRP server into the main Goob codebase. It can be found in the Game Menu > Options > Controls > Walk by default.
Effectively, it turns the walk button into a run button.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Aurafarming.
In all seriousness, I find it more intuitive to walk by default (given that most other games do just that), and given that I'm never in a rush to go anywhere I like to walk anyways to avoid slippage. This helps save my pinky finger.
## Technical details
<!-- Summary of code changes for easier review. -->
Most changes are ported from the old Goob MRP codebase. In effect, it adds a DefaultSprinting member to the InputMoverComponent. The user's decision to walk by default is stored in the DefaultWalk CVar. A SharedMoverController.CVars.cs file has been created which effectively outlines how that component member and CVar interact.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="815" height="136" alt="image" src="https://github.com/user-attachments/assets/0ecfab7f-e96e-4728-a00a-2e2d3705093e" />
I would upload a video, but I don't have an easy way of showing what button I'm pressing on screen. Apologies! I hope that this counts as sufficient media.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Players can now opt to "Run by default" in the control options.