### PR TITLE
fix wizard robes not having armor values

### DIFF
--- a/Resources/Prototypes/_Goobstation/Wizard/Clothing/wizard.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/Clothing/wizard.yml
@@ -116,7 +116,7 @@
 
 # Black
 - type: entity
-  parent: [ClothingHeadHatWizardBase, ClothingHeadHatWizardBaseArmor]
+  parent: [ClothingHeadHatWizardBaseArmor, ClothingHeadHatWizardBase]
   id: ClothingHeadHatBlackwizardReal
   name: black wizard hat
   description: Strange-looking black hat-wear that most certainly belongs to a real lich. Spooky.
@@ -127,7 +127,7 @@
     sprite: _Goobstation/Wizard/Clothing/Head/blackwizard.rsi
 
 - type: entity
-  parent: [ClothingOuterWizardBase, ClothingOuterWizardBaseArmor]
+  parent: [ClothingOuterWizardBaseArmor, ClothingOuterWizardBase]
   id: ClothingOuterWizardBlackReal
   name: black wizard robes
   description: An unnerving black gem-lined robe that reeks of death and decay.
@@ -139,7 +139,7 @@
 
 # Yellow
 - type: entity
-  parent: [ClothingHeadHatWizardBase, ClothingHeadHatWizardBaseArmor]
+  parent: [ClothingHeadHatWizardBaseArmor, ClothingHeadHatWizardBase]
   id: ClothingHeadHatYellowwizardReal
   name: yellow wizard hat
   description: Strange-looking yellow hat-wear that most certainly belongs to a powerful magic user.
@@ -150,7 +150,7 @@
     sprite: _Goobstation/Wizard/Clothing/Head/yellowwizard.rsi
 
 - type: entity
-  parent: [ClothingOuterWizardBase, ClothingOuterWizardBaseArmor]
+  parent: [ClothingOuterWizardBaseArmor, ClothingOuterWizardBase]
   id: ClothingOuterWizardYellowReal
   name: yellow wizard robes
   description: A magnificent yellow gem-lined robe that seems to radiate power.
@@ -162,7 +162,7 @@
 
 # Tape
 - type: entity
-  parent: [ClothingHeadHatWizardBase, ClothingHeadHatWizardBaseArmor]
+  parent: [ClothingHeadHatWizardBaseArmor, ClothingHeadHatWizardBase]
   id: ClothingHeadHatTapewizardReal
   name: tape hat
   description: A magically attuned hat made exclusively from duct tape. You can barely see.
@@ -177,7 +177,7 @@
         offset: "0, 0.2"
 
 - type: entity
-  parent: [ClothingOuterWizardBase, ClothingOuterWizardBaseArmor]
+  parent: [ClothingOuterWizardBaseArmor, ClothingOuterWizardBase]
   id: ClothingOuterWizardTapeReal
   name: tape robes
   description: A fine robe made from magically attuned duct tape.
@@ -189,7 +189,7 @@
 
 # Chanterelle
 - type: entity
-  parent: [ClothingHeadHatWizardBase, ClothingHeadHatWizardBaseArmor]
+  parent: [ClothingHeadHatWizardBaseArmor, ClothingHeadHatWizardBase]
   id: ClothingHeadHatChanterelleReal
   name: chanterelle hat
   description: An oversized chanterelle with hollow out space to fit a head in. Kinda looks like wizard's hat.
@@ -201,7 +201,7 @@
 
 # Paper
 - type: entity
-  parent: [ClothingOuterWizardBase, ClothingOuterWizardBaseArmor]
+  parent: [ClothingOuterWizardBaseArmor, ClothingOuterWizardBase]
   id: ClothingOuterWizardPaperReal
   name: papier-mâché robes
   description: A robe held together by various bits of clear-tape and paste.
@@ -221,13 +221,13 @@
     - ActionSummonStickmen
 
 - type: entity
-  parent: [ClothingHeadHatWizardBase, ClothingHeadHatWizardBaseArmor, ClothingHeadHatPaper]
+  parent: [ClothingHeadHatWizardBaseArmor, ClothingHeadHatPaper, ClothingHeadHatWizardBase]
   id: ClothingHeadHatPaperWizard
   name: paper magic hat
 
 # Mime
 - type: entity
-  parent: [ClothingHeadHatWizardBase, ClothingHeadHatWizardBaseArmor]
+  parent: [ClothingHeadHatWizardBaseArmor, ClothingHeadHatWizardBase]
   id: ClothingHeadHatMimeReal
   name: magical beret
   description: A magical red beret.
@@ -238,7 +238,7 @@
     sprite: _Goobstation/Wizard/Clothing/Head/mimewizard.rsi
 
 - type: entity
-  parent: [ClothingOuterWizardBase, ClothingOuterWizardBaseArmor]
+  parent: [ClothingOuterWizardBaseArmor, ClothingOuterWizardBase]
   id: ClothingOuterWizardMimeReal
   name: mime robes
   description: Red, black, and white robes. There is not much else to say about them.
@@ -250,7 +250,7 @@
 
 # Clown
 - type: entity
-  parent: [ClothingHeadHatWizardBase, ClothingHeadHatWizardBaseArmor]
+  parent: [ClothingHeadHatWizardBaseArmor, ClothingHeadHatWizardBase]
   id: ClothingHeadHatClownReal
   name: purple wizard hat
   description: Strange-looking purple hat-wear that most certainly belongs to a real magic user.
@@ -261,7 +261,7 @@
     sprite: _Goobstation/Wizard/Clothing/Head/clownwizard.rsi
 
 - type: entity
-  parent: [ClothingOuterWizardBase, ClothingOuterWizardBaseArmor]
+  parent: [ClothingOuterWizardBaseArmor, ClothingOuterWizardBase]
   id: ClothingOuterWizardClownReal
   name: clown robes
   description: A set of armoured robes that seem to radiate a dark power. That, and bad fashion decisions.
@@ -273,7 +273,7 @@
 
 # Psy
 - type: entity
-  parent: [ClothingHeadHatWizardBase, ClothingHeadHatWizardBaseArmor]
+  parent: [ClothingHeadHatWizardBaseArmor, ClothingHeadHatWizardBase]
   id: ClothingHeadHatPsyReal
   name: psychic amplifier
   description: A crown-of-thorns psychic amplifier.
@@ -284,7 +284,7 @@
     sprite: _Goobstation/Wizard/Clothing/Head/psywizard.rsi
 
 - type: entity
-  parent: [ClothingOuterWizardBase, ClothingOuterWizardBaseArmor]
+  parent: [ClothingOuterWizardBaseArmor, ClothingOuterWizardBase]
   id: ClothingOuterWizardPsyReal
   name: purple robes
   description: Heavy, royal purple robes threaded with psychic amplifiers and weird, bulbous lenses. Do not machine wash.
@@ -296,7 +296,7 @@
 
 # Oblibion
 - type: entity
-  parent: [ClothingHeadHatWizardBase, ClothingHeadHatWizardBaseArmor]
+  parent: [ClothingHeadHatWizardBaseArmor, ClothingHeadHatWizardBase]
   id: ClothingHeadHatOblivionEnforcer
   name: oblivion enforcer's hood
   description: A hood worn by an Oblivion Enforcer.
@@ -373,62 +373,62 @@
 
 # Blue
 - type: entity
-  parent: [ClothingHeadHatWizardBase, ClothingHeadHatWizardBaseArmor, ClothingHeadHatWizard]
+  parent: [ClothingHeadHatWizardBaseArmor, ClothingHeadHatWizard, ClothingHeadHatWizardBase]
   id: ClothingHeadHatWizardReal
   name: wizard hat
 
 - type: entity
-  parent: [ClothingOuterWizardBase, ClothingOuterWizardBaseArmor, ClothingOuterWizard]
+  parent: [ClothingOuterWizardBaseArmor, ClothingOuterWizard, ClothingOuterWizardBase]
   id: ClothingOuterWizardReal
   name: wizard robes
 
 # Red
 - type: entity
-  parent: [ClothingHeadHatWizardBase, ClothingHeadHatWizardBaseArmor, ClothingHeadHatRedwizard]
+  parent: [ClothingHeadHatWizardBaseArmor, ClothingHeadHatRedwizard, ClothingHeadHatWizardBase]
   id: ClothingHeadHatRedwizardReal
   name: red wizard hat
 
 - type: entity
-  parent: [ClothingOuterWizardBase, ClothingOuterWizardBaseArmor, ClothingOuterWizardRed]
+  parent: [ClothingOuterWizardBaseArmor, ClothingOuterWizardRed, ClothingOuterWizardBase]
   id: ClothingOuterWizardRedReal
   name: red wizard robes
 
 # Violet
 - type: entity
-  parent: [ClothingHeadHatWizardBase, ClothingHeadHatWizardBaseArmor, ClothingHeadHatVioletwizard]
+  parent: [ClothingHeadHatWizardBaseArmor, ClothingHeadHatVioletwizard, ClothingHeadHatWizardBase]
   id: ClothingHeadHatVioletwizardReal
   name: violet wizard hat
 
 - type: entity
-  parent: [ClothingOuterWizardBase, ClothingOuterWizardBaseArmor, ClothingOuterWizardViolet]
+  parent: [ClothingOuterWizardBaseArmor, ClothingOuterWizardViolet, ClothingOuterWizardBase]
   id: ClothingOuterWizardVioletReal
   name: violet wizard robes
 
 # Witch
 - type: entity
-  parent: [ClothingHeadHatWizardBase, ClothingHeadHatWizardBaseArmor, ClothingHeadHatWitch1]
+  parent: [ClothingHeadHatWizardBaseArmor, ClothingHeadHatWitch1, ClothingHeadHatWizardBase]
   id: ClothingHeadHatWitchReal
   name: witch hat
 
 - type: entity
-  parent: [ClothingOuterWizardBase, ClothingOuterWizardBaseArmor, ClothingOuterSuitWitchRobes]
+  parent: [ClothingOuterWizardBaseArmor, ClothingOuterSuitWitchRobes, ClothingOuterWizardBase]
   id: ClothingOuterSuitWitchRobesReal
   name: witch robes
 
 # Shrine maiden
 - type: entity
-  parent: [ClothingHeadHatWizardBase, ClothingHeadHatWizardBaseArmor, ClothingHeadHatShrineMaidenWig]
+  parent: [ClothingHeadHatWizardBaseArmor, ClothingHeadHatShrineMaidenWig, ClothingHeadHatWizardBase]
   id: ClothingHeadHatShrineMaidenWigReal
   name: shrine maiden's wig
 
 - type: entity
-  parent: [ClothingOuterWizardBase, ClothingOuterWizardBaseArmor, ClothingOuterSuitShrineMaiden]
+  parent: [ClothingOuterWizardBaseArmor, ClothingOuterSuitShrineMaiden, ClothingOuterWizardBase]
   id: ClothingOuterSuitShrineMaidenReal
   name: shrine maiden outfit
 
 # Centcomm
 - type: entity
-  parent: [ClothingHeadHatWizardBase, ClothingHeadHatWizardBaseArmor]
+  parent: [ClothingHeadHatWizardBaseArmor, ClothingHeadHatWizardBase]
   id: ClothingHeadHatCentCommwizardReal
   name: CentComm wizard hat
   suffix: ADMIN
@@ -440,7 +440,7 @@
     sprite: _Goobstation/Wizard/Clothing/Head/comwizard.rsi
 
 - type: entity
-  parent: [ClothingOuterWizardBase, ClothingOuterWizardBaseArmor]
+  parent: [ClothingOuterWizardBaseArmor, ClothingOuterWizardBase]
   id: ClothingOuterWizardCentCommReal
   name: CentComm wizard robes
   suffix: ADMIN
@@ -469,7 +469,7 @@
 
 # Crimsom
 - type: entity
-  parent: [ClothingHeadHatWizardBase, ClothingHeadHatWizardBaseArmor]
+  parent: [ClothingHeadHatWizardBaseArmor, ClothingHeadHatWizardBase]
   id: ClothingHeadHatCrimsonReal
   name: crimson wizard hat
   description: A wide-brimmed, pointy wizard hat adorned with a crimson band and a touch of theatrical flair. Feels... explosive.
@@ -480,7 +480,7 @@
     sprite: _Goobstation/Wizard/Clothing/Head/crimsonwizard.rsi
 
 - type: entity
-  parent: [ClothingOuterWizardBase, ClothingOuterWizardBaseArmor]
+  parent: [ClothingOuterWizardBaseArmor, ClothingOuterWizardBase]
   id: ClothingOuterWizardCrimsonReal
   name: crimson wizard robes
   description: A flowing set of red and gold-trimmed robes, made for dramatic spellcasting. You can feel the power flowing through you...


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
title

## Why / Balance
title

## Technical details
swapped the parenting lul

## Media

<img width="527" height="666" alt="image" src="https://github.com/user-attachments/assets/83b6afe5-7a44-4b66-88a8-a0165e01df5a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Wizard robes (the real ones) have their armour values again
