### PR TITLE
NTR can choose centcomm cap and cloak in loadout [BOUNTY]

### DIFF
--- a/Resources/Prototypes/_Goobstation/Loadouts/Jobs/Dignitary/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/Jobs/Dignitary/nanotrasen_representative.yml
@@ -110,6 +110,10 @@
   equipment:
     head: ClothingHeadHatSyndieMAA
 
+- type: loadout
+  id: ClothingHeadHatCentcomcap
+  equipment:
+    head: ClothingHeadHatCentcomcap
 
 - type: loadout
   id: NanotrasenRepresentativeEnvirohelm
@@ -132,6 +136,11 @@
   id: ClothingNeckScarfStripedCentcom
   equipment:
     neck: ClothingNeckScarfStripedCentcom
+
+- type: loadout
+  id: ClothingNeckCloakCentcom
+  equipment:
+    neck: ClothingNeckCloakCentcom
 
 # Backpacks
 - type: loadout

--- a/Resources/Prototypes/_Goobstation/Loadouts/Jobs/Dignitary/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/Jobs/Dignitary/nanotrasen_representative.yml
@@ -75,6 +75,9 @@
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+# SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 floatingfeeling <karaadastra@gmail.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 grub <unalterableness@gmail.com>
 # SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 # SPDX-FileCopyrightText: 2025 shityaml <unalterableness@gmail.com>

--- a/Resources/Prototypes/_Goobstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/loadout_groups.yml
@@ -899,6 +899,7 @@
   - NanotrasenRepresentativeBowler
   - NanotrasenRepresentativeOutlaw
   - NanotrasenRepresentativeMAA
+  - ClothingHeadHatCentcomcap
 
 - type: loadoutGroup
   id: NanotrasenRepresentativeNeck
@@ -906,6 +907,7 @@
   minLimit: 0
   loadouts:
   - ClothingNeckScarfStripedCentcom
+  - ClothingNeckCloakCentcom
 
 - type: loadoutGroup
   id: NanotrasenRepresentativeBackpack

--- a/Resources/Prototypes/_Goobstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/loadout_groups.yml
@@ -14,6 +14,8 @@
 # SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
 # SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 coderabbitai[bot] <136622811+coderabbitai[bot]@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 floatingfeeling <karaadastra@gmail.com>
+# SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 grub <unalterableness@gmail.com>
 # SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 # SPDX-FileCopyrightText: 2025 shityaml <unalterableness@gmail.com>


### PR DESCRIPTION
## About the PR
added centcomm cap and cloak to NTRep loadout

## Why / Balance
bounty

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: The NTR can now choose the CentComm Cap and Cloak in their loadout.
