### PR TITLE
Judo/Secbelt Whitelist Parity

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Belt/belts.yml
@@ -115,6 +115,9 @@
       - CombatKnife
       - Truncheon
       - BolaEnergy
+      - EnergySpeedloader
+      - MilitaryPowerCell
+      - HandGrenade
       components:
       - FlashOnTrigger
       - SmokeOnTrigger


### PR DESCRIPTION
## About the PR
Judo belt now has the same item whitelist as the secbelt (it was missing a few things)

## Why / Balance
why not

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: The judo belt now shares the secbelt whitelist.