### PR TITLE
Update: Adding Surgery Tools & Nitrous Oxide (Sleep tank) to medical equipment.

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -153,6 +153,7 @@
       - id: ClothingMaskSterile # Goobstation
       - id: BoneGel # Shitmed Change
       - id: MedicalStitches # Shitmed Change
+      - id: ClothingMaskBreath # Goobstation
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicateMedicalBundle

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -99,6 +99,7 @@
       - id: BoxLatexGloves
       - id: BoxSterileMask
       - id: NitrousOxideTankFilled # Goobstation
+      - id: ClothingMaskBreath # Goobstation
 
 - type: entity
   id: CrateMedicalScrubs

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -98,6 +98,7 @@
       - id: MedicalStitches
       - id: BoxLatexGloves
       - id: BoxSterileMask
+      - id: NitrousOxideTankFilled # Goobstation
 
 - type: entity
   id: CrateMedicalScrubs

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -405,6 +405,8 @@
     - id: RapidSyringeGun
     - id: BoxSyringePax
     - id: ClothingBeltMilitaryWebbingCMOFilled
+    - id: NitrousOxideTankFilled
+    - id: ClothingBackpackDuffelSurgeryFilled
     # Shitmed
     - id: MedicalBiofabricatorFlatpack
     # Goobstation End

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -405,7 +405,6 @@
     - id: RapidSyringeGun
     - id: BoxSyringePax
     - id: ClothingBeltMilitaryWebbingCMOFilled
-    - id: NitrousOxideTankFilled
     - id: ClothingBackpackDuffelSurgeryFilled
     # Shitmed
     - id: MedicalBiofabricatorFlatpack

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -120,6 +120,7 @@
     VehicleWheelchairFolded: 3
     FoodSnackLollypopWrappedMystery: 10
     FoodSnackLollypopWrappedTricordrazine: 8
+    NitrousOxideTankFilled: 2
   emaggedInventory:
     FoodSnackLollypopWrappedLexorin: 3
     FoodSnackLollypopWrappedMysteryEvil: 5 # Goobstation - end


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->


## About the PR
This PR seeks to resolve the issue that some maps might miss, medical equipment such as the sleeping gas (Nitrous Oxide), by just having them included inside the lockers/crates.

## Why / Balance
The Medical department should always come packed with Nitrous Oxide & backup surgery tools (in CMO's locker).
Some mappers sometimes forget to add those.

## Technical details
- `Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml` added 2x Nitrous Oxide tanks to the machine as backup.
- `Resources/Prototypes/Catalog/Fills/Lockers/heads.yml` added a filled surgery duffel bag into CMO's Locker as backup.
- `Resources/Prototypes/Catalog/Fills/Crates/medical.yml` added to the surgical supplies crate a Nitrous Tank and a breath mask
- `Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml` added a breath mask to the surgery duffelbag.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Media
<img width="616" height="511" alt="image" src="https://github.com/user-attachments/assets/44e95a63-4126-45a2-90de-bfa586f737ce" />

<img width="774" height="597" alt="image" src="https://github.com/user-attachments/assets/8e80cd6d-faf1-47db-8fb0-5e9586f20a93" />

<img width="881" height="608" alt="image" src="https://github.com/user-attachments/assets/bd6293c8-0a12-4d8c-913c-0c71e395f099" />


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Richard Blonski
- add: Nitrous Oxide tanks are now in the medical vendor.
- add: The CMO's locker now comes equipped with an extra surgery duffle bag.
- add: Surgery Crates now have a Nitrous Oxide tank and a breath mask included.
