### PR TITLE
Bingle ghostrole adjustment

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
@@ -9,6 +9,7 @@
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 IrisTheAmped <iristheamped@gmail.com>
+# SPDX-FileCopyrightText: 2025 LuciferEOS <stepanteliatnik2022@gmail.com>
 # SPDX-FileCopyrightText: 2025 Rouge2t7 <81053047+Sarahon@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Theodore Lukin <66275205+pheenty@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 fishbait <gnesse@gmail.com>

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
@@ -32,7 +32,7 @@
     mindRoles:
     - MindRoleGhostRoleTeamAntagonist
     raffle:
-      settings: default
+      settings: short
   - type: Sprite
     drawdepth: Mobs
     sprite: _Goobstation/Mobs/Bingle/bingle.rsi


### PR DESCRIPTION
## About the PR
Bingle ghostroles now have 10 second timer instead of a 30 second one

## Media
tested on debug, works :trollface: 

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.


**Changelog**
:cl: LuciferEOS
- tweak: Bingle raffle timer 30sec -> 10sec

