### PR TITLE
fix coscult stuff being instantly rcdable away

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/Tileset/walls.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Tileset/walls.yml
@@ -13,7 +13,6 @@
     sprite: _DV/CosmicCult/Tileset/cosmicwall.rsi
   - type: Icon
     sprite: _DV/CosmicCult/Tileset/cosmicwall.rsi
-  - type: RCDDeconstructable
   - type: Destructible
     thresholds:
     - trigger:
@@ -122,7 +121,6 @@
     snap:
     - Wall
   components:
-  - type: RCDDeconstructable
   - type: CosmicCultExamine
     cultistText: cosmic-examine-text-forthecult
   - type: Sprite


### PR DESCRIPTION
fix that was never ported here so you were just able to instantly rcd deconstruct everything
since it had 0 time

:cl:
- fix: Fixed being able to RCD away cosmic cult walls and windows instantly.