### PR TITLE
Energycrit

### DIFF
--- a/Content.Client/_EinsteinEngines/Power/Systems/BatteryDrinkerSystem.cs
+++ b/Content.Client/_EinsteinEngines/Power/Systems/BatteryDrinkerSystem.cs
@@ -1,9 +1,87 @@
+using System.Diagnostics.CodeAnalysis;
+using Content.Shared._EinsteinEngines.Power.Components;
+using Content.Shared._EinsteinEngines.Power.Systems;
+using Content.Shared._EinsteinEngines.Silicon.Charge;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.PowerCell;
+using Content.Shared.PowerCell.Components;
+using Content.Shared.Verbs;
+using Content.Shared.Whitelist;
+using Robust.Shared.Utility;
+
 namespace Content.Client._EinsteinEngines.Power.Systems;
 
-public sealed class BatteryDrinkerSystem : EntitySystem
+/// <Goobstation> Energycrit </Goobstation>
+/// <summary>
+///     Client-side prediction for BatteryDrinkerSystem.
+/// </summary>
+/// <remarks>
+///     For some reason, the battery drinking system has a feature letting you drink from anything
+///     with a BatteryComponent, this means that all the logic for figuring out what you can drink
+///     or not has to be entirely serverside. The feature isn't even used anywhere. It was briefly
+///     going to be used in energycrit, but I very quickly realized that it was incredibly broken
+///     and shouldn't have existed in the first place. Because of this, the logic has to be copied
+///     and shoved into the client too!
+/// </remarks>
+public sealed class BatteryDrinkerSystem : SharedBatteryDrinkerSystem
 {
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
+
     public override void Initialize()
     {
+        base.Initialize();
 
+        SubscribeLocalEvent<BatteryDrinkerSourceComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
+        SubscribeLocalEvent<PowerCellSlotComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
+    }
+
+    /// <summary>
+    ///     *Good enough* prediction for the battery drinking verb.
+    /// </summary>
+    private void OnGetVerbs<TComp>(Entity<TComp> ent, ref GetVerbsEvent<AlternativeVerb> args)
+        where TComp : Component
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        if (!TryComp<BatteryDrinkerComponent>(args.User, out var drinker) ||
+            _whitelist.IsBlacklistPass(drinker.Blacklist, ent) ||
+            !SearchForSource(args.User, out _) ||
+            !SearchForSource(ent, out _))
+            return;
+
+        AlternativeVerb verb = new()
+        {
+            Text = Loc.GetString("battery-drinker-verb-drink"),
+            Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/smite.svg.192dpi.png")),
+            Priority = -5
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    private bool SearchForSource(EntityUid ent, [NotNullWhen(true)] out EntityUid? source)
+    {
+        // Are we a battery drinker source
+        if (HasComp<BatteryDrinkerSourceComponent>(ent))
+        {
+            source = ent;
+            return true;
+        }
+
+        // Do we contain a source?
+        if (TryComp<PowerCellSlotComponent>(ent, out var slotId) &&
+            HasComp<ItemSlotsComponent>(ent) &&
+            _itemSlots.TryGetSlot(ent, slotId.CellSlotId, out var slot) &&
+            slot.HasItem && HasComp<BatteryDrinkerSourceComponent>(slot.Item))
+        {
+            source = ent;
+            return true;
+        }
+
+        // We found nothing
+        source = null;
+        return false;
     }
 }

--- a/Content.Client/_EinsteinEngines/Power/Systems/BatteryDrinkerSystem.cs
+++ b/Content.Client/_EinsteinEngines/Power/Systems/BatteryDrinkerSystem.cs
@@ -1,0 +1,9 @@
+namespace Content.Client._EinsteinEngines.Power.Systems;
+
+public sealed class BatteryDrinkerSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+
+    }
+}

--- a/Content.Server/_EinsteinEngines/Power/Components/BatteryDrinkerComponent.cs
+++ b/Content.Server/_EinsteinEngines/Power/Components/BatteryDrinkerComponent.cs
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Shared.Whitelist; // Goobstation - Energycrit
+
 namespace Content.Server._EinsteinEngines.Power.Components;
 
 [RegisterComponent]
@@ -33,4 +35,12 @@ public sealed partial class BatteryDrinkerComponent : Component
     /// </summary>
     [DataField]
     public float DrinkAllMultiplier = 2.5f;
+
+    /// <Goobstation> Energycrit: BatteryDrinker blacklist. </Goobstation>
+    /// <summary>
+    ///     Blacklist for items that can not be drank from. This should not be used to disable drinking from a type
+    ///     of power cell, it is not checked for entities inside a power cell slot.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Blacklist;
 }

--- a/Content.Server/_EinsteinEngines/Power/Systems/BatteryDrinkerSystem.cs
+++ b/Content.Server/_EinsteinEngines/Power/Systems/BatteryDrinkerSystem.cs
@@ -71,7 +71,7 @@ public sealed class BatteryDrinkerSystem : EntitySystem
             Text = Loc.GetString("battery-drinker-verb-drink"),
             Icon = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/smite.svg.192dpi.png")),
             // Goobstation - Energycrit: dont block removing power cells
-            Priority = -100
+            Priority = -5
         };
 
         args.Verbs.Add(verb);

--- a/Content.Server/_EinsteinEngines/Power/Systems/BatteryDrinkerSystem.cs
+++ b/Content.Server/_EinsteinEngines/Power/Systems/BatteryDrinkerSystem.cs
@@ -20,12 +20,16 @@ using Content.Server.PowerCell;
 using Content.Shared.Popups;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
-using Content.Server._EinsteinEngines.Power.Components;
-using Content.Shared.Whitelist; // Goobstation - Energycrit
+// Goobstation Start - Energycrit
+using Content.Shared._EinsteinEngines.Power.Components;
+using Content.Shared._EinsteinEngines.Power.Systems;
+using Content.Shared.Whitelist;
+// Goobstation End
 
 namespace Content.Server._EinsteinEngines.Power;
 
-public sealed class BatteryDrinkerSystem : EntitySystem
+// Goobstation - Energycrit: Create SharedBatteryDrinkerSystem so client can predict drink verbs
+public sealed class BatteryDrinkerSystem : SharedBatteryDrinkerSystem
 {
     [Dependency] private readonly ItemSlotsSystem _slots = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
@@ -55,13 +59,13 @@ public sealed class BatteryDrinkerSystem : EntitySystem
             return;
 
         if (!TryComp<BatteryDrinkerComponent>(args.User, out var drinkerComp) ||
-            !TestDrinkableBattery(uid, drinkerComp) ||
-            // Goobstation - Energycrit: Check blacklist
+            // Goobstation Start - Energycrit
             _whitelist.IsBlacklistPass(drinkerComp.Blacklist, uid) ||
             // Goobstation - replaced battery lookup to allow augment power cells
             !_chargers.SearchForBattery(args.User, out _, out _) ||
-            // Goobstation - Energycrit: Drain from batteries inside electronics
-            !_chargers.SearchForBattery(uid, out var battery, out _))
+            !_chargers.SearchForBattery(uid, out var battery, out _) ||
+            !TestDrinkableBattery(battery.Value, drinkerComp))
+            // Goobstation End - Energycrit
             return;
 
         AlternativeVerb verb = new()

--- a/Content.Server/_EinsteinEngines/Power/Systems/BatteryDrinkerSystem.cs
+++ b/Content.Server/_EinsteinEngines/Power/Systems/BatteryDrinkerSystem.cs
@@ -21,6 +21,7 @@ using Content.Shared.Popups;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Content.Server._EinsteinEngines.Power.Components;
+using Content.Shared.Whitelist; // Goobstation - Energycrit
 
 namespace Content.Server._EinsteinEngines.Power;
 
@@ -35,6 +36,7 @@ public sealed class BatteryDrinkerSystem : EntitySystem
     [Dependency] private readonly PowerCellSystem _powerCell = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly ChargerSystem _chargers = default!; // Goobstation
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!; // Goobstation - Energycrit
 
     public override void Initialize()
     {
@@ -54,6 +56,8 @@ public sealed class BatteryDrinkerSystem : EntitySystem
 
         if (!TryComp<BatteryDrinkerComponent>(args.User, out var drinkerComp) ||
             !TestDrinkableBattery(uid, drinkerComp) ||
+            // Goobstation - Energycrit: Check blacklist
+            _whitelist.IsBlacklistPass(drinkerComp.Blacklist, uid) ||
             // Goobstation - replaced battery lookup to allow augment power cells
             !_chargers.SearchForBattery(args.User, out _, out _) ||
             // Goobstation - Energycrit: Drain from batteries inside electronics

--- a/Content.Server/_EinsteinEngines/Power/Systems/BatteryDrinkerSystem.cs
+++ b/Content.Server/_EinsteinEngines/Power/Systems/BatteryDrinkerSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared._EinsteinEngines.Silicon;
 using Content.Shared.Verbs;
 using Robust.Shared.Utility;
 using Content.Server._EinsteinEngines.Silicon.Charge;
+using Content.Shared._EinsteinEngines.Silicon.Charge; // Goobstation - Energycrit: BatteryDrinkerSourceComponent moved to shared
 using Content.Server.Power.EntitySystems;
 using Content.Server.Popups;
 using Content.Server.PowerCell;
@@ -28,7 +29,7 @@ using Content.Shared.Whitelist;
 
 namespace Content.Server._EinsteinEngines.Power;
 
-// Goobstation - Energycrit: Create SharedBatteryDrinkerSystem so client can predict drink verbs
+// Goobstation - Energycrit: Create SharedBatteryDrinkerSystem and Client BatteryDrinkerSystem so client can predict drink verbs
 public sealed class BatteryDrinkerSystem : SharedBatteryDrinkerSystem
 {
     [Dependency] private readonly ItemSlotsSystem _slots = default!;

--- a/Content.Shared/MouseRotator/SharedMouseRotatorSystem.cs
+++ b/Content.Shared/MouseRotator/SharedMouseRotatorSystem.cs
@@ -57,7 +57,10 @@ public abstract class SharedMouseRotatorSystem : EntitySystem
         if (args.SenderSession.AttachedEntity is not { } ent
             || !TryComp<MouseRotatorComponent>(ent, out var rotator))
         {
+            // Goobstation - Disable stupid chud warning.
+            /*
             Log.Error($"User {args.SenderSession.Name} ({args.SenderSession.UserId}) tried setting local rotation directly without a valid mouse rotator component attached!");
+            */
             return;
         }
 

--- a/Content.Shared/_EinsteinEngines/Power/Components/BatteryDrinkerComponent.cs
+++ b/Content.Shared/_EinsteinEngines/Power/Components/BatteryDrinkerComponent.cs
@@ -39,9 +39,13 @@ public sealed partial class BatteryDrinkerComponent : Component
 
     /// <Goobstation> Energycrit: BatteryDrinker blacklist. </Goobstation>
     /// <summary>
-    ///     Blacklist for battery containers that can not be drank from. This should not be used to disable drinking from a type
-    ///     of power cell, as it is not checked for entities inside a power cell slot.
+    ///     Blacklist for battery containers that can not be drank from.
     /// </summary>
+    /// <remarks>
+    ///     This should not be used to disable drinking from a type of power cell, as it is not checked for entities
+    ///     inside a power cell slot. If you want to ban drinking from a power cell, remove BatteryDrinkerSourceComponent
+    ///     from it.
+    /// </remarks>
     [DataField]
     public EntityWhitelist? Blacklist;
 }

--- a/Content.Shared/_EinsteinEngines/Power/Components/BatteryDrinkerComponent.cs
+++ b/Content.Shared/_EinsteinEngines/Power/Components/BatteryDrinkerComponent.cs
@@ -3,10 +3,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Goobstation - Energycrit: Moved to shared
-/*
-namespace Content.Server._EinsteinEngines.Power.Components;
+using Content.Shared.Whitelist; // Goobstation - Energycrit
 
+namespace Content.Shared._EinsteinEngines.Power.Components;
+
+/// <Goobstation> Moved from EE server to EE shared </Goobstation>
 [RegisterComponent]
 public sealed partial class BatteryDrinkerComponent : Component
 {
@@ -38,10 +39,9 @@ public sealed partial class BatteryDrinkerComponent : Component
 
     /// <Goobstation> Energycrit: BatteryDrinker blacklist. </Goobstation>
     /// <summary>
-    ///     Blacklist for items that can not be drank from. This should not be used to disable drinking from a type
-    ///     of power cell, it is not checked for entities inside a power cell slot.
+    ///     Blacklist for battery containers that can not be drank from. This should not be used to disable drinking from a type
+    ///     of power cell, as it is not checked for entities inside a power cell slot.
     /// </summary>
     [DataField]
     public EntityWhitelist? Blacklist;
 }
-*/

--- a/Content.Shared/_EinsteinEngines/Power/Systems/SharedBatteryDrinkerSystem.cs
+++ b/Content.Shared/_EinsteinEngines/Power/Systems/SharedBatteryDrinkerSystem.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._EinsteinEngines.Power.Systems;
+
+/// <Goobstation> Energycrit: BatteryDrinkerSystem verb prediction </Goobstation>
+public abstract class SharedBatteryDrinkerSystem : EntitySystem;

--- a/Content.Shared/_EinsteinEngines/Silicon/Charge/BatteryDrinkerSourceComponent.cs
+++ b/Content.Shared/_EinsteinEngines/Silicon/Charge/BatteryDrinkerSourceComponent.cs
@@ -5,10 +5,9 @@
 
 using Robust.Shared.Audio;
 
-namespace Content.Server._EinsteinEngines.Silicon.Charge;
+namespace Content.Shared._EinsteinEngines.Silicon.Charge;
 
-// Goobstation - Energycrit: Moved to shared.
-/*
+/// <Goobstation> Energycrit: Moved from server to shared. </Goobstation>
 [RegisterComponent]
 public sealed partial class BatteryDrinkerSourceComponent : Component
 {
@@ -31,4 +30,3 @@ public sealed partial class BatteryDrinkerSourceComponent : Component
     [DataField]
     public SoundSpecifier? DrinkSound = new SoundCollectionSpecifier("sparks");
 }
-*/

--- a/Content.Shared/_EinsteinEngines/Silicon/SharedSiliconSystem.cs
+++ b/Content.Shared/_EinsteinEngines/Silicon/SharedSiliconSystem.cs
@@ -26,11 +26,16 @@ public sealed class SharedSiliconChargeSystem : EntitySystem
         SubscribeLocalEvent<SiliconComponent, ComponentInit>(OnSiliconInit);
         SubscribeLocalEvent<SiliconComponent, SiliconChargeStateUpdateEvent>(OnSiliconChargeStateUpdate);
         SubscribeLocalEvent<SiliconComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);
+        // Monolith - IPC Rework
+        /*
         SubscribeLocalEvent<SiliconComponent, ItemSlotInsertAttemptEvent>(OnItemSlotInsertAttempt);
         SubscribeLocalEvent<SiliconComponent, ItemSlotEjectAttemptEvent>(OnItemSlotEjectAttempt);
-        SubscribeLocalEvent<SiliconComponent, TryingToSleepEvent>(OnTryingToSleep);    
+        */
+        SubscribeLocalEvent<SiliconComponent, TryingToSleepEvent>(OnTryingToSleep);
     }
 
+    // Monolith - IPC Rework
+    /*
     private void OnItemSlotInsertAttempt(EntityUid uid, SiliconComponent component, ref ItemSlotInsertAttemptEvent args)
     {
         if (args.Cancelled
@@ -52,6 +57,7 @@ public sealed class SharedSiliconChargeSystem : EntitySystem
 
         args.Cancelled = true;
     }
+    */
 
     private void OnSiliconInit(EntityUid uid, SiliconComponent component, ComponentInit args)
     {

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -430,6 +430,7 @@
     - CanPilot
     - Unimplantable
     - SiliconMob
+    - IPCDrinkBlacklist # Goobstation - Energycrit: Don't let self antagging IPCs steal power from borgs.
   - type: Emoting
   - type: GuideHelp
     guides:

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -104,6 +104,8 @@
   - type: Riggable
   - type: StealTarget #Goobstation - IPC steal
     stealGroup: Battery
+  - type: BatteryDrinkerSource # Goobstation - Energycrit
+    maxAmount: 360
 
 - type: entity
   name: potato battery

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -196,6 +196,8 @@
     wideAnimationRotation: 90 # -90 if it takes bayonets (hits with muzzle) 90 if not (hits with butt)
     soundHit:
       collection: MetalThud # Goobstation ^
+  - type: BatteryDrinkerSource # Goobstation - Energycrit
+    maxAmount: 180 # you probably don't want to drain your entire gun charging in battle
 
 - type: entity
   id: BaseWeaponPowerCell

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -145,7 +145,7 @@
       3: 1
       2: 0.80
       1: 0.45
-      0: 0.20
+      0: 0.40
   - type: BatteryDrinker
     blacklist: # Goobstation - Energycrit
       tags:

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -78,11 +78,12 @@
   - type: BatterySlotRequiresLock
     itemSlot: cell_slot
   - type: EncryptionHolderRequiresLock
-  - type: SiliconEmitSoundOnDrained
-    sound: "/Audio/_Goobstation/Voice/IPC/energy_low.ogg" # Goobstation - ipc audio
-    minInterval: 8
-    maxInterval: 12
-    popUp: "silicon-power-low"
+  # Goobstation - Energycrit
+  #- type: SiliconEmitSoundOnDrained
+  #  sound: "/Audio/_Goobstation/Voice/IPC/energy_low.ogg" # Goobstation - ipc audio
+  #  minInterval: 8
+  #  maxInterval: 12
+  #  popUp: "silicon-power-low"
   - type: Lock
     locked: true
     lockOnClick: false
@@ -144,8 +145,9 @@
       3: 1
       2: 0.80
       1: 0.45
-      0: 0.00
+      0: 0.20
   - type: BatteryDrinker
+    drinkAll: true # Goobstation - Energycrit
   - type: EncryptionKeyHolder
     keySlots: 4
     examineWhileLocked: false

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -148,6 +148,9 @@
       0: 0.20
   - type: BatteryDrinker
     drinkAll: true # Goobstation - Energycrit
+    blacklist:
+      tags:
+      - IPCDrinkBlacklist
   - type: EncryptionKeyHolder
     keySlots: 4
     examineWhileLocked: false
@@ -176,7 +179,7 @@
     - FootstepSound
     - DoorBumpOpener
     - AnomalyHost
-
+    - IPCDrinkBlacklist # Goobstation - Energycrit: Don't let self antagging IPCs steal power from other ipcs.
 - type: entity
   save: false
   name: Urist McPositronic

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -147,8 +147,7 @@
       1: 0.45
       0: 0.20
   - type: BatteryDrinker
-    drinkAll: true # Goobstation - Energycrit
-    blacklist:
+    blacklist: # Goobstation - Energycrit
       tags:
       - IPCDrinkBlacklist
   - type: EncryptionKeyHolder

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -217,6 +217,7 @@
         - CanPilot
         - FootstepSound
         - DoorBumpOpener
+        - IPCDrinkBlacklist # Goobstation - Energycrit: Don't let self antagging IPCs steal power from other battery powered species.
     - type: Hands
     - type: Inventory
       templateId: human

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -74,6 +74,8 @@
     wideAnimationRotation: 90 # -90 if it takes bayonets (hits with muzzle) 90 if not (hits with butt)
     soundHit:
       collection: MetalThud # Goobstation ^
+  - type: BatteryDrinkerSource # Goobstation - Energycrit
+    maxAmount: 180
 
 - type: entity
   id: BaseWeaponCustomCellSmall

--- a/Resources/Prototypes/_Goobstation/tags.yml
+++ b/Resources/Prototypes/_Goobstation/tags.yml
@@ -319,6 +319,9 @@
   id: IgnoreImmovableRod
 
 - type: Tag
+  id: IPCDrinkBlacklist
+
+- type: Tag
   id: ItemPickaxe
 
 - type: Tag


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Instead of falling asleep and being effectively round removed, when an IPCs power runs out, they drop what they are holding and can crawl towards some sort of power source to recharge. IPCs can now drain power from a battery powered device instead of using an APC.

Ports and builds on https://github.com/Monolith-Station/Monolith/pull/614

## Why / Balance
#4128 was stupid.

## Technical details
Heavily modifies `BatteryDrinkerSystem` and `SiliconChargeDeathSystem`, adds an `IPCDrinkBlacklist` tag to some player controlled to prevent IPCs from stealing power from them.

## Media
https://github.com/user-attachments/assets/c284be39-41fe-44aa-9169-c60f5effd186

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Some EE classes have been moved into shared.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Energycrit
- tweak: IPCs are no longer round removed when they run out of power in maints.
- tweak: IPCs can change their own batteries