### PR TITLE
Plasma cutter is now Normal size instead of Large

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Basic/plasma_cutter.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Basic/plasma_cutter.yml
@@ -19,7 +19,7 @@
     soundGunshot:
       path: /Audio/_Goobstation/Weapons/Guns/Gunshots/plasma_cutter.ogg
   - type: Item
-    size: Large
+    size: Normal
     shape:
     - 0,0,2,2
   - type: Battery


### PR DESCRIPTION
## Why / Balance
makes it actually usable, it still consumes a lot of plasma and this change will let late-game miners to mine evev faster

**Changelog**
:cl: Rouden
- tweak: Plasma cutter now has Normal size instead of Large.
