### PR TITLE
Add EORG Rule (For MRP) to Rulebook

### DIFF
--- a/Resources/Prototypes/Guidebook/rules.yml
+++ b/Resources/Prototypes/Guidebook/rules.yml
@@ -168,6 +168,7 @@
   - RuleR12
   - RuleR13
   - RuleR14
+  - RuleR15
 
 - type: guideEntry
   id: RuleR1
@@ -266,6 +267,13 @@
   ruleEntry: true
   priority: 14
   text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR14NewLifeRule.xml"
+
+- type: guideEntry
+  id: RuleR15
+  name: guide-entry-rules-r15
+  ruleEntry: true
+  priority: 15
+  text: "/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR15EORG.xml"
 
 - type: guideEntry
   id: SiliconRules

--- a/Resources/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC0.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/CoreRules/RuleC0.xml
@@ -11,7 +11,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   # Core Rules
   Roleplay is king, and admins can disregard other rules to this end should it prove beneficial for the experience of the shift. Admins are also allowed to intervene in rounds when it is in the best interest of the player base.
 
-  - [textlink="1. Don't be a dick" link="RuleC1"]
+  - [textlink="1. " link="RuleC1"]
   - [textlink="2. Do not use information gained outside of in-character means" link="RuleC2"]
   - [textlink="3. This is a sandbox roleplaying server" link="RuleC3"]
   - [textlink="4. No sexual or shock content(ZT)" link="RuleC4"]
@@ -26,3 +26,4 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   - [textlink="13. Use realistic character names, and do not use names of famous people" link="RuleC13"]
   - [textlink="14. Do not use LOOC or OOC to share current round information" link="RuleC14"]
 </Document>
+Don't be a dick

--- a/Resources/ServerInfo/Guidebook/ServerRules/DefaultRules.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/DefaultRules.xml
@@ -56,7 +56,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   - [textlink="11. Roleplay and Repetition" link="RuleR11"]
   - [textlink="12. Blueshield Rules" link="RuleR12"]
   - [textlink="13. Nanotrasen Representative Rules" link="RuleR13"]
-  - [textlink="13. Death Amnesia(NLR)" link="RuleR14"]
+  - [textlink="14. Death Amnesia (NLR)" link="RuleR14"]
+  - [textlink="15. End of Round Griefing (MRP Only)" link="RuleR15"]
 
   ## SILICON RULES
   You are only silicon if the game clearly and explicitly tells you that you are a silicon. For players who are silicons, these Silicon Rules override all roleplay rules if there is any conflict. Silicon Rules do not override core rules.

--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR14NewLifeRule.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR14NewLifeRule.xml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
 <Document>
-  # Roleplay Rule 20 - Death Amnesia
+  # Roleplay Rule 14 - Death Amnesia
 
   Players are not allowed to remember the person who killed them, you may [bold]not[/bold] describe the person who killed you at all past their species and gender.
 

--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR15EORG.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR15EORG.xml
@@ -1,7 +1,7 @@
 <Document>
   # Roleplay Rule 15 - End of Round Griefing (MRP Only)
 
-  Non-antagonists are not allowed to engage in any form of End of Round Griefing when they arrive at Centcomm.
+  Non-antagonists are not allowed to engage in End of Round Griefing both on the Evac Shuttle and when they arrive at Centcomm.
 
   Preparing items for End of Round Griefing such as gas canisters of flammable liquid or explosives as a non-antagonist is also against the rules.
 
@@ -16,5 +16,5 @@
   Prohibited:
   - Randomly shooting other people once you reach Centcomm.
   - As a non-antagonist Atmospheric Technician, bringing a can of plasma on evac with the intention of releasing it.
-  - Attacking other crew members on the evacuation shuttle.
+  - As a non-antagonist, attacking other people on the evac shuttle
 </Document>

--- a/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR15EORG.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/RoleplayRules/RuleR15EORG.xml
@@ -1,0 +1,20 @@
+<Document>
+  # Roleplay Rule 15 - End of Round Griefing (MRP Only)
+
+  Non-antagonists are not allowed to engage in any form of End of Round Griefing when they arrive at Centcomm.
+
+  Preparing items for End of Round Griefing such as gas canisters of flammable liquid or explosives as a non-antagonist is also against the rules.
+
+  Antagonists are allowed to engage in EORG however they should strive to make it interesting.
+
+  ## Examples
+  Acceptable:
+  - As a regular shift Bartender, going to the bar for a post-shift drink.
+  - Defending yourself from an antagonist who has attacked you at Centcomm.
+  - Engaging in Admin lead end-of-round mini-events.
+
+  Prohibited:
+  - Randomly shooting other people once you reach Centcomm.
+  - As a non-antagonist Atmospheric Technician, bringing a can of plasma on evac with the intention of releasing it.
+  - Attacking other crew members on the evacuation shuttle.
+</Document>


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
Added Roleplay Rule 15: End of Round Griefing to the rulebook. This is applicable only to MRP and includes examples or allowed/disallowed scenarios. 

Also did some tiny fixes on RR14 as well

## Why / Balance
EORG was something that has been treated as a rule in MRP without integration to the rulebook, leading to some people engaging in EORG not knowing it was against the rules. This aims to close that gap.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Added EORG to the MRP Rulebook
