### PR TITLE
add roundstart abductors gamemode

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/game-ticking/game-presets/abductors.ftl
+++ b/Resources/Locale/en-US/_Goobstation/game-ticking/game-presets/abductors.ftl
@@ -1,0 +1,2 @@
+abductors-title = Abductors
+abductors-description = An alien agent and scientist seek to abduct and experiment on the station's crew.

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -403,3 +403,88 @@
   - type: Tag
     tags:
     - RoundstartAntag
+
+- type: entity
+  parent: DuoAbductorSpawn
+  id: DuoAbductorRoundstart
+  components:
+  - type: StationEvent
+    earliestStart: 0 # its roundstart chud
+  # I LOVE GOIDA COPY PASTING THE ENTIRE THING
+  # this just has ghost roles removed, pref roles added and players are picked roundstart
+  - type: AntagSelection
+    selectionTime: PrePlayerSpawn
+    definitions:
+    - spawnerPrototype: AbductorScientistSpawner
+      prefRoles: [ AbductorScientistAntag ]
+      fallbackRoles: [ AbductorAgentAntag ]
+      min: 1
+      max: 1
+      pickPlayer: true
+      unequipOldGear: true
+      startingGear: AbductorScientistGear
+      briefing:
+        text: abductor-role-greeting
+        color: Green
+        sound: /Audio/_Shitmed/Misc/abductor.ogg
+      components:
+      - type: Abductor
+      - type: ActionGrant
+        actions:
+          - ActionReturnToShip
+      - type: NpcFactionMember
+        factions:
+          - SimpleHostile
+      - type: RandomMetadata
+        nameSegments:
+          - AbductorScientistPrefix
+          - AbductorNames
+        nameFormat: name-format-standard
+      - type: Tag
+        tags:
+          - Abductor
+          - AbductorScientist
+          - CanPilot
+          - FootstepSound
+          - DoorBumpOpener
+      - type: AbductorScientist
+      - type: SurgeryIgnoreClothing
+      - type: Sanitized
+      - type: SurgerySpeedModifier
+        speedModifier: 1.5
+      mindRoles:
+      - MindRoleAbductorScientist
+    - spawnerPrototype: AbductorAgentSpawner
+      prefRoles: [ AbductorAgentAntag ]
+      fallbackRoles: [ AbductorScientistAntag ]
+      min: 1
+      max: 1
+      pickPlayer: true
+      unequipOldGear: true
+      startingGear: AbductorAgentGear
+      briefing:
+        text: abductor-role-greeting
+        color: Green
+        sound: /Audio/_Shitmed/Misc/abductor.ogg
+      components:
+      - type: Abductor
+      - type: ActionGrant
+        actions:
+          - ActionReturnToShip
+      - type: NpcFactionMember
+        factions:
+          - SimpleHostile
+      - type: RandomMetadata
+        nameSegments:
+          - AbductorAgentPrefix
+          - AbductorNames
+        nameFormat: name-format-standard
+      - type: Tag
+        tags:
+          - Abductor
+          - CanPilot
+          - FootstepSound
+          - DoorBumpOpener
+      - type: AbductorScientist # Should be removed when we have proper teleportation system
+      mindRoles:
+      - MindRoleAbductorAgent

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -25,6 +25,7 @@
     Traitor: 0.25
     Changeling: 0.10
     Heretic: 0.11
+    DuoAbductorRoundstart: 0.05
     CorporateAgent: 0.025
 
 # important note: those (and above) weights aren't entirely accurate,
@@ -38,6 +39,7 @@
     Traitor: 0.25
     Changeling: 0.10
     Heretic: 0.11
+    DuoAbductorRoundstart: 0.05
     Nukeops: 0.05
     Revolutionary: 0.05
     Zombie: 0.04 # in search of how to make a rule always run alone? just tag it with LoneRunRule like zombies are

--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -244,3 +244,18 @@
   rules:
     - SecretPlusRampingMid
     - LavalandStormScheduler
+
+# survival+ but it has roundstart abductors and maybe thieves
+- type: gamePreset
+  id: Abductors
+  alias:
+  - ayylmao
+  name: abductors-title
+  description: abductors-description
+  showInVote: false
+  minPlayers: 20
+  rules:
+  - DuoAbductorRoundstart
+  - SubGamemodesRule
+  - SecretPlusRampingMid
+  - LavalandStormScheduler

--- a/Resources/Prototypes/_Shitmed/Roles/Antags/abductor.yml
+++ b/Resources/Prototypes/_Shitmed/Roles/Antags/abductor.yml
@@ -19,12 +19,32 @@
   name: abductor-agent-ghost-role-name
   antagonist: true
   objective: roles-antag-abductor-objective
+  # <Goob>
+  setPreference: true
+  guides: [ Abductors ]
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 18000 #5 hours
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 10800 #3 hours
+  # </Goob>
 
 - type: antag
   id: AbductorScientistAntag
   name: abductor-scientist-ghost-role-name
   antagonist: true
   objective: roles-antag-abductor-objective
+  # <Goob>
+  setPreference: true
+  guides: [ Abductors ]
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 18000 #5 hours
+  - !type:DepartmentTimeRequirement
+    department: Medical
+    time: 10800 #3 hours
+  # </Goob>
 
 - type: antag
   id: AbductorVictimAntag


### PR DESCRIPTION
theres an admin-only gamemode and its in secret+, same weight as nukies

opt in like every other roundstart antag

# why

i want abductor :trollface:

# media
<img width="810" height="64" alt="15:24:28" src="https://github.com/user-attachments/assets/3256b04a-ee79-42ad-80f4-b0a7e5582d74" />
<img width="524" height="485" alt="15:35:04" src="https://github.com/user-attachments/assets/54a887ed-3976-4b57-ac97-aea213f2023c" />


# changelog
:cl:
- add: Abductor duos can now be picked by Secret+ roundstart.