### PR TITLE
military crate flat reduction change (I like Fun)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -177,7 +177,7 @@
       groups:
         Brute: 6
       types:
-        Structural: 31 #Goob
+        Structural: 30
   - type: PhysicalComposition #Goobstation - Recycle update
     materialComposition:
       Steel: 150

--- a/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
@@ -281,13 +281,13 @@
 - type: damageModifierSet
   id: StrongCrates
   coefficients:
-    Blunt: 0.5
+    Blunt: 0.8
     Slash: 0.5
-    Piercing: 0.5
-    Heat: 0.5
+    Piercing: 0.2 #alot of ammo types will be able to shoot it open but will be kind of dog at it, same with telescopic spears
+    Heat: 0.8
   flatReductions:
-    Blunt: 20
+    Blunt: 19 #lets sus toolbox + truncheon open it, was 20 before
     Slash: 20
-    Piercing: 20
-    Heat: 20
-    Structural: 30
+    Piercing: 15
+    Heat: 15 #I imagine you're melting through the armor
+    Structural: 25


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
Changed military crate flat reductions to be more dynamic and intresting (mainly reduced the flat dmg reduction on structural back down to 20 and  allows for more proper use of purchasing weapons from cargo like it was before while still not being overly free (baseball bats cant open it, a pickaxe can) 

## NUMBERS 
(FEEL FREE TO SKIP SECTION NOT ALLAT IMPORTANT TBH)

It took 11 shotgun SLUGS to break the secure military crate 
15 .30 rifle shots
Nearly two lecter magazines, .20 rifle gun
And a frankly ridicilus 8 and a half smg magazines for .35 rounds

it takes 28 spear throws (a regular ass spear) to fully break open an smg crate, the doafter to remove a spear from an embedded object takes ~3 seconds 
Thats a minute 24 seconds spent just removing spears from the crate or about 2 mins total i imagine. 
It took 12 telescopic spear throws to break the crate, i think this speaks to how overtuned spear throwing damage is (and in general this spear is as good as the plasma spear while also being more compact AND printable for 2.5 glass and 1 steel , yummy sec balancing, i think making it do 12 dmg (on par with regular spear) would make it respectable and make sec meele balancing make more sense, personally, unrelated, however) 

Took 4 full valleys from antique laser
Eshotty wasnt able to break it
hos's structural mode on his gun breaks it one shot anyway so this pr didnt even affect that lmao 

## DISCUSSION

I think its fine balancing wise that we let pickaxes open secure crates given that to get a pickaxe you can either go to lavaland and nab a seismic charge or get access to cargos techfab to print a sci unlock (AS IS) which is harder, actually, assuming you arent cargo yourself.

This ideally will not affect crew validhunting all that much, given you can just wait for sci, which will have stuff like diamond tipped drills or exosuit drills resarched by the time you have the money to buy guns or really any want to do so. Even then, from roundstart you still have several options, mainly including spears holy fuck spears are busted for opening crates.

## Technical details
Yml

(unrelated commentary)
The flat reduction system can feel overly limiting to design for, because a weapon that may deal more overall damage (for example, a baseball bat or shotgun spread), it does not pass the flat reduction due to the way it deals damage (in these examples, being split up in multiple damage types or in multiple instances of one larger attack) 

## Media
Tested, works 

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


**Changelog**
:cl:
- tweak: More things can now bust open military crates, pickaxes, .30 rounds and any laser that does over 15 damage being the main new crate busters.