### PR TITLE
fix abductor + bingle goidacode

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Markers/Spawners/bingle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Markers/Spawners/bingle.yml
@@ -24,8 +24,7 @@
     rules: ghost-role-information-bingle-rules
     mindRoles:
     - MindRoleGhostRoleTeamAntagonist
-    raffle:
-      settings: default
+    raffle: null # no raffle for spammed role fuck you
   - type: GhostRoleMobSpawner
     prototype: MobBingle
   - type: Sprite

--- a/Resources/Prototypes/_Shitmed/Actions/abductor.yml
+++ b/Resources/Prototypes/_Shitmed/Actions/abductor.yml
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Actions
 - type: entity
-  parent: BaseAction
+  parent: BaseMentalAction
   id: ActionExitConsole
   name: Exit console
   description: Exit console.
@@ -20,7 +20,7 @@
     event: !type:ExitConsoleEvent
 
 - type: entity
-  parent: BaseAction
+  parent: BaseMentalAction
   id: ActionSendYourself
   name: Send yourself
   description: You need to FTL to the same map as the station to use this ability!


### PR DESCRIPTION
## About the PR
- fix abductors not being able to do anything
- remove raffle from bingle its a fucking spam role like carp
  bingle eye is probably unaffected

shitcode was using the wrong parent so eye could never use actions

## Media
<img width="220" height="173" alt="08:41:04" src="https://github.com/user-attachments/assets/2c5ef18d-9850-4543-8c72-05d864e48ee0" />
<img width="307" height="211" alt="08:41:14" src="https://github.com/user-attachments/assets/d72a4a41-1849-47f4-b0e8-d24aee13a6c0" />
<img width="105" height="115" alt="08:41:19" src="https://github.com/user-attachments/assets/b67be8a2-5108-41ae-ae10-77284841e41a" />
<img width="141" height="202" alt="08:41:23" src="https://github.com/user-attachments/assets/60e0c824-11a5-4840-8cf8-9fd3f4fd1cb5" />

**Changelog**
:cl:
- tweak: Removed raffle from spawned bingle ghost roles.
- fix: Fixed abductors not being able to do anything.
