### PR TITLE
[Fix] Prevent Unsupported Fonts From Being Bolded

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -1144,6 +1144,8 @@ public sealed partial class ChatSystem : SharedChatSystem
     public string WrapMessage(LocId wrapId, InGameICChatType chatType, EntityUid source, string entityName, string message, LanguagePrototype? language)
     {
         language ??= _language.GetLanguage(source);
+
+        wrapId = language.SpeechOverride.UnsupportedBoldFont ? "chat-manager-entity-say-wrap-message" : wrapId; // Goob Edit - Unsupported Bold Fonts
         if (language.SpeechOverride.MessageWrapOverrides.TryGetValue(chatType, out var wrapOverride))
             wrapId = wrapOverride;
 

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -254,7 +254,9 @@ public sealed class RadioSystem : EntitySystem
             ? Loc.GetString("chat-manager-language-prefix", ("language", language.ChatName))
             : "";
 
-        return Loc.GetString(speech.Bold ? "chat-radio-message-wrap-bold" : "chat-radio-message-wrap",
+        var wrapId = (speech.Bold && !language.SpeechOverride.UnsupportedBoldFont) ? "chat-radio-message-wrap-bold" : "chat-radio-message-wrap";
+
+        return Loc.GetString(wrapId,
             ("color", channel.Color),
             ("languageColor", languageColor),
             ("fontType", language.SpeechOverride.FontId ?? speech.FontId),

--- a/Content.Shared/_EinsteinEngines/Language/LanguagePrototype.cs
+++ b/Content.Shared/_EinsteinEngines/Language/LanguagePrototype.cs
@@ -59,6 +59,9 @@ public sealed partial class SpeechOverrideInfo
     public string? FontId;
 
     [DataField]
+    public bool UnsupportedBoldFont = false; // Goob Edit - Bolded Fonts
+
+    [DataField]
     public int? FontSize;
 
     [DataField]

--- a/Resources/Prototypes/_EinsteinEngines/Language/Standard/solcommon.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Language/Standard/solcommon.yml
@@ -5,6 +5,7 @@
   speech:
     color: "#8282fbaa"
     fontId: NotoSansSC
+    unsupportedBoldFont: true
   obfuscation:
     !type:SyllableObfuscation
     minSyllables: 1


### PR DESCRIPTION
## About the PR
Instead of sending the message with the bold message wrap in the radio/chat manager systems, we will instead send it as a regular message but with the same verbs from the bolded message.

## Why / Balance
No more broken characters in the chat window. Making a font bold when the character replacement is unsupported (making broken emoji symbols) is annoying and should be prevented.

## Technical Details
I've added a component to the language prototype, specifically to the speech override part, that is defaulted to false. This boolean, when true, causes the message wraps in ChatSystem and RadioSystem to default to the original wraps without making the message bold.

## Media
<img width="1055" height="397" alt="image" src="https://github.com/user-attachments/assets/446a2e96-20c3-414c-80ec-d26a4f62212a" />
<img width="955" height="370" alt="image" src="https://github.com/user-attachments/assets/af6dc8cd-de16-4cf5-9abf-076c3318fe98" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed the broken Chinese character emojis when yelling/shouting in Sol Common.