### PR TITLE
epipen rework (partial alternative to #3898)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -305,13 +305,13 @@
   - type: SolutionContainerManager
     solutions:
       pen:
-        maxVol: 20 # goobstation
+        maxVol: 15 # Goobstation
         reagents:
-        - ReagentId: Tirimol # Goobstation
-          Quantity: 10
-        - ReagentId: Ibuprofen # Goobstation
+        - ReagentId: Epinephrine # Goobstation
           Quantity: 5
-        - ReagentId: Omnizine # Goobstation
+        - ReagentId: Atropine # Goobstation
+          Quantity: 5
+        - ReagentId: TranexamicAcid # Goobstation
           Quantity: 5
   - type: Tag
     tags:


### PR DESCRIPTION
## About the PR
emergency pens have 5u epinephrine 5u atropine and 5u tranexamic acid

## Why / Balance
partial alternative to #3898 

Atropine not only only heals in critical state, but gives a 0.75 speed debuff for the duration (longer than the epineprine is in the system due to the 0.25/s metabolisation rate). This makes the emergency medipen amazing on people gasping on the floor, while less useful in combat (and while used offensively).
While this could be used offensively, Atropine has no chance to paralyze unless there's at least 35u (SEVEN medipens), and the speed debuff is mild enough to not be too overpowered (and is much less egregious than Tirimol.

Ideally, hardsuits and some softsuits should be given protection from syringe guns and autoinjectors, but it's out of scope for this PR.

## Media
<img width="363" height="200" alt="image" src="https://github.com/user-attachments/assets/93aaf545-2925-4453-b139-cb46e6a73995" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Emergency Medipens now contain 5u Atropine, Epinephrine, and Tranexamic Acid.
