### PR TITLE
Make the Nuke Good Again

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
@@ -115,7 +115,7 @@
     explosionType: Default
     maxIntensity: 100
     intensitySlope: 5
-    totalIntensity: 5000000
+    totalIntensity: 800000 # Goobedit bandaid fix for some reason values higher than 1000000 just stop working
     diskSlot:
       name: nuke-slot-component-slot-name-disk
       insertSound:


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
Nuke does something

Kinda fixes #4288 

## Why / Balance
Nuke currently does actually fucking nothing doesnt even break the tile it's on, now it'll at least put a massive fuck off crater into the station.

## Technical details
Changed totalIntensity from 5000000 to 800000 which seems counter intuitive but for some reason that works. Something tells me that something is overflowing with higher numbers. But in truth I will need to dig further in. This fix at least allows the nuke to do something when detonated.

## Media
Here's what the nuke with this change does to Fland. I have tried playing with values slightly higher/lower and also tried tweaking things like the slope but so far this is the best I can do. I intend to continue chasing this but for now... band aid.
<img width="1842" height="1337" alt="image" src="https://github.com/user-attachments/assets/78747785-676e-4536-8c3d-5c2d0a0aae8b" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Nuke actually nukes now 

