### PR TITLE
Fixes wonderprod sleep mode

### DIFF
--- a/Resources/Prototypes/_Shitmed/Reagents/narcotics.yml
+++ b/Resources/Prototypes/_Shitmed/Reagents/narcotics.yml
@@ -6,13 +6,12 @@
   metabolisms:
     Narcotic:
       effects:
-      - !type:GenericStatusEffect
+      - !type:ModifyStatusEffect
         conditions:
         # this intentionally has no yowie condition so abductors can sleep disgruntled yowies
         - !type:ReagentThreshold
           reagent: NocturineWonderprod
           min: 8
-        key: ForcedSleep
-        component: ForcedSleeping
-        refresh: true # refreshes so hitting someone with wonderprod 10 times doesnt put them to sleep for an hour
+        effectProto: StatusEffectForcedSleeping
+        time: 3
         type: Add


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Upstream broke how WonderprodNocturine works, is working now
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
blease bro i wanna play the cool new duo abductor game mode but this glorpshit doesn't sleep blease. (could probably lower the minimum and raise the metabolism rate so abductors don't need to hit as much to sleep, but that's a balance change and i'm just here for bugfixing)
## Technical details
<!-- Summary of code changes for easier review. -->
Idk how you're supposed to make it "refreshes so hitting someone with wonderprod 10 times doesnt put them to sleep for an hour," but wonderprod nocturine maxes out at 20u like in the video, and stops applying sleep at 8u, so I guess that's fine? I timed it at about 20 seconds of sleep after they stop hitting you, which seems fine for the original purpose of https://github.com/Goob-Station/Goob-Station/pull/4026
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/e199c07a-8b7d-42ba-b1ca-3eac158af7c8


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: RatherUncreativeName
- fix: Fixed wonderprod not sleeping. Abductors can abduct again.
