### PR TITLE
Determination

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/reagents/determination.ftl
+++ b/Resources/Locale/en-US/_Goobstation/reagents/determination.ftl
@@ -7,11 +7,10 @@ determination-effect-focus = Your world narrows into perfect focus.
 determination-effect-free = I went so numb, I felt so free...
 
 determination-effect-run = Run.
-determination-effect-worth = Was it worth it, Player?
+determination-effect-worth = Was it worth it?
 determination-effect-mortal = Mortality is inevitable, you know.
 determination-effect-time = You're running out of time.
 determination-effect-why = Why are you still here?
 determination-effect-choice = This was always your choice.
-determination-effect-concede = Is it time to let go?
 
 determination-effect-tear = Your body is tearing itself apart!

--- a/Resources/Locale/en-US/_Goobstation/reagents/determination.ftl
+++ b/Resources/Locale/en-US/_Goobstation/reagents/determination.ftl
@@ -1,0 +1,17 @@
+determination-effect-hands = Your hands begin to shake...
+determination-effect-hallucination = You can see the sky.
+determination-effect-heartbeat = Your heartbeat thunders in your skull.
+determination-effect-melt = You feel yourself melting at the touch...
+determination-effect-breath = Your breath comes in ragged gasps.
+determination-effect-focus = Your world narrows into perfect focus.
+determination-effect-free = I went so numb, I felt so free...
+
+determination-effect-run = Run.
+determination-effect-worth = Was it worth it, Player?
+determination-effect-mortal = Mortality is inevitable, you know.
+determination-effect-time = You're running out of time.
+determination-effect-why = Why are you still here?
+determination-effect-choice = This was always your choice.
+determination-effect-concede = Is it time to let go?
+
+determination-effect-tear = Your body is tearing itself apart!

--- a/Resources/Locale/en-US/_Goobstation/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/_Goobstation/reagents/meta/medicine.ftl
@@ -104,3 +104,6 @@ reagent-desc-hercuri = Strong coolant, both serviceable for internal and externa
 
 reagent-name-herignis = herignis
 reagent-desc-herignis = Can thaw out most chilled of lizardmen, recommended to only use in small doses, as it can quickly heat up its metaboliser to dangerous levels.
+
+reagent-name-determination = determination
+reagent-desc-determination = But it refused.

--- a/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
@@ -1542,7 +1542,7 @@
   desc: reagent-desc-determination
   physicalDesc: reagent-physical-desc-burning
   flavor: medicine
-  color: "#fcefef"
+  color: "#ffffff"
   metabolisms:
     Medicine:
       metabolismRate: 1
@@ -1553,12 +1553,12 @@
           min: 15
         reagent: Determination
         amount: 2
-      - !type:AdjustReagent
+      - !type:AdjustReagent # must be injected with a syringe, voluntarily, in one dose (invalidates hypospraying some chud for them to die in Sixty Seconds)
         conditions:
         - !type:ReagentThreshold
           max: 14.9
         reagent: Determination
-        amount: -15 # must be injected with a syringe, voluntarily, in one dose - invalidates hypospray use
+        amount: -15
       - !type:HealthChange # obscenely strong heal - practically unkillable, though two people focusing fire can outburst it due to the 1/s meta rate
         conditions:
         - !type:ReagentThreshold
@@ -1579,8 +1579,8 @@
         conditions:
         - !type:ReagentThreshold
           max: 70
-        walkSpeedModifier: 1.2
-        sprintSpeedModifier: 1.2
+        walkSpeedModifier: 1.3
+        sprintSpeedModifier: 1.3
       - !type:GenericStatusEffect
         key: Adrenaline
         component: IgnoreSlowOnDamage
@@ -1606,11 +1606,11 @@
         time: 10
         type: Remove
       - !type:ChemCleanBloodstream
-      - !type:AdjustTemperature
+      - !type:AdjustTemperature # leporazine tempfix
         conditions:
         - !type:Temperature
           max: 293.15
-        amount: 100000 # thermal energy, not temperature!
+        amount: 100000
       - !type:AdjustTemperature
         conditions:
         - !type:Temperature
@@ -1621,22 +1621,22 @@
         - !type:ReagentThreshold
           max: 30
         visualType: Medium
-        messages: [ "determination-effect-hands", "determination-effect-hallucination", "determination-effect-heartbeat", "determination-effect-melt" ]
+        messages: [ "determination-effect-hands", "determination-effect-hallucination", "determination-effect-heartbeat", "determination-effect-melt", "determination-effect-focus", "determination-effect-free" ]
         type: Local
-        probability: 0.5
+        probability: 0.3
       - !type:PopupMessage
         conditions:
         - !type:ReagentThreshold
           min: 30
           max: 70
         visualType: Medium
-        messages: [ "determination-effect-run", "determination-effect-worth", "determination-effect-mortal", "determination-effect-time" ]
+        messages: [ "determination-effect-run", "determination-effect-worth", "determination-effect-mortal", "determination-effect-time", "determination-effect-choice" ]
         type: Local
-        probability: 0.5
+        probability: 0.3
       - !type:PopupMessage
         conditions:
         - !type:ReagentThreshold
-          min: 70
+          min: 71
         visualType: Large
         messages: [ "determination-effect-tear" ]
         type: Local
@@ -1644,7 +1644,7 @@
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold
-          min: 70
+          min: 71
       - !type:MovespeedModifier
         conditions:
         - !type:ReagentThreshold
@@ -1654,16 +1654,16 @@
       - !type:Emote
         conditions:
         - !type:ReagentThreshold
-          min: 70
+          min: 71
         emote: Scream
-        probability: 1
+        probability: 0.3
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 75 # 60 second death trigger - kills the user and prevents cloning
+          min: 75 # 60 second death trigger
         damage:
           types:
-            Blunt: 2000
+            Blunt: 800
       - !type:AdjustReagent
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
@@ -1534,3 +1534,139 @@
         identifier: Suffocation
         amount: -50
         time: 12
+
+- type: reagent
+  id: Determination
+  name: reagent-name-determination
+  group: Medicine
+  desc: reagent-desc-determination
+  physicalDesc: reagent-physical-desc-burning
+  flavor: medicine
+  color: "#fcefef"
+  metabolisms:
+    Medicine:
+      metabolismRate: 1
+      effects:
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentThreshold
+          min: 15
+        reagent: Determination
+        amount: 2
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentThreshold
+          max: 14.9
+        reagent: Determination
+        amount: -15 # must be injected with a syringe, voluntarily, in one dose - invalidates hypospray use
+      - !type:HealthChange # obscenely strong heal - practically unkillable, though two people focusing fire can outburst it due to the 1/s meta rate
+        conditions:
+        - !type:ReagentThreshold
+          min: 15
+        damage:
+          groups:
+            Brute: -300
+            Burn: -400
+            Airloss: -200
+            Toxin: -200
+      - !type:SuppressPain
+        conditions:
+        - !type:ReagentThreshold
+          max: 70
+        amount: 400
+        time: 2
+      - !type:MovespeedModifier
+        conditions:
+        - !type:ReagentThreshold
+          max: 70
+        walkSpeedModifier: 1.2
+        sprintSpeedModifier: 1.2
+      - !type:GenericStatusEffect
+        key: Adrenaline
+        component: IgnoreSlowOnDamage
+        time: 10
+      - !type:GenericStatusEffect
+        key: Stun
+        time: 10
+        type: Remove
+      - !type:GenericStatusEffect
+        key: KnockedDown
+        time: 10
+        type: Remove
+      - !type:GenericStatusEffect
+        key: Drowsiness
+        time: 10
+        type: Remove
+      - !type:GenericStatusEffect
+        key: SeeingRainbows
+        time: 10
+        type: Remove
+      - !type:GenericStatusEffect
+        key: Drunk
+        time: 10
+        type: Remove
+      - !type:ChemCleanBloodstream
+      - !type:AdjustTemperature
+        conditions:
+        - !type:Temperature
+          max: 293.15
+        amount: 100000 # thermal energy, not temperature!
+      - !type:AdjustTemperature
+        conditions:
+        - !type:Temperature
+          min: 293.15
+        amount: -10000
+      - !type:PopupMessage
+        conditions:
+        - !type:ReagentThreshold
+          max: 30
+        visualType: Medium
+        messages: [ "determination-effect-hands", "determination-effect-hallucination", "determination-effect-heartbeat", "determination-effect-melt" ]
+        type: Local
+        probability: 0.5
+      - !type:PopupMessage
+        conditions:
+        - !type:ReagentThreshold
+          min: 30
+          max: 70
+        visualType: Medium
+        messages: [ "determination-effect-run", "determination-effect-worth", "determination-effect-mortal", "determination-effect-time" ]
+        type: Local
+        probability: 0.5
+      - !type:PopupMessage
+        conditions:
+        - !type:ReagentThreshold
+          min: 70
+        visualType: Large
+        messages: [ "determination-effect-tear" ]
+        type: Local
+        probability: 1
+      - !type:Jitter
+        conditions:
+        - !type:ReagentThreshold
+          min: 70
+      - !type:MovespeedModifier
+        conditions:
+        - !type:ReagentThreshold
+          min: 70
+        walkSpeedModifier: 0.65
+        sprintSpeedModifier: 0.65
+      - !type:Emote
+        conditions:
+        - !type:ReagentThreshold
+          min: 70
+        emote: Scream
+        probability: 1
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          min: 75 # 60 second death trigger - kills the user and prevents cloning
+        damage:
+          types:
+            Blunt: 2000
+      - !type:AdjustReagent
+        conditions:
+        - !type:ReagentThreshold
+          min: 75
+        reagent: Determination
+        amount: -75

--- a/Resources/Prototypes/_Goobstation/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Reactions/medicine.yml
@@ -421,3 +421,22 @@
       catalyst: true
   products:
     Oxycodone: 1
+
+- type: reaction
+  id: Determination
+  maxtemp: 100
+  requiredMixerCategories:
+  - Centrifuge
+  reactants:
+    Aluite:
+      amount: 6 # 180u aluite synthesises 30u determination
+    Aranesp:
+      amount: 1
+    Nostalgia:
+      amount: 1
+    Happiness:
+      amount: 1
+    Ash:
+      amount: 1
+  products:
+    Determination: 0.5


### PR DESCRIPTION
## About the PR
Adds Determination, a med that grants pseudo-invincibility for a minute-long period before gibbing the user.

TO DO:
Add specific reagent removal (charcoal, pent, basically anything that removes reagents from the bloodstream)
Maybe make it human only and acidify all non-humans
Make it extend crit range
Custom gib sound (smite sound effect from wizard)
maybe nukie acidify effect???

## Why / Balance
More chemistry content
Balanced for tots because sixty seconds of invincibility before being gibbed doesn't really help you (unless you want to die gloriously)
Balanced for assassinations because it removes itself completely from the bloodstream if less than 15u is injected all at once (cannot be 'activated' in any other way than self-injecting 15u via a syringe)
Balanced for nukeops because it fucking kills you :wilted_flower:
Balanced for crew because what are you going to do with pseudo-invincibility before fucking dying
Balanced in general because it requires:
Aluite (ice from bar for cryostalane, and you need 180u for 15u Determination)
Happiness (grinding bananas/rainbow cannabis/world peas from botany)
Aranesp (pain in the ass to make)
technically antag balance if you really nitpick it but ermmmmmmmmmmmmmmmmmm

## Media
<img width="623" height="889" alt="image" src="https://github.com/user-attachments/assets/62b06874-e339-4673-99e2-ad2e8974c86f" />
Video coming Soon:tm:

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Added Determination.
