### PR TITLE
Fix Wrong Parenting on Cowboy Boots

### DIFF
--- a/Content.IntegrationTests/Tests/_Goobstation/VendingMachine/BlacklistedStatsInVendingMachinesTest.cs
+++ b/Content.IntegrationTests/Tests/_Goobstation/VendingMachine/BlacklistedStatsInVendingMachinesTest.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Linq;
+using Content.Goobstation.Shared.Clothing.Components;
+using Content.Goobstation.Shared.Stunnable;
+using Content.Shared.Prototypes;
+using Content.Shared.Tag;
+using Content.Shared.VendingMachines;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests._Goobstation.VendingMachine;
+
+public sealed class BlacklistedStatsInVendingMachinesTest
+{
+    private static readonly ProtoId<TagPrototype> NoStatModifyingItemsTag = "NoStatModifyingItems";
+
+    /// <summary>
+    /// Checks every prototype in all vending machines that should not have gear with stats
+    /// to ensure they do not have stats.
+    /// </summary>
+    /// <remarks>
+    /// Stop putting fucking jackboots where they do not belong.
+    /// </remarks>
+    [Test]
+    public async Task ValidateNoStatsInBlacklistedMachines()
+    {
+        await using var pair   = await PoolManager.GetServerClient();
+        var             server = pair.Server;
+
+        var protoMan         = server.ProtoMan;
+        var componentFactory = server.Resolve<IComponentFactory>();
+
+        var vendingMachines  = pair.GetPrototypesWithComponent<VendingMachineComponent>();
+        var eligibleMachines = new Dictionary<EntityPrototype, VendingMachineComponent>();
+
+        await server.WaitAssertion(() =>
+        {
+            foreach (var (proto, comp) in vendingMachines)
+            {
+                if (!proto.TryGetComponent(out TagComponent tagComponent, componentFactory))
+                    continue;
+
+                foreach (var _ in tagComponent.Tags.Where(tag => tag == NoStatModifyingItemsTag))
+                    eligibleMachines[proto] = comp;
+            }
+
+            foreach (var (machineProto, component) in eligibleMachines)
+            {
+                var inventory = protoMan.Index<VendingMachineInventoryPrototype>(component.PackPrototypeId);
+                foreach (var (itemProto, _) in inventory.StartingInventory)
+                {
+                    var item = protoMan.Index(itemProto);
+
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(item.HasComponent<ModifyStandingUpTimeComponent>(),
+                            Is.False,
+                            $"\"{itemProto}\" modifies standing up time, yet is in a blacklisted machine! ({machineProto})");
+                        Assert.That(item.HasComponent<ClothingModifyStunTimeComponent>(),
+                            Is.False,
+                            $"\"{itemProto}\" modifies stun time, yet is in a blacklisted machine! ({machineProto})");
+                    });
+                }
+            }
+        });
+
+    await pair.CleanReturnAsync();
+    }
+}

--- a/Resources/Prototypes/Catalog/Fills/Items/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/misc.yml
@@ -32,23 +32,23 @@
   - ClothingShoesBootsWinterSec
   - ClothingShoesBootsSecFilled
 
-- type: entity
-  id: ClothingShoesBootsCowboyBlackFilled
-  parent:
-  - ClothingShoesBootsCowboyBlack
-  - ClothingShoesBootsSecFilled
+#- type: entity
+#  id: ClothingShoesBootsCowboyBlackFilled
+#  parent:
+#  - ClothingShoesBootsCowboyBlack
+#  - ClothingShoesBootsSecFilled
 
-- type: entity
-  id: ClothingShoesBootsCowboyBrownFilled
-  parent:
-  - ClothingShoesBootsCowboyBrown
-  - ClothingShoesBootsSecFilled
+#- type: entity
+#  id: ClothingShoesBootsCowboyBrownFilled
+#  parent:
+#  - ClothingShoesBootsCowboyBrown
+#  - ClothingShoesBootsSecFilled
 
-- type: entity
-  id: ClothingShoesBootsCowboyWhiteFilled
-  parent:
-  - ClothingShoesBootsCowboyWhite
-  - ClothingShoesBootsSecFilled
+#- type: entity
+#  id: ClothingShoesBootsCowboyWhiteFilled
+#  parent:
+#  - ClothingShoesBootsCowboyWhite
+#  - ClothingShoesBootsSecFilled
 
 - type: entity
   id: ClothingShoesBootsCowboyFancyFilled

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -315,7 +315,7 @@
     node: boots
 
 - type: entity
-  parent: ClothingShoesMilitaryBase
+  parent: ClothingShoesBase # Goobstation - Either these stay in the autodrobe, or they lose stats. You don't get both.
   id: ClothingShoesBootsCowboyBrown
   name: brown cowboy boots
   description: They got spurs that jingle and/or jangle.

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -560,6 +560,7 @@
   - type: Tag
     tags:
       - DroneUsable # Goobstation
+      - NoStatModifyingItems # Goobstation - STOP PUTTING JACKBOOTS IN HERE
 
 - type: entity
   parent: VendingMachine
@@ -596,6 +597,7 @@
   - type: Tag
     tags:
     - DroneUsable # Goobstation
+    - NoStatModifyingItems # Goobstation - STOP PUTTING JACKBOOTS IN HERE
 
 - type: entity
   parent: VendingMachine
@@ -1555,6 +1557,7 @@
   - type: Tag
     tags:
     - DroneUsable # Goobstation
+    - NoStatModifyingItems # Goobstation - STOP PUTTING JACKBOOTS IN HERE
 
 - type: entity
   parent: VendingMachine

--- a/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -1750,7 +1750,7 @@
   id: ChallengeVictimHOS
   equipment:
     jumpsuit: ClothingUniformJumpsuitHoSParadeMale
-    shoes: ClothingShoesBootsCowboyBlackFilled
+    shoes: ClothingShoesBootsJack # ClothingShoesBootsCowboyBlackFilled - Goobstation
     gloves: ClothingHandsGlovesCombat
     head: ClothingHeadHatHoshat
     neck: ClothingNeckCloakHos

--- a/Resources/Prototypes/_Goobstation/Loadouts/Jobs/Dignitary/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/Jobs/Dignitary/blueshield_officer.yml
@@ -165,7 +165,7 @@
 - type: loadout
   id: BlackCowboyBoots
   equipment:
-    shoes: ClothingShoesBootsCowboyBlackFilled
+    shoes: ClothingShoesBootsCowboyBlack
 
 - type: loadout
   id: SnowjacksBso

--- a/Resources/Prototypes/_Goobstation/tags.yml
+++ b/Resources/Prototypes/_Goobstation/tags.yml
@@ -439,6 +439,9 @@
   id: NonLethalGrenade
 
 - type: Tag
+  id: NoStatModifyingItems
+
+- type: Tag
   id: NukeOpsCommanderUplink
 
 - type: Tag

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -146,6 +146,9 @@
 # WallSolid: Window
 # Table: null
 
+# Goobstation - Drip or functionality. You don't get both.
+ClothingShoesBootsCowboyBlackFilled: null
+
 # Goobstation - Submarine from DeltaV
 AirlockBoxerGlassLocked: AirlockServiceGlassLocked
 AirlockClownGlassLocked: AirlockServiceGlassLocked


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Some idiot gave cowboy boots jackboot stats, but forgot there's three of them in the fucking autodrobe roundstart for any would-be self-antagger to munch on.

I removed the stats from the boots, and added a test that throws when an item with stats is added to the auto drobe. Fuck you.

## Why / Balance
Because it's clearly an oversight and the autodrobe shouldn't be dispensing security gear.
(On an actual note, this probably won't get merged, I just wanted experience coding tests.)

## Technical details
YAML change + A single test.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Slopstice
- fix: Fixed cowboy boots having stats.
