### PR TITLE
Prevent Burgering EntityStorage and Storage Containers.

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/FoodSequenceSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/FoodSequenceSystem.cs
@@ -79,12 +79,14 @@
 using System.Numerics;
 using System.Text;
 using Content.Server.Nutrition.Components;
+using Content.Server.Storage.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Nutrition.Components;
 using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.Popups;
+using Content.Shared.Storage;
 using Content.Shared.Storage.Components;
 using Content.Shared.Tag;
 using Robust.Shared.Random;
@@ -114,7 +116,9 @@ public sealed class FoodSequenceSystem : SharedFoodSequenceSystem
 
     private void OnInteractUsing(Entity<FoodSequenceStartPointComponent> ent, ref InteractUsingEvent args)
     {
-        if (ent.Comp.AcceptAll) // Goobstation - anythingburgers
+        if (ent.Comp.AcceptAll // Goobstation - anythingburgers
+            && !HasComp<EntityStorageComponent>(args.Used) // Goobstation - Prevent backpacks/pet carriers.
+            && !HasComp<StorageComponent>(args.Used))
             EnsureComp<FoodSequenceElementComponent>(args.Used);
 
         if (TryComp<FoodSequenceElementComponent>(args.Used, out var sequenceElement) && HasComp<ItemComponent>(args.Used) && !HasComp<FoodSequenceStartPointComponent>(args.Used)) // Goobstation - anythingburgers - no non items allowed! otherwise you can grab players and lockers and such and add them to burgers


### PR DESCRIPTION
## About the PR
Removed the ability to burger entity storage (pet carriers and body bags) and storage (backpacks, toolbelts).

## Why / Balance
Gone are the days of easy round removal and accidental round removal. You must work for it the hard way. Dismantle the body parts to burger them. Remove the tools from their belt. Anarchy!

## Technical details
Checking for comps before applying components. <3

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Removed the ability to burger pet carriers and backpacks/belts.