### PR TITLE
Shitmed trauma resistance system + Slime People immune to bone damage

### DIFF
--- a/Content.Shared/_Shitmed/Surgery/Traumas/Components/TraumaResistanceComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Components/TraumaResistanceComponent.cs
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+// SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Goobstation.Maths.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Shitmed.Medical.Surgery.Traumas.Components;
+
+/// <summary>
+/// Component that defines species-specific trauma resistances and modifiers.
+/// This allows different species to have different susceptibilities to various trauma types.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TraumaResistanceComponent : Component
+{
+    /// <summary>
+    /// Multiplier for bone damage chance.
+    /// 0 = completely immune to bone damage
+    /// 1 = normal bone damage chance
+    /// >1 = increased bone damage chance
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 BoneDamageMultiplier { get; set; } = 1.0;
+
+    /// <summary>
+    /// Multiplier for dismemberment chance.
+    /// 0 = completely immune to dismemberment
+    /// 1 = normal dismemberment chance
+    /// >1 = increased dismemberment chance
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 DismembermentMultiplier { get; set; } = 1.0;
+
+    /// <summary>
+    /// Multiplier for organ damage chance.
+    /// 0 = completely immune to organ damage
+    /// 1 = normal organ damage chance
+    /// >1 = increased organ damage chance
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 OrganDamageMultiplier { get; set; } = 1.0;
+
+    /// <summary>
+    /// Multiplier for nerve damage chance.
+    /// 0 = completely immune to nerve damage
+    /// 1 = normal nerve damage chance
+    /// >1 = increased nerve damage chance
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 NerveDamageMultiplier { get; set; } = 1.0;
+
+    /// <summary>
+    /// Maximum dismemberment chance cap for this species.
+    /// This overrides the global maximum if set to a value other than -1.
+    /// values other than -1 = chance aka 0.8 = 80% chance
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 MaxDismembermentChance { get; set; } = -1;
+
+    /// <summary>
+    /// Whether this species is completely immune to bone damage.
+    /// This is a convenience property that sets BoneDamageMultiplier to 0.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool BoneDamageImmune { get; set; } = false;
+}

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Bones.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Bones.cs
@@ -183,6 +183,16 @@ public partial class TraumaSystem
         if (!Resolve(boneEnt, ref boneComp))
             return false;
 
+        // Check for trauma resistance on the body
+        var bodyPart = Comp<BodyPartComponent>(woundable);
+        if (bodyPart.Body.HasValue && TryComp<TraumaResistanceComponent>(bodyPart.Body.Value, out var traumaResistance))
+        {
+            if (traumaResistance.BoneDamageImmune || traumaResistance.BoneDamageMultiplier <= 0)
+                return false;
+            
+            inflicterSeverity *= traumaResistance.BoneDamageMultiplier;
+        }
+
         if (_net.IsServer)
             AddTrauma(boneEnt, woundable, inflicter, TraumaType.BoneDamage, inflicterSeverity);
 

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Data.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Data.cs
@@ -51,5 +51,10 @@ public partial class TraumaSystem
         { WoundableSeverity.Severed, 0 },
     };
 
+    /// <summary>
+    /// Default maximum dismemberment chance cap. Can be overridden by species-specific components.
+    /// </summary>
+    private readonly FixedPoint2 _defaultMaxDismembermentChance = 0.7;
+
     #endregion
 }

--- a/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Process.cs
+++ b/Content.Shared/_Shitmed/Surgery/Traumas/Systems/TraumaSystem.Process.cs
@@ -378,6 +378,10 @@ public partial class TraumaSystem
         if (!bodyPart.Body.HasValue)
             return false; // Can't sever if already severed
 
+        // Slime people are immune to bone damage
+        if (bodyPart.Species == "SlimePerson")
+            return false;
+
         var bone = target.Comp.Bone.ContainedEntities.FirstOrNull();
 
         if (bone == null || !TryComp<BoneComponent>(bone, out var boneComp))

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -198,6 +198,14 @@
           32:
             sprite: Mobs/Species/Human/displacement.rsi
             state: jumpsuit-female
+  - type: TraumaResistance ## Goobstation - shitmed start
+    boneDamageImmune: true
+    boneDamageMultiplier: 0.0
+    dismembermentMultiplier: 1.5
+    maxDismembermentChance: 0.8 # 80%
+    organDamageMultiplier: 1.0
+    nerveDamageMultiplier: 1.0
+    ## Goobstation - shitmed end
 
 - type: entity
   parent: MobHumanDummy

--- a/Resources/Prototypes/Entities/Mobs/Species/trauma_resistance_examples.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/trauma_resistance_examples.yml
@@ -1,0 +1,76 @@
+# Example configuration for species trauma resistance
+# This file demonstrates how to use the TraumaResistanceComponent
+
+# Example for slime people - completely immune to bone damage
+- type: entity
+  parent: BaseMobHuman
+  id: ExampleMobHumanSlimePerson
+  name: slime person
+  description: A gelatinous humanoid creature.
+  components:
+  - type: TraumaResistance
+    # Slime people are completely immune to bone damage (they have no bones!)
+    boneDamageImmune: true
+    boneDamageMultiplier: 0.0
+
+    # They are more resistant to dismemberment due to their gelatinous nature
+    dismembermentMultiplier: 0.3
+    maxDismembermentChance: 0.4  # Lower maximum chance than default 0.7
+
+    # Normal susceptibility to organ and nerve damage
+      maxChance: 0.8 # 80%
+﻿
+
+# Example for dwarves - sturdy and resistant
+- type: entity
+  parent: BaseMobHuman
+  id: ExampleMobHumanDwarf
+  name: dwarf
+  description: A sturdy, short humanoid.
+  components:
+  - type: TraumaResistance
+    # Dwarves have stronger bones
+    boneDamageMultiplier: 0.7
+
+    # More resistant to dismemberment due to their sturdy build
+    dismembermentMultiplier: 0.8
+
+    # Normal organ and nerve damage
+    organDamageMultiplier: 1.0
+    nerveDamageMultiplier: 1.0
+
+# Example for moths - fragile and vulnerable
+- type: entity
+  parent: BaseMobHuman
+  id: ExampleMobHumanMoth
+  name: moth person
+  description: A fragile, winged humanoid.
+  components:
+  - type: TraumaResistance
+    # Moths are more fragile
+    boneDamageMultiplier: 1.3
+    dismembermentMultiplier: 1.4
+    maxDismembermentChance: 0.8  # Higher maximum chance
+
+    # More susceptible to all trauma types
+    organDamageMultiplier: 1.2
+    nerveDamageMultiplier: 1.1
+
+# Example for dionae - extremely resistant to physical trauma
+- type: entity
+  parent: BaseMobHuman
+  id: ExampleMobHumanDiona
+  name: diona
+  description: A plant-like humanoid creature.
+  components:
+  - type: TraumaResistance
+    # Plant-like structure makes them resistant to bone damage
+    boneDamageMultiplier: 0.4
+
+    # Very resistant to dismemberment (can regrow parts)
+    dismembermentMultiplier: 0.2
+    maxDismembermentChance: 0.3
+
+    # Different organ structure, more resistant
+    organDamageMultiplier: 0.6
+    nerveDamageMultiplier: 0.8

--- a/Resources/ServerInfo/Guidebook/Mobs/SlimePerson.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/SlimePerson.xml
@@ -35,4 +35,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
   They take [color=#1e90ff]40% less Blunt damage and 20% less Poison damage[/color], but [color=#ffa500]50% more Cold damage, 20% more Slash damage and 20% more Piercing damage[/color].
 
+  They cannot [color=#1e90ff]suffer bone damage[/color] because their bodies are entirely made of slime, but are [color=#ffa500]1.5x more likely to be dismembered[/color]. <!-- Goobstation, shitmed -->
+
 </Document>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
This PR introduces a new **Shitmed component**: **Trauma Resistances** ✨  

The Trauma Resistance system allows species to define custom modifiers for trauma effects such as:  
- Multiplier for bone damage chance  
- Multiplier for limb dismemberment chance  
- Multiplier for organ damage chance  
- Multiplier for nerve damage chance  
- Maximum dismemberment chance cap (default: 70%)  
- Toggle for full immunity to bone damage  

These values are configurable in each species’ `.yml` file.  
For this PR, the system has only been applied to **Slime People** (`slime.yml`).  

## Why / Balance
This system gives maintainers and contributors fine-grained control over how trauma affects each species, opening the door to more nuanced balance changes.  

For this initial implementation:  
- **Slime People** are now completely immune to bone damage, as they are made of slime.  
- To balance this, they are **1.5× more likely to be dismembered**.  

## Technical details
- Added `TraumaResistanceComponent.cs` to Shitmed (fully documented).  
- Integrated the system into **Slime People** (`slime.yml`):  
  - `immuneToBoneDamage = true`  
  - `dismembermentMultiplier = 1.5`  
  - `maxDismembermentChance = 0.8` (80%)  
- Created `trauma_resistance_example.yml` as a template for future contributors.  
- Updated `TraumaSystem.Bones.cs` to respect Trauma Resistances.  
- Added `_defaultMaxDismembermentChance` to `TraumaSystem.Data.cs`.  
- Updated `TraumaSystem.Process.cs` to ensure Trauma Resistances are calculated properly. 

Species without trauma resistance values defined will continue to behave normally.  

## Media
Warning GORE 😱!!!

https://github.com/user-attachments/assets/9fa49e6e-70ed-4aee-940e-f6c183d646f5



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Richard Blonski
- add: New Shitmed component for trauma resistances (bone, limb, organ, nerve damage).  
- tweak: Slime People are now immune to bone damage, but are 1.5× more likely to be dismembered.  

