### PR TITLE
secret+ tweaks

### DIFF
--- a/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusComponent.cs
+++ b/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusComponent.cs
@@ -7,17 +7,18 @@
 using Content.Goobstation.Common.StationEvents.SecretPlus;
 using Content.Shared.Random;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Goobstation.Server.StationEvents.SecretPlus;
 
-[RegisterComponent, Access(typeof(SecretPlusSystem))]
+[RegisterComponent, AutoGenerateComponentPause, Access(typeof(SecretPlusSystem))]
 public sealed partial class SecretPlusComponent : Component
 {
     /// <summary>
     ///   How long until the next check for an event runs
     ///   Default value is how long until first event is allowed
     /// </summary>
-    [DataField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
     public TimeSpan TimeNextEvent;
 
     /// <summary>

--- a/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
+++ b/Content.Goobstation.Server/StationEvents/SecretPlus/SecretPlusSystem.cs
@@ -9,6 +9,8 @@ using System.Linq;
 using Content.Goobstation.Common.CCVar;
 using Content.Goobstation.Server.StationEvents.Components;
 using Content.Goobstation.Shared.StationEvents;
+using Content.Server.Antag;
+using Content.Server.Antag.Components;
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Managers;
 using Content.Server.GameTicking;
@@ -63,6 +65,7 @@ public sealed class PlayerCount
 [UsedImplicitly]
 public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
 {
+    [Dependency] private readonly AntagSelectionSystem _antagSelection = default!;
     [Dependency] private readonly EventManagerSystem _event = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly IComponentFactory _factory = default!;
@@ -87,14 +90,7 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
 
         _sawmill = _log.GetSawmill("secret_plus");
 
-        SubscribeLocalEvent<SecretPlusComponent, EntityUnpausedEvent>(OnUnpaused);
-
         Subs.CVar(_cfg, GoobCVars.MinimumTimeUntilFirstEvent, value => _minimumTimeUntilFirstEvent = value, true);
-    }
-
-    private void OnUnpaused(EntityUid uid, SecretPlusComponent component, ref EntityUnpausedEvent args)
-    {
-        component.TimeNextEvent += args.PausedTime;
     }
 
     protected override void Added(EntityUid uid, SecretPlusComponent scheduler, GameRuleComponent gameRule, GameRuleAddedEvent args)
@@ -106,23 +102,25 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
         // roll midroundchaos generation variation
         var roll = _random.NextFloat();
         roll = MathF.Pow(roll, scheduler.ChaosChangeVariationExponent);
-        // 50% chance to bias to either higher chaos or lower chaos
-        scheduler.ChaosChangeVariation = 1f + roll * ((_random.Prob(0.5f) ? scheduler.ChaosChangeVariationMin : scheduler.ChaosChangeVariationMax) - 1f);
+        // 50% chance to bias towards either higher chaos or lower chaos
+        scheduler.ChaosChangeVariation = MathHelper.Lerp(1f,
+                                                         _random.Prob(0.5f) ? scheduler.ChaosChangeVariationMin : scheduler.ChaosChangeVariationMax,
+                                                         roll);
         LogMessage($"Using chaos change multiplier of {scheduler.ChaosChangeVariation}");
 
-        TrySpawnRoundstartAntags(scheduler); // Roundstart antags need to be selected in the lobby
+        TrySpawnRoundstartAntags((uid, scheduler)); // Roundstart antags need to be selected in the lobby
         if(TryComp<SelectedGameRulesComponent>(uid, out var selectedRules))
-            SetupEvents(scheduler, CountActivePlayers(), selectedRules);
+            SetupEvents((uid, scheduler), CountActivePlayers(), selectedRules);
         else
-            SetupEvents(scheduler, CountActivePlayers());
+            SetupEvents((uid, scheduler), CountActivePlayers());
     }
 
     /// <summary>
     ///   Build a list of events to use for the entire story
     /// </summary>
-    private void SetupEvents(SecretPlusComponent scheduler, PlayerCount count, SelectedGameRulesComponent? selectedRules = null)
+    private void SetupEvents(Entity<SecretPlusComponent> scheduler, PlayerCount count, SelectedGameRulesComponent? selectedRules = null)
     {
-        scheduler.SelectedEvents.Clear();
+        scheduler.Comp.SelectedEvents.Clear();
 
         if (selectedRules != null)
         {
@@ -134,33 +132,33 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
         }
     }
 
-    private void SelectFromAllEvents(SecretPlusComponent scheduler, PlayerCount count)
+    private void SelectFromAllEvents(Entity<SecretPlusComponent> scheduler, PlayerCount count)
     {
-        foreach (var proto in GameTicker.GetAllGameRulePrototypes())
+        foreach (var proto in _ticker.GetAllGameRulePrototypes())
         {
             if (!proto.TryGetComponent<GameRuleComponent>(out var gameRule, _factory)
                 || !proto.TryGetComponent<StationEventComponent>(out var stationEvent, _factory)
             )
                 continue;
 
-            if (scheduler.DisallowedEvents.Contains(stationEvent.EventType)
-                || (!scheduler.IgnoreTimings
+            if (scheduler.Comp.DisallowedEvents.Contains(stationEvent.EventType)
+                || (!scheduler.Comp.IgnoreTimings
                     && !_event.CanRun(proto, stationEvent, count.Players, _ticker.RoundDuration(), 1f / GetRamping(scheduler)))
             )
                 continue;
 
-            scheduler.SelectedEvents.Add(new SelectedEvent(proto, gameRule, stationEvent));
+            scheduler.Comp.SelectedEvents.Add(new SelectedEvent(proto, gameRule, stationEvent));
         }
     }
 
-    private void SelectFromTable(SecretPlusComponent scheduler, PlayerCount count, SelectedGameRulesComponent? selectedRules)
+    private void SelectFromTable(Entity<SecretPlusComponent> scheduler, PlayerCount count, SelectedGameRulesComponent? selectedRules)
     {
         if (selectedRules == null)
             return;
 
-        var available = _event.AvailableEvents(scheduler.IgnoreTimings,
-                            scheduler.IgnoreTimings ? int.MaxValue : null,
-                            scheduler.IgnoreTimings ? TimeSpan.MaxValue : null,
+        var available = _event.AvailableEvents(scheduler.Comp.IgnoreTimings,
+                            scheduler.Comp.IgnoreTimings ? int.MaxValue : null,
+                            scheduler.Comp.IgnoreTimings ? TimeSpan.MaxValue : null,
                             1f / GetRamping(scheduler));
 
         if (!_event.TryBuildLimitedEvents(selectedRules.ScheduledGameRules, available, out var possibleEvents))
@@ -173,10 +171,10 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
             if (!proto.TryGetComponent<GameRuleComponent>(out var gameRule, _factory))
                 continue;
 
-            if (scheduler.DisallowedEvents.Contains(stationEvent.EventType))
+            if (scheduler.Comp.DisallowedEvents.Contains(stationEvent.EventType))
                 continue;
 
-            scheduler.SelectedEvents.Add(new SelectedEvent(proto, gameRule, stationEvent));
+            scheduler.Comp.SelectedEvents.Add(new SelectedEvent(proto, gameRule, stationEvent));
         }
     }
 
@@ -186,7 +184,7 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
     protected override void ActiveTick(EntityUid uid, SecretPlusComponent scheduler, GameRuleComponent gameRule, float frameTime)
     {
         var count = CountActivePlayers();
-        var ramp = GetRamping(scheduler);
+        var ramp = GetRamping((uid, scheduler));
         var speedup = _event.EventSpeedup;
         var mult = scheduler.ChaosChangeVariation;
 
@@ -212,20 +210,15 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
         LogMessage($"Chaos score: {scheduler.ChaosScore}, Next event at: {_ticker.RoundDuration() + amt} (ramping {ramp})");
 
         if(TryComp<SelectedGameRulesComponent>(uid, out var selectedRules))
-            SetupEvents(scheduler, count, selectedRules);
+            SetupEvents((uid, scheduler), count, selectedRules);
         else
-            SetupEvents(scheduler, count);
+            SetupEvents((uid, scheduler), count);
 
-        var selectedEvent = ChooseEvent(scheduler);
+        var selectedEvent = ChooseEvent((uid, scheduler));
         if (selectedEvent != null)
-        {
-            _event.RunNamedEvent(selectedEvent.Proto.ID);
-            // nullcheck done in ChooseEvent
-            scheduler.ChaosScore += selectedEvent.RuleComp.ChaosScore!.Value;
-        }
-        else {
+            StartRule((uid, scheduler), selectedEvent.Proto.ID, false);
+        else
             LogMessage($"No runnable events");
-        }
 
     }
 
@@ -234,13 +227,13 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
     /// <summary>
     /// Tries to spawn roundstart antags at the beginning of the round.
     /// </summary>
-    private void TrySpawnRoundstartAntags(SecretPlusComponent scheduler)
+    private void TrySpawnRoundstartAntags(Entity<SecretPlusComponent> scheduler)
     {
-        if (scheduler.NoRoundstartAntags)
+        if (scheduler.Comp.NoRoundstartAntags)
             return;
 
-        var primaryWeightList = _prototypeManager.Index(scheduler.PrimaryAntagsWeightTable);
-        var weightList = _prototypeManager.Index(scheduler.RoundStartAntagsWeightTable);
+        var primaryWeightList = _prototypeManager.Index(scheduler.Comp.PrimaryAntagsWeightTable);
+        var weightList = _prototypeManager.Index(scheduler.Comp.RoundStartAntagsWeightTable);
 
         var count = GetTotalPlayerCount(_playerManager.Sessions);
 
@@ -249,7 +242,7 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
         var weights = weightList.Weights.ToDictionary();
         var primaryWeights = primaryWeightList.Weights.ToDictionary();
         int maxIters = 50, i = 0; // in case something dumb is tried
-        while (scheduler.ChaosScore < 0 && i < maxIters)
+        while (scheduler.Comp.ChaosScore < 0 && i < maxIters)
         {
             i++;
 
@@ -263,21 +256,23 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
             )
                 continue;
 
-            if (ruleComp.ChaosScore == null)
+            var chaosScore = GetChaosScore(entProto, ruleComp);
+
+            if (chaosScore == null)
             {
                 Log.Error($"Tried running roundstart event {entProto.ID}, but chaos score was null");
                 continue;
             }
                              // negative
-            var pickProb = (-scheduler.ChaosScore) / ruleComp.ChaosScore.Value;
+            var pickProb = (-scheduler.Comp.ChaosScore) / chaosScore.Value;
             if (i == 1)
-                pickProb *= scheduler.PrimaryAntagChaosBias;
+                pickProb *= scheduler.Comp.PrimaryAntagChaosBias;
             pickProb = MathF.Min(1f, pickProb); // to shut up debug
             if (!_random.Prob(pickProb)) // have a chance to re-pick if we have low chaos budget left compared to this
                 continue;
 
             // for admeme presets
-            if (!scheduler.IgnoreIncompatible)
+            if (!scheduler.Comp.IgnoreIncompatible)
             {
                 weights.Remove(pick);
 
@@ -288,7 +283,7 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
             IndexAndStartGameMode(pick, entProto, ruleComp);
 
             if (weights.Count == 0
-                || (!scheduler.IgnoreIncompatible
+                || (!scheduler.Comp.IgnoreIncompatible
                     && entProto.TryGetComponent<TagComponent>(out var tagComp, _factory)
                     && _tag.HasTag(tagComp, _loneSpawnTag)
                 )
@@ -306,10 +301,20 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
             )
                 return;
 
-            LogMessage($"Roundstart rule chosen: {pick}");
-            GameTicker.AddGameRule(pick);
-            scheduler.ChaosScore += ruleComp.ChaosScore!.Value;
+            LogMessage($"Roundstart rule chosen: {pick} with score {GetChaosScore(pickProto, ruleComp)}");
+            StartRule(scheduler, pick, false, count);
         }
+    }
+
+    /// <summary>
+    ///   Adds and, optionally, starts a gamerule while respecting rules with variable chaos.
+    /// </summary>
+    private void StartRule(Entity<SecretPlusComponent> scheduler, string rule, bool doStart = true, int? players = null)
+    {
+        var ruleUid = _ticker.AddGameRule(rule);
+        scheduler.Comp.ChaosScore += GetChaosScore(ruleUid)!.Value;
+        if (doStart)
+            _ticker.StartGameRule(ruleUid);
     }
 
     /// <summary>
@@ -328,7 +333,9 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
                 //        "significant enough to count as a whole player"
                 if (HasComp<HumanoidAppearanceComponent>(player.AttachedEntity))
                     count.Players += 1;
-                else if (HasComp<GhostComponent>(player.AttachedEntity))
+                // don't count bodyless ghosts aka say roundstart spectators
+                // not reliable but works
+                else if (TryComp<GhostComponent>(player.AttachedEntity, out var ghost) && ghost.CanReturnToBody)
                     count.Ghosts += 1;
             }
         }
@@ -338,35 +345,80 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
         return count;
     }
 
+    public float? GetChaosScore(Entity<GameRuleComponent?> rule, int? players = null)
+    {
+        if (!Resolve(rule, ref rule.Comp))
+            return null;
+
+        if (TryComp<AntagSelectionComponent>(rule, out var selection))
+        {
+            var any = false;
+            var score = 0f;
+
+            foreach (var def in selection.Definitions)
+            {
+                if (def.ChaosScore == null)
+                    continue;
+
+                any = true;
+                var count = _antagSelection.GetTargetAntagCount((rule, selection), players ?? GetTotalPlayerCount(_playerManager.Sessions), def);
+                score += def.ChaosScore.Value * count;
+            }
+
+            if (any)
+                return score;
+        }
+
+        return rule.Comp.ChaosScore;
+    }
+
+    public float? GetChaosScore(EntityPrototype ruleProto, GameRuleComponent? ruleComp, int? players = null)
+    {
+        if (ruleComp == null && !ruleProto.TryGetComponent<GameRuleComponent>(out ruleComp, _factory))
+            return null;
+
+        if (ruleProto.TryGetComponent<AntagSelectionComponent>(out var selection, _factory))
+        {
+            var any = false;
+            var score = 0f;
+
+            foreach (var def in selection.Definitions)
+            {
+                if (def.ChaosScore == null)
+                    continue;
+
+                any = true;
+                var count = _antagSelection.GetTargetAntagCount((EntityUid.Invalid, selection), players ?? GetTotalPlayerCount(_playerManager.Sessions), def);
+                score += def.ChaosScore.Value * count;
+            }
+
+            if (any)
+                return score;
+        }
+
+        return ruleComp.ChaosScore;
+    }
+
     /// <summary>
     ///   Count all the players on the server.
     /// </summary>
     public int GetTotalPlayerCount(IList<ICommonSession> pool)
     {
-        var count = 0;
-        foreach (var session in pool)
-        {
-            if (session.Status is SessionStatus.Disconnected or SessionStatus.Zombie)
-                continue;
-
-            count++;
-        }
-
-        return count + _event.PlayerCountBias;
+        return _antagSelection.GetTotalPlayerCount(pool) + _event.PlayerCountBias;
     }
 
-    public float GetRamping(SecretPlusComponent scheduler)
+    public float GetRamping(Entity<SecretPlusComponent> scheduler)
     {
         var curTime = _ticker.RoundDuration();
-        return 1f + (float)curTime.TotalSeconds * scheduler.SpeedRamping * _event.EventSpeedup;
+        return 1f + (float)curTime.TotalSeconds * scheduler.Comp.SpeedRamping * _event.EventSpeedup;
     }
 
     /// <summary>
     ///   Picks an event based on current chaos score, events' chaos scores and weights.
     /// </summary>
-    private SelectedEvent? ChooseEvent(SecretPlusComponent scheduler)
+    private SelectedEvent? ChooseEvent(Entity<SecretPlusComponent> scheduler)
     {
-        var possible = scheduler.SelectedEvents;
+        var possible = scheduler.Comp.SelectedEvents;
         Dictionary<SelectedEvent, float> weights = new();
 
         foreach (var ev in possible)
@@ -374,20 +426,21 @@ public sealed class SecretPlusSystem : GameRuleSystem<SecretPlusComponent>
             if (ev.EvComp == null)
                 continue;
 
-            if (ev.RuleComp.ChaosScore == null)
+            var chaosScore = GetChaosScore(ev.Proto, ev.RuleComp);
+            if (chaosScore == null)
             {
                 Log.Error($"Tried running event {ev.Proto.ID}, but chaos score was null");
                 continue;
             }
 
-            var weight = ev.RuleComp.ChaosScore.Value;
+            var weight = chaosScore.Value;
             bool negative = weight < 0f;
             weight = MathF.Abs(weight);
-            weight = MathF.Pow(weight, scheduler.ChaosExponent);
+            weight = MathF.Pow(weight, scheduler.Comp.ChaosExponent);
             if (negative) weight = -weight;
-            weight += scheduler.ChaosOffset; // offset negative-chaos events upwards too else they never happen
-            weight += weight < 0f ? -scheduler.ChaosThreshold : scheduler.ChaosThreshold; // make sure it's not in (-1, 1) to not get absurdly low event probabilities
-            var delta = ChaosDelta(-scheduler.ChaosScore, weight, scheduler.ChaosMatching, scheduler.ChaosThreshold * scheduler.ChaosThreshold);
+            weight += scheduler.Comp.ChaosOffset; // offset negative-chaos events upwards too else they never happen
+            weight += weight < 0f ? -scheduler.Comp.ChaosThreshold : scheduler.Comp.ChaosThreshold; // make sure it's not in (-1, 1) to not get absurdly low event probabilities
+            var delta = ChaosDelta(-scheduler.Comp.ChaosScore, weight, scheduler.Comp.ChaosMatching, scheduler.Comp.ChaosThreshold * scheduler.Comp.ChaosThreshold);
             weights[ev] = ev.EvComp.Weight / (delta + 1f);
         }
 

--- a/Content.IntegrationTests/Tests/_Goobstation/SecretPlus/SecretPlusTest.cs
+++ b/Content.IntegrationTests/Tests/_Goobstation/SecretPlus/SecretPlusTest.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Server/Antag/Components/AntagSelectionComponent.cs
+++ b/Content.Server/Antag/Components/AntagSelectionComponent.cs
@@ -318,6 +318,13 @@ public partial struct AntagSelectionDefinition()
     /// </summary>
     [DataField]
     public bool UnequipOldGear;
+
+    /// <summary>
+    /// Goobstation
+    /// If not null, how much chaos should secret+ consider us to have per-antag.
+    /// </summary>
+    [DataField]
+    public float? ChaosScore = null;
 }
 
 /// <summary>

--- a/Content.Server/Antag/Components/AntagSelectionComponent.cs
+++ b/Content.Server/Antag/Components/AntagSelectionComponent.cs
@@ -74,6 +74,7 @@
 // SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Errant <35878406+Errant-4@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 // SPDX-FileCopyrightText: 2025 SX_7 <sn1.test.preria.2002@gmail.com>
 // SPDX-FileCopyrightText: 2025 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -130,6 +130,7 @@
 # SPDX-FileCopyrightText: 2025 Roudenn <romabond091@gmail.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <92227810+SX-7@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
+# SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tayrtahn <tayrtahn@gmail.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -888,7 +888,6 @@
     eventType: HostilesSpawn # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 500
   - type: AlertLevelInterceptionRule
   - type: AntagSelection
     definitions:
@@ -897,6 +896,7 @@
       min: 1
       max: 2
       playerRatio: 10
+      chaosScore: 200 # Goobstation - same as roundstart traitor gamerule
       blacklist:
         components:
         - AntagImmune

--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -34,9 +34,6 @@
   - type: AntagObjectives
     objectives:
     - EscapeThiefShuttleObjective
-  # Goobstation
-  - type: GameRule
-    chaosScore: 300
   - type: AntagRandomObjectives
     sets:
     - groups: ThiefBigObjectiveGroups
@@ -52,6 +49,7 @@
     - prefRoles: [ Thief ]
       max: 3
       playerRatio: 15
+      chaosScore: 100 # Goobstation
       lateJoinAdditional: true
       allowNonHumans: true
       multiAntagSetting: NotExclusive

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -230,9 +230,6 @@
   - type: NukeopsRule
   - type: RuleGrids
   - type: AntagSelection
-  # Goobstation
-  - type: GameRule
-    chaosScore: 1200
   - type: AntagLoadProfileRule
     speciesOverride: Human
     speciesOverrideBlacklist:
@@ -296,6 +293,7 @@
       spawnerPrototype: SpawnPointNukeopsOperative
       max: 10 # Goobstation / 古布空间站 - 没有限制的核特工
       playerRatio: 16 # Goobstation
+      chaosScore: 300 # Goobstation
       startingGear: SyndicateOperativeGearFull
       unequipOldGear: true
       roleLoadout:
@@ -319,9 +317,6 @@
   id: BaseTraitorRuleNoObjectives
   components:
   - type: TraitorRule
-  # Goobstation
-  - type: GameRule
-    chaosScore: 900
   # TODO: codewords in yml
   # TODO: uplink in yml
   - type: AntagSelection
@@ -369,6 +364,7 @@
     - prefRoles: [ Traitor ]
       max: 8
       playerRatio: 10
+      chaosScore: 150 # Goobstation
       blacklist:
         components:
         - CommandStaff # Goobstation
@@ -384,7 +380,7 @@
   components:
   - type: GameRule
     minPlayers: 15
-    chaosScore: 1000 # Goobstation
+    chaosScore: 1000 # Goobstation - intentionally not per-antag
   - type: RevolutionaryRule
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn # Goobstation

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -255,6 +255,7 @@
       spawnerPrototype: SpawnPointNukeopsCommander
       startingGear: SyndicateCommanderGearFull
       unequipOldGear: true
+      chaosScore: 300 # Goobstation
       roleLoadout:
       - RoleSurvivalNukie
       components:
@@ -273,6 +274,7 @@
       spawnerPrototype: SpawnPointNukeopsMedic
       startingGear: SyndicateOperativeMedicFull
       unequipOldGear: true
+      chaosScore: 300 # Goobstation
       roleLoadout:
       - RoleSurvivalNukie
       components:

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -383,7 +383,6 @@
   components:
   - type: DevilRule
   - type: GameRule
-    chaosScore: 350 # low since they tend to revive people and stuff
     minPlayers: 15
   - type: AntagObjectives
     objectives:
@@ -395,6 +394,7 @@
     - prefRoles: [ Devil ]
       max: 1
       playerRatio: 20
+      chaosScore: 150
       jobBlacklist: [ Chaplain, Mime, ChiefEngineer, ResearchDirector, Quartermaster ] #chaplain is obvious, mime can't write.
       mindRoles:
       - DevilMindRole

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -36,7 +36,6 @@
   - type: ChangelingRule
   - type: GameRule
     minPlayers: 15
-    chaosScore: 800
   - type: AntagRandomObjectives
     sets:
     - groups: ChangelingObjectiveGroups
@@ -54,6 +53,7 @@
     - prefRoles: [ Changeling ]
       max: 4
       playerRatio: 12
+      chaosScore: 200
       jobBlacklist: [ Chaplain ] # GOOBSTATION
       blacklist:
         components:
@@ -80,12 +80,12 @@
     delay:
       min: 465
       max: 665 # Delay is so the heads help their department get set up.
-    chaosScore: 500 # It's just one to two people with less tc even if they may be command
   - type: AntagSelection
     definitions:
     - prefRoles: [ Traitor ]
       max: 2
       playerRatio: 25
+      chaosScore: 300
       jobBlacklist: [ NanotrasenRepresentative ]
       whitelist:
         components:
@@ -103,7 +103,6 @@
   components:
   - type: GameRule
     minPlayers: 30
-    chaosScore: 700
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
     definitions:
@@ -128,7 +127,6 @@
   components:
   - type: GameRule
     minPlayers: 30
-    chaosScore: 450
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn
     agentName: changeling-roundend-name
@@ -152,7 +150,6 @@
   components:
   - type: GameRule
     minPlayers: 30
-    chaosScore: 1000
   - type: LoadMapRule
     mapPath: /Maps/_Goobstation/Nonstations/nukieplanet.yml
   - type: AntagSelection
@@ -222,7 +219,6 @@
   components:
   - type: GameRule
     minPlayers: 30
-    chaosScore: 700
   - type: RevolutionaryRule
   - type: AntagSelection
     selectionTime: IntraPlayerSpawn

--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -24,7 +24,6 @@
   - type: HereticRule
   - type: GameRule
     minPlayers: 15
-    chaosScore: 800
   - type: AntagObjectives
     objectives:
     - HereticKnowledgeObjective
@@ -37,6 +36,7 @@
     - prefRoles: [ Heretic ]
       max: 3
       playerRatio: 15
+      chaosScore: 250
       lateJoinAdditional: true
       jobBlacklist: [ Chaplain, ] # GOOBSTATION
       blacklist:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
- now actually accounts for antag selection gamerules having variable amounts of antags
- should hopefully result in better-feeling roundstart antag rolls
- adjusts some chaos scores to account for changes
- devil 350 -> 150 chaos because why was it 350
- code cleanup

## Why / Balance
makes it more stable

## Media
tested, works
:trollface:
even if i were to post a video it'd not really tell you anything

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Secret+ should now be more stable in terms of roundstart antag count.
