### PR TITLE
(Bounty) Revert "epipen rework (partial alternative to #3898)"

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -305,13 +305,13 @@
   - type: SolutionContainerManager
     solutions:
       pen:
-        maxVol: 15 # Goobstation
+        maxVol: 20 # goobstation
         reagents:
-        - ReagentId: Epinephrine # Goobstation
+        - ReagentId: Dexalin # Goobstation
+          Quantity: 10
+        - ReagentId: Ibuprofen # Goobstation
           Quantity: 5
-        - ReagentId: Atropine # Goobstation
-          Quantity: 5
-        - ReagentId: TranexamicAcid # Goobstation
+        - ReagentId: Omnizine # Goobstation
           Quantity: 5
   - type: Tag
     tags:


### PR DESCRIPTION
Reverts Goob-Station/Goob-Station#3922

The medipen doesn't even heal people out of crit

It's ass to interact with woundmend and no one is fixing it

>Get hit by a couple shots
>Topicals are now disabled
>Forced to slowly crawl to med while half dead
>Wait in med for 10 minutes because goob med players are notoriously slow

>Room you're in gets spaced
>Have every single limb damaged within seconds
>Have to sit in med for 10 minutes or ignore the med players and go straight for the chem bag (no med players don't need more half dead people to deal with. They get plenty of action every shift even before this)

>Be valid
>Get shot by security
>No topicals so no healing
>Go to med
>Med attacks you because you're valid

can we just not make negative QOL changes without addressing the main problems first. That'd be great

:cl:
- tweak: Medipens are no longer terrible