### PR TITLE
AddImplantCommand

### DIFF
--- a/Content.Goobstation.Server/Administration/Commands/AddImplant.cs
+++ b/Content.Goobstation.Server/Administration/Commands/AddImplant.cs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+// SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Linq;
+using Content.Server.Administration;
+using Content.Server.Implants;
+using Content.Shared.Access.Components;
+using Content.Shared.Administration;
+using Content.Shared.Clothing.Components;
+using Content.Shared.Implants.Components;
+using Content.Shared.Inventory;
+using Content.Shared.PDA;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+
+namespace Content.Goobstation.Server.Administration.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class AddImplant : LocalizedCommands
+{
+    private const string CommandName = "addimplant";
+    public override string Command => CommandName;
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+        var implantSystem = entityManager.System<SubdermalImplantSystem>();
+
+        if (args.Length < 2)
+        {
+            shell.WriteLine(Loc.GetString("cmd-addimplant-args-error"));
+            return;
+        }
+
+        if (!NetEntity.TryParse(args[0], out var targetNet)
+            || !entityManager.TryGetEntity(targetNet, out var targetEntity))
+        {
+            shell.WriteLine(Loc.GetString("cmd-addimplant-bad-target", ("target", args[0])));
+            return;
+        }
+
+        var target  = targetEntity.Value;
+        var implant = implantSystem.AddImplant(target, args[1]);
+
+        if (implant != null)
+        {
+            shell.WriteLine(Loc.GetString("cmd-addimplant-success",
+                ("implant", entityManager.ToPrettyString(implant)),
+                ("target", entityManager.ToPrettyString(target))));
+        }
+        else
+        {
+            shell.WriteLine(Loc.GetString("cmd-addimplant-failure",
+                ("implant", args[1]),
+                ("target", entityManager.ToPrettyString(target))));
+        }
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
+
+        if (args.Length != 2)
+            return CompletionResult.Empty;
+
+        var options = prototypeManager.EnumeratePrototypes<EntityPrototype>()
+            .Where(p => p.Components.TryGetComponent("SubdermalImplant", out _))
+            .Select(c => c.ID)
+            .OrderBy(c => c)
+            .ToArray();
+
+        return CompletionResult.FromHintOptions(options, Loc.GetString("cmd-addimplant-hint"));
+    }
+}
+

--- a/Resources/Locale/en-US/_Goobstation/administration/commands/addimplant.ftl
+++ b/Resources/Locale/en-US/_Goobstation/administration/commands/addimplant.ftl
@@ -1,0 +1,10 @@
+cmd-addimplant-hint = Implant
+
+cmd-addimplant-desc = Adds an implant to a specified entity.
+cmd-addimplant-help = Usage: addimplant <target> <ProtoId>
+
+cmd-addimplant-args-error = Invalid arguments. { cmd-addimplant-help }
+cmd-addimplant-bad-target = Unable to find entity '{$target}'.
+
+cmd-addimplant-success = Added '{$implant}' to '{$target}'.
+cmd-addimplant-failure = Failed to add '{$implant}' to '{$target}'.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
I added a commnand to add an implant to an entity.

## Why / Balance
I needed it.

## Technical details
It uses the same logic as the AutoImplantComponent, but in command form.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
Not player facing.