### PR TITLE
Port hypophonia trait from Harmony

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -744,7 +744,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         string wrappedMessagePostfix = "" // Goobstation
         )
     {
-        if (!_actionBlocker.CanSpeak(source) && !ignoreActionBlocker)
+        if (!_actionBlocker.CanSpeak(source, true) && !ignoreActionBlocker) // Goobstation - Port hypophonia trait from Harmony - added whisper boolean
             return;
 
         var message = TransformSpeech(source, FormattedMessage.RemoveMarkupOrThrow(originalMessage), language); // Einstein Engines - Language

--- a/Content.Server/_Harmony/Speech/Hypophonia/HypophoniaSystem.cs
+++ b/Content.Server/_Harmony/Speech/Hypophonia/HypophoniaSystem.cs
@@ -1,0 +1,67 @@
+using Content.Server.Chat.Systems;
+using Content.Server.Popups;
+using Content.Server.Speech.EntitySystems;
+using Content.Shared.Chat.Prototypes;
+using Content.Shared.Puppet;
+using Content.Shared.Speech;
+using Content.Shared.Speech.Muting;
+using Content.Shared.Harmony.Speech.Hypophonia;
+
+namespace Content.Server.Harmony.Speech.Hypophonia
+{
+    public sealed class HypophoniaSystem : EntitySystem
+    {
+        [Dependency] private readonly PopupSystem _popupSystem = default!;
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<HypophoniaComponent, SpeakAttemptEvent>(OnSpeakAttempt);
+            SubscribeLocalEvent<HypophoniaComponent, EmoteEvent>(OnEmote, before: new[] { typeof(VocalSystem) });
+            SubscribeLocalEvent<HypophoniaComponent, ScreamActionEvent>(OnScreamAction, before: new[] { typeof(VocalSystem) });
+        }
+
+        private void OnEmote(EntityUid uid, HypophoniaComponent component, ref EmoteEvent args)
+        {
+            if (args.Handled)
+                return;
+
+            // Let MutingSystem handle the event for muted characters (mimes included)
+            if (HasComp<MutedComponent>(uid))
+                return;
+
+            //still leaves the text so it looks like they are pantomiming a laugh
+            if (args.Emote.Category.HasFlag(EmoteCategory.Vocal))
+                args.Handled = true;
+        }
+
+        private void OnScreamAction(EntityUid uid, HypophoniaComponent component, ScreamActionEvent args)
+        {
+            if (args.Handled)
+                return;
+
+            // Let MutingSystem handle the event muted characters (mimes included)
+            if (HasComp<MutedComponent>(uid))
+                return;
+
+            // Mark the event as handled and show the popup
+            _popupSystem.PopupEntity(Loc.GetString("speech-hypophonia"), uid, uid);
+            args.Handled = true;
+        }
+
+
+        private void OnSpeakAttempt(EntityUid uid, HypophoniaComponent component, SpeakAttemptEvent args)
+        {
+            // Let MutingSystem handle the event for puppets and muted characters (mimes included)
+            if (HasComp<VentriloquistPuppetComponent>(uid) || HasComp<MutedComponent>(uid))
+                return;
+
+            // If the entity is whispering, let them speak
+            if (args.Whisper)
+                return;
+
+            // Cancel the event and show the popup
+            _popupSystem.PopupEntity(Loc.GetString("speech-hypophonia"), uid, uid);
+            args.Cancel();
+        }
+    }
+}

--- a/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
+++ b/Content.Shared/ActionBlocker/ActionBlockerSystem.cs
@@ -228,10 +228,11 @@ namespace Content.Shared.ActionBlocker
             return !itemEv.Cancelled;
         }
 
-        public bool CanSpeak(EntityUid uid)
+        // Goobstation - Port hypophonia trait from Harmony - added whisper boolean
+        public bool CanSpeak(EntityUid uid, bool whisper = false)
         {
             // This one is used as broadcast
-            var ev = new SpeakAttemptEvent(uid);
+            var ev = new SpeakAttemptEvent(uid, whisper);
             RaiseLocalEvent(uid, ev, true);
 
             return !ev.Cancelled;

--- a/Content.Shared/Speech/SpeakAttemptEvent.cs
+++ b/Content.Shared/Speech/SpeakAttemptEvent.cs
@@ -10,11 +10,14 @@ namespace Content.Shared.Speech
 {
     public sealed class SpeakAttemptEvent : CancellableEntityEventArgs
     {
-        public SpeakAttemptEvent(EntityUid uid)
+        // Goobstation - Port hypophonia trait from Harmony - added whisper boolean
+        public SpeakAttemptEvent(EntityUid uid, bool whisper)
         {
             Uid = uid;
+            Whisper = whisper;
         }
 
         public EntityUid Uid { get; }
+        public bool Whisper { get; }
     }
 }

--- a/Content.Shared/_Harmony/Hypophonia/HypophoniaComponent.cs
+++ b/Content.Shared/_Harmony/Hypophonia/HypophoniaComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Harmony.Speech.Hypophonia
+{
+    [RegisterComponent, NetworkedComponent]
+    public sealed partial class HypophoniaComponent : Component
+    {
+
+    }
+}

--- a/Resources/Locale/en-US/_Harmony/speech/speech-effects.ftl
+++ b/Resources/Locale/en-US/_Harmony/speech/speech-effects.ftl
@@ -1,0 +1,1 @@
+speech-hypophonia = You can't speak this loud.

--- a/Resources/Locale/en-US/_Harmony/traits/traits.ftl
+++ b/Resources/Locale/en-US/_Harmony/traits/traits.ftl
@@ -1,0 +1,2 @@
+trait-hypophonia-name = Hypophonia
+trait-hypophonia-desc = You can only whisper.

--- a/Resources/Prototypes/_Harmony/disabilities.yml
+++ b/Resources/Prototypes/_Harmony/disabilities.yml
@@ -1,0 +1,10 @@
+- type: trait
+  id: HarmonyHypophonia
+  name: trait-hypophonia-name
+  description: trait-hypophonia-desc
+  category: Disabilities
+  blacklist:
+    components:
+      - BorgChassis
+  components:
+    - type: Hypophonia


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
This PR ports over the Hypophonia disability from Harmony into the Goob codebase. Hypophonia limits the player's ability to talk, restricting them to whispering only. Hypophonia can be selected from the character creator under Traits > Disabilities.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I think the trait is good for roleplay. This is because, if a player decides to restrict themself using this trait, it incentivizes stronger use of the emote system for that player.

Also, I find it easier to roleplay characters that are similar to me as a person, so adding the option to create a naturally nervous/shy-seeming character (i.e. me when i play space station 14) via this trait is nice to have.
## Technical details
<!-- Summary of code changes for easier review. -->
An empty `HypophoniaComponent` class now exists, which is given to players who opt into the hypophonia trait. A `HypophoniaSystem` class exists to handle speaking-attempts, emotes, and screaming for entities with a `HypophoniaComponent`. For players who are both mute and hypophonic, these actions are handled by the `MutingSystem`. 

As well, the `SpeakAttemptEvent` class has gained a "whisper" argument (false by default, when called by `CanSpeak()` in the `ActionBlockerSystem`) and relevant localization has been added.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<i>Hypophonia appears under the Disability tab under Traits in the character creator</i>
<img width="132" height="51" alt="image" src="https://github.com/user-attachments/assets/9846abd4-5c49-44d2-aca6-cbf31cd4faf6" />
<i>`speech-hypophonia` ("You can't speak this loud.") appears in a popup when an entity with a HypophoniaComponent tries to speak. This does not appear when the whisper channel is used.</i>
<img width="149" height="99" alt="Screenshot from 2025-07-26 11-40-03" src="https://github.com/user-attachments/assets/2066cf7f-7924-46b8-a7dd-6ccb439ad745" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Players now have access to the Hypophonia trait in the character creator. Players with hypophonia can whisper, but are unable to speak at a normal volume.