### PR TITLE
Sprinting day 1 tweaks

### DIFF
--- a/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
+++ b/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
@@ -544,6 +544,13 @@ public sealed partial class GoobCVars
 
     #endregion
 
+    #region Movement
+
+    public static readonly CVarDef<float> MaxSpeed =
+        CVarDef.Create("movement.max_speed", 3.8f, CVar.SERVER | CVar.REPLICATED);
+
+    #endregion
+
     #region Misc
 
     /// <summary>

--- a/Content.Goobstation.Shared/MartialArts/Events/CapoeiraEvents.cs
+++ b/Content.Goobstation.Shared/MartialArts/Events/CapoeiraEvents.cs
@@ -20,7 +20,7 @@ public abstract partial class BaseCapoeiraEvent : EntityEventArgs
     public virtual float MinPower { get; set; } = 1f;
 
     [DataField]
-    public virtual float MaxPower { get; set; } = 5f;
+    public virtual float MaxPower { get; set; } = 2.5f;
 
     [DataField]
     public virtual float MinVelocity { get; set; }

--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.Capoeira.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.Capoeira.cs
@@ -83,7 +83,7 @@ public abstract partial class SharedMartialArtsSystem
 
         _status.TryRemoveStatusEffect(ent, "KnockedDown");
         _standingState.Stand(ent);
-        _stamina.TryTakeStamina(ent, args.StaminaToHeal);
+        //_stamina.TryTakeStamina(ent, args.StaminaToHeal);
         ent.Comp.LastAttacks.Clear();
     }
 
@@ -232,7 +232,7 @@ public abstract partial class SharedMartialArtsSystem
         if (ev.MinVelocity <= velocity)
         {
             power = GetCapoeiraPower(ev, velocity);
-            _stamina.TryTakeStamina(uid, ev.StaminaToHeal);
+            //_stamina.TryTakeStamina(uid, ev.StaminaToHeal);
             return true;
         }
 

--- a/Content.Goobstation.Shared/Sprinting/SprinterComponent.cs
+++ b/Content.Goobstation.Shared/Sprinting/SprinterComponent.cs
@@ -38,7 +38,7 @@ public sealed partial class SprinterComponent : Component
     ///     How much stamina is drained per second?
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float StaminaDrainRate = 10f;
+    public float StaminaDrainRate = 9f;
 
     /// <summary>
     ///     By how much do we multiply stamina recovery while sprinting?
@@ -54,13 +54,13 @@ public sealed partial class SprinterComponent : Component
     ///     How much do we multiply stamina drains while theres a StaminaModifierComponent?
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float StaminaDrainMultiplier = 1.3f;
+    public float StaminaDrainMultiplier = 1.4f;
 
     /// <summary>
     ///     How much do we multiply sprint speed?
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float SprintSpeedMultiplier = 1.6f;
+    public float SprintSpeedMultiplier = 1.45f;
 
     /// <summary>
     ///     How long do we have to wait between sprints?
@@ -91,7 +91,7 @@ public sealed partial class SprinterComponent : Component
     /// </summary>
     [ViewVariables]
     public TimeSpan LastStep = TimeSpan.Zero;
-    
+
     /// <summary>
     ///     What entity do we use for stepping visuals?
     /// </summary>

--- a/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
+++ b/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
@@ -91,6 +91,7 @@ using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
 using Robust.Shared.Configuration;
 using Content.Goobstation.Common.Movement; // Goobstation
+using Content.Goobstation.Common.CCVar; // Goobstation
 using Robust.Shared.Timing;
 
 namespace Content.Shared.Movement.Systems
@@ -103,7 +104,7 @@ namespace Content.Shared.Movement.Systems
         private float _frictionModifier;
         private float _airDamping;
         private float _offGridDamping;
-
+        private float _maxSpeed = 3.8f; // Goobstation Change, actual value is given by Cvar, this is a fallback.
         public override void Initialize()
         {
             base.Initialize();
@@ -112,6 +113,7 @@ namespace Content.Shared.Movement.Systems
             Subs.CVar(_configManager, CCVars.TileFrictionModifier, value => _frictionModifier = value, true);
             Subs.CVar(_configManager, CCVars.AirFriction, value => _airDamping = value, true);
             Subs.CVar(_configManager, CCVars.OffgridFriction, value => _offGridDamping = value, true);
+            Subs.CVar(_configManager, GoobCVars.MaxSpeed, value => _maxSpeed = value, true); // Goobstation Change
         }
 
         private void OnModMapInit(Entity<MovementSpeedModifierComponent> ent, ref MapInitEvent args)
@@ -185,8 +187,9 @@ namespace Content.Shared.Movement.Systems
                 MathHelper.CloseTo(ev.SprintSpeedModifier, move.SprintSpeedModifier))
                 return;
 
-            move.WalkSpeedModifier = ev.WalkSpeedModifier;
-            move.SprintSpeedModifier = ev.SprintSpeedModifier;
+
+            move.WalkSpeedModifier = Math.Min(ev.WalkSpeedModifier, _maxSpeed); // Goobstation Change
+            move.SprintSpeedModifier = Math.Min(ev.SprintSpeedModifier, _maxSpeed); // Goobstation Change
             Dirty(uid, move);
         }
 

--- a/Content.Shared/_EinsteinEngines/Flight/FlightComponent.cs
+++ b/Content.Shared/_EinsteinEngines/Flight/FlightComponent.cs
@@ -75,7 +75,7 @@ public sealed partial class FlightComponent : Component
     ///     How much does this modify the weightless acceleration and speed?
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float SpeedModifier = 2.0f;
+    public float SpeedModifier = 1.8f;
 
     /// <summary>
     ///     How much does this modify the weightless friction?

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -442,6 +442,8 @@
   - type: Penetratable # Goobstation - Better snipers
     penetrateDamage: 75 # It's harder to kill iron golem
     damagePenalty: 0.25
+  - type: Sprinter
+    canSprint: false
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -149,7 +149,7 @@
             sprite: Mobs/Species/Human/displacement.rsi
             state: jumpsuit-female
   - type: Sprinter # human major
-    staminaDrainRate: 9
+    staminaDrainRate: 8
 
 
 - type: entity

--- a/Resources/Prototypes/_DV/Entities/Mobs/Player/harpy.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Player/harpy.yml
@@ -36,4 +36,4 @@
     factions:
     - NanoTrasen
   - type: Sprinter # funny feet make you unable to run for long, fly instead.
-    staminaDrainRate: 15
+    staminaDrainRate: 13

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -165,7 +165,7 @@
   - type: DamagedSiliconAccent
   - type: Uncloneable
   - type: Sprinter # slight nerf to speed because heavy robot, mass contest when
-    sprintSpeedMultiplier: 1.35
+    sprintSpeedMultiplier: 1.25
   - type: Tag
     tags:
     - SiliconMob

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -174,10 +174,10 @@ binds:
   key: S
 - function: Walk
   type: State
-  key: C
+  key: Shift
 - function: Sprint
   type: State
-  key: Shift
+  key: C
 - function: ToggleStanding
   type: State
   key: R


### PR DESCRIPTION
## About the PR
yeag

## Why / Balance
- Capoeira was dummy strong with free speed modifiers, duh.
- Its basically impossible to catch someone with a lot of speed modifiers, so it gets clamped now to 15.
- Mechs, vehicles and borgs shouldnt be able to sprint lul
- People kept bitching about 1.6 being too much, so lets try 1.4 which is the same boost value monke has, I'll put down a comparation of speeds, give or take 30-50 milliseconds due to me having to tap stop on my phone as I hear the stamcrits.
- Unlike upstream we have a shitton of movement options now (SPEED legs, strained muscles, sandevistan, meth, stimulants, shadow form, etc.), so clamping sprinting speeds into something reasonable is needed.

For testing the speeds I've used meta, which is one of the few relatively unchanged maps across ss13 servers, and that we have in 14 in a relatively faithful manner too. Route seen here
<img width="1844" height="991" alt="image" src="https://github.com/user-attachments/assets/57943610-425e-4388-9b23-dec915f37058" />

Times might be slightly innacurate due to me using my phone to start and stop, so expect about a .30-.50 tolerance.

> TG

Start to end takes 11.70 seconds approximately, it has the fastest default walk speed of any ss13 server.

> Monkestation

Start to end takes 15.54 seconds approximately if you normal fast walk.
Start to end takes 10.10 seconds approximately if you sprint. *

\* The sprint lasts longer, about 8 tiles into the left side from the air filter, and doesnt stamcrit you when you run out. Only if you keep it held down, at which point about half of your stamina regens and it fires again, then crits you when you bottom out of stamina.

> Goob (Previous)

Start to end takes 18.71 seconds approximately if you fast walk.
Start to end takes 11.79 seconds approximately if you sprint as a human.
Start to end takes 10.27 seconds approximately if you sprint as a non-human. this one stops about 7 tiles before reaching the goal (air vent).

> Goob (After this PR)

Start to end takes 18.71 seconds approximately if you fast walk.
Start to end takes 13.60 seconds approximately if you sprint as a human.
Start to end takes 11.37 seconds approximately if you sprint as a non-human. this one stops about 9 tiles before reaching the goal (air vent).

Not really worth mentioning Goon since it works differently, their sprint auto disables when you reach their hardcoded limit (70 stamina), so its more of a hop than a consistent sprinting ability? Also for some reason feels slower in local vs their live servers.

**Changelog**
:cl: Mocho
- remove: Removed sprinting borgs. God save us.
- tweak: Capped maximum speed at about 17 via a CVAR. (This is as fast as a changeling with strained muscles, sandevistan and sprint on at once more or less).
- fix: Fixed mechs and vehicles being able to sprint.
- fix: Fixed harpies being able to sprint into flying without disabling one of them, all it'd do is just drain 2x stamina while weightless.
- fix: Fixed the default sprint binding being set to shift instead of C unlike stated in the changelog :wellregardedindividual:
- tweak: Capoeira wont rip off heads in one hit anymore.
- tweak: Capoeira doesn't regenerate stamina anymore.
- tweak: Sprinting now is a 40% speed modifier instead of 60%.