### PR TITLE
[Fix] Mime Emergency Boxes and Add Moth Mime Slot Box

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -188,6 +188,17 @@
     - Dwarf
     - Human
     - Reptilian
+    # Goobstation - Custom Races
+    - Vulpkanin
+    - Felinid
+    - Harpy
+    - Gingerbread
+    - Rodentia
+    - Yowie
+    - Oni
+    - Resomi
+    - Tajaran
+    - Shadowkin
 
 - type: loadoutEffectGroup
   id: OxygenBreatherMimeMoth
@@ -221,7 +232,7 @@
     proto: OxygenBreatherMimeMoth
   storage:
     back:
-    - BoxMimeMoth
+    - BoxMimeMothSlots # Goobstation - Slots Bases Survival Boxes
 
 # Engineering / Extended
 - type: loadout

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/emergencybox.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/emergencybox.yml
@@ -463,6 +463,28 @@
 
 - type: entity
   parent: BoxSurvivalSlots
+  id: BoxMimeMothSlots
+  suffix: Mime, Emergency Moth
+  components:
+  - type: ContainerFill
+    containers:
+      water:
+      - DrinkWaterBottleFull
+      nutriblock:
+      - FoodBreadBaguetteCotton
+      flare:
+      - Flare
+      tank:
+      - EmergencyOxygenTankFilled
+      mask:
+      - ClothingMaskBreath
+      emergencypen:
+      - EmergencyMedipen
+      spacepen:
+      - SpaceMedipen
+
+- type: entity
+  parent: BoxSurvivalSlots
   id: BoxMimeSlotsNitrogen
   suffix: Mime, Emergency N2
   components:


### PR DESCRIPTION
## About the PR
This adds the custom species to the custom loadout effect for the mime emergency boxes that Wizden upstream added. Upstream merge did not touch these for whatever reason, so it's being fixed.

This also adds a slot version of the upstream emergency box for Mimes instead of giving them wonky ass regular boxes.

## Why / Balance
This fixes an issue.

## Technical details
I added the custom species.

## Media
<img width="601" height="602" alt="image" src="https://github.com/user-attachments/assets/58e06de8-f853-46d4-b248-b9f8bae95877" />
<img width="557" height="557" alt="image" src="https://github.com/user-attachments/assets/0bada73e-81ff-497f-89e9-de47284e95e7" />
<img width="526" height="561" alt="image" src="https://github.com/user-attachments/assets/a15c5ffd-6ff5-4493-8832-9654ef43ad8a" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Changed Moth Mime emergency boxes to be slotted.
- fix: Fixed Non-Wizden species not getting Mime emergency boxes.