### PR TITLE
What if deathsquad got a small buff

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -1077,9 +1077,17 @@
         Cellular: 0.1
         Radiation: 0.1
         Caustic: 0.1
+      flatReductions:
+        Blunt: 5
+        Slash: 5
+        Piercing: 5
+        Heat: 5
+        Radiation: 2
   - type: FlashImmunity # Goobstation
   - type: FlashSoundSuppression # Goobstation
     protectionRange: 0
+  - type: SpeechSoundsReplacer
+    speechSounds: Chrono # Because it's cool and based
   - type: PointLight # Goobstation - Light to deathsquad hardsuit
     color: "#567fc4"
     rotation: 30

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -696,6 +696,8 @@
         Slash: 0.75
         Piercing: 0.75
         Heat: 0.75
+  - type: SpeechSoundsReplacer
+    speechSounds: Chrono # Because it's cool and based
   - type: Tag
     tags: [] # ignore "WhitelistChameleon" tag
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1364,6 +1364,12 @@
         Cellular: 0.1
         Radiation: 0.1
         Caustic: 0.1
+      flatReductions:
+        Blunt: 5
+        Slash: 5
+        Piercing: 5
+        Heat: 5
+        Radiation: 2
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Hands/gloves.yml
@@ -207,6 +207,7 @@
             soundHit:
               path: /Audio/_Goobstation/Weapons/Effects/metalcrush.ogg
             canWideSwing: false
+          - type: GrabbingItem
           - type: StaminaDamageOnHit
             damage: 45
             overtime: 80


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
I have conceived an idea most ingenious.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<img width="528" height="482" alt="image" src="https://github.com/user-attachments/assets/a7ce488a-5fb0-4bd8-b07a-ead8edfc410b" />


## Technical details
<!-- Summary of code changes for easier review. -->
Your honor, it's all yaml, ALL OF IT. I tell you!

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Tested, works (actually did test it im just lazy to add media)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Deathsquad glazer
- tweak: Deathsquad units have learned to get a grip with their gloves - claw mode remains the same.
- tweak: Deathsquad now uses the speech replacers that the chrono agents had.
- tweak: Deathsquad armor now has flat damage reduction. Try rads or something.