### PR TITLE
Revolutionary Conversion Accounts for Languages

### DIFF
--- a/Content.Server/_EinsteinEngines/Language/LanguageSystem.cs
+++ b/Content.Server/_EinsteinEngines/Language/LanguageSystem.cs
@@ -72,21 +72,8 @@ public sealed partial class LanguageSystem : SharedLanguageSystem
 
     #region public api
 
-    public bool CanUnderstand(Entity<LanguageSpeakerComponent?> ent, ProtoId<LanguagePrototype> language)
-    {
-        if (language == PsychomanticPrototype || language == UniversalPrototype || TryComp<UniversalLanguageSpeakerComponent>(ent, out var uni) && uni.Enabled)
-            return true;
-
-        return Resolve(ent, ref ent.Comp, logMissing: false) && ent.Comp.UnderstoodLanguages.Contains(language);
-    }
-
-    public bool CanSpeak(Entity<LanguageSpeakerComponent?> ent, ProtoId<LanguagePrototype> language)
-    {
-        if (!Resolve(ent, ref ent.Comp, logMissing: false))
-            return false;
-
-        return ent.Comp.SpokenLanguages.Contains(language);
-    }
+    //public bool CanUnderstand(Entity<LanguageSpeakerComponent?> ent, ProtoId<LanguagePrototype> language) // - Goob : moved to Shared
+    //public bool CanSpeak(Entity<LanguageSpeakerComponent?> ent, ProtoId<LanguagePrototype> language) // - Goob : moved to Shared
 
     /// <summary>
     ///     Returns the current language of the given entity, assumes Universal if it's not a language speaker.

--- a/Content.Shared/_EinsteinEngines/Language/Components/UniversalLanguageSpeakerComponent.cs
+++ b/Content.Shared/_EinsteinEngines/Language/Components/UniversalLanguageSpeakerComponent.cs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-namespace Content.Server._EinsteinEngines.Language;
+namespace Content.Shared._EinsteinEngines.Language.Components;
 
 // <summary>
 //     Signifies that this entity can speak and understand any language.

--- a/Content.Shared/_EinsteinEngines/Language/Systems/SharedLanguageSystem.cs
+++ b/Content.Shared/_EinsteinEngines/Language/Systems/SharedLanguageSystem.cs
@@ -1,6 +1,7 @@
-using System.Text;
+using Content.Shared._EinsteinEngines.Language.Components;
 using Content.Shared.GameTicking;
 using Robust.Shared.Prototypes;
+using System.Text;
 
 namespace Content.Shared._EinsteinEngines.Language.Systems;
 
@@ -75,5 +76,21 @@ public abstract class SharedLanguageSystem : EntitySystem
         seed = seed ^ (_ticker.RoundId * 127);
         var random = seed * 1103515245 + 12345;
         return min + Math.Abs(random) % (max - min + 1);
+    }
+
+    public virtual bool CanUnderstand(Entity<LanguageSpeakerComponent?> ent, ProtoId<LanguagePrototype> language)
+    {
+        if (language == PsychomanticPrototype || language == UniversalPrototype || TryComp<UniversalLanguageSpeakerComponent>(ent, out var uni) && uni.Enabled)
+            return true;
+
+        return Resolve(ent, ref ent.Comp, logMissing: false) && ent.Comp.UnderstoodLanguages.Contains(language);
+    }
+
+    public virtual bool CanSpeak(Entity<LanguageSpeakerComponent?> ent, ProtoId<LanguagePrototype> language)
+    {
+        if (!Resolve(ent, ref ent.Comp, logMissing: false))
+            return false;
+
+        return ent.Comp.SpokenLanguages.Contains(language);
     }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Added a check for the RevolutionaryConverterComponent that, if the chosen Converter object uses spoken lines, the spoken language must be understood by the target for conversion to succeed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This prevents someone from learning an obscure language and converting everyone quickly. Conversion happens largely via speech, so this speech should be understood. Also makes languages relevant for Revolutionaries in a positive way, instead of an easily abusable method of free conversion.

## Technical details
I just check the current selected language against the known languages of the target.
I did move a check from Server to Shared so I could check for understood languages in the RevolutionaryConverterSystem

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Head Revolutionaries must now speak a language their target actually understands to convert.

