### PR TITLE
Made Chester mags prinatable.

### DIFF
--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/security.yml
@@ -15,6 +15,8 @@
 - type: latheRecipePack
   id: SecurityAmmoStaticGoob
   recipes:
+  - MagazineShotgunLeverRifleEmpty
+  - MagazineShotgunLeverRifle
   - MagazineBoxShotgunHighCaliber
   - MagazineBoxShotgunSlugHighCaliber
   - MagazineBoxShotgunPracticeHighCaliber


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Made Chester mag (MagazineShotgunLeverRifleEmpty & MagazineShotgunLeverRifle) printable (same category as 8 guage ammo boxes)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Reason: Chester mags eject when emptied thus it is great disadvantage to search for them on the ground mid combat since except rare occurances only 3 may have existed on the station. Overall I would consider this a QOL feature for Chester players.
Balance: if you aquired BSOs Chester you had only one mag to work with and couldnt aquire any more, after teh change it would be possible, however if you got your hands on the Chester you either
A) have enough of other kinds of weaponary that is doesnt change much.
B) have a whole security force against you and hard time to print more ammunition.
(even so if you are an antag there are usually much better options for geting your hands on weapons and infinite ammunition for them, than stealing the Chester from BSO and emaging a lathe)
Additionaly if you stole the Chester it was already with one mag so you could shoot it anyways.

## Technical details
<!-- Summary of code changes for easier review. -->
Added Chester mags (empty and full) to be printable in the same category that ammo boxes for Chester are.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="376" height="227" alt="8 guage printable proof 1" src="https://github.com/user-attachments/assets/54d4c142-b233-449f-8c83-84138fdbaf62" />
<img width="706" height="269" alt="8 guage printable proof 2" src="https://github.com/user-attachments/assets/675b8f01-4826-4fba-8ab0-b676adc98dba" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Chester mags being printable.
-->
