### PR TITLE
[MALD PR] remove zombies from secret classic

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -48,7 +48,6 @@
     Revolutionary: 0.04
     RevTraitor: 0.01
     RevLing: 0.03
-    Zombie: 0.03
     Survival: 0.03
     Blob: 0.04
     Wizard: 0.25 # TEMP INCREASE FROM 10


### PR DESCRIPTION
its not even a gamemode its just dogshit from 6 years ago when there was just traitor and nothing else

absolute dogshit just ruins rounds for anyone wanting to do gimmicks and its terrible for the IIs because some shitter just turns in the bar immediately, you can't even plan anything good

:cl:
- remove: Removed zombies from secret classic.