### PR TITLE
[MALD] Disable Revenant from being able to spawn.

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -509,7 +509,7 @@
   id: RevenantSpawn
   components:
   - type: StationEvent
-    weight: 3.5
+    weight: 0 # Disables Revenant spawn - fuck Revenants!
     duration: 1
     earliestStart: 30
     minimumPlayers: 20

--- a/Resources/Prototypes/_Goobstation/GameRules/Admeme/token.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/Admeme/token.yml
@@ -66,6 +66,7 @@
     prototype: MobRevenantToken
   - type: StationEvent
     isSelectable: false
+    weight: 0 # This will prevent it from being selected - fuck revenants
 
 - type: entity
   parent: LoneOpsSpawn


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## About the PR
This PR disables Revenant from spawning by setting all of its spawn weights to **0**.

## Why / Balance
The Revenant is a mid-round antagonist that can appear via chaos events or be selected with antagonist tokens. 
While it can be fun for the Revenant player, the gameplay experience for everyone else especially the victims is overwhelmingly negative.

The core problem is that Revenants rarely create engaging, interactive gameplay. Instead, they spend most of their time harassing players with little meaningful counterplay. This is especially punishing for the medical department, which Revenants disproportionately target due to the concentration of vulnerable bodies and soul energy.

Common scenarios include:
- Revenants camping Medbay for easy farming opportunities.
- Using their AoE shocks to repeatedly incapacitate or kill everyone in the medbay.
- Effectively halting revivals and dragging out downtime for players waiting to re-enter the round.

The result is that medical becomes non-functional until someone **validhunts** the Revenant, which is both unfun for medical players and frustrating for the broader round. Instead of creating tension or interesting decision-making, the Revenant tends to stall gameplay and grief critical departments.

Removing Revenant from the spawn pool avoids these repeated negative experiences while leaving room for future antagonist design or reworks that better support dynamic gameplay.

## Technical details
- In `Resources/Prototypes/_Goobstation/GameRules/Admeme/token.yml` changed weight to 0.
- In `Resources/Prototypes/GameRules/events.yml` changed weight to 0.

## Media

<img width="457" height="390" alt="image" src="https://github.com/user-attachments/assets/41e77a1e-aae6-4a1c-bdcf-1b70d479ceec" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Richard Blonski
- remove: Disabled Revenant from being able to spawn as a mid-round antagonist.

