### PR TITLE
Wideswing baton users given a pity buff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -182,10 +182,10 @@
     angle: 0
     animation: WeaponArcThrust
   # it was ~35 now it's 55 so it's a buff ig
-  - type: StaminaDamageOnHit # goob edited
+  - type: StaminaDamageOnHit # goob edited - Give Wideswingers a tiny bit of pity
     damage: 5
-    overtime: 1
-    lightAttackOvertimeDamageMultiplier: 50
+    overtime: 25
+    lightAttackOvertimeDamageMultiplier: 2
     sound: /Audio/Weapons/egloves.ogg
   - type: DelayedKnockdownOnHit # Goobstation
     useDelay: stunbaton

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/blueshield.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/blueshield.yml
@@ -71,8 +71,8 @@
       path: /Audio/_Goobstation/Weapons/Effects/metalcrush.ogg
   - type: StaminaDamageOnHit
     damage: 5
-    overtime: 1
-    lightAttackOvertimeDamageMultiplier: 50
+    overtime: 25
+    lightAttackOvertimeDamageMultiplier: 2.3 # Why the fuck was the one of a kind baton given the same stunbaton stats as a batong
     sound: /Audio/Weapons/egloves.ogg
   - type: LandAtCursor
   - type: Battery


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Armok's tendency to be heavy handed must be studied. 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Light Attacks are still superior but wideswing stunbaton usage now isn't a literal battery burner for zero purpose.
BSO mace given a tiny bit more stamina damage overtime, because why was it just a basebatong bruhhhh
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Read the yaml, do the math. 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 
- tweak: Stunbaton wideswing damage buffed to not be entirely useless, spriteclicking is still superior. 
- tweak: GreatShield Mace given minor staminadamage buff. 