### PR TITLE
Fix BSO modsuit gloves.

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Entities/Modsuits/praetorian.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Modsuits/praetorian.yml
@@ -68,6 +68,7 @@
         - state: equipped-HAND-sealed
         - state: equipped-HAND-sealed-unshaded
           shader: unshaded
+    - type: Insulated # Goob Edit (WHY IS IT NOT INSULATED??)
 
 - type: entity
   parent: ClothingModsuitHelmetStandard


### PR DESCRIPTION
## About the PR
I made the Praetorian modsuit have insulation on the gloves.

## Why / Balance
IT'S ACTUALLY STUPID WHY BSO CAN JUST SHOCKED AGAINST A GRILLE IN THEIR MODSUIT BUT THEY HAVE COMBAT GLOVES ON BY DEFAULT.

## Technical details
1 line YAML edit go brrrr.

## Media
<img width="340" height="165" alt="image" src="https://github.com/user-attachments/assets/5bbf9b16-b3cb-41bf-9090-ac86882315d4" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: BSO no longer gets shocked on grilles when using their modsuit.