### PR TITLE
Robotic arm bugfix

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/robotic_arm.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/robotic_arm.yml
@@ -87,7 +87,8 @@
         whitelist:
           components:
           - AutomationFilter
-  - type: RoboticArm
+  - type:
+    MovingPowerDraw: 50 # changing power draw causes APC flickering, which ruins automation
   - type: FilterSlot
   - type: AutomationSlots
     slots:


### PR DESCRIPTION
robotic arm power changes causes APC flickering which ruins factories