### PR TITLE
Radiation Overhaul Tweaks

### DIFF
--- a/Content.Goobstation.Server/Supermatter/Systems/SupermatterSystem.cs
+++ b/Content.Goobstation.Server/Supermatter/Systems/SupermatterSystem.cs
@@ -249,8 +249,10 @@ public sealed class SupermatterSystem : SharedSupermatterSystem
         //Radiate stuff
         if (TryComp<RadiationSourceComponent>(uid, out var rad))
         {
+            // Goobstation Start - Radiation Overhaul
             var transmittedpower = sm.Power * Math.Max(0, 1f + transmissionBonus / 10f);
             rad.Intensity = transmittedpower * sm.RadiationOutputFactor;
+            // Goobstation End - Radiation Overhaul
         }
 
         //Power * 0.55 * a value between 1 and 0.8

--- a/Content.Goobstation.Shared/Supermatter/Components/SupermatterComponent.cs
+++ b/Content.Goobstation.Shared/Supermatter/Components/SupermatterComponent.cs
@@ -99,6 +99,7 @@ public sealed partial class SupermatterComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     public float HeatThreshold = 2500f;
 
+    /// <Goobstation> Radiation Overhaul </Goobstation>
     [DataField("radiationOutputFactor")]
     [ViewVariables(VVAccess.ReadWrite)]
     public float RadiationOutputFactor = 0.03f;

--- a/Content.Server/Radiation/Components/RadiationBlockingContainerComponent.cs
+++ b/Content.Server/Radiation/Components/RadiationBlockingContainerComponent.cs
@@ -19,5 +19,12 @@ public sealed partial class RadiationBlockingContainerComponent : Component
     ///     How many rads per second does the blocker absorb?
     /// </summary>
     [DataField("resistance")]
-    public float RadResistance = 1f;
+    public float RadResistance = 0f;
+
+    /// <Goobstation> Radiation Rework </Goobstation>
+    /// <summary>
+    ///     Radiation decay for the Goobstation radiation overhaul after applying the flat reduction.
+    /// </summary>
+    [DataField("decay")]
+    public float RadDecay = 1f;
 }

--- a/Content.Server/Radiation/Systems/RadiationSystem.GridCast.cs
+++ b/Content.Server/Radiation/Systems/RadiationSystem.GridCast.cs
@@ -19,7 +19,7 @@ using Content.Server.Radiation.Components;
 using Content.Server.Radiation.Events;
 using Content.Shared.Radiation.Components;
 using Content.Shared.Radiation.Systems;
-using Content.Shared.Singularity.Components;
+using Content.Shared.Singularity.Components; // Goobstation - Radiation Overhaul
 using Robust.Shared.Collections;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Timing;
@@ -151,6 +151,7 @@ public partial class RadiationSystem
 
         var mapId = destTrs.MapID;
 
+        // Goobstation Start - Radiation Overhaul
         // get direction from rad source to destination and its distance
         var dir = destWorld - source.WorldPosition;
         var dist = Math.Max(dir.Length(),0.5f);
@@ -159,6 +160,7 @@ public partial class RadiationSystem
         var rads = source.Intensity / (dist );
         if (rads < 0.01)
             return null;
+        // Goobstation End - Radiation Overhaul
 
         // create a new radiation ray from source to destination
         // at first we assume that it doesn't hit any radiation blockers
@@ -203,12 +205,14 @@ public partial class RadiationSystem
 
         return ray;
     }
-/// <summary>
-/// Similar to GridLineEnumerator, but also returns the distance the ray traveled in each cell
-/// </summary>
-/// <param name="sourceGridPos">source of the ray, in grid space</param>
-/// <param name="destGridPos"></param>
-/// <returns></returns>
+
+    /// <Goobstation> Radiation Overhaul </Goobstation>
+    /// <summary>
+    /// Similar to GridLineEnumerator, but also returns the distance the ray traveled in each cell
+    /// </summary>
+    /// <param name="sourceGridPos">source of the ray, in grid space</param>
+    /// <param name="destGridPos"></param>
+    /// <returns></returns>
     private static IEnumerable<(Vector2i cell, float distInCell)> AdvancedGridRaycast(Vector2 sourceGridPos,Vector2 destGridPos)
     {
         var delta = destGridPos - sourceGridPos;
@@ -281,6 +285,8 @@ public partial class RadiationSystem
 
         // get coordinate of source and destination in grid coordinates
 
+        // Goobstation Start - Radiation Overhaul
+
         // TODO Grid overlap. This currently assumes the grid is always parented directly to the map (local matrix == world matrix).
         // If ever grids are allowed to overlap, this might no longer be true. In that case, this should precompute and cache
         // inverse world matrices.
@@ -322,6 +328,8 @@ public partial class RadiationSystem
             }
         }
 
+        // Goobstation End - Radiation Overhaul
+
 
         if (!saveVisitedTiles || blockers!.Count <= 0)
             return ray;
@@ -353,10 +361,12 @@ public partial class RadiationSystem
 
             if (_blockerQuery.TryComp(xform.ParentUid, out var blocker))
             {
-                var ratio =blocker.RadResistance>2? 1 / (blocker.RadResistance/2):1;
-                rads *= ratio;
-                if (rads < 0)
+                // Goobstation Start - Radiation Overhaul
+                var ratio = blocker.RadDecay>2? 1 / (blocker.RadDecay/2):1;
+                rads = (rads - blocker.RadResistance) * ratio;
+                if (rads < 0.1)
                     return 0;
+                // Goobstation End - Radiation Overhaul
             }
 
             child = parent;

--- a/Resources/Prototypes/Entities/Debugging/item.yml
+++ b/Resources/Prototypes/Entities/Debugging/item.yml
@@ -26,6 +26,7 @@
     - 1, 4, 6, 4
     - 6, 2, 6, 2
     - 5, 3, 5, 5
+# Goobstation Start - Radiation Overhaul
 - type: entity
   parent: PonderingOrb
   id: PonderingOrbRadioactive
@@ -63,3 +64,4 @@
     maxExternalPressure: 4500
     spawnAmount: 40000
     spawnTemperature: 70
+# Goobstation End - Radiation Overhaul

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -132,7 +132,7 @@
   - type: Singularity
     energy: 180
     level: 1
-    radsPerLevel: 6
+    radsPerLevel: 6 # Goobstation - Radiation Overhaul
     energyLoss: 1
   - type: RandomWalk # To make the singularity move around.
     maxSpeed: 2.5
@@ -142,7 +142,7 @@
     intensity: 3645
   - type: RadiationSource
     slope: 0.2 # its emit really far away
-    intensity: 6
+    intensity: 6 # Goobstation - Radiation Overhaul
   - type: PointLight
     enabled: true
     radius: 10

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -67,7 +67,10 @@
     reflectProb: 0.2
     spread: 90
   - type: RadiationBlockingContainer
-    resistance: 2.5
+    # Goobstation Start - Radiation Overhaul
+    # resistance: 2.5
+    decay: 2.5
+    # Goobstation End - Radiation Overhaul
   - type: PhysicalComposition #Goobstation - Recycle update
     materialComposition:
       Steel: 125

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -644,7 +644,7 @@
     key: walls
     base: plasma
   - type: RadiationBlocker
-    resistance: 10
+    resistance: 10 # Goobstation - Radiation Overhaul
   - type: CosmicCorruptible # DeltaV - Cosmic Cult
     convertTo: WallCosmicCult
 
@@ -1401,7 +1401,7 @@
     key: walls
     base: uranium
   - type: RadiationBlocker
-    resistance: 20
+    resistance: 20 # Goobstation - Radiation Overhaul
   - type: CosmicCorruptible # DeltaV - Cosmic Cult
     convertTo: WallCosmicCult
 

--- a/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plasma.yml
@@ -85,7 +85,7 @@
   - type: StaticPrice
     price: 100
   - type: RadiationBlocker
-    resistance: 2.5
+    resistance: 2.5 # Goobstation - Radiation Overhaul
   - type: Penetratable # Goobstation - Better snipers
     penetrateDamage: 75
     damagePenalty: 0.1
@@ -146,7 +146,7 @@
   - type: StaticPrice
     price: 50
   - type: RadiationBlocker
-    resistance: 2.444
+    resistance: 2.444 # Goobstation - Radiation Overhaul
   - type: Penetratable # Goobstation - Better snipers
     penetrateDamage: 50
     damagePenalty: 0.1

--- a/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
@@ -49,7 +49,7 @@
     damageContainer: StructuralInorganic
     damageModifierSet: RGlass
   - type: RadiationBlocker
-    resistance: 10
+    resistance: 10 # Goobstation - Radiation Overhaul
   - type: Destructible
     thresholds:
     - trigger:
@@ -122,7 +122,7 @@
   - type: Damageable
     damageModifierSet: RGlass
   - type: RadiationBlocker
-    resistance: 5
+    resistance: 5 # Goobstation - Radiation Overhaul
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/ruranium.yml
@@ -73,7 +73,7 @@
   - type: StaticPrice
     price: 215
   - type: RadiationBlocker
-    resistance: 20
+    resistance: 20 # Goobstation - Radiation Overhaul
   - type: CosmicCorruptible # DeltaV - Cosmic Cult
     convertTo: WindowCosmicCult
 
@@ -133,7 +133,7 @@
   - type: StaticPrice
     price: 110
   - type: RadiationBlocker
-    resistance: 10
+    resistance: 10 # Goobstation - Radiation Overhaul
 
 - type: entity
   parent: ReinforcedUraniumWindow

--- a/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/uranium.yml
@@ -75,7 +75,7 @@
   - type: StaticPrice
     price: 200
   - type: RadiationBlocker
-    resistance: 3
+    resistance: 3 # Goobsatation - Radiation Overhaul
   - type: Penetratable # Goobstation - Better snipers
     penetrateDamage: 75
     damagePenalty: 0.1
@@ -133,7 +133,7 @@
   - type: StaticPrice
     price: 100
   - type: RadiationBlocker
-    resistance: 2.222
+    resistance: 2.222 # Goobstation - Radiation Overhaul
   - type: Penetratable # Goobstation - Better snipers
     penetrateDamage: 50
     damagePenalty: 0.1


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Added goob comments to changes outside _Goobstation/in core. Made artifact containers work how they used to.

## Why / Balance
artifact container - science qol
goob comments - me when I edit core without telling anyone.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
The `RadResistance` field of `RadiationBlockingContainerComponent` is once again a flat reduction on radiation. If you want to use the radiation overhaul behavior, use `RadDecay`.

**Changelog**
:cl:
- tweak: Artifact containers block rads again.
