### PR TITLE
[Fix] Give Squackroach Speech

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/NPCs/animals.yml
@@ -113,6 +113,13 @@
       amount: 2
   - type: Extractable
     grindableSolutionName: food
+  - type: LanguageKnowledge
+    speaks:
+    - TauCetiBasic # Goob Edit
+    - ValyrianStandard
+    understands:
+    - TauCetiBasic # Goob Edit
+    - ValyrianStandard
   - type: Vocal
     sounds:
       Male: SoundsHarpyMale


### PR DESCRIPTION
## About the PR
Evidently I forgot to make them actual beings... maybe. In any case, I should fix them, so here's the PR to do so. They actually have a language knowledge

## Why / Balance
Actual fix. They should be able to speak common and Harpy.

## Technical details
I overrode the LanguageKnowledge component.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed Squackroach languages. They can now speak Tau-Ceti Basic and Valyrian Standard (Harpy).