### PR TITLE
Fixes: NTR Report missing the science department

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/paper/station-report.ftl
+++ b/Resources/Locale/en-US/_Goobstation/paper/station-report.ftl
@@ -14,6 +14,8 @@ station-report-text =
     >[mono][/mono]
     • [bold]Medical Departmental Report[/bold]
     >[mono][/mono]
+    • [bold]Science Departmental Report[/bold]
+    >[mono][/mono]
     • [bold]Service Departmental Report[/bold]
     >[mono][/mono]
     • [bold]Silicon Report[/bold]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->


## About the PR
This PR edits the `Resources/Locale/en-US/_Goobstation/paper/station-report.ftl` and adds the science department to the list.

## Why / Balance
The Science department was missing
https://discord.com/channels/1202734573247795300/1413996730671693854

## Technical details
Edited ``Resources/Locale/en-US/_Goobstation/paper/station-report.ftl``

## Media
<img width="911" height="829" alt="image" src="https://github.com/user-attachments/assets/0df22ab1-c3ef-405c-a3d1-09829fefa209" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Richard Blonski
- fix: The NTR Station Report now includes the science department by default.