### PR TITLE
Update nanotrasen_representative.yml

### DIFF
--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/nanotrasen_representative.yml
@@ -97,9 +97,36 @@
   description: "Represent NT, Send reports back to them on the station's situation, Inform the heads of anything CentCom orders them to do."
   playTimeTracker: JobNanotrasenRepresentative
   requirements:
-    - !type:DepartmentTimeRequirement
-      department: Command
-      time: 180000  #50 hours
+- !type:RoleTimeRequirement
+      role: JobCaptain
+      time: 32400000 #9001 hrs OVER 9000!!!!
+ - !type:RoleTimeRequirement
+      role: JobQuartermaster
+      time: 32400000 #9001 hrs OVER 9000!!!!
+  - !type:RoleTimeRequirement
+      role: JobResearchDirector
+      time: 32400000 #9001 hrs OVER 9000!!!!
+  - !type:RoleTimeRequirement
+      role: JobChiefMedicalOfficer
+      time: 32400000 #9001 hrs OVER 9000!!!!
+  - !type:RoleTimeRequirement
+      role: JobHeadOfPersonnel
+      time: 32400000 #9001 hrs OVER 9000!!!!
+  - !type:RoleTimeRequirement
+      role: JobHeadOfSecurity
+      time: 32400000 #9001 hrs OVER 9000!!!!
+ - !type:RoleTimeRequirement
+      role: JobChiefEngineer
+      time: 32400000 #9001 hrs OVER 9000!!!!
+  - !type:RoleTimeRequirement
+      role:  JobBlueshieldOfficer
+      time: 32400000 #9001 hrs OVER 9000!!!!
+  - !type:RoleTimeRequirement
+      role: JobBartender
+      time: 32400000 #9001 hrs OVER 9000!!!!
+  - !type:RoleTimeRequirement
+      role: JobLibrarian
+      time: 32400000 #9001 hrs OVER 9000!!!!
     - !type:AgeRequirement
       requiredAge: 21
   weight: 20


### PR DESCRIPTION
Job requirements lock for NTR role

<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Job requirements lock for NTR role until this role will be reworked. More of a draft for discussion and a complete removal from player available job list

## Why / Balance
NTR job is lacking gameplay, poorly described in job requirements and can be frustrating to play, thus job requirement locking it until it will be reworked

## Technical details
Job requirements modified in .yml file

## Media
Not required, small change

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- remove: NTR role as playable before it will be reworked
- tweak: Change job requirements for NTR role to be unachievable by a player (OVER 9000!!!).
