### PR TITLE
Fixes #4171 - Xenomorph Fixes

### DIFF
--- a/Content.Server/_White/Actions/ActionsSystem.cs
+++ b/Content.Server/_White/Actions/ActionsSystem.cs
@@ -1,5 +1,7 @@
 using Content.Server.DoAfter;
+using Content.Shared._White.Actions;
 using Content.Shared._White.Actions.Events;
+using Content.Shared.Actions.Components;
 using Content.Shared.Construction.EntitySystems;
 using Content.Shared.Coordinates;
 using Content.Shared.DoAfter;
@@ -22,6 +24,7 @@ public sealed class ActionsSystem : EntitySystem
     [Dependency] private readonly ContainerSystem _container = default!;
     [Dependency] private readonly DoAfterSystem _doAfter = default!;
     [Dependency] private readonly MapSystem _mapSystem = default!;
+    [Dependency] private readonly PlasmaCostActionSystem _plasmaCost = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
 
     public override void Initialize()
@@ -42,6 +45,13 @@ public sealed class ActionsSystem : EntitySystem
     {
         if (args.Handled)
             return;
+
+        // Check plasma cost if this is a plasma-cost action
+        if (TryComp<PlasmaCostActionComponent>(args.Action, out var plasmaCost) &&
+            !_plasmaCost.CheckPlasmaCost(args.Performer, plasmaCost.PlasmaCost))
+        {
+            return;
+        }
 
         if (args.Length != 0)
         {

--- a/Content.Server/_White/Actions/ActionsSystem.cs
+++ b/Content.Server/_White/Actions/ActionsSystem.cs
@@ -49,6 +49,7 @@ public sealed class ActionsSystem : EntitySystem
         // Check plasma cost if this is a plasma-cost action
         if (TryComp<PlasmaCostActionComponent>(args.Action, out var plasmaCost) &&
             !_plasmaCost.CheckPlasmaCost(args.Performer, plasmaCost.PlasmaCost))
+            // TODO Fix plasma check to be done after the check if our actin got broken
         {
             return;
         }
@@ -72,8 +73,9 @@ public sealed class ActionsSystem : EntitySystem
             {
                 BlockDuplicate = true,
                 BreakOnDamage = true,
-                CancelDuplicate = true,
                 BreakOnMove = true,
+                NeedHand = false,
+                CancelDuplicate = true,
                 Broadcast = true
             };
 
@@ -87,7 +89,10 @@ public sealed class ActionsSystem : EntitySystem
 
     private void OnPlaceTileEntityDoAfter(PlaceTileEntityDoAfterEvent args)
     {
-        if (!args.Handled && CreationTileEntity(args.User, GetCoordinates(args.Target), args.TileId, args.Entity, args.Audio, args.BlockedCollisionLayer, args.BlockedCollisionMask))
+        if (args.Cancelled || args.Handled)
+            return;
+
+        if (CreationTileEntity(args.User, GetCoordinates(args.Target), args.TileId, args.Entity, args.Audio, args.BlockedCollisionLayer, args.BlockedCollisionMask))
             args.Handled = true;
     }
 

--- a/Content.Shared/_White/Actions/Events/SpawnActionEvent.cs
+++ b/Content.Shared/_White/Actions/Events/SpawnActionEvent.cs
@@ -90,5 +90,8 @@ public sealed partial class PlaceTileEntityDoAfterEvent : DoAfterEvent
 
     public int BlockedCollisionLayer;
 
+    [DataField("plasmaCost")]
+    public int PlasmaCost;
+
     public override DoAfterEvent Clone() => this;
 }

--- a/Content.Shared/_White/Actions/PlasmaCostActionSystem.cs
+++ b/Content.Shared/_White/Actions/PlasmaCostActionSystem.cs
@@ -1,5 +1,7 @@
+using Content.Goobstation.Maths.FixedPoint;
 using Content.Shared._White.Xenomorphs;
 using Content.Shared._White.Xenomorphs.Plasma;
+using Content.Shared._White.Xenomorphs.Plasma.Components;
 using Content.Shared.Actions;
 using Content.Shared.Actions.Events;
 
@@ -16,6 +18,25 @@ public sealed class PlasmaCostActionSystem : EntitySystem
         SubscribeLocalEvent<PlasmaCostActionComponent, ActionPerformedEvent>(OnActionPerformed);
     }
 
+    /// <summary>
+    /// Call this from systems that handle placement events to check plasma cost.
+    /// Returns true if the action should proceed, false if it should be blocked.
+    /// </summary>
+    public bool CheckPlasmaCost(EntityUid performer, FixedPoint2 cost)
+    {
+        if (cost <= 0)
+            return true;
+
+        if (!TryComp<PlasmaVesselComponent>(performer, out var plasmaVessel) ||
+            plasmaVessel.Plasma < cost)
+        {
+            return false;
+        }
+
+        _plasma.ChangePlasmaAmount(performer, -cost);
+        return true;
+    }
+
     private void OnPlasmaAmountChange(EntityUid uid, PlasmaCostActionComponent component, ActionRelayedEvent<PlasmaAmountChangeEvent> args)
     {
         _actions.SetEnabled(uid, component.PlasmaCost <= args.Args.Amount);
@@ -26,4 +47,5 @@ public sealed class PlasmaCostActionSystem : EntitySystem
         if (component.ShouldChangePlasma)
             _plasma.ChangePlasmaAmount(args.Performer, -component.PlasmaCost);
     }
+
 }

--- a/Resources/Prototypes/_White/Actions/xenomorph.yml
+++ b/Resources/Prototypes/_White/Actions/xenomorph.yml
@@ -72,6 +72,7 @@
       - MidImpassable
       - LowImpassable
   - type: PlasmaCostAction
+    plasmaCost: 50
 
 - type: entity
   id: ActionSpawnXenomorphEgg
@@ -116,6 +117,7 @@
       blockedCollisionLayer:
       - WallLayer
   - type: PlasmaCostAction
+    plasmaCost: 50
 
 # TODO: delete it # Goobstation - removed
 #- type: entity
@@ -187,6 +189,7 @@
       - TableLayer
       - BulletImpassable
   - type: PlasmaCostAction
+    plasmaCost: 50
 
 # Tail lash action
 - type: entity

--- a/Resources/Prototypes/_White/Actions/xenomorph.yml
+++ b/Resources/Prototypes/_White/Actions/xenomorph.yml
@@ -111,7 +111,7 @@
   - type: WorldTargetAction
     event: !type:PlaceTileEntityEvent
       entity: WallResin
-      length: 0.5
+      length: 2
       blockedCollisionMask:
       - FullTileMask
       blockedCollisionLayer:
@@ -157,7 +157,7 @@
   - type: WorldTargetAction
     event: !type:PlaceTileEntityEvent
       entity: ResinDoor
-      length: 0.5
+      length: 2
       blockedCollisionMask:
       - TableMask
       blockedCollisionLayer:
@@ -182,7 +182,7 @@
   - type: WorldTargetAction
     event: !type:PlaceTileEntityEvent
       entity: ResinNest
-      length: 0.5
+      length: 2
       blockedCollisionMask:
       - TableMask
       blockedCollisionLayer:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## About the PR
This PR Fixes #4171
TODO


- [ ] Fix structures do not take any resources to build
- [ ] Fix the structures ToDoAfter not canceling the building action.
- [ ] Fix Plasma being used before the ToDoAfter action finishes.
- [ ] Fix Emag/ninja gloves work on resin doors (xenomorph doors)

Fix #4236
- [ ] Ensure Xenomorphs slowly heal while on resin.

Fix #4247
- [ ] Fix Xeno Corrosive Acid has no mouse hover active sprite likely shit draw depth.

Make #4315
- [ ] Add the ability for face-huggers to inject some type of sleep chemical (likely a low tier one).
- [ ] Add the ability for face-huggers to remove or destroy face masks that aren't sealed (Maybe also they shouldn't be able to remove welding masks? I dunno)
- [ ] Add the ability to have facehuggers proply be throwable (aka try to attach to whatever they are being thrown near)


## Why / Balance
This PR Fixes #4171 
TODO

## Technical details
TODO

## Media
TODO WHEN DONE

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Richard Blonski
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!

