### PR TITLE
make PTL not be a neutron star

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
@@ -74,6 +74,7 @@
     fireCost: 1000
   - type: Physics
     bodyType: Static
+  - type: Rotatable # or people end up trying to rotate it by edging on solid ents in space, which never works
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 McBosserson <148172569+McBosserson@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 McBosserson <mcbosserson@hotmail.com>
 # SPDX-FileCopyrightText: 2025 SoundingExpert <204983230+SoundingExpert@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 john git <113782077+whateverusername0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 router <messagebus@vk.com>
 # SPDX-FileCopyrightText: 2025 whateverusername0 <whateveremail>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/power_laser.yml
@@ -78,7 +78,7 @@
         shape:
           !type:PhysShapeAabb
           bounds: "-1.5,-1.5,1.5,1.5"
-        density: 3125
+        density: 50
         mask:
         - LargeMobMask
         layer:


### PR DESCRIPTION
<!--- LICENSE: MIT -->
## About the PR
i made the PTL significantly lighter and also made it rotatable

## Why / Balance
solves the issue of accidentally flinging PTL into space and not being able to bring it back even with jetpack  
also makes people not want to do that in the first place

## Technical details
no

## Media
no

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
no

**Changelog**
:cl: router
- fix: Power Transmission Lasers no longer have weights of small cargo ships, and can now be safely manipulated.