### PR TITLE
Raises minimum sizes for all species, makes some species wider

### DIFF
--- a/Resources/Prototypes/Species/dwarf.yml
+++ b/Resources/Prototypes/Species/dwarf.yml
@@ -23,5 +23,5 @@
   maxHeight: 0.9
   minWidth: 0.9
   defaultWidth: 1
-  maxWidth: 1.2
+  maxWidth: 1.3
   # end Goobstation: port EE height/width sliders

--- a/Resources/Prototypes/Species/dwarf.yml
+++ b/Resources/Prototypes/Species/dwarf.yml
@@ -18,10 +18,10 @@
   skinColoration: HumanToned
   # begin Goobstation: port EE height/width sliders
   sizeRatio: 1.3
-  minHeight: 0.7
+  minHeight: 0.75
   defaultHeight: 0.8
   maxHeight: 0.9
   minWidth: 0.9
   defaultWidth: 1
-  maxWidth: 1.1
+  maxWidth: 1.2
   # end Goobstation: port EE height/width sliders

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -33,6 +33,14 @@
   markingLimits: MobHumanMarkingLimits
   dollPrototype: MobHumanDummy
   skinColoration: HumanToned
+  # begin Goobstation: port EE height/width sliders
+  minHeight: 0.90
+  defaultHeight: 1
+  maxHeight: 1.20
+  minWidth: 0.90
+  defaultWidth: 1
+  maxWidth: 1.10
+  # end Goobstation: port EE height/width sliders
 
 # The lack of a layer means that
 # this person cannot have round-start anything

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -32,13 +32,12 @@
   femaleFirstNames: NamesMothFirstFemale
   lastNames: NamesMothLast
   # begin Goobstation: port EE height/width sliders
-  # Moths have massive sprites, so they can get away with being scaled smaller (totally not biased)
   minHeight: 0.8
   defaultHeight: 1
   maxHeight: 1.20
   minWidth: 0.80
   defaultWidth: 1
-  maxWidth: 1.20
+  maxWidth: 1.25
   # end Goobstation: port EE height/width sliders
 
 - type: speciesBaseSprites

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -33,7 +33,7 @@
   lastNames: NamesMothLast
   # begin Goobstation: port EE height/width sliders
   # Moths have massive sprites, so they can get away with being scaled smaller (totally not biased)
-  minHeight: 0.75
+  minHeight: 0.8
   defaultHeight: 1
   maxHeight: 1.20
   minWidth: 0.80

--- a/Resources/Prototypes/_DV/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Species/harpy.yml
@@ -27,7 +27,7 @@
   dollPrototype: MobHarpyDummy
   skinColoration: HumanToned
   # begin Goobstation: port EE height/width sliders
-  minHeight: 0.75
+  minHeight: 0.80
   defaultHeight: 0.80
   maxHeight: 1.0
   minWidth: 0.80

--- a/Resources/Prototypes/_DV/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Species/rodentia.yml
@@ -29,7 +29,7 @@
   naming: LastFirst
   # begin Goobstation: port EE height/width sliders
   sizeRatio: 1.1 # i don't know WHY, but disproportionate rodentia always look weird.
-  minHeight: 0.75
+  minHeight: 0.8
   defaultHeight: 0.80
   maxHeight: 1.15
   minWidth: 0.80

--- a/Resources/Prototypes/_EinsteinEngines/Species/shadowkin.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Species/shadowkin.yml
@@ -25,7 +25,7 @@
     - Male
     - Female
   # begin Goobstation: port EE height/width sliders
-  minHeight: 0.75
+  minHeight: 0.80
   defaultHeight: 0.85
   maxHeight: 1.15
   minWidth: 0.77

--- a/Resources/Prototypes/_Floofstation/Species/resomi.yml
+++ b/Resources/Prototypes/_Floofstation/Species/resomi.yml
@@ -24,6 +24,15 @@
   - Unsexed
   - Male
   - Female
+  # begin Goobstation: port EE height/width sliders
+  # Moths have massive sprites, so they can get away with being scaled smaller (totally not biased)
+  minHeight: 0.75
+  defaultHeight: 1
+  maxHeight: 1.20
+  minWidth: 0.80
+  defaultWidth: 1
+  maxWidth: 1.20
+  # end Goobstation: port EE height/width sliders
 
 - type: speciesBaseSprites
   id: MobResomiSprites

--- a/Resources/Prototypes/_Floofstation/Species/resomi.yml
+++ b/Resources/Prototypes/_Floofstation/Species/resomi.yml
@@ -26,8 +26,8 @@
   - Female
   # begin Goobstation: port EE height/width sliders
   # resomi sprites look very wrong when too big or too wide
-  minHeight: 0.85
-  defaultHeight: 0.85
+  minHeight: 0.80
+  defaultHeight: 0.90
   maxHeight: 1
   minWidth: 0.85
   defaultWidth: 1

--- a/Resources/Prototypes/_Floofstation/Species/resomi.yml
+++ b/Resources/Prototypes/_Floofstation/Species/resomi.yml
@@ -25,13 +25,13 @@
   - Male
   - Female
   # begin Goobstation: port EE height/width sliders
-  # Moths have massive sprites, so they can get away with being scaled smaller (totally not biased)
-  minHeight: 0.75
-  defaultHeight: 1
-  maxHeight: 1.20
-  minWidth: 0.80
+  # resomi sprites look very wrong when too big or too wide
+  minHeight: 0.85
+  defaultHeight: 0.85
+  maxHeight: 1
+  minWidth: 0.85
   defaultWidth: 1
-  maxWidth: 1.20
+  maxWidth: 1
   # end Goobstation: port EE height/width sliders
 
 - type: speciesBaseSprites

--- a/Resources/Prototypes/_Goobstation/Species/tajaran.yml
+++ b/Resources/Prototypes/_Goobstation/Species/tajaran.yml
@@ -23,12 +23,12 @@
   femaleFirstNames: NamesTajaranFirst
   lastNames: NamesTajaranLast
   # begin Goobstation: port EE height/width sliders
-  minHeight: 0.80
-  defaultHeight: 0.80
+  minHeight: 0.85
+  defaultHeight: 0.90
   maxHeight: 1.15
-  minWidth: 0.80
-  defaultWidth: 0.80
-  maxWidth: 1.15
+  minWidth: 0.85
+  defaultWidth: 0.90
+  maxWidth: 1.10
   # end Goobstation: port EE height/width sliders
 
 - type: markingPoints

--- a/Resources/Prototypes/_Goobstation/Species/tajaran.yml
+++ b/Resources/Prototypes/_Goobstation/Species/tajaran.yml
@@ -23,12 +23,12 @@
   femaleFirstNames: NamesTajaranFirst
   lastNames: NamesTajaranLast
   # begin Goobstation: port EE height/width sliders
-  minHeight: 0.75
+  minHeight: 0.80
   defaultHeight: 0.80
   maxHeight: 1.15
   minWidth: 0.80
   defaultWidth: 0.80
-  maxWidth: 1.10
+  maxWidth: 1.15
   # end Goobstation: port EE height/width sliders
 
 - type: markingPoints


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
we knew this would happen, the same happened in EE
i dont know who thought allowing the small species to be even smaller was a good idea

## Why / Balance
resomi sprites look horrid when the sizes of oni's
and other species get so small, that theyre practically impossible to hit with any weapon or even to just chase them around
also because sprites look horrible when the sizes of cockroaches
species to be wider because wide = funny

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- tweak: All species' minimum size has been raised.
- tweak: Species like dwarfs and humans can now be wider, rejoice
