### PR TITLE
fix shitsalv

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -80,6 +80,7 @@
   icon: "JobIconShaftMiner"
   startingGear: SalvageSpecialistGear
   goobcoins: 20 #Goob content
+  canBeAntag: false # Goobstation - salv lings crashing the economy
   supervisors: job-supervisors-qm
   access:
   - Cargo


### PR DESCRIPTION
sponsored by this gif
![armok](https://github.com/user-attachments/assets/314a230c-55f9-43f5-9055-f5b96d165193)

salv cant be roundstart antags (not mindshielded so it doesnt affect revs/cult)
salv ling eating everyone and crippling the economy will be much rarer (now a random tider has to go to lavaland and eat everyone instead of "lol im evil im going to eat you all on the shuttle ftl"

:cl:
- tweak: Salvage can no longer be antagonists.