### PR TITLE
Fix Cosmic Cult Recall Loop

### DIFF
--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -284,7 +284,9 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
             _ui.SetUiState(component.MonumentInGame.Owner, MonumentKey.Key, new MonumentBuiState(component.MonumentInGame.Comp)); //not sure if this is needed but I'll be safe
         }
         //Goobstation: recalls shuttle upon reaching tier 2
-        if (component.CurrentTier >= 2 && _roundEnd.ExpectedCountdownEnd != null)
+        if (component.CurrentTier >= 2
+            && _roundEnd.ExpectedCountdownEnd != null
+            && CultistsAlive()) // Check for cultists alive (prevent infinite recall)
         {
             foreach (var station in _station.GetStations())
             {


### PR DESCRIPTION
## About the PR
This fixes the recall loop by adding another conditional to check for, utilizing the built-in function to check if Cultists are Alive.

## Why / Balance
Currently, this is a bug and this fixes #3536, somewhat.

## Technical details
This adds another conditional utilizing CultistsAlive() to check if all cultists are alive. When all cultists die, the shuttle is already immediately called.

There is one caveat, once revived, it automatically recalls the shuttle. Cultists must be deconverted for this to work... I need feedback here from maintainers.

## Media
<img width="457" height="433" alt="image" src="https://github.com/user-attachments/assets/e52ffd71-157c-4c02-a80c-ee8a634c28ce" />
<img width="436" height="304" alt="image" src="https://github.com/user-attachments/assets/3fcf0870-01d8-458b-bcf5-c48c988823b4" />
<img width="481" height="328" alt="image" src="https://github.com/user-attachments/assets/909074af-0b25-4f40-b799-fe20b038f554" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed Cosmic Cult Recall Loop