### PR TITLE
kill pets in loadout (partially reverts 3378)

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_Goobstation/preferences/loadout-groups.ftl
@@ -51,5 +51,3 @@ loadout-group-brigmedic-outer = Brigmedic outer clothing
 loadout-group-brigmedic-backpack = Brigmedic backpack
 
 loadout-group-security-melee = Security melee weapon
-
-loadout-group-animals = Animals

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -240,17 +240,6 @@
   - CheapSunglasses # Goobstation
 
 - type: loadoutGroup
-  id: Animals  # Goobstation
-  name: loadout-group-animals
-  minLimit: 0
-  maxLimit: 1
-  loadouts:
-  - Squackroach
-  - Mouse
-  - Mothroach
-  - Goldfish
-
-- type: loadoutGroup
   id: GroupTankHarness
   name: loadout-group-tank-harness
   minLimit: 1

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -127,7 +127,6 @@
   - CaptainOuterClothing
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - CaptainEnvirohelm
@@ -147,7 +146,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - HoPEnvirohelm
@@ -180,7 +178,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - AssistantEnvirohelm
@@ -198,7 +195,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - BartenderEnvirohelm
@@ -214,7 +210,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - ServiceWorkerEnvirohelm
@@ -233,7 +228,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - ChefEnvirohelm
@@ -249,7 +243,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - LibrarianEnvirohelm
@@ -266,7 +259,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - LawyerEnvirohelm
@@ -286,7 +278,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - ChaplainEnvirohelm
@@ -306,7 +297,6 @@
   - Survival
   - Trinkets
   - JanitorPlunger
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - JanitorEnvirohelm
@@ -324,7 +314,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - BotanistEnvirohelm
@@ -344,7 +333,6 @@
   - Glasses
   - SurvivalClown
   - Trinkets
-  - Animals
   # Goobstation - EE Plasmeme Change.
   - ClownEnvirohelm
   - ClownEnvirosuit
@@ -364,7 +352,6 @@
   - Glasses
   - SurvivalMime
   - Trinkets
-  - Animals
   # Goobstation - EE Plasmeme Change.
   - MimeEnvirohelm
   - MimeEnvirosuit
@@ -382,7 +369,6 @@
   - Survival
   - Trinkets
   - Instruments
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - MusicianEnvirohelm
@@ -403,7 +389,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - QuartermasterEnvirohelm
@@ -422,7 +407,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - CargoTechnicianEnvirohelm
@@ -440,7 +424,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - SalvageEnvirohelm
@@ -460,7 +443,6 @@
   - ChiefEngineerShoes
   - SurvivalExtended
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - ChiefEngineerEnvirohelm
@@ -475,7 +457,6 @@
   - StationEngineerBackpack
   - SurvivalExtended
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - TechnicalAssistantEnvirohelm
@@ -494,7 +475,6 @@
   - StationEngineerID
   - SurvivalExtended
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - StationEngineerEnvirohelm
@@ -512,7 +492,6 @@
   - AtmosphericTechnicianShoes
   - SurvivalExtended
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - AtmosEnvirohelm
@@ -534,7 +513,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - ResearchDirectorEnvirosuit
@@ -556,7 +534,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - ScientistEnvirohelm
@@ -572,7 +549,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - ResearchAssistantEnvirohelm
@@ -594,7 +570,6 @@
   - SurvivalSecurity
   - Trinkets
   - SecurityStar
-  - Animals
   - GroupSpeciesBreathToolSecurity
   # Goobstation - EE Plasmeme Change.
   - HeadofSecurityEnvirohelm
@@ -616,7 +591,6 @@
   - SurvivalSecurity
   - Trinkets
   - SecurityStar
-  - Animals
   - GroupSpeciesBreathToolSecurity
   # Goobstation - EE Plasmeme Change.
   - WardenEnvirohelm
@@ -638,7 +612,6 @@
   - SurvivalSecurity
   - Trinkets
   - SecurityStar
-  - Animals
   - GroupSpeciesBreathToolSecurity
   # Goobstation - EE Plasmeme Change.
   - SecurityOfficerEnvirohelm
@@ -657,7 +630,6 @@
   - SurvivalSecurity
   - Trinkets
   - SecurityStar
-  - Animals
   - GroupSpeciesBreathToolSecurity
   # Goobstation - EE Plasmeme Change.
   - DetectiveEnvirohelm
@@ -675,7 +647,6 @@
   - SecurityNeck
   - SecurityOuterClothing # Goobstation - Why not.
   - Trinkets
-  - Animals
   - GroupSpeciesBreathToolSecurity
   # Goobstation - EE Plasmeme Change.
   - SecurityCadetEnvirohelm
@@ -698,7 +669,6 @@
   - MedicalEyewear
   - SurvivalMedical
   - Trinkets
-  - Animals
   - GroupSpeciesBreathToolMedical
   # Goobstation - EE Plasmeme Change.
   - ChiefMedicalOfficerEnvirohelm
@@ -720,7 +690,6 @@
   - MedicalEyewear
   - SurvivalMedical
   - Trinkets
-  - Animals
   - GroupSpeciesBreathToolMedical
   # Goobstation - EE Plasmeme Change.
   - MedicalDoctorEnvirohelm
@@ -736,7 +705,6 @@
   - MedicalEyewear
   - SurvivalMedical
   - Trinkets
-  - Animals
   - GroupSpeciesBreathToolMedical
   # Goobstation - EE Plasmeme Change.
   - MedicalInternEnvirohelm
@@ -756,7 +724,6 @@
   - MedicalShoes
   - SurvivalMedical
   - Trinkets
-  - Animals
   - GroupSpeciesBreathToolMedical
   # Goobstation - EE Plasmeme Change.
   - ChemistEnvirohelm
@@ -777,7 +744,6 @@
   - MedicalEyewear
   - SurvivalMedical
   - Trinkets
-  - Animals
   - GroupSpeciesBreathToolMedical
   # Goobstation - EE Plasmeme Change.
   - ParamedicEnvirohelm
@@ -795,7 +761,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - ZookeeperEnvirohelm
@@ -812,7 +777,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - ReporterEnvirohelm
@@ -828,7 +792,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - PsychologistEnvirohelm
@@ -845,7 +808,6 @@
   - Glasses
   - Survival
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   # Goobstation - EE Plasmeme Change.
   - BoxerEnvirohelm

--- a/Resources/Prototypes/_Goobstation/Loadouts/Jobs/misc.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/Jobs/misc.yml
@@ -67,28 +67,3 @@
   id: CheapSunglasses
   equipment:
     eyes: ClothingEyesGlassesCheapSunglasses
-
-# Animals
-- type: loadout
-  id: Squackroach
-  storage:
-    back:
-    - MobSquackroach
-
-- type: loadout
-  id: Mouse
-  storage:
-    back:
-    - MobMouse
-
-- type: loadout
-  id: Mothroach
-  storage:
-    back:
-    - MobMothroach
-
-- type: loadout
-  id: Goldfish
-  storage:
-    back:
-    - MobCarpGoldfish

--- a/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/role_loadouts.yml
@@ -100,7 +100,6 @@
   - NanotrasenRepresentativeBelt
   - Glasses
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   - Survival
   - NanotrasenRepresentativeGloves
@@ -120,7 +119,6 @@
   - BlueshieldOfficerMask
   - BlueshieldOfficerShoes
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   - SurvivalSecurity
   # Goobstation - EE Plasmeme Change.
@@ -141,7 +139,6 @@
   - NanotrasenTrainerGloves
   - NanotrasenTrainerBelt
   - Trinkets
-  - Animals
   - GroupSpeciesBreathTool
   - Survival
   # Goobstation - EE Plasmeme Change.
@@ -170,7 +167,6 @@
   - SecurityNeck
   - SurvivalSecurity
   - Trinkets
-  - Animals
   - SecurityStar
   - GroupSpeciesBreathToolSecurity
   # Goobstation - EE Plasmeme Change.


### PR DESCRIPTION

## About the PR
removes pets from being a loadout option, does not touch other parts of 3378

## Why
They're annoying to see and hear. 
Ghostrole bloat
Free heretic organs (work harder lazy ass, theres a reason mice dont butcher into organs anymore)
They automatically gib after a while when theres any spacing
We're using server resources on this
I dont like mrp slop 
Le realism 

## Technical details
yml, merge if no testfail, if testfail, tell me why so i fix

## Media
not tested, works

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Removed pets from being an option in loadout
