### PR TITLE
Moth antennae (head, top) marking limit increase

### DIFF
--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -88,7 +88,7 @@
       points: 1
       required: false
     HeadTop:
-      points: 2
+      points: 6
       required: true
       defaultMarkings: [ MothAntennasDefault ]
     HeadSide:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Very simple change, increases the moth antennae marking limit (top, head) from two (2) to six (6), just as we had it pre-rebase.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
1. It used to be this way prior to the rebase,
2. Why shouldn't we allow more options to make new pretty antennae from our options to our players? A higher limit means more options for mixing and matching existing markings to make your moth's antennae look way cooler.
3. I am sure that I am not the only pre-rebase player who made their characters antennae consist of at least 3 markings, so this makes the characters look the way they were supposed to.
(I opted for 6 rather than 3 for the limit just in case someone used more than 3 markings and so the limit wouldn't have to be increased AGAIN in the future. Besides like I said, it used to be exactly 6 in the past.)
## Technical details
<!-- Summary of code changes for easier review. -->
Your honor, it's all yamlmaxxing :3c
(literally one number change lol)
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
JUST IN CASE:
<img width="696" height="373" alt="Zrzut ekranu 2025-08-27 154523" src="https://github.com/user-attachments/assets/d891ca20-f0f8-4f5b-ab84-0a20ec9a87b8" />
<img width="912" height="459" alt="Zrzut ekranu 2025-08-27 154540" src="https://github.com/user-attachments/assets/20ce10ab-28eb-4e6b-9bc8-d6172a61bfcb" />
<img width="64" height="70" alt="Zrzut ekranu 2025-08-27 154724" src="https://github.com/user-attachments/assets/8996a499-0f31-41a7-8376-67db0a1cd09a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Increased the moth antennae marking limit (head, top) from two (2) to six (6)!
