### PR TITLE
centcomm space proof implanter makes you actually space proof

### DIFF
--- a/Content.Goobstation.Server/Implants/Components/SpaceProofImplantComponent.cs
+++ b/Content.Goobstation.Server/Implants/Components/SpaceProofImplantComponent.cs
@@ -18,4 +18,9 @@ public sealed partial class SpaceProofImplantComponent : Component
     /// </summary>
     [DataField] public bool NeededAir = false;
 
+    /// <summary>
+    /// Was the entity low temp immune before being implanted?
+    /// </summary>
+    [DataField] public bool WasntLowTempProof = false;
+
 }

--- a/Content.Goobstation.Server/Implants/Systems/SpaceProofImplantSystem.cs
+++ b/Content.Goobstation.Server/Implants/Systems/SpaceProofImplantSystem.cs
@@ -4,9 +4,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Goobstation.Server.Implants.Components;
+using Content.Goobstation.Shared.Temperature.Components;
 using Content.Server.Atmos.Components;
 using Content.Shared._Shitmed.Body.Components;
 using Content.Shared.Implants;
+using Content.Shared.Temperature.Components;
 using Robust.Shared.Containers;
 
 namespace Content.Goobstation.Server.Implants.Systems;
@@ -29,8 +31,8 @@ public sealed class SpaceProofImplantSystem : EntitySystem
         var user = args.Implanted.Value;
 
         EnsureComp<BreathingImmunityComponent>(user);
-        EnsureComp<PressureImmunityComponent>(user); // Add the temperature slow immune comp from the ling update when thats here.
-
+        EnsureComp<PressureImmunityComponent>(user);
+        EnsureComp<SpecialLowTempImmunityComponent>(user);
     }
 
     private void OnUnimplanted(Entity<SpaceProofImplantComponent> ent, ref EntGotRemovedFromContainerMessage args)
@@ -41,5 +43,7 @@ public sealed class SpaceProofImplantSystem : EntitySystem
             RemCompDeferred<BreathingImmunityComponent>(user);
         if (!TerminatingOrDeleted(user))
             RemCompDeferred<PressureImmunityComponent>(user);
+        if (!TerminatingOrDeleted(user))
+            RemCompDeferred<SpecialLowTempImmunityComponent>(user);
     }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Adjusted the centcomm space proof implanter to add the low temp immunity component
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Well, despite its name, it didnt actually make you space proof. I suspect this is a side effect of Solstice breaking space immunity into multiple parts with their Devil antag, but I didn't bother checking.

On a side note, the normal temperature immunity component didn't work for this for whatever reason so I used the component the Devil gives you for Fear of Freezing. G-Man also uses this component for this so it's probably fine I think...
## Technical details
<!-- Summary of code changes for easier review. -->
added a component to the spaceproofimplanter
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
I can take a screenshot of the component if you'd like
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

Not player facing 