### PR TITLE
[Fix] Heretic rift visibility fix

### DIFF
--- a/Content.Server/_Shitcode/Heretic/EntitySystems/HereticSystem.cs
+++ b/Content.Server/_Shitcode/Heretic/EntitySystems/HereticSystem.cs
@@ -137,10 +137,10 @@ public sealed class HereticSystem : EntitySystem
 
     private void OnCompInit(Entity<HereticComponent> ent, ref ComponentInit args)
     {
-        var eyeVisVal = ((int)VisibilityFlags.EldritchInfluence) + ((int)VisibilityFlags.EldritchInfluenceSpent); // Splitting the visibility layer in 2 and then adding the values for heretics is the only way I thought of doing this
+        // Splitting the visibility layer in 2 and then adding the values for heretics is the only way I thought of doing this
         // add influence layer
         if (TryComp<EyeComponent>(ent, out var eye)) // As a result, I'm afraid its complete shitcode however it's working shitcode.
-            _eye.SetVisibilityMask(ent, eye.VisibilityMask | eyeVisVal); 
+            _eye.SetVisibilityMask(ent, eye.VisibilityMask | ((int) VisibilityFlags.EldritchInfluence) + ((int) VisibilityFlags.EldritchInfluenceSpent)); //Moved the addition code here, it does not initiate correctly roundstart if moved into a variable.
 
         foreach (var knowledge in ent.Comp.BaseKnowledge)
             _knowledge.AddKnowledge(ent, ent.Comp, knowledge);


### PR DESCRIPTION
## About the PR
After the crew and chaplain rift visibility changes roundstart heretics couldn't see rifts unless cloned and made antag by admin panel.

## Technical details
Moved visibility flags addition from a separate variable into SetVisibilityMask args.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


**Changelog**
:cl:
- fix: Fixed roundstart heretic's inability to see reality rifts.

