### PR TITLE
small refactor to how breathing immunity is handled

### DIFF
--- a/Content.Goobstation.Shared/Body/Events/BreathingImmunityEvent.cs
+++ b/Content.Goobstation.Shared/Body/Events/BreathingImmunityEvent.cs
@@ -1,0 +1,6 @@
+namespace Content.Goobstation.Shared.Body.Events;
+
+public sealed class BreathingImmunityEvent : EntityEventArgs
+{
+    public bool NeedsAir;
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Breathing immunity will now let you respire regardless of whatever gas is present (e.g can now ACTUALLY breathe even when theres no atmosphere/gases)
This comes with the (intentional :trollface: ) side-effect of leaving them still vulnerable to the effects of certain gases such as nitrous oxide or frezon.

## Why / Balance
Getting breathing immunity when you had a lack of oxygen or airloss was a pain in the ass considering there was literally nothing you could do to get rid of it

## Technical details
The methods "CanBreathe" and "UpdateSaturation" will raise an event checking for the user's breathing immunity component(s).
This leads to:
CanBreathe preventing the user from taking any asphyxiation damage from things such as choke grabs or low oxygen.
UpdateSaturation constantly having the lungs filled with "air".
(if the user has the immunities)

## Media

https://github.com/user-attachments/assets/b0a4790b-830c-4949-9923-37ef6bdd1492

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: the biggest bruh
- tweak: Breathing immunity now lets the user breathe regardless of present gases. This also means that they can now be affected by both dangerous and beneficial gases.
- fix: People with breathing immunity will now be able to clear airloss if they had any.
