### PR TITLE
Halve spreadChance on all kudzu variants that matter

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
@@ -19,7 +19,11 @@
 # SPDX-FileCopyrightText: 2024 Tayrtahn <tayrtahn@gmail.com>
 # SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 DeusMaldPr <dusanduski@gmail.com>
 # SPDX-FileCopyrightText: 2025 NazrinNya <137837419+NazrinNya@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
+# SPDX-FileCopyrightText: 2025 Victor Shen <71985089+Vexerot@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 #

--- a/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
@@ -20,6 +20,7 @@
 # SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 DeusMaldPr <dusanduski@gmail.com>
+# SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 NazrinNya <137837419+NazrinNya@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
 # SPDX-FileCopyrightText: 2025 Victor Shen <71985089+Vexerot@users.noreply.github.com>

--- a/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
@@ -109,7 +109,7 @@
     - type: AtmosExposed
     - type: Kudzu
       growthTickChance: 0.3
-      spreadChance: 0.4
+      spreadChance: 0.2
     - type: SpeedModifierContacts
       walkSpeedModifier: 0.2
       sprintSpeedModifier: 0.2
@@ -135,7 +135,7 @@
   suffix: Weak
   components:
     - type: Kudzu
-      spreadChance: 0.3
+      spreadChance: 0.1
 
 - type: entity
   id: KudzuFlowerFriendly
@@ -179,7 +179,7 @@
   parent: KudzuFlowerFriendly
   components:
     - type: Kudzu
-      spreadChance: 0.2
+      spreadChance: 0.1
     - type: RandomSpawner
       chance: 0.05
       rarePrototypes:
@@ -239,7 +239,7 @@
         - Flesh
     - type: Kudzu
       growthTickChance: 0.1
-      spreadChance: 0.4
+      spreadChance: 0.2
       # Heals each time it manages to do a growth tick:
       damageRecovery:
         types:


### PR DESCRIPTION
## About the PR
Halves the chance any agresssive kudzu (or variant like fleshkudzu) has to spread 

## Why / Balance
Makes kudzu less ass to deal with

## Technical details
like a few numbers in one yml got tweaked 
Rouge (head of staff) said yes if this pr counts for balance/antag freeze slop (it really isnt)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Halved kudzu, fleshkudzu (meat anom), floralkudzu (plant anom) vine spread speed.
