### PR TITLE
[Tweak] Returning species passive regeneration

### DIFF
--- a/Content.Shared/Damage/Components/PassiveDamageComponent.cs
+++ b/Content.Shared/Damage/Components/PassiveDamageComponent.cs
@@ -15,6 +15,7 @@ using Content.Shared.Mobs;
 using Content.Goobstation.Maths.FixedPoint;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 using Robust.Shared.GameStates;
+using Content.Shared._Shitmed.Damage;
 
 namespace Content.Shared.Damage.Components;
 
@@ -50,4 +51,11 @@ public sealed partial class PassiveDamageComponent : Component
 
     [DataField("nextDamage", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
     public TimeSpan NextDamage = TimeSpan.Zero;
+
+    /// <summary>
+    /// Goobstation - How passive damage split damage between parts
+    /// Split for damage and SplitEnsureAllDamagedAndOrganic for passive regen
+    /// </summary>
+    [DataField]
+    public SplitDamageBehavior SplitBehavior = SplitDamageBehavior.Split;
 }

--- a/Content.Shared/Damage/Components/PassiveDamageComponent.cs
+++ b/Content.Shared/Damage/Components/PassiveDamageComponent.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 LankLTE <135308300+LankLTE@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -660,12 +660,29 @@ namespace Content.Shared.Damage
                     return newDamage;
                 case SplitDamageBehavior.Split:
                     return newDamage / parts.Count;
+                case SplitDamageBehavior.SplitEnsureAllDamaged:
+                    var damagedParts = parts.Where(part =>
+                        part.Damageable.TotalDamage > FixedPoint2.Zero).ToList();
+
+                    parts.Clear();
+                    parts.AddRange(damagedParts);
+
+                    goto case SplitDamageBehavior.SplitEnsureAll;
                 case SplitDamageBehavior.SplitEnsureAllOrganic:
                     var organicParts = parts.Where(part =>
                         part.Component.PartComposition == BodyPartComposition.Organic).ToList();
 
                     parts.Clear();
                     parts.AddRange(organicParts);
+
+                    goto case SplitDamageBehavior.SplitEnsureAll;
+                case SplitDamageBehavior.SplitEnsureAllDamageAndOrganic:
+                    var compatableParts = parts.Where(part =>
+                        part.Damageable.TotalDamage > FixedPoint2.Zero &&
+                        part.Component.PartComposition == BodyPartComposition.Organic).ToList();
+
+                    parts.Clear();
+                    parts.AddRange(compatableParts);
 
                     goto case SplitDamageBehavior.SplitEnsureAll;
                 case SplitDamageBehavior.SplitEnsureAll:

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -36,6 +36,7 @@
 // SPDX-FileCopyrightText: 2025 Aineias1 <dmitri.s.kiselev@gmail.com>
 // SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aviu00 <aviu00@protonmail.com>
+// SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 // SPDX-FileCopyrightText: 2025 FaDeOkno <143940725+FaDeOkno@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Fildrance <fildrance@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -676,7 +676,7 @@ namespace Content.Shared.Damage
                     parts.AddRange(organicParts);
 
                     goto case SplitDamageBehavior.SplitEnsureAll;
-                case SplitDamageBehavior.SplitEnsureAllDamageAndOrganic:
+                case SplitDamageBehavior.SplitEnsureAllDamagedAndOrganic:
                     var compatableParts = parts.Where(part =>
                         part.Damageable.TotalDamage > FixedPoint2.Zero &&
                         part.Component.PartComposition == BodyPartComposition.Organic).ToList();

--- a/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
+++ b/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
@@ -64,7 +64,7 @@ public sealed class PassiveDamageSystem : EntitySystem
             // Damage them
             foreach (var allowedState in comp.AllowedStates)
                 if (allowedState == mobState.CurrentState)
-                    _damageable.TryChangeDamage(uid, comp.Damage, true, false, damage, targetPart: TargetBodyPart.All, splitDamage: _Shitmed.Damage.SplitDamageBehavior.SplitEnsureAllDamageAndOrganic); // Shitmed Change
+                    _damageable.TryChangeDamage(uid, comp.Damage, true, false, damage, targetPart: TargetBodyPart.All, splitDamage: comp.SplitBehavior); // Shitmed Change
         }
     }
 }

--- a/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
+++ b/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
 // SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>

--- a/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
+++ b/Content.Shared/Damage/Systems/PassiveDamageSystem.cs
@@ -64,7 +64,7 @@ public sealed class PassiveDamageSystem : EntitySystem
             // Damage them
             foreach (var allowedState in comp.AllowedStates)
                 if (allowedState == mobState.CurrentState)
-                    _damageable.TryChangeDamage(uid, comp.Damage, true, false, damage, targetPart: TargetBodyPart.All); // Shitmed Change
+                    _damageable.TryChangeDamage(uid, comp.Damage, true, false, damage, targetPart: TargetBodyPart.All, splitDamage: _Shitmed.Damage.SplitDamageBehavior.SplitEnsureAllDamageAndOrganic); // Shitmed Change
         }
     }
 }

--- a/Content.Shared/_Shitmed/Damage/DamageBehaviors.cs
+++ b/Content.Shared/_Shitmed/Damage/DamageBehaviors.cs
@@ -9,6 +9,8 @@ public enum SplitDamageBehavior
 {
     None,
     Split,
-    SplitEnsureAll,
     SplitEnsureAllOrganic,
+    SplitEnsureAllDamaged,
+    SplitEnsureAllDamageAndOrganic,
+    SplitEnsureAll,
 }

--- a/Content.Shared/_Shitmed/Damage/DamageBehaviors.cs
+++ b/Content.Shared/_Shitmed/Damage/DamageBehaviors.cs
@@ -11,6 +11,6 @@ public enum SplitDamageBehavior
     Split,
     SplitEnsureAllOrganic,
     SplitEnsureAllDamaged,
-    SplitEnsureAllDamageAndOrganic,
+    SplitEnsureAllDamagedAndOrganic,
     SplitEnsureAll,
 }

--- a/Content.Shared/_Shitmed/Damage/DamageBehaviors.cs
+++ b/Content.Shared/_Shitmed/Damage/DamageBehaviors.cs
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -509,15 +509,15 @@
       types:
         Blunt: 0.50 #per second, scales with pressure and other constants.
         Heat: 0.1
-  #- type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute.
-  #  allowedStates:
-  #   - Alive
-  #   damageCap: 20
-  #   damage:
-  #     types:
-  #       Heat: -0.07
-  #    groups:
-  #      Brute: -0.07
+  - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute.
+    allowedStates:
+    - Alive
+    damageCap: 20
+    damage:
+      types:
+        Heat: -0.07
+      groups:
+        Brute: -0.07
   - type: Fingerprint
   - type: Blindable
   # Other

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -510,6 +510,7 @@
         Blunt: 0.50 #per second, scales with pressure and other constants.
         Heat: 0.1
   - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute.
+    splitBehavior: SplitEnsureAllDamagedAndOrganic
     allowedStates:
     - Alive
     damageCap: 20

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -128,15 +128,15 @@
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: Slime
-#  - type: PassiveDamage # Around 8 damage a minute healed
-#    allowedStates:
-#    - Alive
-#    damageCap: 65
-#    damage:
-#      types:
-#        Heat: -0.14
-#      groups:
-#        Brute: -0.14
+  - type: PassiveDamage # Around 8 damage a minute healed
+    allowedStates:
+    - Alive
+    damageCap: 65
+    damage:
+      types:
+        Heat: -0.14
+      groups:
+        Brute: -0.14
   #  - type: DamageVisuals
   #    damageOverlayGroups:
   #      Brute:

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -54,6 +54,9 @@
 # SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 # SPDX-FileCopyrightText: 2025 BombasterDS2 <shvalovdenis.workmail@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 John Willis <143434770+CerberusWolfie@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Kittygyat <202250949+Kittygyat@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>

--- a/Resources/Prototypes/_Shitmed/Entities/Mobs/Species/abductor.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Mobs/Species/abductor.yml
@@ -60,15 +60,15 @@
 #        color: "#878787"
 #      Burn:
 #        sprite: Mobs/Effects/burn_damage.rsi
-#  - type: PassiveDamage
-#    allowedStates:
-#    - Alive
-#    damageCap: 40
-#    damage:
-#      types:
-#        Heat: -0.14
-#      groups:
-#        Brute: -0.14
+  - type: PassiveDamage
+    allowedStates:
+    - Alive
+    damageCap: 40
+    damage:
+      types:
+        Heat: -0.14
+      groups:
+        Brute: -0.14
   - type: Targeting
   - type: SurgeryTarget
   - type: Bloodstream

--- a/Resources/Prototypes/_Shitmed/Entities/Mobs/Species/abductor.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Mobs/Species/abductor.yml
@@ -1,12 +1,15 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 BombasterDS <deniskaporoshok@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 John Willis <143434770+CerberusWolfie@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2025 Poips <Hanakohashbrown@gmail.com>
 # SPDX-FileCopyrightText: 2025 Rinary <72972221+Rinary1@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 Theodore Lukin <66275205+pheenty@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
 # SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 kamkoi <poiiiple1@gmail.com>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Uncommenting PassiveDamage components in species prototypes. Now system tries heal (negative damage) only damaged part instead of trying to heal all parts.

## Why / Balance
Having 0.53 damage on parts was not really comfortable to play.

Didn't found any problems with changed PassiveDamage system.

## Technical details
Added two new SplitDamageBehavior - SplitEnsureAllDamaged (splits damage only on damaged parts) and SplitEnsureAllDamagedAndOrganic (splits damage only on damaged and organic parts). Without this old heal values didn't work because PassiveDamageSystem tried to split damage on non damaged parts.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Species now gain their slight regeneration once again.

