### PR TITLE
nerf intercom spam

### DIFF
--- a/Content.Goobstation.Server/Speech/ListenBlacklistSystem.cs
+++ b/Content.Goobstation.Server/Speech/ListenBlacklistSystem.cs
@@ -1,0 +1,27 @@
+using Content.Goobstation.Shared.Speech;
+using Content.Server.Speech;
+using Content.Shared.Whitelist;
+
+namespace Content.Goobstation.Server.Speech;
+
+/// <summary>
+/// Handles <see cref="ListenAttemptEvent"/> for <see cref="ListenBlacklistComponent"/>.
+/// </summary>
+public sealed class ListenBlacklistSystem : EntitySystem
+{
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ListenBlacklistComponent, ListenAttemptEvent>(OnListenAttempt);
+    }
+
+    // TODO: if chat ever gets refactored move this system to shared
+    private void OnListenAttempt(Entity<ListenBlacklistComponent> ent, ref ListenAttemptEvent args)
+    {
+        if (_whitelist.IsBlacklistPass(ent.Comp.Blacklist, args.Source))
+            args.Cancel();
+    }
+}

--- a/Content.Goobstation.Shared/Speech/ListenBlacklistComponent.cs
+++ b/Content.Goobstation.Shared/Speech/ListenBlacklistComponent.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+
+namespace Content.Goobstation.Shared.Speech;
+
+/// <summary>
+/// Prevents this entity from listening to entities that match a blacklist.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ListenBlacklistComponent : Component
+{
+    /// <summary>
+    /// The blacklist the source entity gets checked against.
+    /// </summary>
+    [DataField(required: true)]
+    public EntityWhitelist Blacklist = new();
+}

--- a/Resources/Prototypes/Entities/Objects/Devices/radio.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/radio.yml
@@ -35,6 +35,10 @@
   - type: RadioSpeaker
     channels:
     - Handheld
+  - type: ListenBlacklist # Goobstation - annoying as shit
+    blacklist:
+      components:
+      - Advertise
   - type: Speech
     speechVerb: Robotic
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/intercom.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/intercom.yml
@@ -54,6 +54,10 @@
     toggleOnInteract: false
   - type: RadioSpeaker
     toggleOnInteract: false
+  - type: ListenBlacklist # Goobstation - its annoying as shit
+    blacklist:
+      components:
+      - Advertise
   - type: Intercom
   - type: Speech
     speechVerb: Robotic


### PR DESCRIPTION
intercoms and handheld radios no longer listen to anything with Advertise: vending machines, medibot (the old meta), goidabot...

:cl:
- tweak: Intercoms and radios no longer spam everything vending machines or bots say.