### PR TITLE
Fix Shadowkin's having no visible left leg

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Species/shadowkin.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Species/shadowkin.yml
@@ -149,10 +149,10 @@
       - map: ["enum.HumanoidVisualLayers.LArm"]
       - map: ["enum.HumanoidVisualLayers.RLeg"]
       - map: ["enum.HumanoidVisualLayers.LLeg"]
-#      shader: StencilClear
-#      sprite: Mobs/Species/Human/parts.rsi
-#      state: l_leg
-        shader: StencilMask
+      - shader: StencilClear
+        sprite: Mobs/Species/Human/parts.rsi
+        state: l_leg
+      - shader: StencilMask
       - map: ["enum.HumanoidVisualLayers.StencilMask"]
         sprite: Mobs/Customization/masking_helpers.rsi
         state: full
@@ -248,9 +248,9 @@
         - map: ["enum.HumanoidVisualLayers.LArm"]
         - map: ["enum.HumanoidVisualLayers.RLeg"]
         - map: ["enum.HumanoidVisualLayers.LLeg"]
-#     - shader: StencilClear
-#      sprite: Mobs/Species/Human/parts.rsi
-#      state: l_leg
+        - shader: StencilClear
+          sprite: Mobs/Species/Human/parts.rsi
+          state: l_leg
         - shader: StencilMask
           map: ["enum.HumanoidVisualLayers.StencilMask"]
           sprite: Mobs/Customization/masking_helpers.rsi


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
Gave shadowkins back their left leg (at least visibly) 

Fixes #3872 

## Why / Balance
Idk what was going on in that marking's PR but for some reason StencilClear was commented out and StencilMask wasn't properly formatted so shadowkin sprites just stopped showing their left legs. 

Also [ummmmmmmmmmmmmmmm](https://github.com/space-wizards/space-station-14/pull/12217#issuecomment-1291677115)

## Media
<img width="276" height="306" alt="image" src="https://github.com/user-attachments/assets/39d6984a-f421-4805-b84d-dadfc71e3b99" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

:cl:
- fix: Shadowkin Left Legs are visible again

