### PR TITLE
Veichle sprinting adjustment

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Vehicles/clowncar.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Vehicles/clowncar.yml
@@ -28,8 +28,8 @@
     weightlessModifier: 0
     acceleration: 1
     friction: 1
-    baseWalkSpeed: 4.5
-    baseSprintSpeed: 7
+    baseWalkSpeed: 6.5 #65
+    baseSprintSpeed: 10
   - type: ItemSlots
     slots:
       key_slot:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Vehicles/clowncar.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Vehicles/clowncar.yml
@@ -28,7 +28,7 @@
     weightlessModifier: 0
     acceleration: 1
     friction: 1
-    baseWalkSpeed: 6.5 #65
+    baseWalkSpeed: 4.5
     baseSprintSpeed: 10
   - type: ItemSlots
     slots:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Vehicles/vehicles.yml
@@ -80,8 +80,8 @@
   - type: MovementSpeedModifier
     baseAcceleration: 8
     baseFriction: 0.2 # wheels dont stop instantly
-    baseSprintSpeed: 6
-    baseWalkSpeed: 4.5 # default walking speed
+    baseSprintSpeed: 8.5
+    baseWalkSpeed: 6.5 # default walking speed 
   - type: ItemSlots
     slots:
       key_slot:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Vehicles/vehicles.yml
@@ -81,7 +81,7 @@
     baseAcceleration: 8
     baseFriction: 0.2 # wheels dont stop instantly
     baseSprintSpeed: 8.5
-    baseWalkSpeed: 6.5 # default walking speed 
+    baseWalkSpeed: 4.5 # default walking speed 
   - type: ItemSlots
     slots:
       key_slot:


### PR DESCRIPTION

<!--- LICENSE: AGPL -->
## About the PR
updated speed of veichles by 1.4 +- rounding 

## Why / Balance
sprinting, "go do it yourself"

## Technical details
yml 

## Media
Not tested, works

## Requirements

- [X] I have not read and are not following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have not added media to this PR or it does require an ingame showcase.


**Changelog**
:cl:
- fix: Vehicles now move at 1.4 of their original values. This is due to spritning being added making them semi obsolete. Beware of clown cars. 
