### PR TITLE
[Tweak] Greatshield recharge percentage

### DIFF
--- a/Content.Server/_White/Blocking/RechargeableBlockingComponent.cs
+++ b/Content.Server/_White/Blocking/RechargeableBlockingComponent.cs
@@ -15,6 +15,10 @@ public sealed partial class RechargeableBlockingComponent : Component
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float ChargedRechargeRate = 2f;
 
+    // Percentage of maxCharge to be able to activate item again.
+    [DataField]
+    public float RechargePercentage = 0.1f;
+
     [ViewVariables]
     public bool Discharged;
 }

--- a/Content.Server/_White/Blocking/RechargeableBlockingSystem.cs
+++ b/Content.Server/_White/Blocking/RechargeableBlockingSystem.cs
@@ -71,8 +71,11 @@ public sealed class RechargeableBlockingSystem : EntitySystem
         if (!component.Discharged)
             return;
 
-        args.Popup = Loc.GetString("rechargeable-blocking-remaining-time-popup",
-            ("remainingTime", GetRemainingTime(uid)));
+        if (HasComp<BatterySelfRechargerComponent>(uid))
+            args.Popup = Loc.GetString("rechargeable-blocking-remaining-time-popup", ("remainingTime", GetRemainingTime(uid)));
+        else
+            args.Popup = Loc.GetString("rechargeable-blocking-not-enough-charge-popup");
+
         args.Cancelled = true;
     }
     private void OnChargeChanged(EntityUid uid, RechargeableBlockingComponent component, ChargeChangedEvent args)
@@ -101,11 +104,11 @@ public sealed class RechargeableBlockingSystem : EntitySystem
             return;
         }
 
-        if (battery.CurrentCharge < battery.MaxCharge)
+        if (MathF.Round(battery.CurrentCharge / battery.MaxCharge, 2) < component.RechargePercentage)
             return;
 
         component.Discharged = false;
         if (TryComp(uid, out recharger))
-                recharger.AutoRechargeRate = component.ChargedRechargeRate;
+            recharger.AutoRechargeRate = component.ChargedRechargeRate;
     }
 }

--- a/Resources/Locale/en-US/_white/rechargeable-blocking/rechargeable-blocking.ftl
+++ b/Resources/Locale/en-US/_white/rechargeable-blocking/rechargeable-blocking.ftl
@@ -7,3 +7,4 @@
 rechargeable-blocking-discharged = It is [color=red]discharged[/color].
 rechargeable-blocking-remaining-time = Time left to charge: [color=green]{ $remainingTime }[/color] seconds.
 rechargeable-blocking-remaining-time-popup = { $remainingTime } seconds left to charge.
+rechargeable-blocking-not-enough-charge-popup = Not enough charge.

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -273,6 +273,8 @@
           - ProjectileBatteryAmmoProvider
           - Stunbaton
           - PowerCell
+          tags:
+          - FitsInCharger # Goobstation
         blacklist:
           tags:
           - PotatoBattery


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Changed RechargeBlockingSystem to allow activating item if charge is more than some percentage of maxCharge (basically 10%).
Changed popup flavor if item don't have BatterySelfRechargerComponent.

## Why / Balance
It was inconvenient to use great shield because of requirement to be fully charged after discharge.

## Technical details
Replaced battery.Charge < battery.MaxCharge with MathF.Round(battery.CurrentCharge / battery.MaxCharge, 2) < component.RechargePercentage condition in RechargableBlockingSystem, line 107.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: More items that could fit into basic recharger can now be fit into turbo recharger.
- tweak: Greatshield now be reactivated after full discharge if it's charge more than 10% of max charge.