### PR TITLE
closes #3828 - Fixes & Balances PTL from being able to make free spesos

### DIFF
--- a/Content.Goobstation.Shared/Power/PTL/PTLComponent.cs
+++ b/Content.Goobstation.Shared/Power/PTL/PTLComponent.cs
@@ -20,8 +20,8 @@ public sealed partial class PTLComponent : Component
 
     [DataField, AutoNetworkedField] public double SpesosHeld = 0f;
 
-    [DataField] public double MinShootPower = 1e6; // 1 MJ
-    [DataField] public double MaxEnergyPerShot = 1e8; // 100 MJ, Used to limit evil effects, but not coded so doesn't do anything
+    [DataField] public double MinShootPower = 1e6f; // 1 MJ
+    [DataField] public double MaxEnergyPerShot = 5e6; // 5 MJ
 
     [DataField, AutoNetworkedField] public float ShootDelay = 10f;
     [DataField, AutoNetworkedField] public float ShootDelayIncrement = 5f;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
closes #3828 
Balances and fixes PTL issues.
Along to addressing several issues with the PTL

## Why / Balance
PTL was capable of generating free spesos whilst not using the battery charge, in addition the PTL's "shot" maximum in minium power per shot was changed that at maximum the PTL exchanges up to 592 Spesos per shot which means (5920 Spesos per minute if fire delay is 10 seconds by default and it has enough power).

Before the power per shot change the PTL would be capable of eatting it's entire battery in a single shot, which defeats a purpose of a battery and instantly generates a huge amounts of spesos.

## Technical details
- Prevents radiation intensity from going negative.
- Caps energy consumption and damage based on the component's energy limit, preventing exploits.
- Calculates spesos and evil effect based on actual energy used, not planned energy.
- Prevents anchored PTLs from being deconstructed for infinite money.
- Fixes an issue where PTLs could make free spesos.

## Media
[Screencast_20250820_163642.webm](https://github.com/user-attachments/assets/462954cc-ed22-49d2-9c2f-ccbc269f73e7)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Richard Blonski
- tweak: Power Transmission Laser now shots a maximum of 5MJ which is (592 spesos per shot).
- fix: Power Transmission Laser will now consume battery charge when fired, and will stop firing when there isn't enough battery.

