### PR TITLE
Some Glowing eyes glow again!

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
@@ -274,4 +274,4 @@
   sprites:
   - sprite: Mobs/Customization/tattoos.rsi
     state: tattoo_eye_l
-    shader: unshaded
+  shader: unshaded

--- a/Resources/Prototypes/_Imp/Mobs/Customization/arachnid.yml
+++ b/Resources/Prototypes/_Imp/Mobs/Customization/arachnid.yml
@@ -89,7 +89,7 @@
     state: jumper3
   - sprite: _Impstation/Mobs/Customization/Arachnid/eyes.rsi
     state: jumper4
-    shader: unshaded
+  shader: unshaded
 
 
 - type: marking

--- a/Resources/Prototypes/_Imp/Mobs/Customization/slimeperson.yml
+++ b/Resources/Prototypes/_Imp/Mobs/Customization/slimeperson.yml
@@ -167,7 +167,7 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/SlimePerson/eyes.rsi
     state: glow
-
+shader: unshaded
 
 - type: marking
   id: SlimeEyesDroopy

--- a/Resources/Prototypes/_Imp/Mobs/Customization/slimeperson.yml
+++ b/Resources/Prototypes/_Imp/Mobs/Customization/slimeperson.yml
@@ -167,7 +167,7 @@
   sprites:
   - sprite: _Impstation/Mobs/Customization/SlimePerson/eyes.rsi
     state: glow
-shader: unshaded
+  shader: unshaded
 
 - type: marking
   id: SlimeEyesDroopy


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
some shader lines in yaml were incorrectly formatted causing the "glow" in the eyes to not work.

## Why / Balance
I like glowy eyes and having only one glowy eye pissed me off way too much.

## Media
Left Eye wasnt working:
Before:
<img width="1280" height="720" alt="non glowy left eye" src="https://github.com/user-attachments/assets/b691511f-6db1-4f55-a7d2-49b042b76c1f" />
After:
<img width="1280" height="720" alt="left eye working" src="https://github.com/user-attachments/assets/104cdeca-4cbd-40f5-bd32-83ace94f88d9" />
Jumper glowing eyes wasnt working:
Before:
<img width="1280" height="720" alt="non glowy jumper eye" src="https://github.com/user-attachments/assets/b32d2385-56aa-48b4-8824-3dd72c302fd8" />
After:
<img width="1280" height="720" alt="jumper eyes glowing" src="https://github.com/user-attachments/assets/4792390f-badd-4b64-944c-58a1aa9fae5a" />
Slime Glowy eyes:
Before:
<img width="1280" height="720" alt="non glowy slime eye" src="https://github.com/user-attachments/assets/b4f9c4f7-4188-4f47-87a8-c98ab817834f" />
After:
<img width="1280" height="720" alt="slime glowy eyes" src="https://github.com/user-attachments/assets/2666d3ab-dcaf-4a66-979a-316d8eed5423" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
🆑 (KMano10000/ConfusedBumm)
- fix: Some glowing eyes not really glowing