### PR TITLE
Update Jukebox Audio Names for Lauren Loveless

### DIFF
--- a/Resources/Prototypes/_Goobstation/Catalog/Jukebox/Standard.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Jukebox/Standard.yml
@@ -247,19 +247,19 @@
 
 - type: jukebox
   id: pwmur
-  name: Alexander Divine - Phoron Will Make Us Rich
+  name: Lauren Loveless - Phoron Will Make Us Rich
   path:
     path: /Audio/Lobby/pwmur.ogg
 
 - type: jukebox
   id: lasers_rip_apart_the_bulkhead
-  name: Alexander Divine - Lasers Rip Apart the Bulkhead
+  name: Lauren Loveless - Lasers Rip Apart the Bulkhead
   path:
     path: /Audio/Lobby/lasers_rip_apart_the_bulkhead.ogg
 
 - type: jukebox
   id: every_light_is_blinking_at_once
-  name: Alexander Divine - Every Light is Blinking at Once
+  name: Lauren Loveless - Every Light is Blinking at Once
   path:
     path: /Audio/Lobby/every_light_is_blinking_at_once.ogg
 


### PR DESCRIPTION
## About the PR
I changed the names attributed to the musics in the Jukebox. This was originally done in #2182, specifically the cherry-pick for https://github.com/space-wizards/space-station-14/pull/35817.

## Why / Balance
The names associated with the audio files in the jukebox were not changed, effectively not updating the actual in-game attributions that are seen more often than the actual attributions file.

## Technical details
Changed the name...

## Media
<img width="1211" height="560" alt="image" src="https://github.com/user-attachments/assets/e5cb7800-3d0e-4b92-a134-be35a85cc2e3" />
<img width="398" height="390" alt="image" src="https://github.com/user-attachments/assets/ad715204-3c92-4298-b9b3-a6bf813f4e45" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
None, not particularly player facing outside of the updated names. Nothing game-wise was changed worthy of notifying in a changelog.