### PR TITLE
The Traitor objective Rebalance: Bring back the glory days of ss13 and pre 2024 ss14 objectives + Gimmick objectives [First Ever Nostalgia PR Ever]

### DIFF
--- a/Content.Goobstation.Server/Objectives/Components/AutoCompleteConditionComponent.cs
+++ b/Content.Goobstation.Server/Objectives/Components/AutoCompleteConditionComponent.cs
@@ -1,0 +1,10 @@
+using Content.Server.Objectives.Systems;
+
+namespace Content.Server.Objectives.Components;
+
+// Automatically an assign objective as complete.
+
+[RegisterComponent, Access(typeof(AutoCompleteConditionSystem))]
+public sealed partial class AutoCompleteConditionComponent : Component
+{
+}

--- a/Content.Goobstation.Server/Objectives/Systems/AutoCompleteConditionSystem.cs
+++ b/Content.Goobstation.Server/Objectives/Systems/AutoCompleteConditionSystem.cs
@@ -1,0 +1,24 @@
+using Content.Server.Objectives.Components;
+using Content.Shared.Objectives.Components;
+using Content.Shared.Mind;
+
+namespace Content.Server.Objectives.Systems;
+
+// Automatically assign an objective as complete.
+
+public sealed class AutoCompleteConditionSystem : EntitySystem
+{
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AutoCompleteConditionComponent, ObjectiveGetProgressEvent>(OnGetProgress);
+    }
+
+    private void OnGetProgress(EntityUid uid, AutoCompleteConditionComponent comp, ref ObjectiveGetProgressEvent args)
+    {
+        args.Progress = 1f;
+    }
+}

--- a/Resources/Locale/en-US/_Goobstation/objectives/gimmick-targeted.yml
+++ b/Resources/Locale/en-US/_Goobstation/objectives/gimmick-targeted.yml
@@ -1,0 +1,3 @@
+objective-condition-stalk-person-title = Keep an eye on a person of interest, {$targetName}, {CAPITALIZE($job)}. 
+objective-condition-harass-person-title = Make {$targetName}, {CAPITALIZE($job)}'s life a living hell.
+objective-condition-frame-person-title = Frame {$targetName}, {CAPITALIZE($job)} with a permabrig worthy crime.

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -335,7 +335,7 @@
   - type: AntagRandomObjectives
     sets:
     - groups: TraitorObjectiveGroups
-    maxDifficulty: 5
+    maxDifficulty: 3 # Goob - Around 3 objectives give or take for difficulty
 
 # Goobstation - order swapped since admin verbs use .Last() for some reason
 # TODO: Fix that

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -108,6 +108,8 @@
     TraitorObjectiveGroupKill: 1
     TraitorObjectiveGroupState: 1 #As in, something about your character. Alive, dead, arrested, gained an ability...
     TraitorObjectiveGroupSocial: 1 #Involves helping/harming others without killing them or stealing their stuff
+    TraitorGimmickObjectivesMinor: 0.15 # Goobstation - intended as 1 agent per every 8 or so really
+    TraitorGimmickObjectivesMajor: 0.05 # Goobstation - Basically passes to pull off larger antag plays in reality so pretty rare
 
 - type: weightedRandom
   id: TraitorObjectiveGroupSteal
@@ -228,3 +230,28 @@
   weights:
     EscapeThiefShuttleObjective: 1
 #Changeling, crew, wizard, when you code it...
+
+# Goob
+
+- type: weightedRandom
+  id: TraitorGimmickObjectivesMinor
+  weights:
+    TresspassGimmickObjective: 1
+    MasqueradeGimmickObjective: 1
+    TrustedGimmickObjective: 1
+    HackerGimmickObjective: 1
+    StalkerGimmickObjective: 1
+    LivingHellGimmickObjective: 1
+    FrameGimmickObjective: 1
+    HazardGimmickObjective: 1
+    PromotedGimmickObjective: 1
+    AllegianceGimmickObjective: 1
+
+- type: weightedRandom
+  id: TraitorGimmickObjectivesMajor
+  weights:
+    SerialKillerGimmickObjective: 1
+    SabotageGimmickObjective: 1
+    HeistGimmickObjective: 1 
+    AccompliceGimmickObjective: 1 
+    TakeoverGimmickObjective: 1

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -120,7 +120,7 @@
   - type: StealCondition
     verifyMapExistence: false
   - type: Objective
-    difficulty: 2.75
+    difficulty: 1 # Goob - Bribes are easier than a 1x murder which is easier than prevention of revival, /but/ you have to keep it on you! Lower steals placed at the same as murder here, greater? 1.5 - 2.25!
   - type: ObjectiveLimit
     limit: 2 # there is usually only 1 of each steal objective, have 2 max for drama
 
@@ -133,7 +133,7 @@
   description: One of our undercover agents will debrief you when you arrive. Don't show up in cuffs.
   components:
   - type: Objective
-    difficulty: 1.3
+    difficulty: 0.75 # Goob - more of a condition than an objective, but it's actually decently challenging at times. 0.75 for the "2 kills and evac" classic ss13 parity experience
     icon:
       sprite: Structures/Furniture/chairs.rsi
       state: shuttle
@@ -146,7 +146,7 @@
   description: Die.
   components:
   - type: Objective
-    difficulty: 0.5
+    difficulty: 0.5 # Goob - Still less freedom than a major gimmick. More of a condition on the regular objectives, thus at gimmick obj diff
     icon:
       sprite: Mobs/Ghosts/ghost_human.rsi
       state: icon
@@ -164,7 +164,7 @@
   description: Leave on the shuttle free and clear of the loyal Nanotrasen crew on board. Use ANY methods available to you. Syndicate agents, Nanotrasen enemies, and handcuffed hostages may remain alive on the shuttle. Ignore assistance from anyone other than a support agent.
   components:
     - type: Objective
-      difficulty: 5 # insane, default config max difficulty
+      difficulty: 3 # insane, default config max difficulty - Goob: 5 > 3 Max
       icon:
         sprite: Objects/Tools/emag.rsi
         state: icon
@@ -178,7 +178,7 @@
   description: Do it however you like, just make sure they don't get off the station.
   components:
   - type: Objective
-    difficulty: 1.75
+    difficulty: 1 # Goob - The default objective really.
     unique: false
   - type: TargetObjective
     title: objective-condition-maroon-person-title
@@ -193,7 +193,7 @@
   components:
   - type: Objective
     # technically its still possible for KillRandomPersonObjective to roll a head but this is guaranteed, so higher difficulty
-    difficulty: 3.0
+    difficulty: 1.5 # Goob - Harder than the normal K, no M. Similar difficulty to offing a rival agent. Can't bribe / "teach a lesson" like a steal either.
     # killing 1 head is enough
     unique: true
   - type: TargetObjective
@@ -213,7 +213,7 @@
   description: Identify yourself at your own risk. We just need them alive.
   components:
   - type: Objective
-    difficulty: 1.75
+    difficulty: 0.75 # Goob
   - type: TargetObjective
     title: objective-condition-other-traitor-alive-title
   - type: RandomTraitorAlive
@@ -224,7 +224,7 @@
   description: Identify yourself at your own risk. We just need them to succeed.
   components:
   - type: Objective
-    difficulty: 2.5
+    difficulty: 1.25 # Goob - Nearly half your objectives for half of theirs, a fair trade isn't it?
   - type: TargetObjective
     title: objective-condition-other-traitor-progress-title
   - type: RandomTraitorProgress
@@ -277,7 +277,7 @@
     stealGroup: ClothingOuterHardsuitRd
   - type: Objective
     # This item must be worn or stored in a slowing duffelbag, very hard to hide.
-    difficulty: 3
+    difficulty: 1.5 # Goob - Storage hog, but a smart traitor can handle it.
 
 - type: entity
   parent: BaseRDStealObjective
@@ -294,7 +294,7 @@
   components:
   - type: Objective
     # Warden will have this on them a lot of the time so..
-    difficulty: 3
+    difficulty: 1.75 # Goob - Requires you to literally enter brig to off the warden. At least it doesn't create rads and can fit in a bag after the struggle.
   - type: NotJobRequirement
     job: Warden # Goob edit
   - type: StealCondition
@@ -355,6 +355,8 @@
   - type: StealCondition
     stealGroup: FoodMeatCorgi
     owner: objective-condition-steal-Ian
+  - type: Objective
+    difficulty: 1.25 # Goob - HoP's *usually* inside the office + the extra drama
 
 ## cap
 
@@ -365,7 +367,7 @@
   components:
   - type: Objective
     # sorry ce but your jordans are not as high security as the caps gear
-    difficulty: 3.5
+    difficulty: 1.25 # Goob - Except for the gun, you can pretty often grab these from the cap office or thief-glove the id. still harder than a normal head though
   - type: NotJobRequirement
     job: Captain
 
@@ -390,6 +392,8 @@
   - type: StealCondition
     stealGroup: WeaponAntiqueLaser
     owner: job-name-captain
+  - type: Objective # Goob - usually *on* the captain.
+    difficulty: 1.5
 
 - type: entity
   parent: BaseCaptainObjective
@@ -399,7 +403,7 @@
     # high difficulty since the hardest item both to steal, and to not get caught down the road,
     # since anyone with a pinpointer can track you down and kill you
     # it's close to being a stealth loneop
-    difficulty: 4
+    difficulty: 2.25 # Goob
   - type: NotCommandRequirement
   - type: StealCondition
     stealGroup: NukeDisk

--- a/Resources/Prototypes/_Goobstation/Objectives/traitor.yml
+++ b/Resources/Prototypes/_Goobstation/Objectives/traitor.yml
@@ -26,7 +26,7 @@
   description: Do it however you like, as long as they're not breathing anymore.
   components:
   - type: Objective
-    difficulty: 2.5 # Most cases tots are armed themselves so have fun
+    difficulty: 1.5 # Most cases tots are armed themselves so have fun
     unique: false
   - type: TargetObjective
     title: objective-condition-pkill-person
@@ -43,7 +43,7 @@
   description: Do it however you like, as long as they're not breathing anymore.
   components:
   - type: Objective
-    difficulty: 1.75
+    difficulty: 1.25
     unique: false
   - type: TargetObjective
     title: objective-condition-pkill-person
@@ -55,14 +55,14 @@
 
 # another traitor's target
 # Note: The possibility of having both protect and kill objectives on the same person is intentional
-# to cause kino situations where the traitor kills the person they were protecting at the end of the round
+# to cause kino situations where the traitor kills the person they were protecting at the end of the round. Also kidnapping... maroon today!
 - type: entity
   parent: [BaseTraitorSocialObjective, BaseKeepAliveObjective]
   id: RandomTraitorTargetAliveObjective
   description: Rival agents intend to assassinate this target. Identify yourself at your own risk.
   components:
   - type: Objective
-    difficulty: 1 # This can be either protect HoS (objective solves itself) or having some tider die in maints silently. Difficulty is set to 1 to have other objectives.
+    difficulty: 0.5 # This can be either protect HoS (objective solves itself) or having some tider die in maints silently. Difficulty is set to 0.5 to have other objectives.
   - type: TargetObjective
     title: objective-condition-traitor-target-alive-title
   - type: RandomTraitorTarget
@@ -76,7 +76,7 @@
   id: StealSupermatterSliverObjective
   components:
   - type: Objective
-    difficulty: 3.5
+    difficulty: 1.75 # No disk but still hard, requires a HEV/CE Suit unless you be extra careful THEN any rad protect after.
   - type: StealCondition
     verifyMapExistence: true
     stealGroup: SupermatterSliver
@@ -88,8 +88,8 @@
   id: LawbringerStealObjective
   components:
   - type: Objective
-    # HoS will have this on them a lot of the time so..
-    difficulty: 3
+    # HoS will have this on them a lot of the time so... at least they leave the brig.
+    difficulty: 1.5
   - type: NotJobRequirement
     job: HeadOfSecurity
   - type: StealCondition
@@ -101,7 +101,7 @@
   id: JusticeStealObjective
   components:
   - type: Objective
-    difficulty: 5 #Cannot be pocketed/bagged like Lawbringer or similar, requires your belt slot or hand to hold.
+    difficulty: 2.25 #Cannot be pocketed/bagged like Lawbringer or similar, requires your belt slot or hand to hold. unironically hard as disk because the item itself shall rat you out.
   - type: NotJobRequirement
     job: HeadOfSecurity
   - type: StealCondition
@@ -115,7 +115,7 @@
   - type: StealCondition
     stealGroup: RapidSyringeGun
   - type: Objective
-    difficulty: 3 # Slightly more than normal as it does not fit into storage implant
+    difficulty: 1.25 # Slightly more than normal as it does not fit into storage implant
 
 - type: entity
   parent: BaseRDStealObjective
@@ -128,4 +128,222 @@
     descriptionText: objective-condition-steal-gemini-projector-description
   - type: Objective
     # This bad boy is LITERALLY directly screwed into the RDs spinal cord. Good luck!
-    difficulty: 3.5
+    difficulty: 1.75
+
+# Minor Gimmick - all 0.5
+
+- type: entity
+  parent: [BaseTraitorObjective]
+  id: TresspassGimmickObjective
+  name: Gain access to the entire station
+  description: Attempt to Tresspass and gain as much access as possible for yourself and any lucky crew. This objective is not tracked and will automatically succeed, so just have fun with it!
+  components:
+  - type: Objective
+    unique: true
+    difficulty: 0.5
+    icon:
+      sprite: Objects/Tools/acess_breaker.rsi
+      state: icon
+  - type: AutoCompleteCondition
+
+- type: entity
+  parent: [BaseTraitorObjective]
+  id: MasqueradeGimmickObjective
+  name: Eliminate those that have their black market connections revealed.
+  description: Maybe vampires were on to something with the Masquerade. Enforce a Black Market Masquerade by eliminating revealed agents. This objective is not tracked and will automatically succeed, so just have fun with it!
+  components:
+  - type: Objective
+    unique: true
+    difficulty: 0.5
+    icon:
+      sprite: Clothing/Head/Hats/brownfedora.rsi
+      state: icon
+  - type: AutoCompleteCondition
+
+- type: entity
+  parent: [BaseTraitorObjective]
+  id: TrustedGimmickObjective
+  name: Become a Trusted Ally of Security
+  description: Try to become a trusted ally of the security team while secretly committing crimes. This objective is not tracked and will automatically succeed, so just have fun with it!
+  components:
+  - type: Objective
+    unique: true
+    difficulty: 0.5
+    icon:
+      sprite: Clothing/Head/Helmets/security.rsi
+      state: icon
+  - type: AutoCompleteCondition
+
+- type: entity
+  parent: [BaseTraitorObjective]
+  id: HackerGimmickObjective
+  name: Hack Station Equipment
+  description: Hack and mess around with station equipment as much as possible. This objective is not tracked and will automatically succeed, so just have fun with it!
+  components:
+    - type: Objective
+      difficulty: 0.5
+      unique: true
+      icon:
+        sprite: Objects/Tools/emag.rsi
+        state: icon
+    - type: AutoCompleteCondition
+
+- type: entity
+  parent: [BaseTraitorObjective]
+  id: StalkerGimmickObjective
+  description: Contacts in a certain intelligence agency want details on how they act once you are recovered. This objective is not tracked and will automatically succeed, so just have fun with it!
+  components:
+    - type: Objective
+      difficulty: 0.5
+      unique: true
+      icon:
+        sprite: Objects/Tools/binoculars.rsi
+        state: icon
+    - type: TargetObjective
+      title: objective-condition-stalk-person-title
+    - type: PickRandomPerson
+    - type: AutoCompleteCondition
+
+- type: entity
+  parent: [BaseTraitorObjective]
+  id: LivingHellGimmickObjective
+  description: Some old partner or friend of the target wants revenge. Harass, Antagonise, Bully and Torture them. This objective is not tracked and will automatically succeed, so just have fun with it!
+  components:
+    - type: Objective
+      difficulty: 0.5
+      unique: true
+      icon:
+        sprite: Objects/Tools/welder.rsi
+        state: icon
+    - type: TargetObjective
+      title: objective-condition-harass-person-title
+    - type: PickRandomPerson
+    - type: AutoCompleteCondition
+
+- type: entity
+  parent: [BaseTraitorObjective]
+  id: FrameGimmickObjective
+  description: The target must be discredited at all costs, frame them with something major! This objective is not tracked and will automatically succeed, so just have fun with it!
+  components:
+    - type: Objective
+      difficulty: 0.5
+      unique: true
+      icon:
+        sprite: Objects/Misc/handcuffs.rsi
+        state: handcuff
+    - type: TargetObjective
+      title: objective-condition-frame-person-title
+    - type: PickRandomPerson
+    - type: AutoCompleteCondition
+
+- type: entity
+  parent: [BaseTraitorObjective]
+  id: HazardGimmickObjective
+  name: Place hazards around the station that cause harm or even death
+  description: Make the station more dangerous with traps and hazards. This objective is not tracked and will automatically succeed, so just have fun with it!
+  components:
+    - type: Objective
+      difficulty: 0.5
+      unique: true
+      icon:
+        sprite: Objects/Tools/wirecutters.rsi
+        state: icon
+    - type: AutoCompleteCondition
+
+- type: entity
+  parent: [BaseTraitorObjective]
+  id: PromotedGimmickObjective
+  name: Get a better job via promotion
+  description: You could use a better paycheck, and your employer prefers further infiltration. A win for all! This objective is not tracked and will automatically succeed, so just have fun with it!
+  components:
+    - type: Objective
+      difficulty: 0.5
+      unique: true
+      icon:
+        sprite: Objects/Devices/pda.rsi
+        state: pda-captain
+    - type: AutoCompleteCondition
+
+- type: entity
+  parent: [BaseTraitorObjective]
+  id: AllegianceGimmickObjective
+  name: Prove your loyalty by strictly following your faction rules
+  description: Show your allegiance on the field! Support faction allies, sabotage enemies and ignore the inbetween while obeying the rules. This objective is not tracked and will automatically succeed, so just have fun with it!
+  components:
+    - type: Objective
+      difficulty: 0.5
+      unique: true
+      icon:
+        sprite: Objects/Misc/bureaucracy.rsi/syndicate_card.png
+    - type: AutoCompleteCondition
+
+# Major Gimmick - Basically extra-antag passes being real, 2 to leave some space for an M / Lower theft for those that are gonna be lame with them.
+
+- type: entity
+  parent: [BaseTraitorObjective]
+  id: SerialKillerGimmickObjective
+  name: Become an infamous serial killer
+  description: Your employers have low expectations, but they can be higher if the body count is higher and you evade capture. This objective is not tracked and will automatically succeed, but has to be followed in some form.
+  - type: Objective
+    unique: true
+    difficulty: 2
+    icon:
+      sprite: Objects/Weapons/Guns/Melee/cleaver.rsi
+      state: butch
+  - type: AutoCompleteCondition
+
+- type: entity
+  parent: [BaseTraitorObjective]
+  id: SabotageGimmickObjective
+  name: Create as much chaos as possible by sabotage.
+  description: Your employers want chaos? Chaos is what they get. Avoid being caught. This objective is not tracked and will automatically succeed, but has to be followed in some form.
+  components:
+  - type: Objective
+    unique: true
+    difficulty: 2
+    icon:
+      sprite: Objects/Weapons/Bombs/c4.rsi
+      state: icon
+  - type: AutoCompleteCondition
+
+- type: entity
+  parent: [BaseTraitorObjective]
+  id: HeistGimmickObjective
+  name: Attempt a massive heist or steal as much from the crewmembers.
+  description: Armory? Vault? Bank Accounts? Crew Belongings? The choice is yours. This objective is not tracked and will automatically succeed, but has to be followed in some form.
+  components:
+  - type: Objective
+    unique: true
+    difficulty: 2
+    icon:
+      sprite: Objects/Tools/Toolboxes/toolbox_thief.rsi/icon.png
+      state: icon
+  - type: AutoCompleteCondition
+
+- type: entity
+  parent: [BaseTraitorObjective]
+  id: AccompliceGimmickObjective
+  name: Become an Accomplice to other threats to the station by helping all enemies of the corporation, agent or not.
+  description: Maybe some stranger allies can be of use. The enemy of your enemy is our friend, agent. This objective is not tracked and will automatically succeed, but has to be followed in some form.
+  components:
+  - type: Objective
+    unique: true
+    difficulty: 2
+    icon:
+      sprite: Objects/Weapons/Melee/armblade.rsi
+      state: icon
+  - type: AutoCompleteCondition
+
+- type: entity
+  parent: [BaseTraitorObjective]
+  id: TakeoverGimmickObjective
+  name: Take control of the station for your faction
+  description: Mindslaves? Replacement? Threats? Force? Anything is on the table. Make them kneel to us! This objective is not tracked and will automatically succeed, but has to be followed in some form.
+  components:
+  - type: Objective
+    unique: true
+    difficulty: 2
+    icon:
+      sprite: Objects/Devices/declaration_of_war.rsi
+      state: declarator
+  - type: AutoCompleteCondition

--- a/Resources/Prototypes/_Goobstation/Objectives/traitor.yml
+++ b/Resources/Prototypes/_Goobstation/Objectives/traitor.yml
@@ -295,7 +295,7 @@
 - type: entity
   parent: [BaseTraitorObjective]
   id: SabotageGimmickObjective
-  name: Create as much chaos as possible by sabotage.
+  name: Create as much chaos as possible by sabotage
   description: Your employers want chaos? Chaos is what they get. Avoid being caught. This objective is not tracked and will automatically succeed, but has to be followed in some form.
   components:
   - type: Objective
@@ -309,7 +309,7 @@
 - type: entity
   parent: [BaseTraitorObjective]
   id: HeistGimmickObjective
-  name: Attempt a massive heist or steal as much from the crewmembers.
+  name: Attempt a massive heist or steal as much from the crewmembers
   description: Armory? Vault? Bank Accounts? Crew Belongings? The choice is yours. This objective is not tracked and will automatically succeed, but has to be followed in some form.
   components:
   - type: Objective
@@ -323,7 +323,7 @@
 - type: entity
   parent: [BaseTraitorObjective]
   id: AccompliceGimmickObjective
-  name: Become an Accomplice to other threats to the station by helping all enemies of the corporation, agent or not.
+  name: Become an Accomplice to other threats to the station by helping all enemies of the corporation, agent or not
   description: Maybe some stranger allies can be of use. The enemy of your enemy is our friend, agent. This objective is not tracked and will automatically succeed, but has to be followed in some form.
   components:
   - type: Objective


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Something was lost with the traitor antag when a bug fix fixed going above the 5 difficulty cap: Actually having objectives past "steal x then evac"!!! The objectives traitor had at the time were balanced around this and the "1 kill, 1 steal, 1 evac" roll ss13 gave you pretty often, hell, it'd pretty often slap you with "Kill 4 fucking people" which was actually, quite fun.

Now? An agent can thief glove a steal target and evac, nearly 0 antaggery from the agent. This longgg overdue PR that's been made like 3 times [from like, PR 1000 to funky to now] actually finally balances back the objectives to before / 13 parity minus the "kill 4 people!" part because fun or not it was kinda... objectively shitty.

oh and gimmick objectives are real now in minor and ShitterPass:TM: flavour :godo: [10 Minor, 5 Major!]
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Seriously watch any old lilten video playing den 2023 or so. Get that old tator_alert.ogg remix nostalgia. You'll see the amount of antaggery in a tot game farrrr exceed current traitors. 8 Traitors? Half of them may be actual threats back then.

There's 1 i can't remember the name of back in my early sayor-vanka LRP days [oh how far i've come, albeit i remember that game being particularly low effort, pretty often i was still a better RPer than the people i generally interacted with] that i was a decently large character in as a traitor that killed the cap by cremation that game and gave the pda to lilten when they witnessed me then told them they weren't cuffed and got them free after an arrest. Blah blah blah i shall get to the point: shit, actually, HAPPENS! 2/7 agents leave 4 dead, create a shooting, a bombing, and have AA all while i never even realised they were an agent, never even helping them except accidentally letting them take a pda. what were the other 5 agents doing? well, he never showed them and i can't even remember what agent i helped besides them that lilten never even showed, so who the fuck knows.

That was a very, very average traitor game back then. Now? that same level of chaos rarely happens with a full agent game except the rare massacre / grand sabo that let's be real happens even less, and more often by a John NRP Shitter type than a decent player, even on MRP.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [:godo:] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added 10 Minor and 5 major gimmick objectives! Maybe fate has Tresspasing Extreme or The Greatest Heist plus many other fun gimmicks / challenges in store for the average traitor.
- tweak: Traitor objectives have been completely rebalanced, now aiming for the "1 Kill 1 Steal 1 Evac" mark most ss13 servers and ss14 pre-2024 targeted. No more "steal x then evac!!!" that barely uses even half your TC. Be a REAL Traitor and kill three people today, like the not-very-glorious old days. 

