### PR TITLE
[Fix] Chat Sanitization

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -661,7 +661,8 @@ public sealed partial class ChatSystem : SharedChatSystem
             return;
 
         // The Original Message [-] Einstein Engines - Language
-        var message = TransformSpeech(source, originalMessage, language);
+        var message = FormattedMessage.RemoveMarkupOrThrow(originalMessage);  // Remove markup before transforming.
+        message = TransformSpeech(source, message, language);
 
         if (message.Length == 0)
             return;


### PR DESCRIPTION
## About the PR
This **should** fix Chat Sanitation issues resulting in the chaos shown in #3681 and #3631. For whatever reason, the message is never sanitized in regular speech, but is in everything else? Must've missed it. 🤷 Everything speech related is affected by the chat wrapper, so this shouldn't break languages at all.

As for the issue with backslash cutting off the rest of the text if you put it in the middle, there is nothing I can do about that without touching RobustToolbox since that is how the parser works, at least to my knowledge.

## Why / Balance
Fixes #3631 
Fixes #3681 

## Technical details
Sanitize the message before transforming it for all future occurrences of the message.

## Media
<img width="967" height="371" alt="image" src="https://github.com/user-attachments/assets/e76dd4fa-3a2d-40ed-bd74-df74891e4e1a" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
No CL, this isn't really player-facing per se; despite it being very well known.