### PR TITLE
[HOTFIX} Fixes time clause.

### DIFF
--- a/Content.Goobstation.Server/Devil/CheatDeath/CheatDeathSystem.cs
+++ b/Content.Goobstation.Server/Devil/CheatDeath/CheatDeathSystem.cs
@@ -71,7 +71,7 @@ public sealed partial class CheatDeathSystem : EntitySystem
     private void OnDelayedDeath(Entity<CheatDeathComponent> ent, ref DelayedDeathEvent args)
     {
         if (args.PreventRevive)
-            RemComp(ent.Owner, ent.Comp);
+            RemCompDeferred(ent.Owner, ent.Comp);
     }
 
 

--- a/Content.Server/_Shitmed/DelayedDeath/DelayedDeathSystem.cs
+++ b/Content.Server/_Shitmed/DelayedDeath/DelayedDeathSystem.cs
@@ -59,7 +59,7 @@ public partial class DelayedDeathSystem : EntitySystem
                 }
 
                 if (!string.IsNullOrWhiteSpace(comp.DeathMessageId)) // Goobstation
-                    _popupSystem.PopupEntity(Loc.GetString(comp.DeathMessageId), ent, PopupType.LargeCaution);
+                    _popupSystem.PopupEntity(Loc.GetString(comp.DeathMessageId), ent, ent, PopupType.LargeCaution);
             }
         }
     }
@@ -69,7 +69,7 @@ public partial class DelayedDeathSystem : EntitySystem
         // can't defib someone without a heart or brain pal
         args.Cancel();
 
-        var failPopup = Loc.GetString(ent.Comp.DeathMessageId); // Goobstation
+        var failPopup = Loc.GetString(ent.Comp.DefibFailMessageId); // Goobstation
         _chat.TrySendInGameICMessage(args.Defib, failPopup, InGameICChatType.Speak, true);
     }
 }

--- a/Resources/Prototypes/_Goobstation/Devil/clauses.yml
+++ b/Resources/Prototypes/_Goobstation/Devil/clauses.yml
@@ -218,5 +218,6 @@
   clauseWeight: 150
   addedComponents:
   - type: DelayedDeath
+    preventAllRevives: true # :trol:
     deathTime: 300
     deathMessageId: devil-deal-time-ran-out


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Fixes #3998 

## Why / Balance
Fixes #3998 

## Technical details
Put the wrong locale in a place and forgot a bool.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed the "Time" clause not working properly.
