### PR TITLE
Make Smoking Great Again

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/cigar.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigars/cigar.yml
@@ -73,6 +73,9 @@
     equippedPrefix: unlit
   - type: Item
     size: Tiny
+  - type: Tag
+    tags:
+      - Cigarette #Goobstation - whitelisted cig pack strorage (added tag)
 
 - type: entity
   id: CigarGoldSpent

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
@@ -62,7 +62,7 @@
         maxVol: 25
         reagents:
           - ReagentId: Nicotine
-            Quantity: 10
+            Quantity: 13
 
 - type: entity
   parent: BaseSmokable

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
@@ -59,7 +59,7 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 20
+        maxVol: 25
         reagents:
           - ReagentId: Nicotine
             Quantity: 10

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
@@ -62,7 +62,7 @@
         maxVol: 25
         reagents:
           - ReagentId: Nicotine
-            Quantity: 13
+            Quantity: 15
 
 - type: entity
   parent: BaseSmokable

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -307,6 +307,9 @@
   - type: UseDelay
   - type: IgnitionSource
     ignited: false
+  - type: Tag
+    tags:
+      - Lighter #Goobstation - whitelisted cig pack strorage (added tag)
 
 - type: entity
   name: flippo engraved lighter

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/lighters.yml
@@ -97,3 +97,6 @@
   - type: UseDelay
   - type: IgnitionSource
     ignited: false
+  - type: Tag
+    tags:
+      - Lighter #Goobstation - whitelisted cig pack strorage (added tag)


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
You can stick Zippos in Cigarette Boxes again.
Also you can now specifically insert premium Havanian cigar's into them too
Also increased cigarette burn time by 20%

## Why / Balance
I don't need a good reason for the flippo because um it's not really that deep
<img width="780" height="520" alt="image" src="https://github.com/user-attachments/assets/91177385-519a-4db3-a643-aec3c0ab815f" />

Also some of us like to find a premium cigar for evac, don't think we need to wring hands about smokers finding efficient methods of inventory management

Finally it's become too easy to smoke a full pack in a single shift, Nanotrasen's Anaerobic Health department suggests only smoking 8 cigarettes per shift and instead sharing spares with tiders, the clown and any aliens you find in maints

## Technical details
In the time between thinking of doing this, making the changes and creating this PR I have been fiending for a cigarette. Which I will now go for

## Media
<img width="236" height="315" alt="image" src="https://github.com/user-attachments/assets/09ea7151-43c0-4d1a-8482-1984a46fdafb" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Flippos can be inserted into cigarette packs again
- tweak: Premium Havanian cigar's can also be inserted into cigarette packs again
- tweak: Cigarettes burn 20% slower now
- fix : Made smoking cool again
