### PR TITLE
Substation faliure event

### DIFF
--- a/Content.Goobstation.Server/StationEvents/Components/SubstationFaultRuleComponent.cs
+++ b/Content.Goobstation.Server/StationEvents/Components/SubstationFaultRuleComponent.cs
@@ -1,0 +1,11 @@
+using Content.Server.StationEvents.Events;
+namespace Content.Goobstation.Server.StationEvents.Components;
+
+/// <summary>
+/// This is used for...
+/// </summary>
+[RegisterComponent, Access(typeof(SubstationFaultRule))]
+public sealed partial class SubstationFaultRuleComponent : Component
+{
+
+}

--- a/Content.Goobstation.Server/StationEvents/SubstationFaultRule.cs
+++ b/Content.Goobstation.Server/StationEvents/SubstationFaultRule.cs
@@ -1,0 +1,69 @@
+using System.Diagnostics;
+using Content.Goobstation.Server.StationEvents.Components;
+using Content.Server.Power.Components;
+using Content.Server.StationEvents.Components;
+using Content.Shared.GameTicking.Components;
+using Content.Server.StationEvents.Events;
+using Content.Shared.Tag;
+using JetBrains.Annotations;
+
+namespace Content.Goobstation.Server.StationEvents;
+
+/// <summary>
+/// This handles...
+/// </summary>
+
+[UsedImplicitly]
+public sealed class SubstationFaultRule : StationEventSystem<SubstationFaultRuleComponent>
+{
+    [Dependency] private readonly TagSystem _tag = default!;
+
+    protected override void Added(EntityUid uid, SubstationFaultRuleComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
+    {
+        if (!TryComp<StationEventComponent>(uid, out var stationEvent))
+            return;
+
+        var str = Loc.GetString("station-event-substation-fault-announcement", ("data", Loc.GetString(Loc.GetString($"random-sentience-event-data-{RobustRandom.Next(1, 6)}"))));
+        stationEvent.StartAnnouncement = str;
+
+        base.Added(uid, component, gameRule, args);
+    }
+
+    protected override void Started(EntityUid uid,
+        SubstationFaultRuleComponent component,
+        GameRuleComponent gameRule,
+        GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        if (!TryGetRandomStation(out var chosenStation))
+            return;
+
+        var stationSubstations = new List<Entity<PowerNetworkBatteryComponent>>();
+        var query = EntityQueryEnumerator<PowerNetworkBatteryComponent, TransformComponent>();
+        while (query.MoveNext(out var powerUid, out var power, out var xform))
+        {
+           if( _tag.HasTag(powerUid,"Substation") &&
+               power.CanCharge &&
+               power.CanDischarge &&
+               xform.Anchored
+               )
+               stationSubstations.Add((powerUid,power));
+        }
+
+        var toDisable = Math.Min( Math.Max(stationSubstations.Count/10, 1), stationSubstations.Count);
+        if (toDisable == 0)
+            return;
+
+        RobustRandom.Shuffle(stationSubstations);
+
+        for (var i = 0; i < toDisable; i++)
+        {
+            if(RobustRandom.Next(1, 2) == 2)
+                stationSubstations[i].Comp.CanCharge = false;
+            else
+                stationSubstations[i].Comp.CanDischarge = false;
+        }
+
+    }
+}

--- a/Resources/Locale/en-US/_Goobstation/station-events/events/substation-fault.ftl
+++ b/Resources/Locale/en-US/_Goobstation/station-events/events/substation-fault.ftl
@@ -1,0 +1,3 @@
+
+
+station-event-substation-fault-announcement = Based on { $data }, we have opted to disable some substations to avoid damage to equipment. Please contact the engineering department to re-enable them.

--- a/Resources/Prototypes/Entities/Structures/Power/substation.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/substation.yml
@@ -124,6 +124,9 @@
     supplyRampTolerance: 5000
     supplyRampRate: 1000
   - type: StationInfiniteBatteryTarget
+  - type: Tag # Goobstation - Added tag for substation fault event
+    tags:
+      - Substation
 
   # Interface
   - type: BatteryInterface

--- a/Resources/Prototypes/_Goobstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/events.yml
@@ -47,3 +47,18 @@
       min: 1
       max: 1
       pickPlayer: false
+
+- type: entity
+  id: SubstationFaultGameRule
+  parent: BaseGameRule
+  components:
+  - type: StationEvent
+    weight: 5
+    duration: 1
+    minimumPlayers: 15
+    chaos:
+      Power: 100
+    eventType: Maintenance
+  - type: GameRule
+    chaosScore: 60
+  - type: SubstationFaultRule

--- a/Resources/Prototypes/_Goobstation/tags.yml
+++ b/Resources/Prototypes/_Goobstation/tags.yml
@@ -517,6 +517,9 @@
   id: Stomach
 
 - type: Tag
+  id: Substation
+
+- type: Tag
   id: SummonSimiansMaxLevelAction
 
 - type: Tag


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
added new event where the substations toggles off

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
more buzy work for engineers
Ui was added to the Substations. this expands on that and makes them toggle off on events.

## Technical details
<!-- Summary of code changes for easier review. -->
used same chane of the event as the APc off toggle. so shud happen once or twice a round.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--

- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: fishbait_x
- add: Added new random event that toggles off substations