### PR TITLE
make devil handshake require a hand

### DIFF
--- a/Content.Goobstation.Server/Devil/DevilSystem.Handshake.cs
+++ b/Content.Goobstation.Server/Devil/DevilSystem.Handshake.cs
@@ -8,6 +8,7 @@
 using Content.Goobstation.Shared.CheatDeath;
 using Content.Goobstation.Shared.Devil;
 using Content.Goobstation.Shared.Devil.Condemned;
+using Content.Shared.Body.Part;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
@@ -31,6 +32,8 @@ public sealed partial class DevilSystem
         || !HasComp<MobStateComponent>(args.Target)
         || HasComp<CondemnedComponent>(args.Target)
         || args.Target == args.User
+        || !_body.BodyHasPartType(uid, BodyPartType.Hand) // cant shake if you have no hands
+        || !_body.BodyHasPartType(args.Target, BodyPartType.Hand) // or if they have none
         || !_contract.IsUserValid(args.Target, out _))
             return;
 


### PR DESCRIPTION
intuitive counterplay to devil, cut his hands off and no more handshake
also no bingle handshake fixes #4159

:cl:
- fix: Fixed devils being able to offer handless mobs handshakes, or do so when they have no hands.