### PR TITLE
FIX heretic locale

### DIFF
--- a/Resources/Prototypes/_Goobstation/Heretic/Heretic/heretic_rituals.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Heretic/heretic_rituals.yml
@@ -69,8 +69,8 @@
 
 - type: hereticRitual
   id: Reminiscence
-  locName: heretic-ritual-basic-remeniscence
-  locDesc: heretic-ritual-basic-remeniscence-desc
+  locName: heretic-ritual-basic-reminiscence
+  locDesc: heretic-ritual-basic-reminiscence-desc
   icon:
     sprite: _Goobstation/Heretic/Blades/eldritch_blade.rsi
     state: icon


### PR DESCRIPTION
## About the PR
fixes the minor spelling mistake in heretic ritual

https://tenor.com/bA1NR.gif

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: LuciferEOS
- fix: Heretic reminiscence ritual is now properly named.