### PR TITLE
Xenomorph stuff

### DIFF
--- a/Content.Server/_White/Xenomorphs/FaceHugger/FaceHuggerComponent.cs
+++ b/Content.Server/_White/Xenomorphs/FaceHugger/FaceHuggerComponent.cs
@@ -43,13 +43,13 @@ public sealed partial class FaceHuggerComponent : Component
     public TimeSpan MaxInfectTime = TimeSpan.FromSeconds(20);
 
     [DataField]
-    public TimeSpan MaxRestTime = TimeSpan.FromSeconds(20);
+    public TimeSpan MaxRestTime = TimeSpan.FromSeconds(5); // Goobstation - 20 to 5. Facehuggers shouldn't take that long to recover.
 
     [DataField]
     public TimeSpan MinInfectTime = TimeSpan.FromSeconds(10);
 
     [DataField]
-    public TimeSpan MinRestTime = TimeSpan.FromSeconds(10);
+    public TimeSpan MinRestTime = TimeSpan.FromSeconds(2); // Goobstation - 10 to 2. Facehuggers shouldn't take that long to recover.
 
     [ViewVariables]
     public bool Active = true;

--- a/Content.Shared/_White/Xenomorphs/XenomorphShoveTracker/XenomorphShoveTrackerComponent.cs
+++ b/Content.Shared/_White/Xenomorphs/XenomorphShoveTracker/XenomorphShoveTrackerComponent.cs
@@ -21,13 +21,13 @@ public sealed partial class XenomorphShoveTrackerComponent : Component
     /// Duration of the knockdown effect
     /// </summary>
     [DataField]
-    public TimeSpan KnockdownDuration = TimeSpan.FromSeconds(15);
+    public TimeSpan KnockdownDuration = TimeSpan.FromSeconds(7);
 
     /// <summary>
     /// Time after which shove counts reset if no new shoves occur
     /// </summary>
     [DataField]
-    public TimeSpan ShoveResetTime = TimeSpan.FromSeconds(10);
+    public TimeSpan ShoveResetTime = TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// Dictionary tracking when each target was last shoved

--- a/Resources/Locale/en-US/_Goobstation/access/accesslevel.ftl
+++ b/Resources/Locale/en-US/_Goobstation/access/accesslevel.ftl
@@ -1,0 +1,1 @@
+id-card-access-level-xenomorph = Xenomorph

--- a/Resources/Locale/en-US/_Goobstation/collective-mind/collective-mind.ftl
+++ b/Resources/Locale/en-US/_Goobstation/collective-mind/collective-mind.ftl
@@ -14,3 +14,4 @@ collective-mind-mousemind = Piepmind
 collective-mind-dronemind = Dronemind
 collective-mind-empathy = Empathy
 collective-mind-bingle = Binglemind
+collective-mind-xeno = Hivemind

--- a/Resources/Prototypes/_Goobstation/Access/xenomorph.yml
+++ b/Resources/Prototypes/_Goobstation/Access/xenomorph.yml
@@ -3,3 +3,8 @@
     id: XenomorphAccess
     tags:
     - Xenomorph
+
+  - type: accessLevel
+    id: Xenomorph
+    name: id-card-access-level-xenomorph
+    canAddToIdCard: false

--- a/Resources/Prototypes/_Goobstation/Access/xenomorph.yml
+++ b/Resources/Prototypes/_Goobstation/Access/xenomorph.yml
@@ -2,8 +2,4 @@
   - type: accessGroup
     id: XenomorphAccess
     tags:
-      - Xenomorph
-  - type: accessGroup # Goobstation - xeno doors
-    id: XenomorphAccess
-    tags:
     - Xenomorph

--- a/Resources/Prototypes/_Goobstation/Access/xenomorph.yml
+++ b/Resources/Prototypes/_Goobstation/Access/xenomorph.yml
@@ -1,0 +1,9 @@
+
+  - type: accessGroup
+    id: XenomorphAccess
+    tags:
+      - Xenomorph
+  - type: accessGroup # Goobstation - xeno doors
+    id: XenomorphAccess
+    tags:
+    - Xenomorph

--- a/Resources/Prototypes/_Goobstation/CollectiveMind/collective_minds.yml
+++ b/Resources/Prototypes/_Goobstation/CollectiveMind/collective_minds.yml
@@ -75,3 +75,9 @@
   name: collective-mind-bingle
   keycode: 'w'
   color: "#386a9b"
+
+- type: collectiveMind
+  id: Xenomorphivemind
+  name: collective-mind-xeno
+  keycode: 'z'
+  color: "#8c3986"

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Doors/Airlocks/access.yml
@@ -108,3 +108,6 @@
       board: [ DoorElectronicsAllService ]
   - type: Wires
     layoutId: AirlockService
+
+# Xenomorph locked
+

--- a/Resources/Prototypes/_Goobstation/tags.yml
+++ b/Resources/Prototypes/_Goobstation/tags.yml
@@ -610,6 +610,9 @@
 - type: Tag
   id: WizardHat
 
+- type: Tag # These tags are NOT alphabetical!!
+  id: Xenomorph
+
 - type: Tag
   id: HudMedicalSecurity
 

--- a/Resources/Prototypes/_White/Actions/xenomorph.yml
+++ b/Resources/Prototypes/_White/Actions/xenomorph.yml
@@ -140,7 +140,7 @@
 #      - GlassLayer
 #  - type: PlasmaCostAction
 
-- type: entity
+- type: entity # Goobstation - new action
   id: ActionSpawnResinDoor
   parent: BaseAction
   name: Build a resin door (75)

--- a/Resources/Prototypes/_White/Actions/xenomorph.yml
+++ b/Resources/Prototypes/_White/Actions/xenomorph.yml
@@ -117,28 +117,52 @@
       - WallLayer
   - type: PlasmaCostAction
 
-# TODO: delete it
+# TODO: delete it # Goobstation - removed
+#- type: entity
+#  id: ActionSpawnResinMembrane
+#  parent: BaseAction
+#  name: Build a resin membrane (50)
+#  description: Secrete tough malleable resin.
+#  components:
+#  - type: Action
+#    useDelay: 1
+#    itemIconStyle: BigAction
+#    icon: { sprite: _RMC14/Structures/Xenos/xeno_resin_wall.rsi, state: membrane } # Goobstation new sprites
+#  - type: TargetAction
+#    range: 2
+#  - type: WorldTargetAction
+#    event: !type:PlaceTileEntityEvent
+#      entity: ResinMembrane
+#      length: 0.5
+#      blockedCollisionMask:
+#      - FullTileMask
+#      blockedCollisionLayer:
+#      - GlassLayer
+#  - type: PlasmaCostAction
+
 - type: entity
-  id: ActionSpawnResinMembrane
+  id: ActionSpawnResinDoor
   parent: BaseAction
-  name: Build a resin membrane (50)
+  name: Build a resin door (75)
   description: Secrete tough malleable resin.
   components:
   - type: Action
     useDelay: 1
     itemIconStyle: BigAction
-    icon: { sprite: _RMC14/Structures/Xenos/xeno_resin_wall.rsi, state: membrane } # Goobstation new sprites
+    icon: { sprite :  _RMC14/Structures/Xenos/xeno_resin_door.rsi, state: resin }
   - type: TargetAction
     range: 2
   - type: WorldTargetAction
     event: !type:PlaceTileEntityEvent
-      entity: ResinMembrane
+      entity: ResinDoor
       length: 0.5
       blockedCollisionMask:
-      - FullTileMask
+      - TableMask
       blockedCollisionLayer:
-      - GlassLayer
+      - TableLayer
+      - BulletImpassable
   - type: PlasmaCostAction
+    plasmaCost: 75
 
 # TODO: delete it
 - type: entity

--- a/Resources/Prototypes/_White/Body/Organs/Animal/xenomorph.yml
+++ b/Resources/Prototypes/_White/Body/Organs/Animal/xenomorph.yml
@@ -92,6 +92,7 @@
       damagePerSecond:
         types:
           Caustic: 20
+          Heat: 20 # Goobstation
 
 - type: entity
   parent: BaseXenomorphOrgan

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
@@ -142,8 +142,6 @@
     enabled: true
     groups:
     - XenomorphAccess
-    tags:
-    - Xenomorph
 
 
 - type: entity

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
@@ -128,12 +128,16 @@
   - type: LanguageKnowledge
     speaks:
     - Xeno
-    - XenoHivemind
+#    - XenoHivemind # Goobstation - collective mind
     understands:
     - Xeno
-    - XenoHivemind
+#    - XenoHivemind # Goobstation - collective mind
     - Hissing
     - Draconic
+  - type: CollectiveMind # Goobstation
+    defaultChannel: Xenomorphivemind
+    channels:
+    - Xenomorphivemind
   - type: SSDIndicator
   - type: Emoting
   - type: BodyEmotes

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/base.yml
@@ -10,12 +10,12 @@
   abstract: true
   components:
   - type: Xenomorph
-    weedHeal:
+    weedHeal: # Goobstation - nerfed healing
       groups:
-        Burn: -5
-        Toxin: -5
+        Burn: -2
+        Toxin: -3
         Airloss: -10
-        Brute: -5
+        Brute: -3
   - type: Pinpointer
     whitelist:
       components:
@@ -138,6 +138,12 @@
   - type: Emoting
   - type: BodyEmotes
     soundsId: GeneralBodyEmotes
+  - type: Access # Goobstation - xeno doors
+    enabled: true
+    groups:
+    - XenomorphAccess
+    tags:
+    - Xenomorph
 
 
 - type: entity

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/drone.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/drone.yml
@@ -23,7 +23,8 @@
     actions:
     - ActionTransferPlasma
     - ActionSpawnWallResin
-    - ActionSpawnResinMembrane
+#    - ActionSpawnResinMembrane
+    - ActionSpawnResinDoor
     - ActionSpawnResinNest
     - ActionSpawnResinWeedNode
   - type: VentCrawler

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/drone.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/drone.yml
@@ -23,8 +23,8 @@
     actions:
     - ActionTransferPlasma
     - ActionSpawnWallResin
-#    - ActionSpawnResinMembrane
-    - ActionSpawnResinDoor
+#    - ActionSpawnResinMembrane # Goobstation - removed
+    - ActionSpawnResinDoor # Goobstation - xeno doors
     - ActionSpawnResinNest
     - ActionSpawnResinWeedNode
   - type: VentCrawler

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/praetorian.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/praetorian.yml
@@ -18,7 +18,7 @@
   - type: TailLash
     tailDamage:
       groups:
-        Brute: 12
+        Brute: 5
     inject:
       ChloralHydrate: 5 # Goobstation - new chemical
   - type: ActionGrant

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/praetorian.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/praetorian.yml
@@ -25,7 +25,8 @@
     actions:
     - ActionTransferPlasma
     - ActionSpawnWallResin
-    - ActionSpawnResinMembrane
+#    - ActionSpawnResinMembrane
+    - ActionSpawnResinDoor 
     - ActionSpawnResinNest
     - ActionSpawnResinWeedNode
   - type: Body

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/praetorian.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/praetorian.yml
@@ -25,8 +25,8 @@
     actions:
     - ActionTransferPlasma
     - ActionSpawnWallResin
-#    - ActionSpawnResinMembrane
-    - ActionSpawnResinDoor 
+#    - ActionSpawnResinMembrane # Goobstation - removed
+    - ActionSpawnResinDoor # Goobstation - xeno doors
     - ActionSpawnResinNest
     - ActionSpawnResinWeedNode
   - type: Body

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/praetorian.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/praetorian.yml
@@ -20,7 +20,7 @@
       groups:
         Brute: 12
     inject:
-      Tirizene: 5
+      ChloralHydrate: 5 # Goobstation - new chemical
   - type: ActionGrant
     actions:
     - ActionTransferPlasma

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/queen.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/queen.yml
@@ -26,8 +26,8 @@
     actions:
     - ActionTransferPlasma
     - ActionSpawnWallResin
-#    - ActionSpawnResinMembrane
-    - ActionSpawnResinDoor
+#    - ActionSpawnResinMembrane # Goobstation - removed
+    - ActionSpawnResinDoor # Goobstation - xeno doors
     - ActionSpawnResinNest
     - ActionSpawnResinWeedNode
     - ActionSpawnXenomorphEgg

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/queen.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/queen.yml
@@ -19,7 +19,7 @@
   - type: TailLash
     tailDamage:
       groups:
-        Brute: 17
+        Brute: 5
     inject:
       ChloralHydrate: 10 # Goobstation - new chemical
   - type: ActionGrant

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/queen.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/queen.yml
@@ -21,7 +21,7 @@
       groups:
         Brute: 17
     inject:
-      Tirizene: 5
+      ChloralHydrate: 10 # Goobstation - new chemical
   - type: ActionGrant
     actions:
     - ActionTransferPlasma

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/queen.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/queen.yml
@@ -71,11 +71,11 @@
   - type: LanguageKnowledge
     speaks:
     - Xeno
-    - XenoHivemind
+#    - XenoHivemind # Goobstation - collective mind
     - TauCetiBasic
     understands:
     - Xeno
-    - XenoHivemind
+#    - XenoHivemind # Goobstation - collective mind
     - Hissing
     - Draconic
     - TauCetiBasic

--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/queen.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/queen.yml
@@ -26,7 +26,8 @@
     actions:
     - ActionTransferPlasma
     - ActionSpawnWallResin
-    - ActionSpawnResinMembrane
+#    - ActionSpawnResinMembrane
+    - ActionSpawnResinDoor
     - ActionSpawnResinNest
     - ActionSpawnResinWeedNode
     - ActionSpawnXenomorphEgg

--- a/Resources/Prototypes/_White/Entities/Structures/Doors/resin.yml
+++ b/Resources/Prototypes/_White/Entities/Structures/Doors/resin.yml
@@ -1,0 +1,93 @@
+- type: entity
+  parent: CMBaseXenoStructure
+  id: ResinDoor
+  name: resin Door
+  description: Thick resin solidified into a door.
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: InteractionOutline
+  - type: Sprite
+    sprite: _RMC14/Structures/Xenos/xeno_resin_door.rsi
+    layers:
+    - state: resin
+      map: ["enum.DoorVisualLayers.Base"]
+    - state: closed_unlit
+      map: ["enum.DoorVisualLayers.BaseUnlit"]
+    - state: closed_unlit
+      map: ["enum.DoorVisualLayers.BaseBolted"]
+  - type: AnimationPlayer
+  - type: Physics
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.49,-0.49,0.49,0.49" # don't want this colliding with walls or they won't close
+        density: 100
+        mask:
+        - FullTileMask
+        layer:
+        - AirlockLayer
+  - type: IconSmooth
+    key: walls
+    mode: NoSprite
+  - type: Door
+    canPry: false
+    crushDamage:
+      types:
+        Blunt: 15
+    openSpriteState: resinopen
+    closedSpriteState: resin
+    openingSpriteState: resinopening
+    closingSpriteState: resinclosing
+    openSound:
+      path: /Audio/_RMC14/Xeno/alien_resin_move1.ogg
+    closeSound:
+      path: /Audio/_RMC14/Xeno/alien_resin_move2.ogg
+  - type: Appearance
+  - type: Airtight
+    fixVacuum: true
+    noAirWhenFullyAirBlocked: false
+  - type: Occluder
+  - type: Damageable
+    damageContainer: Biological
+    damageModifierSet: Resin
+  - type: MeleeSound
+    soundGroups:
+      Brute:
+        collection: blood
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Blunt
+        damage: 60
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: gib
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Heat
+        damage: 25
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawnInContainer: true
+        spawn:
+          Ash:
+            min: 0
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: Airlock
+    emergencyAccessLayer: false
+    animatePanel: false
+    powered: true
+    openingSpriteState: closed_unlit
+    closingSpriteState: closed_unlit
+  - type: AccessReader
+    access: [["Xenomorph"]]
+

--- a/Resources/Prototypes/_White/Entities/Structures/Doors/resin.yml
+++ b/Resources/Prototypes/_White/Entities/Structures/Doors/resin.yml
@@ -89,5 +89,5 @@
     openingSpriteState: closed_unlit
     closingSpriteState: closed_unlit
   - type: AccessReader
-    access: [["Xenomorph"]]
+    access: [["XenomorphAccess"]]
 

--- a/Resources/Prototypes/_White/Entities/Structures/Doors/resin.yml
+++ b/Resources/Prototypes/_White/Entities/Structures/Doors/resin.yml
@@ -89,5 +89,5 @@
     openingSpriteState: closed_unlit
     closingSpriteState: closed_unlit
   - type: AccessReader
-    access: [["XenomorphAccess"]]
+    access: [["Xenomorph"]]
 

--- a/Resources/Prototypes/_White/Entities/Structures/Walls/resin.yml
+++ b/Resources/Prototypes/_White/Entities/Structures/Walls/resin.yml
@@ -24,7 +24,7 @@
     - trigger:
         !type:DamageTypeTrigger
         damageType: Blunt
-        damage: 120
+        damage: 100 # Goobstation
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -34,7 +34,7 @@
     - trigger:
         !type:DamageTypeTrigger
         damageType: Heat
-        damage: 80
+        damage: 60 # Goobstation
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawnInContainer: true

--- a/Resources/Prototypes/_White/Entities/Structures/Walls/resin.yml
+++ b/Resources/Prototypes/_White/Entities/Structures/Walls/resin.yml
@@ -24,7 +24,7 @@
     - trigger:
         !type:DamageTypeTrigger
         damageType: Blunt
-        damage: 100 # Goobstation
+        damage: 100 # Goobstation - nerfed health
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -34,7 +34,7 @@
     - trigger:
         !type:DamageTypeTrigger
         damageType: Heat
-        damage: 60 # Goobstation
+        damage: 50 # Goobstation - nerfed health
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawnInContainer: true

--- a/Resources/Prototypes/_White/GameRules/events.yml
+++ b/Resources/Prototypes/_White/GameRules/events.yml
@@ -3,7 +3,7 @@
   id: XenomorphsInfestation
   components:
   - type: StationEvent
-    weight: 5
+    weight: 7.5 # New antag I wanna be able to actually play it
     duration: null
     minimumPlayers: 20
     earliestStart: 35


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Added super weak xenomorph doors. They die to three welder hits. It's basically only good so you aren't forced to fully close off a hallway that you might need to go into

Removed xenomorph Resin Windows. They had no real use as xenomorphs have thermal vision, and screwed over the hive because you could shoot lasers through it.

Nerfed xenomorph wall health to help combat wall spamming

Nerfed xenomorph healing as it basically just made xenomorph queens immortal

Nerfed the stun. It still allows them to perma stun people but now they actually have to pay attention to who they're stunning or they could get back up in a reasonable amount of time

Facehuggers not latching to people is a huge issue so hopefully the lowered rest time will help it

Acid spit now does heat damage so the larger xeno's (Queen / Praetorians) can have an easier time breaking down resin walls. Before it would take 30~ seconds of constantly biting it

Made tail whip inject chloral hydrate as only the Queen / praetorians have it. they're the main ones that will be staying near the nests, and can't use the shove stun because of their bullet ability. Lowered the brute for the same reason as above

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added xenomorph doors. They are really extremely weak to heat so I recommend only using them for privacy
- remove: Removed xenomorph windows (There was no reason to use them and it just griefed your hive)
- tweak: Nerfed Xenomorph healing
- tweak: Nerfed Xenomorph stun
- tweak: Nerfed Xenomorph structure health
- tweak: Massively lowered the rest state for Facehuggers. They should latch to people much more often now
- tweak: Acid spit is now stronger and should be able to destroy resin walls much quicker.
- tweak: Xenomorphs are now slightly more common
- tweak: Tail whip now injects sleepy chemicals and deals less brute
- tweak: Hivemind now uses collective mind (+Z) instead of being a separate language

