### PR TITLE
Balance: Decrease Devil spawn frequency (20~% → 10~%)

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -161,7 +161,7 @@
     - id: Heretic # goob edit
       prob: 0.2
     - id: Devil # Goob
-      prob: 0.1
+      prob: 0.05
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -20,7 +20,7 @@
   weights:
     # subgamemodes
     Thief: 0.2
-    Devil: 0.1
+    Devil: 0.05
     # normal
     Traitor: 0.25
     Changeling: 0.10
@@ -51,7 +51,7 @@
   id: SecretPlusChaos
   weights:
     Thief: 0.2
-    Devil: 0.1
+    Devil: 0.02
     Traitor: 0.25
     Changeling: 0.10
     Heretic: 0.11


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->


## About the PR
Previously, Devils had a 10% spawn rate at round start and an additional 10% chance as a sub-game mode.
This PR reduces both chances to 5% each, resulting in an overall ~10% chance per round.

## Why / Balance
**Devils currently appear too frequently.**
With the old rates, Devils were showing up almost every third round, which makes them feel less like a rare antagonist and more like a common occurrence.

**Roleplay & gameplay impact.**
Devils are often played in a crew-aligned manner, despite being antagonists. This reduces the variety and tension that proper antagonists are meant to provide. Lowering their spawn rate helps ensure more diverse antagonist experiences.

**Security interaction.**
Security rarely prioritizes devils, since they are not an immediate threat compared to other antagonists. Most of the time, devils only provide buffs in exchange for contracts, which is less engaging from a conflict perspective.

**Balance through rarity.**
Reducing their frequency makes devil rounds feel more unique and special, while giving other antagonist types more room to appear and influence the round.





## Technical details
Changed SecretPlus & RoundStart devil spawn rate values to `0.05` (5%)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Richard Blonski
- tweak: Devils are less likely to spawn.

