### PR TITLE
Save processing power

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -430,14 +430,14 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      15: Critical
-      30: Dead
+      15: Dead #goob
+  - type: Bloodstream
+    bloodMaxVolume: 10 #goob (he is very small)
   - type: Destructible
     thresholds:
     - trigger:
-        !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 60
+        !type:DamageTrigger
+        damage: 15
       behaviors:
       - !type:GibBehavior
         recursive: false


### PR DESCRIPTION
Dead rat servants pop into organs and blood, so they dont continue to be newmed processed while dead in the dozens

Makes the rat husbandry exploit more obvious but whatever
