### PR TITLE
[Tweak] Add Custom Bold Fonts DataField and Boldified Sol Common!

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -1164,6 +1164,7 @@ public sealed partial class ChatSystem : SharedChatSystem
             ("verb", Loc.GetString(verbId)),
             ("fontType", language.SpeechOverride.FontId ?? speech.FontId),
             ("fontSize", language.SpeechOverride.FontSize ?? speech.FontSize),
+            ("boldFontType", language.SpeechOverride.BoldFontId ?? speech.FontId), // Goob Edit - Custom Bold Fonts
             ("message", message),
             ("language", languageDisplay));
     }

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -259,6 +259,7 @@ public sealed class RadioSystem : EntitySystem
             ("languageColor", languageColor),
             ("fontType", language.SpeechOverride.FontId ?? speech.FontId),
             ("fontSize", language.SpeechOverride.FontSize ?? speech.FontSize),
+            ("boldFontType", language.SpeechOverride.BoldFontId ?? speech.FontId), // Goob Edit - Custom Bold Fonts
             ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
             ("channel", $"\\[{channel.LocalizedName}\\]"),
             ("name", name),

--- a/Content.Shared/_EinsteinEngines/Language/LanguagePrototype.cs
+++ b/Content.Shared/_EinsteinEngines/Language/LanguagePrototype.cs
@@ -62,6 +62,9 @@ public sealed partial class SpeechOverrideInfo
     public int? FontSize;
 
     [DataField]
+    public string? BoldFontId; // Goob Edit - Custom Bolded Fonts
+
+    [DataField]
     public bool AllowRadio = true;
 
     /// <summary>

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -57,7 +57,7 @@ chat-manager-sender-announcement-wrap-message = [font size=14][bold]{$sender} An
 # For the message in double quotes, the font/color/bold/italic elements are repeated twice, outside the double quotes and inside.
 # The outside elements are for formatting the double quotes, and the inside elements are for formatting the text in speech bubbles ([BubbleContent]).
 chat-manager-entity-say-wrap-message = [BubbleHeader][bold][Name]{$entityName}[/Name][/bold][/BubbleHeader] {$verb}, [font={$fontType} size={$fontSize}]"[BubbleContent][font="{$fontType}" size={$fontSize}][color={$color}]{$message}[/color][/font][/BubbleContent]"[/font]
-chat-manager-entity-say-bold-wrap-message = [BubbleHeader][bold][Name]{$entityName}[/Name][/bold][/BubbleHeader] {$verb}, [font={$fontType} size={$fontSize}]"[BubbleContent][font="{$fontType}" size={$fontSize}][bold][color={$color}]{$message}[/color][/font][/bold][/BubbleContent]"[/font]
+chat-manager-entity-say-bold-wrap-message = [BubbleHeader][bold][Name]{$entityName}[/Name][/bold][/BubbleHeader] {$verb}, [font={$fontType} size={$fontSize}]"[BubbleContent][font="{$boldFontType}" size={$fontSize}][bold][color={$color}]{$message}[/color][/font][/bold][/BubbleContent]"[/font]
 
 chat-manager-entity-whisper-wrap-message = [font size=11][italic][BubbleHeader][Name]{$entityName}[/Name][/BubbleHeader] whispers, "[BubbleContent][color={$color}][font="{$fontType}"]{$message}[/font][/color][/BubbleContent][font size=11]"[/italic][/font]
 chat-manager-entity-whisper-unknown-wrap-message = [font size=11][italic][BubbleHeader]Someone[/BubbleHeader] whispers, "[BubbleContent][color={$color}][font="{$fontType}"]{$message}[/color][/font][/BubbleContent][font size=11]"[/italic][/font]

--- a/Resources/Locale/en-US/headset/headset-component.ftl
+++ b/Resources/Locale/en-US/headset/headset-component.ftl
@@ -25,7 +25,7 @@
 # Chat window radio wrap (prefix and postfix)
 # Einstein Engines - Languages begin (change text color based on language color set in handler)
 chat-radio-message-wrap = [color={$color}]{$channel} [bold]{$name}[/bold] {$verb}, "[/color][font="{$fontType}" size={$fontSize}][color={$languageColor}]{$message}[/color][/font][color={$color}]"[/color]
-chat-radio-message-wrap-bold = [color={$color}]{$channel} [bold]{$name}[/bold] {$verb}, "[/color][font="{$fontType}" size={$fontSize}][color={$languageColor}][bold]{$message}[/bold][/font][/color][color={$color}]"[/color]
+chat-radio-message-wrap-bold = [color={$color}]{$channel} [bold]{$name}[/bold] {$verb}, "[/color][font="{$boldFontType}" size={$fontSize}][color={$languageColor}][bold]{$message}[/bold][/font][/color][color={$color}]"[/color]
 # Einstein Engines - Languages end
 
 examine-headset-default-channel = Use {$prefix} for the default channel ([color={$color}]{$channel}[/color]).

--- a/Resources/Prototypes/_EinsteinEngines/Language/Standard/solcommon.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Language/Standard/solcommon.yml
@@ -5,6 +5,7 @@
   speech:
     color: "#8282fbaa"
     fontId: NotoSansSC
+    boldFontId: NotoSansSCBold
   obfuscation:
     !type:SyllableObfuscation
     minSyllables: 1

--- a/Resources/Prototypes/_Goobstation/fonts.yml
+++ b/Resources/Prototypes/_Goobstation/fonts.yml
@@ -1,3 +1,7 @@
 - type: font
   id: NotoSansSC
   path: /Fonts/NotoSans/NotoSansSC-Regular.ttf
+
+- type: font
+  id: NotoSansSCBold
+  path: /Fonts/NotoSans/NotoSansSC-Bold.ttf


### PR DESCRIPTION
## About the PR
This adds a new DataField to the Language Prototype for adding a specific bold font. This is primarily for use with alternate language fonts like Sol Common's Chinese where bolding isn't supported at an engine level.

## Why / Balance
So we can bold fonts that should be bolded. 🤷 

## Technical details
This adds a new DataField to Language Prototype that is just a mimicry of FontId and there is now a specialized localization for this bold font. If the datafield is null, it just defaults to the language font or the original font (if not language font).
> #3598 must be merged first! This does not fix bold issues, this just adds a new DataField!!

## Media
<img width="1227" height="463" alt="image" src="https://github.com/user-attachments/assets/ff2f2cb0-22c2-4f8d-ba1b-2fe9a80f1547" />
<img width="1125" height="545" alt="image" src="https://github.com/user-attachments/assets/5ddef51e-634c-4383-abac-bab7cd988e8e" />

> Note: These are using a modified chat-manager.ftl and headset-component.ftl that would be updated once #3598 is merged. Hence this will 100% have a merge conflict, but I can fix that once the first PR is merged.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Made Chinese more BOLD!!