### PR TITLE
raider buff

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/goidabot.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/goidabot.yml
@@ -23,6 +23,11 @@
         Structural: 15
     soundHit:
       collection: MetalThud
+  - type: StaminaDamageOnHit
+    damage: 15
+  - type: MeleeThrowOnHit
+    distance: 0.5 #half as strong as a baseball bat
+    speed: 5
   - type: HTN
     rootTask:
       task: HonkbotCompound
@@ -47,6 +52,8 @@
   - type: InteractionPopup
     interactSuccessString: goida-1
     interactFailureString: goida-1
+  - type: DashAction # GOIIIIIIDAAAAAAAAAAAAA
+    actionProto: ActionDashMoth
 
 - type: localizedDataset
   id: Goida


### PR DESCRIPTION

## About the PR
gave goidabot a knockback that was half as strong as a baseball bat and some stamina damage on hit, aswell as moth 65 dash

## Why / Balance
The unrobust shall fear the strong.
makes it more fun to be a goidabot, gives you tech to beat people with skill issues should you happen to be in the rare circumstance where you're a sentient goidabot
they're relatively hard to make soooo

## Technical details
yml


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


**Changelog**
:cl: Raiders
- add: Goidabot buff

