### PR TITLE
Balance Suggestion - Some species don't have bones, so they can't be broken.

### DIFF
--- a/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Bones.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Bones.cs
@@ -39,7 +39,6 @@ public partial class TraumaSystem
     private static readonly HashSet<string> _boneImmuneSpecies = new()
     {
         "SlimePerson",
-        "Plasmaman",
         "IPC",
     };
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Adds a check for specific species (which can be added, removed easily in a single file).
Which disables the entire bone damage mechanics on them. 

## Why / Balance
I don't see how you can break a slime person's bones when they have none, they are a walking slime - I've added IPC's technically have no bones.

## Technical details
Within TraumaSystem.Bones.cs I've added field for adding species names such as "SlimePerson"
` 
    private static readonly HashSet<string> _boneImmuneSpecies = new()
    {
        "SlimePerson",
        "IPC",
    };
`
along checks inside the code for if a _boneImmuneSpecies is true that it skips it.

## Media

https://github.com/user-attachments/assets/5afeb666-1f56-426d-9097-a645f3388171
(Video is after I've beaten them up with a hammer to the chest, this is before I've removed the plasmaman.)



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Richard Blonski
- tweak: Slime People and IPC's are now immune to bone damage.

