### PR TITLE
slop tot med consumables buff

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -833,7 +833,7 @@
   description: uplink-combat-medkit-desc
   productEntity: MedkitCombatFilled
   cost:
-    Telecrystal: 15 # goob
+    Telecrystal: 10 #goob
   categories:
   - UplinkChemicals
 
@@ -844,7 +844,7 @@
   description: uplink-combat-medipen-desc
   productEntity: CombatMedipen
   cost:
-    Telecrystal: 12 # Goobstation - Combat pen rebalance
+    Telecrystal: 8 # Goobstation - Combat pen rebalance
   categories:
   - UplinkChemicals
 
@@ -1185,7 +1185,7 @@
   categories:
   - UplinkDisruption
 # Goob - Antimov was given the same price for traitors and nukies
-#  conditions:                     
+#  conditions:
 #  - !type:StoreWhitelistCondition
 #     blacklist:
 #       tags:
@@ -1205,7 +1205,7 @@
 #  - !type:StoreWhitelistCondition
 #    whitelist:
 #      tags:
-#      - NukeOpsUplink 
+#      - NukeOpsUplink
 
 
 

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -775,7 +775,7 @@
   description: uplink-advanced-combat-medipen-desc
   productEntity: AdvancedCombatMedipen
   cost:
-    Telecrystal: 28
+    Telecrystal: 20
   categories:
   - UplinkChemicals
 


### PR DESCRIPTION
makes combat medkit and combat medipen cheaper in uplink

## Why 
spending your tc on consumabels feels Bad when you have other options which are more permanent
also these options inadvertently got nerfed by making topicals Shit and making brute and burn medipens aquirable by crew (therefore you have less reason to spend your tc on something you can just get for just a little effort) 
slop

## Media
<img width="347" height="191" alt="image" src="https://github.com/user-attachments/assets/9ef85414-eb4d-4751-b11c-1fd6c6e7b7ed" />

**Changelog**

:cl:
- tweak: Medical items in Uplink are now cheaper in TC: Combat medkit 15->10, combat medipen 12->8, advanced medipen 28->20.
