### PR TITLE
Nerf metal pipe sound

### DIFF
--- a/Resources/Prototypes/_Goobstation/SoundCollections/items.yml
+++ b/Resources/Prototypes/_Goobstation/SoundCollections/items.yml
@@ -10,5 +10,46 @@
     - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
     - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
     - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
-    # 1 in 10 chance for a metal pipe drop sound...
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    - /Audio/_Goobstation/Items/Pipe/metal_pipe_fall.ogg
+    # 1 in 50 chance for a metal pipe drop sound...
     - /Audio/_Goobstation/Items/Pipe/metal_pipe_meme.ogg


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Metal pipe was stopped. Now it has 1/50 chance to play the funny sound instead of 1/9.

## Why / Balance
ts pmo (it was funny for only 1 day)

## Technical details
added 41 more copy pasted lines to change the chance of funny metal pipe sound occuring from 1/9 to 1/50

## Breaking changes
Metal pipe was stopped.

**Changelog**
:cl: Rouden
- tweak: Metal pipe was stopped.
