### PR TITLE
Repoban JoeHamaSS14 on the crime of shitting it all up

### DIFF
--- a/.github/workflows/check-author-repoban.yml
+++ b/.github/workflows/check-author-repoban.yml
@@ -5,12 +5,14 @@ on:
     types: [opened, reopened]
 
 env:
-  BLOCKED_AUTHORS: |
-    201311861
+  BLOCKED_AUTHORS: "201311861"
 
 jobs:
   check-author:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
     steps:
     - name: Check if author is blocked
       id: check_blocked
@@ -18,10 +20,12 @@ jobs:
       run: |
         AUTHOR_ID="${{ github.event.pull_request.user.id }}"
         echo "Author ID: $AUTHOR_ID"
-        if echo "${BLOCKED_AUTHORS}" | grep -x "$AUTHOR_ID" >/dev/null; then
+        if echo "${BLOCKED_AUTHORS}" | tr ' ' '\n' | grep -x "$AUTHOR_ID" >/dev/null; then
           echo "blocked=true" >> $GITHUB_OUTPUT
+          echo "Author $AUTHOR_ID is repobanned"
         else
           echo "blocked=false" >> $GITHUB_OUTPUT
+          echo "Author $AUTHOR_ID is not repobanned"
         fi
 
     - name: Close PR if author is blocked
@@ -29,17 +33,18 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
+          const prNumber = context.payload.pull_request.number;
 
           await github.rest.pulls.update({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            pull_number: context.issue.number,
+            pull_number: prNumber,
             state: 'closed'
           });
 
           await github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            issue_number: context.issue.number,
+            issue_number: prNumber,
             body: 'This pull request has been automatically closed because the author is soft‑banned.'
           });

--- a/.github/workflows/check-author-repoban.yml
+++ b/.github/workflows/check-author-repoban.yml
@@ -1,0 +1,45 @@
+﻿name: soft-repoban check
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+env:
+  BLOCKED_AUTHORS: |
+    201311861
+
+jobs:
+  check-author:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check if author is blocked
+      id: check_blocked
+      shell: bash
+      run: |
+        AUTHOR_ID="${{ github.event.pull_request.user.id }}"
+        echo "Author ID: $AUTHOR_ID"
+        if echo "${BLOCKED_AUTHORS}" | grep -x "$AUTHOR_ID" >/dev/null; then
+          echo "blocked=true" >> $GITHUB_OUTPUT
+        else
+          echo "blocked=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Close PR if author is blocked
+      if: steps.check_blocked.outputs.blocked == 'true'
+      uses: actions/github-script@v7
+      with:
+        script: |
+
+          await github.rest.pulls.update({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number,
+            state: 'closed'
+          });
+
+          await github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            body: 'This pull request has been automatically closed because the author is soft‑banned.'
+          });


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Gives the public an option to soft repoban other users.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<img width="921" height="288" alt="image" src="https://github.com/user-attachments/assets/87ac188e-ebf5-4e52-aeac-f53ff7e5036b" />

This is as much as "BANHIM!" as it is a roundabout way to force the issue.

Every contribution as follows (this excludes irrelevant or other non-notable PR's):
https://github.com/Goob-Station/Goob-Station/pull/1980 - gave traitors warden gear for no reason
https://github.com/Goob-Station/Goob-Station/pull/2020 - unprompted medkit buff
https://github.com/Goob-Station/Goob-Station/pull/2159 - new grenade for nukeops because "no area denial" as if suppressive fire doesn't exist
https://github.com/Goob-Station/Goob-Station/pull/2200 - Unwarranted cobra buff, inflates ammo types beyond a reasonable amount, adds M7S also for no reason other than serving own larp, invalidates Hristov with Heaven's Gate.
https://github.com/Goob-Station/Goob-Station/pull/2034 - Adds modsuit RSI's when not implemented fully
https://github.com/Goob-Station/Goob-Station/pull/2473 - Resomi nerf att. 1
https://github.com/Goob-Station/Goob-Station/pull/2514 - Resome nerf att. 2
https://github.com/Goob-Station/Goob-Station/pull/2519 - Raises NukeOp time requirements, gives agent id by default and automatically injects acidifier.
https://github.com/Goob-Station/Goob-Station/pull/2430 - Gunnerd shotgun that adds way too many unique shell types for a single gun. Also traitor only, also just mauls everything.
https://github.com/Goob-Station/Goob-Station/pull/2655 - I mean lol lmao? rstart specie cull
https://github.com/Goob-Station/Goob-Station/pull/2447 - Unprompted, for no reason whatsoever, renames every hardsuit into "voidsuit" and modsuit into "hardsuit" with zero elaboration. This also introduces a selector between "voidsuit" and "hardsuit", thus introducing an unfinished modsuit implementation to general availability to players.
https://github.com/Goob-Station/Goob-Station/pull/2594 - Crew one-grenade CL, enough said.
https://github.com/Goob-Station/Goob-Station/pull/2795 - Maps the above crew china lake.
https://github.com/Goob-Station/Goob-Station/pull/2818 - adds more storage slop, attempts to sneak a **security web vest**.
https://github.com/Goob-Station/Goob-Station/pull/2920 - weapon melee bash. Generally speaking this is the only good addition so far.
https://github.com/Goob-Station/Goob-Station/pull/2760 - Swung pain into irrelevance
https://github.com/Goob-Station/Goob-Station/pull/2827 - Pouch attempt 2
https://github.com/Goob-Station/Goob-Station/pull/2982 - HoS buff
https://github.com/Goob-Station/Goob-Station/pull/2941 - Rocket launchers which outperform grenades for the same cost. Unprompted, for no reason.
https://github.com/Goob-Station/Goob-Station/pull/3155 - Bodycameras, see https://github.com/space-wizards/space-station-14/pull/38296 as to why this is bad. Also **security web vest** attempt 2.

I wish to inform the court that this is continued, repeated behavior as exhibited on https://github.com/space-wizards/space-station-14 as @JoeHammad1844.
As since that account is deleted and the new one, being PunishedJoe is `created_at | "2025-03-01T04:11:37Z"` I am forced to rely on wizden's #github channel for the PR's he has made previously. The following images are from the top of the stack as there are about 1900 entries on github by that username.
<img width="342" height="84" alt="DiscordCanary_4lKru7b3Da" src="https://github.com/user-attachments/assets/af4ac07c-9dc6-4eda-8924-187ff4fec629" />

<img width="470" height="496" alt="DiscordCanary_0eXjBjiokS" src="https://github.com/user-attachments/assets/aacb56ee-5be8-4618-9f16-cc5d2e1199ac" />
<img width="336" height="340" alt="DiscordCanary_BlL9JkltPb" src="https://github.com/user-attachments/assets/1591ce8f-ccbb-44af-b894-93aa6f2adc89" />
<img width="488" height="417" alt="DiscordCanary_C76lupIc5S" src="https://github.com/user-attachments/assets/bd7eb9ca-171e-408b-9bce-75e37dfa2eb1" />
<img width="488" height="507" alt="DiscordCanary_Jf4byhF7AD" src="https://github.com/user-attachments/assets/8559d02c-6fa0-482c-b106-71a3ceebec0e" />

# How do I repoban people in the future

go to https://api.github.com/users/username where `username` is an account's username.
copy the `id` value from the json object
add it to list in the workflow yml file at the top.