### PR TITLE
Goidaweapon instead of cringe

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Goobstation/store/uplink-catalog.ftl
@@ -100,6 +100,9 @@ uplink-weapon-heavy-shotgun-desc = Merciless heavy explosive weapon. The recoil 
 uplink-WSPR-name = WSPR
 uplink-WSPR-desc = This rifle operates silently and uses 9.5mm caseless magnum hollow-point bullets, which are more effective against flesh but less effective against armor.
 
+uplink-AKM-name = Automatic Kalashnikov Modern
+uplink-AKM-desc = Old, reliable, mass produced, cult classic rifle. Uses .30 rounds. The Syndicate is counting on you, brave soul.
+
 uplink-c20r-name = C-20r
 uplink-c20r-desc = Old faithful: The classic C-20r Submachine Gun.
 
@@ -150,14 +153,17 @@ uplink-frag-grenade-desc = Lower damage, bigger radius. Compatible with the Chin
 uplink-mpapers-grenade-name = MP-APERS shell (40mm)
 uplink-mpapers-grenade-desc = Fires out 20 small pellets to turn your grenade launcher into a shotgun. Compatible with the China-Lake.
 
-uplink-rifle-mag-name = Rifle Magazine (.20)
-uplink-rifle-mag-desc = A 25 round magazine containing .20 rifle bullets. Supports the Lecter and M-90.
+# uplink-rifle-mag-name = Rifle Magazine (.20)
+# uplink-rifle-mag-desc = A 25 round magazine containing .20 rifle bullets. Supports the Lecter and M-90.
 
 uplink-rifle-caseless-mag-name = Rifle Magazine (9.5mm HP)
 uplink-rifle-caseless-mag-desc = A 30 round rifle magazine filled with 9.5mm caseless magnum hollow-point bullets. Compatible with the WSPR.
 
 uplink-pistol-magazine-caseless-saphe-name = Pistol Magazine (9.5mm SAP-HE)
 uplink-pistol-magazine-caseless-saphe-desc = 10 rounds of 9.5mm caseless magnum semi-armor-piercing high-explosive ammunition. It is exactly what you have read. Compatible with the Cobra.
+
+uplink-akm-magazine-name = Rifle Magazine (.30 rifle)
+uplink-akm-magazine-desc = Ammo for the .30 AKM.
 
 uplink-l6-box-name = Magazine Box (.30 rifle)
 uplink-l6-box-desc = Magazine box with 100 catridges. Compatible with the L6 SAW.

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -99,8 +99,9 @@
 uplink-pistol-viper-name = Viper
 uplink-pistol-viper-desc = A small, easily concealable, but somewhat underpowered gun. Retrofitted with a fully automatic receiver. Uses pistol magazines (.35 auto).
 
-uplink-estoc-bundle-name = Estoc DMR
-uplink-estoc-bundle-desc = A designated marksman rifle, fitted with a mid-range optic for longer-range combat. Bundled with two rifle magazines (.20 rifle).
+# goob, replaced estoc with akm
+# uplink-estoc-bundle-name = Estoc DMR
+# uplink-estoc-bundle-desc = A designated marksman rifle, fitted with a mid-range optic for longer-range combat. Bundled with two rifle magazines (.20 rifle).
 
 uplink-revolver-python-name = Python
 uplink-revolver-python-desc = A brutally simple, effective, and loud Syndicate revolver. Comes loaded with armor-piercing rounds. Uses .45 magnum.

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -335,16 +335,17 @@
   categories:
   - UplinkWeaponry
 
-- type: listing
-  id: UplinkEstoc # goob unbundle
-  name: uplink-estoc-name # goob unbundle
-  description: uplink-estoc-desc # goob unbundle
-  icon: { sprite: /Textures/Objects/Weapons/Guns/Rifles/estoc.rsi, state: icon }
-  productEntity: WeaponRifleEstoc # goob unbundle
-  cost:
-    Telecrystal: 55 # goob unbundle
-  categories:
-  - UplinkWeaponry
+# goob, removed from uplink, replaced with akm
+#- type: listing
+#  id: UplinkEstoc # goob unbundle
+#  name: uplink-estoc-name # goob unbundle
+#  description: uplink-estoc-desc # goob unbundle
+#  icon: { sprite: /Textures/Objects/Weapons/Guns/Rifles/estoc.rsi, state: icon }
+#  productEntity: WeaponRifleEstoc # goob unbundle
+#  cost:
+#    Telecrystal: 55 # goob unbundle
+#  categories:
+#  - UplinkWeaponry
 
 - type: listing
   id: UplinkBulldog #goob
@@ -717,16 +718,17 @@
   categories:
   - UplinkAmmo
 
+#GOOB, replaced estoc with AK
 # For the Estoc
-- type: listing
-  id: UplinkEstocAmmo
-  name: uplink-estoc-ammo-name
-  description: uplink-estoc-ammo-desc
-  productEntity: MagazineRifle
-  cost:
-    Telecrystal: 5 # goob - on par with c20
-  categories:
-  - UplinkAmmo
+# - type: listing
+#  id: UplinkEstocAmmo
+#  name: uplink-estoc-ammo-name # goob, Wrong name and desc btw LMAOOOOO
+#  description: uplink-estoc-ammo-desc
+#  productEntity: MagazineRifle
+#  cost:
+#    Telecrystal: 5 # goob - on par with c20
+#  categories:
+#  - UplinkAmmo
 
 # for the hristov
 - type: listing
@@ -1185,7 +1187,7 @@
   categories:
   - UplinkDisruption
 # Goob - Antimov was given the same price for traitors and nukies
-#  conditions:                     
+#  conditions:
 #  - !type:StoreWhitelistCondition
 #     blacklist:
 #       tags:
@@ -1205,7 +1207,7 @@
 #  - !type:StoreWhitelistCondition
 #    whitelist:
 #      tags:
-#      - NukeOpsUplink 
+#      - NukeOpsUplink
 
 
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -163,7 +163,7 @@
 
 - type: entity
   name: AKM
-  parent: [BaseWeaponRifle, BaseSecurityContraband]
+  parent: [BaseWeaponRifle, BaseSyndicateContraband] #goob, removed BaseSecurityContraband
   id: WeaponRifleAk
   description: A somewhat battered combat rifle of a design originating from old Earth. Favored by criminals, militias, and terrorists due to its famed reliability and easy-to-manufacture design. Feeds from .30 rifle magazines.
   components:
@@ -175,6 +175,14 @@
       - state: mag-0
         map: ["enum.GunVisualLayers.Mag"]
   - type: Gun
+    fireRate: 6 #goobstart
+    shotsPerBurst: 3
+    selectedMode: SemiAuto
+    availableModes:
+    - Burst
+    - SemiAuto
+    burstFireRate: 12
+    burstCooldown: 0.6 #goobend
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rifle2.ogg
   - type: ChamberMagazineAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -163,7 +163,7 @@
 
 - type: entity
   name: AKM
-  parent: [BaseWeaponRifle, BaseSyndicateContraband] #goob, removed BaseSecurityContraband
+  parent: [BaseWeaponRifle, BaseSecurityContraband]
   id: WeaponRifleAk
   description: A somewhat battered combat rifle of a design originating from old Earth. Favored by criminals, militias, and terrorists due to its famed reliability and easy-to-manufacture design. Feeds from .30 rifle magazines.
   components:
@@ -175,14 +175,6 @@
       - state: mag-0
         map: ["enum.GunVisualLayers.Mag"]
   - type: Gun
-    fireRate: 6 #goobstart
-    shotsPerBurst: 3
-    selectedMode: SemiAuto
-    availableModes:
-    - Burst
-    - SemiAuto
-    burstFireRate: 12
-    burstCooldown: 0.6 #goobend
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/rifle2.ogg
   - type: ChamberMagazineAmmoProvider

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -387,6 +387,17 @@
   - UplinkWeaponry
 
 - type: listing
+  id: UplinkAKM
+  name: uplink-AKM-name
+  description: uplink-AKM-desc
+  icon: { sprite: /Textures/Objects/Weapons/Guns/Rifles/ak.rsi, state: icon }
+  productEntity: WeaponRifleAk
+  cost:
+    Telecrystal: 80
+  categories:
+  - UplinkWeaponry
+
+- type: listing
   id: UplinkWeaponRifleBurner
   name: uplink-weapon-burner-name
   description: uplink-weapon-burner-desc
@@ -1038,6 +1049,17 @@
   productEntity: MagazineShotgun
   cost:
     Telecrystal: 5
+  categories:
+  - UplinkAmmo
+
+- type: listing
+  id: UplinkMagazineLightRifle
+  name: uplink-akm-magazine-name
+  description: uplink-akm-magazine-desc
+  icon: { sprite: /Textures/Objects/Weapons/Guns/Ammunition/Magazine/LightRifle/light_rifle_mag.rsi, state: base }
+  productEntity: MagazineLightRifle
+  cost:
+    Telecrystal: 10
   categories:
   - UplinkAmmo
 

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -391,7 +391,7 @@
   name: uplink-AKM-name
   description: uplink-AKM-desc
   icon: { sprite: /Textures/Objects/Weapons/Guns/Rifles/ak.rsi, state: icon }
-  productEntity: WeaponRifleAk
+  productEntity: WeaponRifleAkSyndicate
   cost:
     Telecrystal: 80
   categories:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifle.yml
@@ -215,3 +215,61 @@
     steps: 1
     zeroVisible: true
   - type: Appearance
+
+- type: entity
+  name: AKM
+  parent: [BaseWeaponRifle, BaseSyndicateContraband] #exists so i can remove BaseSecurityContraband without affecting parent
+  id: WeaponRifleAkSyndicate
+  description: A somewhat battered combat rifle of a design originating from old Earth. Favored by criminals, militias, and terrorists due to its famed reliability and easy-to-manufacture design. Feeds from .30 rifle magazines.
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Rifles/ak.rsi
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-0
+      map: ["enum.GunVisualLayers.Mag"]
+  - type: Gun
+    fireRate: 6 #goobstart
+    shotsPerBurst: 3
+    selectedMode: SemiAuto
+    availableModes:
+    - Burst
+    - SemiAuto
+    - FullAuto
+    burstFireRate: 12
+    burstCooldown: 0.6 #goobend, goobcommenting even though its in goob comment to note how its diffrent from parent, todo, paint a bit of it red or smtn
+    soundGunshot:
+      path: /Audio/Weapons/Guns/Gunshots/rifle2.ogg
+  - type: ChamberMagazineAmmoProvider
+    boltClosed: null # Goobstation
+    soundRack:
+      path: /Audio/Weapons/Guns/Cock/ltrifle_cock.ogg
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        startingItem: MagazineLightRifle
+        insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
+        ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
+        priority: 2
+        whitelist:
+          tags:
+          - MagazineLightRifle
+        whitelistFailPopup: gun-magazine-whitelist-fail
+      gun_chamber:
+        name: Chamber
+        startingItem: CartridgeLightRifle
+        priority: 1
+        whitelist:
+          tags:
+          - CartridgeLightRifle
+  - type: ContainerContainer
+    containers:
+      gun_magazine: !type:ContainerSlot
+      gun_chamber: !type:ContainerSlot
+  - type: MagazineVisuals
+    magState: mag
+    steps: 1
+    zeroVisible: true
+  - type: Appearance

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/misc.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/misc.yml
@@ -18,6 +18,8 @@
   - MagazineCaselessRifleEmpty
   - MagazineCaselessRifle
   - MagazineLowCaliberM7S
+  - MagazineLightRifle
+  - MagazineLightRifleEmpty
 
 - type: latheRecipePack
   id: SyndicateAmmoHeavyStatic


### PR DESCRIPTION
## About the PR
Replaced estoc in uplink with AKM, slightly buffed akm to make it feel better to use and make it worth buying
Added .30 rifle mags to SyndicateAmmoLightStatic (aka emagged secfabs and autolathes)

## Why / Balance
I have always felt the need for an accurate and reliable gun thats somewhat inbetween the l6 and cr20. This should hopefully scratch that itch.

**Estoc**: Sucks ass to use, worse than a lecter, slow fire rate and dogshit ttk, shitty sound design, inaccurate, overall has no reason to exist, fulfills no niche (buy a cr20 for cheaper and better dps lmao),
**Akm**: Accurate, good fire rate, good ttk, high price, not so high its your only uplink item, VERY goida
**Advantages compared to l6**: 20 tc cheaper, more accurate, better ttk at longer ranges, you can larp, hard
**Disadvantages compared to l6**: Slower fire rate, worse ttk at closer ranges, less ammo capacity, worse crowd control, more precision requirement

If the 100 tc bundle of akm + emag + emagged autolathe is too goida for goobmaints i can move the .30 mags to SyndicateAmmoHeavyStatic to make it so you have to emag a secfab inorder to be able to print .30 ammo 

im avoiding gunslop by replacing a shitty wizden gun with zero reason to exist with one thats good

## Technical details
yml and ftl

## Media
<img width="349" height="106" alt="image" src="https://github.com/user-attachments/assets/ad9c27ea-a3de-4f0e-90f4-61fb92cf6ec9" />
<img width="343" height="75" alt="image" src="https://github.com/user-attachments/assets/bd9a7a35-5e57-4b2b-96b2-d7d31f515587" />

You can buy an akm and 2 mags

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: AKM to the syndicate uplinks
- tweak: Improved AKM's fire rate, and added a burst option
- remove: Estoc from syndicate uplinks
- tweak: Added .30 rifle ammo mags to emagged secfab and autolathes