### PR TITLE
Mech Tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -104,7 +104,7 @@
   - type: InteractionOutline
   - type: MovementSpeedModifier
     baseWalkSpeed: 1
-    baseSprintSpeed: 2
+    baseSprintSpeed: 1 #Goobedit
   - type: Tag
     tags:
     - DoorBumpOpener
@@ -224,7 +224,7 @@
         Structural: 30 # Goobstation - Make ripley punch hard
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.25
-    baseSprintSpeed: 3.6
+    baseSprintSpeed: 2.25 #Goobedit
 
 - type: entity
   id: MechRipleyBattery
@@ -309,7 +309,7 @@
         Structural: 2
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.4
-    baseSprintSpeed: 3.7
+    baseSprintSpeed: 2.4 #Goobedit
 
 - type: entity
   parent: MechHamtr
@@ -372,7 +372,7 @@
         Structural: 2
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.25
-    baseSprintSpeed: 3.6
+    baseSprintSpeed: 2.25 #Goobedit
   - type: Access
     tags:
     - Maintenance

--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -254,6 +254,9 @@
       collection: FootstepClown
       params:
         variation: 0.17
+  - type: MovementSpeedModifier
+    baseWalkSpeed: 2
+    baseSprintSpeed: 2.5 #Goobedit
   - type: Mech
     baseState: honker
     openState: honker-open

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
@@ -90,8 +90,8 @@
       types:
         Blunt: 20
   - type: MovementSpeedModifier
-    baseWalkSpeed: 1
-    baseSprintSpeed: 1 #Goobedit
+    baseWalkSpeed: 2
+    baseSprintSpeed: 2 #Goobedit
   - type: Damageable
     damageModifierSet: MediumArmorNT
   - type: StaticPrice

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
@@ -148,8 +148,8 @@
       types:
         Blunt: 26
   - type: MovementSpeedModifier
-    baseWalkSpeed: 2.5
-    baseSprintSpeed: 2.5 #Goobedit
+    baseWalkSpeed: 3.5
+    baseSprintSpeed: 3.5 #Goobedit
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
   - type: StaticPrice

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mechs.yml
@@ -91,7 +91,7 @@
         Blunt: 20
   - type: MovementSpeedModifier
     baseWalkSpeed: 1
-    baseSprintSpeed: 2
+    baseSprintSpeed: 1 #Goobedit
   - type: Damageable
     damageModifierSet: MediumArmorNT
   - type: StaticPrice
@@ -149,7 +149,7 @@
         Blunt: 26
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.5
-    baseSprintSpeed: 4.5
+    baseSprintSpeed: 2.5 #Goobedit
   - type: CanMoveInAir
   - type: MovementAlwaysTouching
   - type: StaticPrice
@@ -223,7 +223,7 @@
   - type: MovementAlwaysTouching
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
-    baseSprintSpeed: 2.6
+    baseSprintSpeed: 2 #Goobedit
   - type: StaticPrice
     price: 3000
   - type: Tag
@@ -281,7 +281,7 @@
         Structural: 220
   - type: MovementSpeedModifier
     baseWalkSpeed: 1.5
-    baseSprintSpeed: 2
+    baseSprintSpeed: 1.5 #Goobedit
   - type: Damageable
     damageModifierSet: MediumArmorNT
   - type: CanMoveInAir
@@ -349,7 +349,7 @@
         Structural: 200
   - type: MovementSpeedModifier
     baseWalkSpeed: 1
-    baseSprintSpeed: 1.5
+    baseSprintSpeed: 1 #Goobedit
   - type: Damageable
     damageModifierSet: HeavyArmorNT
   - type: CanMoveInAir
@@ -422,7 +422,7 @@
         Structural: 400
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.2
-    baseSprintSpeed: 3.7
+    baseSprintSpeed: 2.2 
   - type: Damageable
     damageModifierSet: HeavyArmorNT
   - type: CanMoveInAir
@@ -498,7 +498,7 @@
         Structural: 200
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.2
-    baseSprintSpeed: 3.7
+    baseSprintSpeed: 2.2 #Goobedit
   - type: Damageable
     damageModifierSet: MediumArmorSyndi
   - type: CanMoveInAir
@@ -571,7 +571,7 @@
         Structural: 400
   - type: MovementSpeedModifier
     baseWalkSpeed: 1
-    baseSprintSpeed: 1.5
+    baseSprintSpeed: 1 #Goobedit
   - type: Damageable
     damageModifierSet: HeavyArmorSyndi
   - type: CanMoveInAir


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
Fix #4155 (For the most part)
H.O.N.K mech retains the ability to sprint but it's only a tiny difference in speed
All other mechs have had their basesprintspeed and basewalkspeed made equal (Yaml fix do something about it)
Ripley MK2 is disasterously slow, so I bumped its speed

## Why / Balance
Mech's dont have a downside to sprinting such as stamina drain so it's a bit ass.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: All mechs (Except the H.O.N.K) can no longer sprint
- tweak: Doubled the move speed of the Ripley MkII (It's still pretty damn slow)
- tweak: Clarke movespeed increased from 2.5 to 3.5
