### PR TITLE
Network IsEquipment field for night vision

### DIFF
--- a/Content.Goobstation.Shared/Overlays/SwitchableOverlaySystem.cs
+++ b/Content.Goobstation.Shared/Overlays/SwitchableOverlaySystem.cs
@@ -101,6 +101,7 @@ public abstract class SwitchableOverlaySystem<TComp, TEvent> : EntitySystem // t
         args.State = new SwitchableVisionOverlayComponentState
         {
             Color = component.Color,
+            IsEquipment = component.IsEquipment,
             IsActive = component.IsActive,
             FlashDurationMultiplier = component.FlashDurationMultiplier,
             ActivateSound = component.ActivateSound,
@@ -116,6 +117,7 @@ public abstract class SwitchableOverlaySystem<TComp, TEvent> : EntitySystem // t
             return;
 
         component.Color = state.Color;
+        component.IsEquipment = state.IsEquipment;
         component.FlashDurationMultiplier = state.FlashDurationMultiplier;
         component.ActivateSound = state.ActivateSound;
         component.DeactivateSound = state.DeactivateSound;

--- a/Content.Goobstation.Shared/Overlays/SwitchableVisionOverlayComponent.cs
+++ b/Content.Goobstation.Shared/Overlays/SwitchableVisionOverlayComponent.cs
@@ -55,6 +55,7 @@ public abstract partial class SwitchableVisionOverlayComponent : BaseVisionOverl
 public sealed class SwitchableVisionOverlayComponentState : IComponentState
 {
     public Color Color;
+    public bool IsEquipment;
     public bool IsActive;
     public float FlashDurationMultiplier;
     public SoundSpecifier? ActivateSound;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!--- LICENSE: AGPL -->

## About the PR
This PR networks the IsEquipment field of the `SwitchableVisionOverlayComponent` by adding it to the `SwitchableVisionOverlayComponentState`

## Why / Balance
Fixes a bug. Previously, if night vision was added to a piece of equipment by the server, and the IsEquipment field was set to true on the server, it would not work on the client, as the IsEquipment field would be false clientside.

## Technical details
Three lines of C#. One line for the component state, one line for the `OnGetState()` method, one for the `OnHandleState` method.

## Media
none needed (i think)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**