### PR TITLE
fix mousebites "stunlock" when crit

### DIFF
--- a/Resources/Prototypes/_Goobstation/Reagents/fun.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/fun.yml
@@ -83,6 +83,12 @@
         conditions:
         - !type:ReagentThreshold
           min: 9
+      - !type:AdjustReagent
+        reagent: Carpolin
+        amount: -10
+        conditions:
+        - !type:ReagentThreshold
+          min: 9 # keep it the same as above
       - !type:PopupMessage
         type: Local
         messages: [ "reagent-popup-carpolin" ]

--- a/Resources/Prototypes/_Goobstation/Reagents/narcotics.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/narcotics.yml
@@ -370,6 +370,12 @@
         conditions:
         - !type:ReagentThreshold
           min: 50 # raised because mouse retaliation is now a thing
+      - !type:AdjustReagent
+        reagent: MouseBites
+        amount: -20
+        conditions:
+        - !type:ReagentThreshold
+          min: 50 # keep it the same as above
       - !type:PopupMessage
         conditions:
         - !type:ReagentThreshold


### PR DESCRIPTION
added the thing weh juice has where it removes the reagent

this fixes transforming back into a mouse 1000 times because your original body doesnt metabolize in nullspace

same for carpolin

:cl:
- fix: Going crit as a transformed mouse/carp no longer "stunlocks" you by transforming over and over.