### PR TITLE
[Tweak] Unpowered door bolt interaction

### DIFF
--- a/Content.Shared/Doors/Components/DoorBoltComponent.cs
+++ b/Content.Shared/Doors/Components/DoorBoltComponent.cs
@@ -7,8 +7,12 @@
 // SPDX-License-Identifier: MIT
 
 using Content.Shared.Doors.Systems;
+using Content.Shared.Tools;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Doors.Components;
 
@@ -55,4 +59,13 @@ public sealed partial class DoorBoltComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool Powered;
+
+    /// <summary>
+    /// Goobstation - Tool that used to bolt unpowered door
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<ToolQualityPrototype>))]
+    public string UnboltToolQuality = "Anchoring";
+
+    [DataField]
+    public TimeSpan ManualUnboltTime = TimeSpan.FromSeconds(10);
 }

--- a/Content.Shared/Doors/DoorEvents.cs
+++ b/Content.Shared/Doors/DoorEvents.cs
@@ -12,7 +12,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Shared.DoAfter;
 using Content.Shared.Doors.Components;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Doors
 {
@@ -94,4 +96,12 @@ namespace Content.Shared.Doors
     public sealed class BeforeDoorAutoCloseEvent : CancellableEntityEventArgs
     {
     }
+
+
+    /// <summary>
+    /// Goobstation - Event for manual door bolting when door is not powered
+    /// </summary>
+    [Serializable, NetSerializable]
+    public sealed partial class ManualBoltingDoAfterEvent : SimpleDoAfterEvent;
+
 }

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -71,6 +71,8 @@ using Robust.Shared.Timing;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Map.Components;
+using Content.Shared.DoAfter;
+using Content.Shared.Wires;
 
 namespace Content.Shared.Doors.Systems;
 
@@ -94,6 +96,11 @@ public abstract partial class SharedDoorSystem : EntitySystem
     [Dependency] private readonly SharedMapSystem _mapSystem = default!;
     [Dependency] private readonly SharedPowerReceiverSystem _powerReceiver = default!;
 
+    // Goobstation - Start - Manual unbolting
+    [Dependency] private readonly SharedToolSystem _toolsSystem = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
+    [Dependency] private readonly SharedWiresSystem _sharedWiresSystem = default!;
+    // Goobstation - End
 
     [ValidatePrototypeId<TagPrototype>]
     public const string DoorBumpTag = "DoorBumpOpener";


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Players can now bolt and unbolt unpowered doors with open wire panel using wrench. It takes 10 seconds doafter to do it (with standard wrench speed).
Cut bolt wire will allow players bolt and unbolt powered doors.

## Why / Balance
Unbolting and unpowering door was super effective blocking strat, especially for AI players. It would be impossible for most players to bypass this obstacle without RCD or good structure weapon.

## Technical details
Added new ManualBoltDoAfterEvent and two methods in SharedDoorSystem.Bolts. Can't goobmod this because it mostly touch existing system. Simple InteractUsing event check.

## Media
Unbolting unpowered door:
https://github.com/user-attachments/assets/6cdeb474-bdcd-4b62-b0c8-8bafc0668111

Unbolting powered door with cut wire:
https://github.com/user-attachments/assets/5e536662-4d69-40f6-bd0f-953c436a43f6

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Unpowered doors now can be bolted and unbolted with wrench if it's wire panel is open and not secured. Cut wire allows bolting and unbolting powered doors.


