### PR TITLE
Wet Slop

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -172,12 +172,22 @@
         scaleByQuantity: true
         damage:
           types:
-            Heat: 0.1
+            Heat: 0.25 # goob edit
+        conditions:
+        - !type:HasComponentOnEquipmentCondition # goob edit - make suits protect slimes from water damage
+          components:
+          - type: PressureProtection
+          invert: true
       - !type:PopupMessage
         type: Local
         visualType: Large
         messages: [ "slime-hurt-by-water-popup" ]
         probability: 0.25
+        conditions:
+        - !type:HasComponentOnEquipmentCondition # goob edit - make suits protect slimes from water damage
+          components:
+          - type: PressureProtection
+          invert: true
   - type: Butcherable
     butcheringType: Spike
     spawned:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
## About the PR
Makes slimes able to avoid damage from water by wearing pressure-protective clothing an increases the damage they take otherwise.

## Why / Balance
The damage slime people take from water is barely relevant (a 20u splash does 2 damage). This makes the damage somewhat real while making it not work in combat scenarios where hardsuits are common.

## Technical details
Adds an inverted HasComponentOnEquipmentCondition to slimes' water damage, similar to spray medicine.

## Media
https://github.com/user-attachments/assets/2dd9afc5-9301-41bf-95e8-b3bdcedcbc36

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Spacesuits protect slimes from water damage
- tweak: Slime people take more damage from water
