### PR TITLE
Realistic caliber names / More flavourful gun descriptions (WORK IN PROGRESS)

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Goobstation/store/uplink-catalog.ftl
@@ -151,7 +151,7 @@ uplink-mpapers-grenade-name = MP-APERS shell (40mm)
 uplink-mpapers-grenade-desc = Fires out 20 small pellets to turn your grenade launcher into a shotgun. Compatible with the China-Lake.
 
 uplink-rifle-mag-name = Rifle Magazine (.20)
-uplink-rifle-mag-desc = A 25 round magazine containing .20 rifle bullets. Supports the Lecter and M-90.
+uplink-rifle-mag-desc = A 25 round magazine containing 5.56x45mm bullets. Supports the Lecter and M-90.
 
 uplink-rifle-caseless-mag-name = Rifle Magazine (9.5mm HP)
 uplink-rifle-caseless-mag-desc = A 30 round rifle magazine filled with 9.5mm caseless magnum hollow-point bullets. Compatible with the WSPR.
@@ -159,7 +159,7 @@ uplink-rifle-caseless-mag-desc = A 30 round rifle magazine filled with 9.5mm cas
 uplink-pistol-magazine-caseless-saphe-name = Pistol Magazine (9.5mm SAP-HE)
 uplink-pistol-magazine-caseless-saphe-desc = 10 rounds of 9.5mm caseless magnum semi-armor-piercing high-explosive ammunition. It is exactly what you have read. Compatible with the Cobra.
 
-uplink-l6-box-name = Magazine Box (.30 rifle)
+uplink-l6-box-name = Magazine Box (7.62x51mm FMJ)
 uplink-l6-box-desc = Magazine box with 100 catridges. Compatible with the L6 SAW.
 
 uplink-shotgun-magazine-name = Shotgun Drum (12 gauge pellet)
@@ -168,7 +168,7 @@ uplink-shotgun-magazine-desc = Shotgun drum with 8 pellet shells. Compatible wit
 uplink-shotgun-magazine-slug-name = Shotgun Drum (12 gauge slug)
 uplink-shotgun-magazine-slug-desc = Shotgun drum with 8 slug shells. Compatible with the Bulldog.
 
-uplink-high-caliber-magazine-name = Rifle Magazine (.50 anti-materiel)
+uplink-high-caliber-magazine-name = Rifle Magazine (.50 BMG anti-materiel)
 uplink-high-caliber-magazine-desc = Heavy rifle magazine with 15 cartridges. Compatible with the Burner.
 
 uplink-high-caliber-explosive-magazine-name = Rifle Magazine (.50 HEI)
@@ -177,7 +177,7 @@ uplink-high-caliber-explosive-magazine-desc = Heavy rifle magazine with 15 High 
 uplink-high-caliber-box-name = .50 Ammo box
 uplink-high-caliber-box-desc = A box of 30 .50 caliber anti-materiel rounds.
 
-uplink-highcap-pistol-mag-name = High Capacity Pistol Magazine (.35 auto)
+uplink-highcap-pistol-mag-name = High Capacity Pistol Magazine (9x19mm FMJ)
 uplink-highcap-pistol-mag-desc = High capacity pistol magazine holds 4 extra bullets for a total of 16 rounds.
 
 uplink-heavy-shotgun-magazine-name = Heavy Shotgun Drum (2 gauge HE pellet)
@@ -186,8 +186,8 @@ uplink-heavy-shotgun-magazine-desc = Shotgun magazine with 15 high-explosive pel
 uplink-heavy-shotgun-magazine-slug-name = Heavy Shotgun Drum (2 gauge HE slug)
 uplink-heavy-shotgun-magazine-slug-desc = Shotgun magazine with 15 high-eplosive shrapnel slug shells. Compatible with the NZ CSG-242.
 
-uplink-m7s-mag-name = Side-mounted SMG Magazine (5x23mm)
-uplink-m7s-mag-desc = A 48 round 5x23mm rifle magazine. Compatible with M7S.
+uplink-m7s-mag-name = Side-mounted SMG Magazine (5.7x28mm)
+uplink-m7s-mag-desc = A 48 round 5.7x28mm rifle magazine. Compatible with M7S.
 
 uplink-cartridge-G8-demolishing-name = G8 demolishing cartridge
 uplink-cartridge-G8-demolishing-desc = This cartridge shots "The Spear of Ares" bullet, demolishing whole lines of walls, dealing massive stamina damage to people and overcharging energy vortexes. Used by HE1S-G8.
@@ -207,7 +207,7 @@ uplink-high-caliber-shotgun-box-flash-slug-desc = 16 shells of 8 Gauge flashbang
 uplink-high-caliber-shotgun-box-sarin-name = 8 Gauge sarin gas shell box
 uplink-high-caliber-shotgun-box-sarin-desc = 16 shells of 8 Gauge sarin shells for the combat shotgun, which release a small plus-shaped cloud of sarin gas.
 
-uplink-estoc-ammo-name = Rifle Magazine (.20 rifle)
+uplink-estoc-ammo-name = Rifle Magazine (5.56x45mm)
 uplink-estoc-ammo-desc = Rifle magazine with 25 rounds. Compatable with the Estoc.
 
 # Grenades

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -97,13 +97,13 @@
 
 # Weapons
 uplink-pistol-viper-name = Viper
-uplink-pistol-viper-desc = A small, easily concealable, but somewhat underpowered gun. Retrofitted with a fully automatic receiver. Uses pistol magazines (.35 auto).
+uplink-pistol-viper-desc = A small, easily concealable, but somewhat underpowered gun. Retrofitted with a fully automatic receiver. Uses pistol magazines (9x19mm).
 
 uplink-estoc-bundle-name = Estoc DMR
-uplink-estoc-bundle-desc = A designated marksman rifle, fitted with a mid-range optic for longer-range combat. Bundled with two rifle magazines (.20 rifle).
+uplink-estoc-bundle-desc = A designated marksman rifle, fitted with a mid-range optic for longer-range combat. Bundled with two rifle magazines (5.56x45mm).
 
 uplink-revolver-python-name = Python
-uplink-revolver-python-desc = A brutally simple, effective, and loud Syndicate revolver. Comes loaded with armor-piercing rounds. Uses .45 magnum.
+uplink-revolver-python-desc = A brutally simple, effective, and loud Syndicate revolver. Comes loaded with armor-piercing rounds. Uses .44 magnum.
 
 uplink-gloves-knuckleduster-name = Syndicate Knuckle Dusters
 uplink-gloves-knuckleduster-desc = A pair of plastitanium knuckle dusters that let you punch hard enough to break the captains jaw into pieces.
@@ -189,22 +189,22 @@ uplink-shrapnel-grenade-name = Shrapnel Grenade
 uplink-shrapnel-grenade-desc = Launches a spray of sharp fragments dealing great damage against unarmored targets.
 
 # Ammo
-uplink-pistol-magazine-name = Pistol Magazine (.35 auto)
+uplink-pistol-magazine-name = Pistol Magazine (9x19mm FMJ)
 uplink-pistol-magazine-desc = Pistol magazine with 12 catridges. Compatible with the Viper.
 
-uplink-pistol-magazine-c20r-name = SMG magazine (.35 auto)
+uplink-pistol-magazine-c20r-name = SMG magazine (9x19mm FMJ)
 uplink-pistol-magazine-c20r-desc = Rifle magazine with 30 catridges. Compatible with C-20r.
 
-uplink-pistol-magazine-caseless-name = Pistol Magazine (9.5mm HP)
+uplink-pistol-magazine-caseless-name = Pistol Magazine (9.5x18mm HP)
 uplink-pistol-magazine-caseless-desc = Pistol magazine with 10 hollow-point caseless catridges. Compatible with the Cobra.
 
-uplink-speedloader-magnum-name = Speedloader (.45 magnum AP)
+uplink-speedloader-magnum-name = Speedloader (.44 magnum AP)
 uplink-speedloader-magnu-desc = Revolver speedloader with 6 armor-piercing catridges, capable of ignoring armor entirely. Compatible with the Python.
 
-uplink-mosin-ammo-name = Ammunition box (.30 rifle)
+uplink-mosin-ammo-name = Ammunition box (7.62x51mm FMJ)
 uplink-mosin-ammo-desc = A box of 60 cartridges for the surplus rifle.
 
-uplink-sniper-ammo-name = Ammunition box (.60 antimateriel)
+uplink-sniper-ammo-name = Ammunition box (14.5x114mm anti-materiel)
 uplink-sniper-ammo-desc = A box of 10 cartridges for the Hristov sniper rifle.
 
 # Utility

--- a/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
@@ -62,10 +62,10 @@
 
 # LightRifle
 - type: entity
-  name: box of .30 rifle magazines
+  name: box of 7.62x51mm magazines
   parent: BoxMagazine
   id: BoxMagazineLightRifle
-  description: A box full of .30 rifle magazines.
+  description: A box full of 7.62x51mm magazines.
   components:
   - type: StorageFill
     contents:
@@ -73,10 +73,10 @@
         amount: 4
 
 - type: entity
-  name: box of .30 rifle (practice) magazines
+  name: box of 7.62x51mm (practice) magazines
   parent: BoxMagazine
   id: BoxMagazineLightRiflePractice
-  description: A box full of .30 rifle (practice) magazines.
+  description: A box full of 7.62x51mm (practice) magazines.
   components:
   - type: StorageFill
     contents:
@@ -85,10 +85,10 @@
 
 # Magnum
 - type: entity
-  name: box of SMG .45 magnum magazines
+  name: box of SMG .44 magnum magazines
   parent: BoxMagazine
   id: BoxMagazineMagnumSubMachineGun
-  description: A box full of SMG .45 magnum magazines.
+  description: A box full of SMG .44 magnum magazines.
   components:
   - type: StorageFill
     contents:
@@ -96,10 +96,10 @@
         amount: 3
 
 - type: entity
-  name: box of SMG .45 magnum (practice) magazines
+  name: box of SMG .44 magnum (practice) magazines
   parent: BoxMagazine
   id: BoxMagazineMagnumSubMachineGunPractice
-  description: A box full of SMG .45 magnum (practice) magazines.
+  description: A box full of SMG .44 magnum (practice) magazines.
   components:
   - type: StorageFill
     contents:
@@ -108,10 +108,10 @@
 
 # Pistol
 - type: entity
-  name: box of WT550 .35 auto magazines
+  name: box of WT550 9x19mm magazines
   parent: BoxMagazine
   id: BoxMagazinePistolSubMachineGunTopMounted
-  description: A box full of WT550 .35 auto magazines.
+  description: A box full of WT550 9x19mm magazines.
   components:
   - type: StorageFill
     contents:
@@ -119,10 +119,10 @@
         amount: 3
 
 - type: entity
-  name: box of pistol .35 auto magazines
+  name: box of pistol 9x19mm magazines
   parent: BoxMagazine
   id: BoxMagazinePistol
-  description: A box full of pistol .35 auto magazines.
+  description: A box full of pistol 9x19mm magazines.
   components:
   - type: StorageFill
     contents:
@@ -130,7 +130,7 @@
         amount: 4
 
 - type: entity
-  name: box of pistol .35 auto (practice) magazines
+  name: box of pistol 9x19mm (practice) magazines
   parent: BoxMagazine
   id: BoxMagazinePistolPractice
   description: A box full of  magazines.
@@ -141,10 +141,10 @@
         amount: 4
 
 - type: entity
-  name: box of machine pistol .35 auto magazines
+  name: box of machine pistol 9x19mm magazines
   parent: BoxMagazine
   id: BoxMagazinePistolHighCapacity
-  description: A box full of machine pistol .35 auto magazines.
+  description: A box full of machine pistol 9x19mm magazines.
   components:
   - type: StorageFill
     contents:
@@ -152,10 +152,10 @@
         amount: 4
 
 - type: entity
-  name: box of machine pistol .35 auto (practice) magazines
+  name: box of machine pistol 9x19mm (practice) magazines
   parent: BoxMagazine
   id: BoxMagazinePistolHighCapacityPractice
-  description: A box full of machine pistol .35 auto (practice) magazines.
+  description: A box full of machine pistol 9x19mm (practice) magazines.
   components:
   - type: StorageFill
     contents:
@@ -163,10 +163,10 @@
         amount: 4
 
 - type: entity
-  name: box of SMG .35 auto magazines
+  name: box of SMG 9x19mm magazines
   parent: BoxMagazine
   id: BoxMagazinePistolSubMachineGun
-  description: A box full of SMG .35 auto magazines.
+  description: A box full of SMG 9x19mm magazines.
   components:
   - type: StorageFill
     contents:
@@ -174,10 +174,10 @@
         amount: 3
 
 - type: entity
-  name: box of SMG .35 auto (practice) magazines
+  name: box of SMG 9x19mm (practice) magazines
   parent: BoxMagazine
   id: BoxMagazinePistolSubMachineGunPractice
-  description: A box full of SMG .35 auto (practice) magazines.
+  description: A box full of SMG 9x19mm (practice) magazines.
   components:
   - type: StorageFill
     contents:
@@ -231,10 +231,10 @@
 
 # Rifle
 - type: entity
-  name: box of .20 rifle magazines
+  name: box of 5.56x45mm magazines
   parent: BoxMagazine
   id: BoxMagazineRifle
-  description: A box full of .20 rifle magazines.
+  description: A box full of 5.56x45mm magazines.
   components:
   - type: StorageFill
     contents:
@@ -242,10 +242,10 @@
         amount: 4
 
 - type: entity
-  name: box of .20 rifle (practice) magazines
+  name: box of 5.56x45mm (practice) magazines
   parent: BoxMagazine
   id: BoxMagazineRiflePractice
-  description: A box full of .20 rifle (practice) magazines.
+  description: A box full of 5.56x45mm (practice) magazines.
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/antimateriel.yml
@@ -32,9 +32,9 @@
   abstract: true
   parent: [ BaseItem, BaseSecurityContraband ]
   id: BaseMagazineBoxAntiMateriel
-  name: ammunition box (.60 anti-materiel)
-  components:
   # Goobstation edit start
+  name: ammunition box (14.5x114mm anti-materiel)
+  components:
   - type: EmitSoundOnPickup
     sound:
       path: /Audio/_Goobstation/Items/handling/ammobox_pickup.ogg
@@ -69,7 +69,7 @@
 - type: entity
   parent: BaseMagazineBoxAntiMateriel
   id: MagazineBoxAntiMaterielBig
-  name: ammunition box (.60 anti-materiel)
+  name: ammunition box (14.5x114mm anti-materiel) # Goobstation
   components:
   - type: BallisticAmmoProvider
     capacity: 30
@@ -89,7 +89,7 @@
 - type: entity
   parent: BaseMagazineBoxAntiMateriel
   id: MagazineBoxAntiMateriel
-  name: ammunition box (.60 anti-materiel)
+  name: ammunition box (14.5x114mm anti-materiel) # Goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeAntiMateriel

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/caseless_rifle.yml
@@ -21,7 +21,7 @@
   abstract: true
   parent: BaseItem
   id: BaseMagazineBoxCaselessRifle
-  name: ammunition box (9.5mm HP) # Goob edit
+  name: ammunition box (9.5x18mm HP) # Goob edit
   components:
   # Goobstation edit start
   - type: EmitSoundOnPickup
@@ -58,7 +58,7 @@
 - type: entity
   parent: BaseMagazineBoxCaselessRifle
   id: MagazineBoxCaselessRifle10x24
-  name: ammunition box (9.5mm HP) # Goob edit
+  name: ammunition box (9.5x18mm HP) # Goob edit
   components:
   - type: BallisticAmmoProvider
     capacity: 200
@@ -78,7 +78,7 @@
 - type: entity
   parent: BaseMagazineBoxCaselessRifle
   id: MagazineBoxCaselessRifleBig
-  name: ammunition box (9.5mm HP) # Goob edit
+  name: ammunition box (9.5x18mm HP) # Goob edit
   components:
   - type: BallisticAmmoProvider
     capacity: 200
@@ -98,8 +98,8 @@
 - type: entity
   parent: BaseMagazineBoxCaselessRifle
   id: MagazineBoxCaselessRifle
-  name: ammunition box (9.5mm HP)
-  description: A cardboard box of 9.5mm caseless rounds. Intended to hold general-purpose kinetic ammunition.
+  name: ammunition box (9.5x18mm HP)
+  description: A cardboard box of 9.5x18mm caseless rounds. Intended to hold general-purpose kinetic ammunition.
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeCaselessRifle
@@ -113,8 +113,8 @@
 - type: entity
   parent: BaseMagazineBoxCaselessRifle
   id: MagazineBoxCaselessRiflePractice
-  name: ammunition box (9.5mm practice)
-  description: A cardboard box of 9.5mm caseless rounds. Intended to hold non-harmful chalk ammunition.
+  name: ammunition box (9.5x18mm practice)
+  description: A cardboard box of 9.5x18mm caseless rounds. Intended to hold non-harmful chalk ammunition.
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeCaselessRiflePractice

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/light_rifle.yml
@@ -23,9 +23,9 @@
   abstract: true
   parent: BaseItem
   id: BaseMagazineBoxLightRifle
-  name: ammunition box (.30 rifle)
-  components:
   # Goobstation edit start
+  name: ammunition box (7.62x51mm)
+  components:
   - type: EmitSoundOnPickup
     sound:
       path: /Audio/_Goobstation/Items/handling/ammobox_pickup.ogg
@@ -60,7 +60,7 @@
 - type: entity
   parent: BaseMagazineBoxLightRifle
   id: MagazineBoxLightRifleBig
-  name: ammunition box (.30 rifle)
+  name: ammunition box (7.62x51mm FMJ) # Goobstation
   components:
   - type: BallisticAmmoProvider
     capacity: 200
@@ -80,8 +80,8 @@
 - type: entity
   parent: BaseMagazineBoxLightRifle
   id: MagazineBoxLightRifle
-  name: ammunition box (.30 rifle)
-  description: A cardboard box of .30 rifle rounds. Intended to hold general-purpose kinetic ammunition.
+  name: ammunition box (7.62x51mm FMJ) # Goobstation
+  description: A cardboard box of 7.62x51mm rounds. Intended to hold general-purpose kinetic ammunition. # Goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeLightRifle
@@ -95,8 +95,8 @@
 - type: entity
   parent: BaseMagazineBoxLightRifle
   id: MagazineBoxLightRiflePractice
-  name: ammunition box (.30 rifle practice)
-  description: A cardboard box of .30 rifle rounds. Intended to hold non-harmful chalk ammunition.
+  name: ammunition box (7.62x51mm practice) # Goobstation
+  description: A cardboard box of 7.62x51mm rounds. Intended to hold non-harmful chalk ammunition. # Goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeLightRiflePractice
@@ -111,8 +111,8 @@
 - type: entity
   id: MagazineBoxLightRifleIncendiary
   parent: BaseMagazineBoxLightRifle
-  name: ammunition box (.30 rifle incendiary)
-  description: A cardboard box of .30 rifle rounds. Intended to hold self-igniting incendiary ammunition.
+  name: ammunition box (7.62x51mm incendiary) # Goobstation
+  description: A cardboard box of 7.62x51mm rounds. Intended to hold self-igniting incendiary ammunition. # Goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeLightRifleIncendiary
@@ -127,8 +127,8 @@
 - type: entity
   parent: BaseMagazineBoxLightRifle
   id: MagazineBoxLightRifleUranium
-  name: ammunition box (.30 rifle uranium)
-  description: A cardboard box of .30 rifle rounds. Intended to hold exotic uranium-core ammunition.
+  name: ammunition box (7.62x51mm uranium) # Goobstation
+  description: A cardboard box of 7.62x51mm rounds. Intended to hold exotic uranium-core ammunition. # Goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeLightRifleUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magnum.yml
@@ -67,8 +67,8 @@
 - type: entity
   parent: BaseMagazineBoxMagnum
   id: MagazineBoxMagnum
-  name: ammunition box (.45 magnum)
-  description: A cardboard box of .45 magnum rounds. Intended to hold general-purpose kinetic ammunition.
+  name: ammunition box (.44 magnum) # Goobstation
+  description: A cardboard box of .44 magnum rounds. Intended to hold general-purpose kinetic ammunition. # Goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeMagnum
@@ -82,8 +82,8 @@
 - type: entity
   parent: BaseMagazineBoxMagnum
   id: MagazineBoxMagnumPractice
-  name: ammunition box (.45 magnum practice)
-  description: A cardboard box of .45 magnum rounds. Intended to hold non-harmful chalk ammunition.
+  name: ammunition box (.44 magnum practice) # Goobstation
+  description: A cardboard box of .44 magnum rounds. Intended to hold non-harmful chalk ammunition. # Goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeMagnumPractice
@@ -98,8 +98,8 @@
 - type: entity
   id: MagazineBoxMagnumIncendiary
   parent: BaseMagazineBoxMagnum
-  name: ammunition box (.45 magnum incendiary)
-  description: A cardboard box of .45 magnum rounds. Intended to hold self-igniting incendiary ammunition.
+  name: ammunition box (.44 magnum incendiary) # Goobstation
+  description: A cardboard box of .44 magnum rounds. Intended to hold self-igniting incendiary ammunition. # Goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeMagnumIncendiary
@@ -114,8 +114,8 @@
 - type: entity
   id: MagazineBoxMagnumUranium
   parent: BaseMagazineBoxMagnum
-  name: ammunition box (.45 magnum uranium)
-  description: A cardboard box of .45 magnum rounds. Intended to hold exotic uranium-core ammunition.
+  name: ammunition box (.44 magnum uranium) # Goobstation
+  description: A cardboard box of .44 magnum rounds. Intended to hold exotic uranium-core ammunition. # Goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeMagnumUranium
@@ -130,8 +130,8 @@
 - type: entity
   id: MagazineBoxMagnumAP
   parent: BaseMagazineBoxMagnum
-  name: ammunition box (.45 magnum armor-piercing)
-  description: A cardboard box of .45 magnum rounds. Intended to hold rare armor-piercing ammunition.
+  name: ammunition box (.44 magnum armor-piercing) # Goobstation
+  description: A cardboard box of .44 magnum rounds. Intended to hold rare armor-piercing ammunition. # Goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeMagnumAP

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/pistol.yml
@@ -29,7 +29,7 @@
   abstract: true
   parent: BaseItem
   id: BaseMagazineBoxPistol
-  name: ammunition box (.35 auto)
+  name: ammunition box (9x19mm) # Goobstation
   components:
   # Goobstation edit start
   - type: EmitSoundOnPickup
@@ -66,8 +66,8 @@
 - type: entity
   parent: BaseMagazineBoxPistol
   id: MagazineBoxPistol
-  name: ammunition box (.35 auto)
-  description: A cardboard box of .35 auto rounds. Intended to hold general-purpose kinetic ammunition.
+  name: ammunition box (9x19mm FMJ) # Goobstation
+  description: A cardboard box of 9x19mm rounds. Intended to hold general-purpose kinetic ammunition. # Goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistol
@@ -81,8 +81,8 @@
 - type: entity
   parent: BaseMagazineBoxPistol
   id: MagazineBoxPistolPractice
-  name: ammunition box (.35 auto practice)
-  description: A cardboard box of .35 auto rounds. Intended to hold non-harmful chalk ammunition.
+  name: ammunition box (9x19mm practice) # Goobstation
+  description: A cardboard box of 9x19mm rounds. Intended to hold non-harmful chalk ammunition. # Goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistolPractice
@@ -97,8 +97,8 @@
 - type: entity
   id: MagazineBoxPistolIncendiary
   parent: BaseMagazineBoxPistol
-  name: ammunition box (.35 auto incendiary)
-  description: A cardboard box of .35 auto rounds. Intended to hold self-igniting incendiary ammunition.
+  name: ammunition box (9x19mm incendiary) # Goobstation
+  description: A cardboard box of 9x19mm rounds. Intended to hold self-igniting incendiary ammunition. # Goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistolIncendiary
@@ -113,8 +113,8 @@
 - type: entity
   id: MagazineBoxPistolUranium
   parent: BaseMagazineBoxPistol
-  name: ammunition box (.35 auto uranium)
-  description: A cardboard box of .35 auto rounds. Intended to hold exotic uranium-core ammunition.
+  name: ammunition box (9x19mm uranium) # Goobstation
+  description: A cardboard box of 9x19mm rounds. Intended to hold exotic uranium-core ammunition. # Goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistolUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/rifle.yml
@@ -59,7 +59,7 @@
 - type: entity
   parent: BaseMagazineBoxRifle
   id: MagazineBoxRifleBig
-  name: ammunition box (.20 rifle)
+  name: ammunition box (5.56x45mm) # Goobstation
   components:
   - type: BallisticAmmoProvider
     capacity: 200
@@ -79,7 +79,8 @@
 - type: entity
   parent: BaseMagazineBoxRifle
   id: MagazineBoxRifle
-  name: ammunition box (.20 rifle)
+  name: ammunition box (5.56x45mm) # Goobstation
+  description: A cardboard box of 5.56x45mm rounds. Intended to hold general-purpose kinetic ammunition. # Goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeRifle
@@ -93,7 +94,8 @@
 - type: entity
   parent: BaseMagazineBoxRifle
   id: MagazineBoxRiflePractice
-  name: ammunition box (.20 rifle practice)
+  name: ammunition box (5.56x45mm practice) # Goobstation
+  description: A cardboard box of 5.56x45mm rounds. Intended to hold non-harmful chalk ammunition.
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeRiflePractice
@@ -108,7 +110,8 @@
 - type: entity
   id: MagazineBoxRifleIncendiary
   parent: BaseMagazineBoxRifle
-  name: ammunition box (.20 rifle incendiary)
+  name: ammunition box (5.56x45mm incendiary) # Goobstation
+  description: A cardboard box of 5.56x45mm rounds. Intended to hold self-igniting incendiary ammunition.
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeRifleIncendiary
@@ -123,7 +126,8 @@
 - type: entity
   id: MagazineBoxRifleUranium
   parent: BaseMagazineBoxRifle
-  name: ammunition box (.20 rifle uranium)
+  name: ammunition box (5.56x45mm uranium) # Goobstation
+  description: A cardboard box of 5.56x45mm rounds. Intended to hold exotic uranium-core ammunition.
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeRifleUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/antimateriel.yml
@@ -24,7 +24,7 @@
 - type: entity
   parent: [ BaseCartridge, BaseMajorContraband ]
   id: CartridgeAntiMateriel
-  name: cartridge (.60 anti-materiel)
+  name: cartridge (.50 BMG)
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless_rifle.yml
@@ -21,7 +21,7 @@
 
 - type: entity
   id: BaseCartridgeCaselessRifle
-  name: cartridge (9.5mm) # Goob edit
+  name: cartridge (9.5x18mm) # Goob edit
   parent: [ BaseCartridge, BaseSecurityContraband ]
   abstract: true
   components:
@@ -44,18 +44,18 @@
 
 - type: entity
   id: CartridgeCaselessRifle
-  name: cartridge (9.5mm HP) # Goob edit
+  name: cartridge (9.5x18mm HP) # Goob edit
   parent: BaseCartridgeCaselessRifle
-  description: A small caliber utilizing caseless technology, omitting conventional brass casing in favor of hardened propellant. Standard kinetic ammunition is common and useful in most situations.
+  description: A small cartridge utilizing caseless technology, omitting conventional brass casing in favor of hardened propellant.
   components:
   - type: CartridgeAmmo
     proto: BulletCaselessRifle
 
 - type: entity
   id: CartridgeCaselessRiflePractice
-  name: cartridge (9.5mm practice) # Goob edit
+  name: cartridge (9.5x18mm practice) # Goob edit
   parent: BaseCartridgeCaselessRifle
-  description: A small caliber utilizing caseless technology, omitting conventional brass casing in favor of hardened propellant. Chalk ammunition is generally non-harmful, used for practice.
+  description: A small cartridge utilizing caseless technology, omitting conventional brass casing in favor of hardened propellant. This chalk ammunition is generally non-harmful, and used for practice.
   components:
   - type: CartridgeAmmo
     proto: BulletCaselessRiflePractice

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/heavy_rifle.yml
@@ -28,7 +28,7 @@
 
 - type: entity
   id: BaseCartridgeHeavyRifle
-  name: cartridge (.20 rifle)
+  name: cartridge (5.56x45mm)
   parent: [ BaseCartridge, BaseSecurityContraband ]
   abstract: true
   components:
@@ -50,7 +50,7 @@
 
 - type: entity
   id: CartridgeMinigun
-  name: cartridge (.10 rifle)
+  name: cartridge (.22 LR) # Goobstation
   parent: BaseCartridgeHeavyRifle
   components:
   - type: CartridgeAmmo

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
@@ -21,7 +21,7 @@
 
 - type: entity
   id: BaseCartridgeLightRifle
-  name: cartridge (.30 rifle)
+  name: cartridge (7.62x51mm)
   parent: [ BaseCartridge, BaseSecurityContraband ]
   abstract: true
   components:
@@ -41,18 +41,18 @@
 
 - type: entity
   id: CartridgeLightRifle
-  name: cartridge (.30 rifle)
+  name: cartridge (7.62x51mm FMJ) # Goobstation
   parent: BaseCartridgeLightRifle
-  description: A classic intermediate cartridge used by many combat rifles and LMGs. Standard kinetic ammunition is common and useful in most situations.
+  description: A full-power rifle cartridge that's become the standard for small arms. This standard full metal jacket ammunition is designed to be as cheap to produce as possible. # Goobstation
   components:
   - type: CartridgeAmmo
     proto: BulletLightRifle
 
 - type: entity
   id: CartridgeLightRiflePractice
-  name: cartridge (.30 rifle practice)
+  name: cartridge (7.62x51mm practice) # Goobstation
   parent: BaseCartridgeLightRifle
-  description: A classic intermediate cartridge used by many combat rifles and LMGs. Chalk ammunition is generally non-harmful, used for practice.
+  description: A full-power rifle cartridge that's become the standard for small arms. This chalk ammunition is generally non-harmful, and used for practice. # Goobstation
   components:
   - type: CartridgeAmmo
     proto: BulletLightRiflePractice
@@ -66,9 +66,9 @@
 
 - type: entity
   id: CartridgeLightRifleIncendiary
-  name: cartridge (.30 rifle incendiary)
+  name: cartridge (7.62x51mm incendiary) # Goobstation
   parent: BaseCartridgeLightRifle
-  description: A classic intermediate cartridge used by many combat rifles and LMGs. Incendiary ammunition contains a self-igniting compound that sets the target ablaze.
+  description: A full-power rifle cartridge that's become the standard for small arms. This incendiary ammunition contains a phosphorus charge that ignites upon hitting a target. # Goobstation
   components:
   - type: CartridgeAmmo
     proto: BulletLightRifleIncendiary
@@ -82,9 +82,9 @@
 
 - type: entity
   id: CartridgeLightRifleUranium
-  name: cartridge (.30 rifle uranium)
+  name: cartridge (7.62x51mm uranium) # Goobstation
   parent: BaseCartridgeLightRifle
-  description: A classic intermediate cartridge used by many combat rifles and LMGs. Uranium ammunition replaces the lead core of the bullet with fissile material, irradiating the target from the inside.
+  description: A full-power rifle cartridge that's become the standard for small arms. This uranium ammunition contains a fissile core that irradiates the target from the inside, held within a lead case that breaks away on impact. # Goobstation
   components:
   - type: CartridgeAmmo
     proto: BulletLightRifleUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
@@ -34,8 +34,8 @@
 
 - type: entity
   id: BaseCartridgeMagnum
-  name: cartridge (.45 magnum)
-  parent: [ BaseCartridge, BaseSecurityCommandContraband ] # Goob edit - captain's N1984
+  name: cartridge (.44 magnum)
+  parent: [ BaseCartridge, BaseSecurityCommandContraband ]
   abstract: true
   components:
   - type: Tag
@@ -54,18 +54,18 @@
 
 - type: entity
   id: CartridgeMagnum
-  name: cartridge (.45 magnum)
+  name: cartridge (.44 magnum FMJ) # Goobstation
   parent: BaseCartridgeMagnum
-  description: Heavy magnum cartridge mostly used by revolvers. Standard kinetic ammunition is common and useful in most situations.
+  description: A heavy, rimmed cartridge designed for use in revolvers. This standard full metal jacket ammunition is designed to be as cheap to produce as possible. # Goobstation
   components:
   - type: CartridgeAmmo
     proto: BulletMagnum
 
 - type: entity
   id: CartridgeMagnumPractice
-  name: cartridge (.45 magnum practice)
+  name: cartridge (.44 magnum practice) # Goobstation
   parent: BaseCartridgeMagnum
-  description: Heavy magnum cartridge mostly used by revolvers. Chalk ammunition is generally non-harmful, used for practice.
+  description: A heavy, rimmed cartridge designed for use in revolvers. This chalk ammunition is generally non-harmful, and used for practice. # Goobstation
   components:
   - type: CartridgeAmmo
     proto: BulletMagnumPractice
@@ -79,9 +79,9 @@
 
 - type: entity
   id: CartridgeMagnumIncendiary
-  name: cartridge (.45 magnum incendiary)
+  name: cartridge (.44 magnum incendiary) # Goobstation
   parent: BaseCartridgeMagnum
-  description: Heavy magnum cartridge mostly used by revolvers. Incendiary ammunition contains a self-igniting compound that sets the target ablaze.
+  description: A heavy, rimmed cartridge designed for use in revolvers. This incendiary ammunition contains a phosphorus charge that ignites upon hitting a target. # Goobstation
   components:
   - type: CartridgeAmmo
     proto: BulletMagnumIncendiary
@@ -95,9 +95,9 @@
 
 - type: entity
   id: CartridgeMagnumAP
-  name: cartridge (.45 magnum armor-piercing)
+  name: cartridge (.44 magnum armor-piercing) # Goobstation
   parent: BaseCartridgeMagnum
-  description: Heavy magnum cartridge mostly used by revolvers. Armor piercing ammunition is renowned for its ability to cut straight through body armor.
+  description: A heavy, rimmed cartridge designed for use in revolvers. This armor-piercing ammunition is built around a plasteel core, allowing it to penetrate most vests and hardsuits at the cost of damage. # Goobstation
   components:
   - type: CartridgeAmmo
     proto: BulletMagnumAP
@@ -111,9 +111,9 @@
 
 - type: entity
   id: CartridgeMagnumUranium
-  name: cartridge (.45 magnum uranium)
+  name: cartridge (.44 magnum uranium) # Goobstation
   parent: BaseCartridgeMagnum
-  description: Heavy magnum cartridge mostly used by revolvers. Uranium ammunition replaces the lead core of the bullet with fissile material, irradiating the target from the inside.
+  description: A heavy, rimmed cartridge designed for use in revolvers. This uranium ammunition contains a fissile core that irradiates the target from the inside, held within a lead case that breaks away on impact. # Goobstation
   components:
   - type: CartridgeAmmo
     proto: BulletMagnumUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
@@ -35,7 +35,7 @@
 
 - type: entity
   id: BaseCartridgePistol
-  name: cartridge (.35 auto)
+  name: cartridge (9x19mm)
   parent: [ BaseCartridge, BaseSecurityContraband ]
   abstract: true
   components:
@@ -55,8 +55,8 @@
 
 - type: entity
   id: CartridgePistol
-  name: cartridge (.35 auto)
-  description: Arguably the most popular caliber on the market, used by all manner of pistols and submachine guns. Standard kinetic ammunition is common and useful in most situations.
+  name: cartridge (9x19mm FMJ) # Goobstation
+  description: Arguably the most common caliber on the market, used by all manner of pistols and submachine guns. This full metal jacket ammunition is designed to be as cheap to produce as possible.
   parent: BaseCartridgePistol
   components:
   - type: CartridgeAmmo
@@ -64,8 +64,8 @@
 
 - type: entity
   id: CartridgePistolPractice
-  name: cartridge (.35 auto practice)
-  description: Arguably the most popular caliber on the market, used by all manner of pistols and submachine guns. Chalk ammunition is generally non-harmful, used for practice.
+  name: cartridge (9x19mm practice) # Goobstation
+  description: Arguably the most common caliber on the market, used by all manner of pistols and submachine guns. This chalk ammunition is generally non-harmful, and used for practice.
   parent: BaseCartridgePistol
   components:
   - type: CartridgeAmmo
@@ -80,8 +80,8 @@
 
 - type: entity
   id: CartridgePistolIncendiary
-  name: cartridge (.35 auto incendiary)
-  description: Arguably the most popular caliber on the market, used by all manner of pistols and submachine guns. Incendiary ammunition contains a self-igniting compound that sets the target ablaze.
+  name: cartridge (9x19mm incendiary) # Goobstation
+  description: Arguably the most common caliber on the market, used by all manner of pistols and submachine guns. This incendiary ammunition contains a phosphorus charge that ignites upon hitting a target.
   parent: BaseCartridgePistol
   components:
   - type: CartridgeAmmo
@@ -96,8 +96,8 @@
 
 - type: entity
   id: CartridgePistolUranium
-  name: cartridge (.35 auto uranium)
-  description: Arguably the most popular caliber on the market, used by all manner of pistols and submachine guns. Uranium core ammunition features a load of fissile material, irradiating the target from the inside.
+  name: cartridge (9x19mm uranium) # Goobstation
+  description: Arguably the most common caliber on the market, used by all manner of pistols and submachine guns. This uranium ammunition contains a fissile core that irradiates the target from the inside, held within a lead case that breaks away on impact.
   parent: BaseCartridgePistol
   components:
   - type: CartridgeAmmo
@@ -112,7 +112,8 @@
 
 - type: entity
   id: CartridgePistolSpent
-  name: cartridge (.35 auto)
+  name: cartridge (9x19mm) # Goobstation
+  description: An empty brass case. Smells like gunpowder.
   suffix: spent
   parent: BaseCartridgePistol
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
@@ -21,7 +21,7 @@
 
 - type: entity
   id: BaseCartridgeRifle
-  name: cartridge (.20 rifle)
+  name: cartridge (5.56x45mm)
   parent: [ BaseCartridge, BaseSecurityContraband ]
   abstract: true
   components:
@@ -41,16 +41,18 @@
 
 - type: entity
   id: CartridgeRifle
-  name: cartridge (.20 rifle)
+  name: cartridge (5.56x45mm FMJ) # Goobstation
   parent: BaseCartridgeRifle
+  description: An intermediate rifle cartridge that trades lighter recoil for less punch. This standard full metal jacket ammunition is designed to be as cheap to produce as possible. # Goobstation
   components:
   - type: CartridgeAmmo
     proto: BulletRifle
 
 - type: entity
   id: CartridgeRiflePractice
-  name: cartridge (.20 rifle practice)
+  name: cartridge (5.56x45mm practice) # Goobstation
   parent: BaseCartridgeRifle
+  description: An intermediate rifle cartridge that trades lighter recoil for less punch. This chalk ammunition is generally non-harmful, and used for practice. # Goobstation
   components:
   - type: CartridgeAmmo
     proto: BulletRiflePractice
@@ -64,8 +66,9 @@
 
 - type: entity
   id: CartridgeRifleIncendiary
-  name: cartridge (.20 rifle incendiary)
+  name: cartridge (5.56x45mm incendiary) # Goobstation
   parent: BaseCartridgeRifle
+  description: An intermediate rifle cartridge that trades lighter recoil for less punch. This incendiary ammunition contains a phosphorus charge that ignites upon hitting a target. # Goobstation
   components:
   - type: CartridgeAmmo
     proto: BulletRifleIncendiary
@@ -79,8 +82,9 @@
 
 - type: entity
   id: CartridgeRifleUranium
-  name: cartridge (.20 rifle uranium)
+  name: cartridge (5.56x45mm uranium) # Goobstation
   parent: BaseCartridgeRifle
+  description: An intermediate rifle cartridge that trades lighter recoil for less punch. This uranium ammunition contains a fissile core that irradiates the target from the inside, held within a lead case that breaks away on impact. # Goobstation
   components:
   - type: CartridgeAmmo
     proto: BulletRifleUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless_rifle.yml
@@ -23,7 +23,7 @@
 
 - type: entity
   id: BaseMagazineCaselessRifle
-  name: "magazine (9.5mm HP)" # Goob edit
+  name: "magazine (9.5x18mm HP)" # Goob edit
   parent: [ BaseItem, BaseSecurityContraband ]
   abstract: true
   components:
@@ -57,7 +57,7 @@
 
 - type: entity
   id: BaseMagazineCaselessRifleShort
-  name: "caseless rifle short magazine (9.5mm HP)" # Goob edit
+  name: "caseless rifle short magazine (9.5x18mm HP)" # Goob edit
   parent: BaseMagazineCaselessRifle
   abstract: true
   components:
@@ -76,7 +76,7 @@
 
 - type: entity
   id: BaseMagazinePistolCaselessRifle
-  name: "pistol magazine (9.5mm HP)" # Goob edit
+  name: "pistol magazine (9.5x18mm HP)" # Goob edit
   parent: BaseMagazineCaselessRifle
   abstract: true
   components:
@@ -106,7 +106,7 @@
 
 - type: entity
   id: MagazineCaselessRifle10x24
-  name: "box magazine (9.5mm HP)" # Goob edit
+  name: "box magazine (9.5x18mm HP)" # Goob edit
   parent: BaseMagazineCaselessRifle
   components:
   - type: BallisticAmmoProvider
@@ -121,7 +121,7 @@
 
 - type: entity
   id: MagazinePistolCaselessRifle
-  name: "pistol magazine (9.5mm HP)" # Goob edit
+  name: "pistol magazine (9.5x18mm HP)" # Goob edit
   parent: BaseMagazinePistolCaselessRifle
   description: 10-round magazine for the Cobra pistol. Intended to hold general-purpose kinetic ammunition.
   components:
@@ -149,7 +149,7 @@
 
 - type: entity
   id: MagazinePistolCaselessRiflePractice
-  name: "pistol magazine (9.5mm practice)" # Goob edit
+  name: "pistol magazine (9.5x18mm practice)" # Goob edit
   parent: BaseMagazinePistolCaselessRifle
   description: 10-round magazine for the Cobra pistol. Intended to hold non-harmful chalk ammunition.
   components:
@@ -182,7 +182,7 @@
 
 - type: entity
   id: MagazineCaselessRifle
-  name: "magazine (9.5mm HP)" # Goob edit
+  name: "magazine (9.5x18mm HP)" # Goob edit
   parent: BaseMagazineCaselessRifle
   components:
   - type: BallisticAmmoProvider
@@ -202,7 +202,7 @@
 
 - type: entity
   id: MagazineCaselessRiflePractice
-  name: "magazine (9.5mm practice)" # Goob edit
+  name: "magazine (9.5x18mm practice)" # Goob edit
   parent: BaseMagazineCaselessRifle
   components:
   - type: BallisticAmmoProvider
@@ -228,7 +228,7 @@
 
 - type: entity
   id: MagazineCaselessRifleShort
-  name: "short magazine (9.5mm HP)" # Goob edit
+  name: "short magazine (9.5x18mm HP)" # Goob edit
   parent: BaseMagazineCaselessRifleShort
   components:
   - type: BallisticAmmoProvider
@@ -249,7 +249,7 @@
 
 - type: entity
   id: MagazineCaselessRifleShortPractice
-  name: "short magazine (9.5mm practice)" # Goob edit
+  name: "short magazine (9.5x18mm practice)" # Goob edit
   parent: BaseMagazineCaselessRifleShort
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/heavy_rifle.yml
@@ -20,7 +20,7 @@
 
 - type: entity
   id: BaseMagazineHeavyRifle
-  name: "magazine (.20 rifle)"
+  name: "magazine (5.56x45mm)"
   parent: [ BaseItem, BaseSecurityContraband ]
   abstract: true
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/light_rifle.yml
@@ -25,7 +25,7 @@
 # Empty mags
 - type: entity
   id: BaseMagazineLightRifle
-  name: "magazine (.30 rifle)"
+  name: "magazine (7.62x51mm FMJ)"
   parent: [ BaseItem, BaseSecurityContraband ]
   abstract: true
   components:
@@ -60,9 +60,9 @@
 # Magazines
 - type: entity
   id: MagazineLightRifleBox
-  name: "L6 SAW magazine box (.30 rifle)"
+  name: "L6 SAW magazine box (7.62x51mm FMJ)"
   parent: BaseMagazineLightRifle
-  description: Box containing a 100-round belt of linked .30 rifle rounds, used by light machine guns such as the L6. Intended to hold general-purpose kinetic ammunition.
+  description: Box containing a 100-round belt of linked 7.62x51mm rounds, used by light machine guns such as the L6 SAW. Intended to hold general-purpose kinetic ammunition.
   components:
   - type: Tag
     tags:
@@ -81,7 +81,7 @@
 
 - type: entity # Goobstation
   id: MagazineLightRifleBoxEmpty
-  name: "L6 SAW magazine box (.30 rifle any)"
+  name: "L6 SAW magazine box (7.62x51mm any)"
   parent: MagazineLightRifleBox
   components:
   - type: BallisticAmmoProvider
@@ -89,9 +89,9 @@
 
 - type: entity
   id: MagazineLightRifle
-  name: "magazine (.30 rifle)"
+  name: "magazine (7.62x51mm)"
   parent: BaseMagazineLightRifle
-  description: Curved 30-round double stack magazine for combat rifles. Intended to hold general-purpose kinetic ammunition.
+  description: A curved 30-round double stack magazine for combat rifles. Intended to hold general-purpose kinetic ammunition.
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeLightRifle
@@ -110,10 +110,10 @@
 
 - type: entity
   id: MagazineLightRifleEmpty
-  name: "magazine (.30 rifle any)"
+  name: "magazine (7.62x51mm any)"
   suffix: empty
   parent: MagazineLightRifle
-  description: Curved 30-round double stack magazine for combat rifles.
+  description: A curved 30-round double stack magazine for combat rifles.
   components:
   - type: BallisticAmmoProvider
     proto: null
@@ -132,9 +132,9 @@
 
 - type: entity
   id: MagazineLightRiflePractice
-  name: "magazine (.30 rifle practice)"
+  name: "magazine (7.62x51mm practice)"
   parent: BaseMagazineLightRifle
-  description: Curved 30-round double stack magazine for combat rifles. Intended to hold non-harmful chalk ammunition.
+  description: A curved 30-round double stack magazine for combat rifles. Intended to hold non-harmful chalk ammunition.
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeLightRiflePractice
@@ -159,9 +159,9 @@
 
 - type: entity
   id: MagazineLightRifleUranium
-  name: "magazine (.30 rifle uranium)"
+  name: "magazine (7.62x51mm uranium)"
   parent: BaseMagazineLightRifle
-  description: Curved 30-round double stack magazine for combat rifles. Intended to hold exotic uranium-core ammunition.
+  description: A curved 30-round double stack magazine for combat rifles. Intended to hold exotic uranium-core ammunition.
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeLightRifleUranium
@@ -186,9 +186,9 @@
 
 - type: entity
   id: MagazineLightRifleIncendiary
-  name: "magazine (.30 rifle incendiary)"
+  name: "magazine (7.62x51mm incendiary)"
   parent: MagazineLightRifle
-  description: Curved 30-round double stack magazine for combat rifles. Intended to hold self-igniting incendiary ammunition.
+  description: A curved 30-round double stack magazine for combat rifles. Intended to hold self-igniting incendiary ammunition.
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeLightRifleIncendiary
@@ -213,7 +213,7 @@
 
 - type: entity
   id: MagazineLightRifleMaxim
-  name: "pan magazine (.30 rifle)"
+  name: "pan magazine (7.62x51mm FMJ)"
   parent: BaseMagazineLightRifle
   components:
   - type: Tag
@@ -227,7 +227,7 @@
 
 - type: entity
   id: MagazineLightRiflePkBox
-  name: "PK munitions box (.30 rifle)"
+  name: "PK munitions box (7.62x51mm FMJ)"
   parent: BaseMagazineLightRifle
   components:
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
@@ -35,7 +35,7 @@
 
 - type: entity
   id: BaseMagazineMagnum
-  name: pistol magazine (.45 magnum)
+  name: pistol magazine (.44 magnum)
   parent: [ BaseMagazinePistol, BaseSecurityContraband ]
   abstract: true
   components:
@@ -51,7 +51,7 @@
 
 - type: entity
   id: BaseMagazineMagnumSubMachineGun
-  name: SMG magazine (.45 magnum)
+  name: SMG magazine (.44 magnum)
   parent: BaseItem
   abstract: true
   components:
@@ -84,7 +84,7 @@
 
 - type: entity
   id: MagazineMagnumEmpty
-  name: pistol magazine (.45 magnum any)
+  name: pistol magazine (.44 magnum any)
   suffix: empty
   parent: BaseMagazineMagnum
   description: 7-round single stack pistol magazine.
@@ -106,7 +106,7 @@
 
 - type: entity
   id: MagazineMagnum
-  name: pistol magazine (.45 magnum)
+  name: pistol magazine (.44 magnum)
   parent: BaseMagazineMagnum
   description: 7-round single stack pistol magazine. Intended to hold general-purpose kinetic ammunition.
   components:
@@ -127,7 +127,7 @@
 
 - type: entity
   id: MagazineMagnumPractice
-  name: pistol magazine (.45 magnum practice)
+  name: pistol magazine (.44 magnum practice)
   parent: BaseMagazineMagnum
   description: 7-round single stack pistol magazine. Intended to hold non-harmful chalk ammunition.
   components:
@@ -154,7 +154,7 @@
 
 - type: entity
   id: MagazineMagnumUranium
-  name: pistol magazine (.45 magnum uranium)
+  name: pistol magazine (.44 magnum uranium)
   parent: BaseMagazineMagnum
   description: 7-round single stack pistol magazine. Intended to hold exotic uranium-core ammunition.
   components:
@@ -181,7 +181,7 @@
 
 - type: entity
   id: MagazineMagnumAP
-  name: pistol magazine (.45 magnum armor-piercing)
+  name: pistol magazine (.44 magnum armor-piercing)
   parent: BaseMagazineMagnum
   description: 7-round single stack pistol magazine. Intended to hold rare armor-piercing ammunition.
   components:
@@ -208,7 +208,7 @@
 
 - type: entity
   id: MagazineMagnumSubMachineGunEmpty
-  name: SMG magazine (.45 magnum any)
+  name: SMG magazine (.44 magnum any)
   suffix: empty
   parent: BaseMagazineMagnumSubMachineGun
   components:
@@ -229,7 +229,7 @@
 
 - type: entity
   id: MagazineMagnumSubMachineGun
-  name: SMG magazine (.45 magnum)
+  name: SMG magazine (.44 magnum)
   parent: BaseMagazineMagnumSubMachineGun
   components:
   - type: BallisticAmmoProvider
@@ -249,7 +249,7 @@
 
 - type: entity
   id: MagazineMagnumSubMachineGunPractice
-  name: SMG magazine (.45 magnum practice)
+  name: SMG magazine (.44 magnum practice)
   parent: BaseMagazineMagnumSubMachineGun
   components:
   - type: BallisticAmmoProvider
@@ -275,7 +275,7 @@
 
 - type: entity
   id: MagazineMagnumSubMachineGunUranium
-  name: SMG magazine (.45 magnum uranium)
+  name: SMG magazine (.44 magnum uranium)
   parent: BaseMagazineMagnumSubMachineGun
   components:
   - type: BallisticAmmoProvider
@@ -301,7 +301,7 @@
 
 - type: entity
   id: MagazineMagnumSubMachineGunPiercing
-  name: SMG magazine (.45 magnum armour-piercing)
+  name: SMG magazine (.44 magnum armour-piercing)
   parent: BaseMagazineMagnumSubMachineGun
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -40,7 +40,7 @@
 
 - type: entity
   id: BaseMagazinePistol
-  name: pistol magazine (.35 auto)
+  name: pistol magazine (9x19mm)
   parent: [ BaseItem, BaseSecurityContraband ]
   abstract: true
   components:
@@ -73,7 +73,7 @@
 
 - type: entity
   id: BaseMagazinePistolHighCapacity
-  name: machine pistol magazine (.35 auto)
+  name: machine pistol magazine (9x19mm)
   parent: BaseItem
   abstract: true
   components:
@@ -106,7 +106,7 @@
 
 - type: entity
   id: BaseMagazinePistolSubMachineGun  # Yeah it's weird but it's pistol caliber
-  name: SMG magazine (.35 auto)
+  name: SMG magazine (9x19mm)
   parent: [ BaseItem, BaseSecurityContraband ]
   abstract: true
   components:
@@ -139,9 +139,9 @@
 
 - type: entity
   id: MagazinePistolSubMachineGunTopMounted
-  name: WT550 magazine (.35 auto top-mounted)
+  name: WT550 magazine (9x19mm top-mounted FMJ)
   parent: [ BaseItem, BaseSecurityContraband ]
-  description: Unconventional 30-round top feeding magazine for the WT550 SMG. Intended to hold general-purpose kinetic ammunition.
+  description: An unconventional 30-round top feeding magazine for the WT550 SMG. Intended to hold general-purpose kinetic ammunition.
   components:
   - type: Tag
     tags:
@@ -171,18 +171,18 @@
 
 - type: entity
   id: MagazinePistolSubMachineGunTopMountedEmpty
-  name: WT550 magazine (.35 auto top-mounted any)
+  name: WT550 magazine (9x19mm top-mounted any)
   parent: MagazinePistolSubMachineGunTopMounted
-  description: Unconventional 30-round top feeding magazine for the WT550 SMG.
+  description: An unconventional 30-round top feeding magazine for the WT550 SMG.
   components:
   - type: BallisticAmmoProvider
     proto: null
 
 - type: entity
   id: MagazinePistol
-  name: pistol magazine (.35 auto)
+  name: pistol magazine (9x19mm FMJ)
   parent: BaseMagazinePistol
-  description: 12-round single-stack magazine for pistols. Intended to hold general-purpose kinetic ammunition. #goobstation
+  description: A 12-round single-stack magazine for pistols. Intended to hold general-purpose kinetic ammunition. #goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistol
@@ -201,10 +201,10 @@
 
 - type: entity
   id: MagazinePistolEmpty
-  name: pistol magazine (.35 auto any)
+  name: pistol magazine (9x19mm any)
   suffix: empty
   parent: MagazinePistol
-  description: 12-round single-stack magazine for pistols. #goobstation
+  description: A 12-round single-stack magazine for pistols. #goobstation
   components:
   - type: BallisticAmmoProvider
     proto: null
@@ -223,9 +223,9 @@
 
 - type: entity
   id: MagazinePistolIncendiary
-  name: pistol magazine (.35 auto incendiary)
+  name: pistol magazine (9x19mm incendiary)
   parent: MagazinePistol
-  description: 12-round single-stack magazine for pistols. Intended to hold self-igniting incendiary ammunition. #goobstation
+  description: A 12-round single-stack magazine for pistols. Intended to hold self-igniting incendiary ammunition. #goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistolIncendiary
@@ -250,9 +250,9 @@
 
 - type: entity
   id: MagazinePistolPractice
-  name: pistol magazine (.35 auto practice)
+  name: pistol magazine (9x19mm practice)
   parent: BaseMagazinePistol
-  description: 12-round single-stack magazine for pistols. Intended to hold non-harmful chalk ammunition. #goobstation
+  description: A 12-round single-stack magazine for pistols. Intended to hold non-harmful chalk ammunition. #goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistolPractice
@@ -277,9 +277,9 @@
 
 - type: entity
   id: MagazinePistolUranium
-  name: pistol magazine (.35 auto uranium)
+  name: pistol magazine (9x19mm uranium)
   parent: BaseMagazinePistol
-  description: 12-round single-stack magazine for pistols. Intended to hold exotic uranium-core ammunition. #goobstation
+  description: A 12-round single-stack magazine for pistols. Intended to hold exotic uranium-core ammunition. #goobstation
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistolUranium
@@ -304,7 +304,7 @@
 
 - type: entity
   id: MagazinePistolHighCapacityEmpty
-  name: machine pistol magazine (.35 auto any)
+  name: machine pistol magazine (9x19mm any)
   suffix: empty
   parent: BaseMagazinePistolHighCapacity
   components:
@@ -325,7 +325,7 @@
 
 - type: entity
   id: MagazinePistolHighCapacity
-  name: machine pistol magazine (.35 auto)
+  name: machine pistol magazine (9x19mm FMJ)
   parent: BaseMagazinePistolHighCapacity
   components:
   - type: BallisticAmmoProvider
@@ -345,7 +345,7 @@
 
 - type: entity
   id: MagazinePistolHighCapacityPractice
-  name: machine pistol magazine (.35 auto practice)
+  name: machine pistol magazine (9x19mm practice)
   parent: BaseMagazinePistolHighCapacity
   components:
   - type: BallisticAmmoProvider
@@ -371,7 +371,7 @@
 
 - type: entity
   id: MagazinePistolHighCapacityRubber
-  name: machine pistol magazine (.35 auto rubber)
+  name: machine pistol magazine (9x19mm rubber)
   parent: BaseMagazinePistolHighCapacity
   components:
   - type: BallisticAmmoProvider
@@ -385,9 +385,9 @@
 
 - type: entity
   id: MagazinePistolSubMachineGun
-  name: SMG magazine (.35 auto)
+  name: SMG magazine (9x19mm FMJ)
   parent: BaseMagazinePistolSubMachineGun
-  description: 30-round double-stack magazine for submachine guns. Intended to hold general-purpose kinetic ammunition.
+  description: A 30-round double-stack magazine for submachine guns. Intended to hold general-purpose kinetic ammunition.
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistol
@@ -411,10 +411,10 @@
 
 - type: entity
   id: MagazinePistolSubMachineGunEmpty
-  name: SMG magazine (.35 auto any)
+  name: SMG magazine (9x19mm any)
   suffix: empty
   parent: BaseMagazinePistolSubMachineGun
-  description: 30-round double-stack magazine for submachine guns.
+  description: A 30-round double-stack magazine for submachine guns.
   components:
   - type: BallisticAmmoProvider
     proto: null
@@ -433,9 +433,9 @@
 
 - type: entity
   id: MagazinePistolSubMachineGunPractice
-  name: SMG magazine (.35 auto practice)
+  name: SMG magazine (9x19mm practice)
   parent: BaseMagazinePistolSubMachineGun
-  description: 30-round double-stack magazine for submachine guns. Intended to hold non-harmful chalk ammunition.
+  description: A 30-round double-stack magazine for submachine guns. Intended to hold non-harmful chalk ammunition.
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistolPractice
@@ -460,9 +460,9 @@
 
 - type: entity
   id: MagazinePistolSubMachineGunUranium
-  name: SMG magazine (.35 auto uranium)
+  name: SMG magazine (9x19mm uranium)
   parent: BaseMagazinePistolSubMachineGun
-  description: 30-round double-stack magazine for submachine guns. Intended to hold exotic uranium-core ammunition.
+  description: A 30-round double-stack magazine for submachine guns. Intended to hold exotic uranium-core ammunition.
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistolUranium
@@ -488,8 +488,8 @@
 - type: entity
   parent: BaseMagazinePistolSubMachineGun
   id: MagazinePistolSubMachineGunIncendiary
-  name: SMG magazine (.35 auto incendiary)
-  description: 30-round double-stack magazine for submachine guns. Intended to hold self-igniting incendiary ammunition.
+  name: SMG magazine (9x19mm incendiary)
+  description: A 30-round double-stack magazine for submachine guns. Intended to hold self-igniting incendiary ammunition.
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistolIncendiary

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/rifle.yml
@@ -24,7 +24,7 @@
 # Empty mags
 - type: entity
   id: BaseMagazineRifle
-  name: "magazine (.20 rifle)"
+  name: "magazine (5.56x45mm)"
   parent: [ BaseItem, BaseSecurityContraband ]
   abstract: true
   components:
@@ -57,7 +57,7 @@
 
 - type: entity
   id: MagazineRifle
-  name: "magazine (.20 rifle)"
+  name: "magazine (5.56x45mm)"
   parent: BaseMagazineRifle
   components:
   - type: BallisticAmmoProvider
@@ -77,7 +77,7 @@
 
 - type: entity
   id: MagazineRifleEmpty
-  name: "magazine (.20 rifle any)"
+  name: "magazine (5.56x45mm any)"
   suffix: empty
   parent: MagazineRifle
   components:
@@ -98,7 +98,7 @@
 
 - type: entity
   id: MagazineRifleIncendiary
-  name: "magazine (.20 rifle incendiary)"
+  name: "magazine (5.56x45mm incendiary)"
   parent: MagazineRifle
   components:
   - type: BallisticAmmoProvider
@@ -124,7 +124,7 @@
 
 - type: entity
   id: MagazineRiflePractice
-  name: "magazine (.20 rifle practice)"
+  name: "magazine (5.56x45mm practice)"
   parent: BaseMagazineRifle
   components:
   - type: BallisticAmmoProvider
@@ -150,7 +150,7 @@
 
 - type: entity
   id: MagazineRifleUranium
-  name: "magazine (.20 rifle uranium)"
+  name: "magazine (5.56x45mm uranium)"
   parent: BaseMagazineRifle
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -40,7 +40,7 @@
   categories: [ HideSpawnMenu ]
   parent: BaseBullet
   id: BulletAntiMateriel
-  name: bullet (.60 anti-materiel)
+  name: bullet (14.5x114mm)
   components:
   - type: Projectile
     damage:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
@@ -15,7 +15,7 @@
 
 - type: entity
   id: BulletHeavyRifle
-  name: bullet (.20 rifle)
+  name: bullet (5.56x45mm)
   parent: BaseBullet
   categories: [ HideSpawnMenu ]
   components:
@@ -26,7 +26,7 @@
 
 - type: entity
   id: BulletMinigun
-  name: minigun bullet (.10 rifle)
+  name: minigun bullet (.22 LR)
   parent: BulletHeavyRifle
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -40,7 +40,7 @@
 
 - type: entity
   id: BulletMagnum
-  name: bullet (.45 magnum)
+  name: bullet (.44 magnum)
   parent: BaseBullet
   categories: [ HideSpawnMenu ]
   components:
@@ -51,7 +51,7 @@
 
 - type: entity
   id: BulletMagnumPractice
-  name: bullet (.45 magnum practice)
+  name: bullet (.44 magnum practice)
   parent: BaseBulletPractice
   categories: [ HideSpawnMenu ]
   components:
@@ -63,7 +63,7 @@
 - type: entity
   id: BulletMagnumIncendiary
   parent: BaseBulletIncendiary
-  name: bullet (.45 magnum incendiary)
+  name: bullet (.44 magnum incendiary)
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
@@ -74,7 +74,7 @@
 
 - type: entity
   id: BulletMagnumAP
-  name: bullet (.45 magnum armor-piercing)
+  name: bullet (.44 magnum armor-piercing)
   parent: BaseBullet # Goobstation edit
   categories: [ HideSpawnMenu ]
   components:
@@ -86,7 +86,7 @@
 
 - type: entity
   id: BulletMagnumUranium
-  name: bullet (.45 magnum uranium)
+  name: bullet (.44 magnum uranium)
   parent: BaseBulletUranium
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -29,7 +29,7 @@
 
 - type: entity
   id: BulletPistol
-  name: bullet (.35 auto)
+  name: bullet (9x19mm)
   parent: BaseBullet
   categories: [ HideSpawnMenu ]
   components:
@@ -40,7 +40,7 @@
 
 - type: entity
   id: BulletPistolPractice
-  name: bullet (.35 auto practice)
+  name: bullet (9x19mm practice)
   parent: BaseBulletPractice
   categories: [ HideSpawnMenu ]
   components:
@@ -52,7 +52,7 @@
 - type: entity
   id: BulletPistolIncendiary
   parent: BaseBulletIncendiary
-  name: bullet (.35 auto incendiary)
+  name: bullet (9x19mm incendiary)
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
@@ -64,7 +64,7 @@
 - type: entity
   id: BulletPistolUranium
   parent: BaseBulletUranium
-  name: bullet (.35 auto uranium)
+  name: bullet (9x19mm uranium)
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -33,7 +33,7 @@
 
 - type: entity
   id: BulletRifle
-  name: bullet (0.20 rifle)
+  name: bullet (05.56x45mm)
   parent: BaseBullet
   categories: [ HideSpawnMenu ]
   components:
@@ -45,7 +45,7 @@
 
 - type: entity
   id: BulletRiflePractice
-  name: bullet (0.20 rifle practice)
+  name: bullet (05.56x45mm practice)
   parent: BaseBulletPractice
   categories: [ HideSpawnMenu ]
   components:
@@ -57,7 +57,7 @@
 - type: entity
   id: BulletRifleIncendiary
   parent: BaseBulletIncendiary
-  name: bullet (0.20 rifle incendiary)
+  name: bullet (05.56x45mm incendiary)
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile
@@ -69,7 +69,7 @@
 - type: entity
   id: BulletRifleUranium
   parent: BaseBulletUranium
-  name: bullet (0.20 rifle uranium)
+  name: bullet (05.56x45mm uranium)
   categories: [ HideSpawnMenu ]
   components:
   - type: Projectile

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/magnum.yml
@@ -26,7 +26,7 @@
 
 - type: entity
   id: BaseSpeedLoaderMagnum
-  name: "speed loader (.45 magnum)"
+  name: "speed loader (.44 magnum)"
   parent: [ BaseItem, BaseSecurityContraband ]
   abstract: true
   components:
@@ -47,7 +47,7 @@
 
 - type: entity
   id: SpeedLoaderMagnum
-  name: "speed loader (.45 magnum)"
+  name: "speed loader (.44 magnum)"
   parent: BaseSpeedLoaderMagnum
   description: Designed to quickly refill an empty revolver, it fits up to six rounds. Intended to hold general-purpose kinetic ammunition.
   components:
@@ -76,7 +76,7 @@
 
 - type: entity
   id: SpeedLoaderMagnumEmpty
-  name: "speed loader (.45 magnum any)"
+  name: "speed loader (.44 magnum any)"
   parent: SpeedLoaderMagnum
   description: Designed to quickly refill an empty revolver, it fits up to six rounds for the big iron on your hip. #Big Iron reference (duh)
   components:
@@ -101,7 +101,7 @@
 
 - type: entity
   id: SpeedLoaderMagnumIncendiary
-  name: "speed loader (.45 magnum incendiary)"
+  name: "speed loader (.44 magnum incendiary)"
   parent: SpeedLoaderMagnum
   description: Designed to quickly refill an empty revolver, it fits up to six rounds. Intended to hold self-igniting incendiary ammunition.
   components:
@@ -110,7 +110,7 @@
 
 - type: entity
   id: SpeedLoaderMagnumPractice
-  name: "speed loader (.45 magnum practice)"
+  name: "speed loader (.44 magnum practice)"
   parent: BaseSpeedLoaderMagnum
   description: Designed to quickly refill an empty revolver, it fits up to six rounds. Intended to hold non-harmful chalk ammunition, perfect for practicing your quick draw.
   components:
@@ -143,7 +143,7 @@
 
 - type: entity
   id: SpeedLoaderMagnumAP
-  name: "speed loader (.45 magnum armor-piercing)"
+  name: "speed loader (.44 magnum armor-piercing)"
   parent: BaseSpeedLoaderMagnum
   description: Designed to quickly refill an empty revolver, it fits up to six rounds. Intended to hold rare armor-piercing ammunition.
   components:
@@ -176,7 +176,7 @@
 
 - type: entity
   id: SpeedLoaderMagnumUranium
-  name: "speed loader (.45 magnum uranium)"
+  name: "speed loader (.44 magnum uranium)"
   parent: BaseSpeedLoaderMagnum
   description: Designed to quickly refill an empty revolver, it fits up to six rounds. Intended to hold exotic uranium-core ammunition.
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/rifle_light.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/rifle_light.yml
@@ -17,9 +17,9 @@
 
 - type: entity
   id: SpeedLoaderLightRifle
-  name: "speed loader (.30 rifle)"
+  name: "speed loader (7.62x51mm)"
   parent: [ BaseItem, BaseSecurityContraband ]
-  description: 5-round 'stripper clip' for quickly reloading the Kardashev-Mosin. Holds 5 rounds of .30 rifle.
+  description: 5-round 'stripper clip' for quickly reloading the Kardashev-Mosin. Holds 5 rounds of 7.62x51mm.
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/HMGs/hmgs.yml
@@ -126,7 +126,7 @@
   name: minigun
   id: WeaponMinigun
   parent: [ BaseWeaponHeavyMachineGun, BaseMajorContraband ]
-  description: Vzzzzzt! Rahrahrahrah! Vrrrrr! Uses .10 rifle ammo.
+  description: Vzzzzzt! Rahrahrahrah! Vrrrrr! Uses .22 LR ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/HMGs/minigun.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -159,7 +159,7 @@
   name: L6C ROW
   id: WeaponLightMachineGunL6C
   parent: BaseItem
-  description: A L6 SAW for use by cyborgs. Creates .30 rifle ammo on the fly from an internal ammo fabricator, which slowly self-charges.
+  description: A L6 SAW for use by cyborgs. Creates 7.62x51mm ammo on the fly from an internal ammo fabricator, which slowly self-charges.
   components:
     - type: Gun
       minAngle: 4

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -130,7 +130,7 @@
   name: Deckard
   parent: [BaseWeaponRevolver, BaseSecurityCommandContraband]
   id: WeaponRevolverDeckard
-  description: A beautifully machined, custom-built revolver. Used when there is no time for the Voight-Kampff test. Loads 5 rounds of .45 magnum.
+  description: A beautifully machined, custom-built revolver. Used when there is no time for the Voight-Kampff test. Loads 5 rounds of .44 magnum.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/deckard.rsi
@@ -158,7 +158,7 @@
   name: Inspector
   parent: [BaseWeaponRevolver, BaseSecurityContraband]
   id: WeaponRevolverInspector
-  description: A single-action revolver manufactured by various companies. It is readily available on the civilian market, making it a popular choice among private investigators. You feel lucky just holding it. Loads 6 rounds of .45 magnum.
+  description: A single-action revolver manufactured by various companies. It is readily available on the civilian market, making it a popular choice among private investigators. You feel lucky just holding it. Loads 6 rounds of .44 magnum.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/inspector.rsi
@@ -173,7 +173,7 @@
   name: Mateba
   parent: [BaseWeaponRevolver, BaseCentcommContraband]
   id: WeaponRevolverMateba
-  description: A modern revolver used by Nanotrasen’s elite, near mythical ‘Death Squad’ task force. Its unique trigger action and barrel placement enable a high fire rate with minimal muzzle flip. Many have looked down this barrel, but few have lived to tell of it. Loads 6 rounds of .45 magnum.
+  description: A modern revolver used by Nanotrasen’s elite, near mythical ‘Death Squad’ task force. Its unique trigger action and barrel placement enable a high fire rate with minimal muzzle flip. Many have looked down this barrel, but few have lived to tell of it. Loads 6 rounds of .44 magnum.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/mateba.rsi
@@ -209,7 +209,7 @@
   name: Python
   parent: [BaseWeaponRevolver, BaseSyndicateContraband]
   id: WeaponRevolverPython
-  description: A powerful double-action revolver manufactured by the Syndicate. Loud and flashy, perfect for any agent looking to make a statement. Loads 6 rounds of .45 magnum.
+  description: A powerful double-action revolver manufactured by the Syndicate. Loud and flashy, perfect for any agent looking to make a statement. Loads 6 rounds of .44 magnum.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/python.rsi
@@ -244,7 +244,7 @@
   name: pirate revolver
   parent: [BaseWeaponRevolver, BaseMajorContraband]
   id: WeaponRevolverPirate
-  description: A crude single-action revolver handmade by a space pirate. Old and covered in rust, it somehow still works. Loads 5 rounds of .45 magnum.
+  description: A crude single-action revolver handmade by a space pirate. Old and covered in rust, it somehow still works. Loads 5 rounds of .44 magnum.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/pirate_revolver.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -167,7 +167,7 @@
   name: AKM
   parent: [BaseWeaponRifle, BaseSecurityContraband]
   id: WeaponRifleAk
-  description: A somewhat battered combat rifle of a design originating from old Earth. Favored by criminals, militias, and terrorists due to its famed reliability and easy-to-manufacture design. Feeds from .30 rifle magazines.
+  description: A somewhat battered combat rifle of a design originating from old Earth. Favored by criminals, militias, and terrorists due to its famed reliability and easy-to-manufacture design. Feeds from 7.62x51mm magazines.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Rifles/ak.rsi
@@ -216,7 +216,7 @@
   name: M-90gl
   parent: [BaseWeaponRifle, BaseSyndicateContraband]
   id: WeaponRifleM90GrenadeLauncher
-  description: An older bullpup carbine model, with an attached underbarrel grenade launcher. Uses .20 rifle ammo.
+  description: An older bullpup carbine model, with an attached underbarrel grenade launcher. Uses 5.56x45mm ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Rifles/carbine.rsi
@@ -262,7 +262,7 @@
   name: Lecter
   parent: [BaseWeaponRifle, BaseSecurityContraband]
   id: WeaponRifleLecter
-  description: A high end military grade assault rifle. Uses .20 rifle ammo.
+  description: A high end military grade assault rifle. Uses 5.56x45mm ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Rifles/lecter.rsi
@@ -310,7 +310,7 @@
   name: Estoc # goob
   parent: [BaseWeaponRifle, BaseSyndicateContraband]
   id: WeaponRifleEstoc
-  description: A designated assault rifle with a scope, favored for medium-to-long range engagements. Uses .20 rifle ammo. # goob
+  description: A designated assault rifle with a scope, favored for medium-to-long range engagements. Uses 5.56x45mm ammo. # goob
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Rifles/estoc.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -150,7 +150,7 @@
   name: Atreides
   parent: [BaseWeaponSubMachineGun, BaseSecurityContraband]
   id: WeaponSubMachineGunAtreides
-  description: A rare machine pistol hailing from the Corporate Wars. Its extremely high fire rate and compact profile make it useful in close quarters combat. Despite its age, it is in remarkably good condition. Feeds from .35 SMG magazines.
+  description: A rare machine pistol hailing from the Corporate Wars. Its extremely high fire rate and compact profile make it useful in close quarters combat. Despite its age, it is in remarkably good condition. Feeds from 9x19mm SMG magazines.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/SMGs/atreides.rsi
@@ -173,7 +173,7 @@
   name: C-20r submachine gun
   parent: [BaseWeaponSubMachineGun, BaseSyndicateContraband]
   id: WeaponSubMachineGunC20r
-  description: A classic and widespread submachine gun, infamous for its use by the Gorlex Marauders. One of the first homegrown Waffle Corp. designs, it remains in service today. Feeds from .35 SMG magazines.
+  description: A classic and widespread submachine gun, infamous for its use by the Gorlex Marauders. One of the first homegrown Waffle Corp. designs, it remains in service today. Feeds from 9x19mm SMG magazines.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/SMGs/c20r.rsi
@@ -216,7 +216,7 @@
   name: Drozd
   parent: [BaseWeaponSubMachineGun, BaseSecurityContraband]
   id: WeaponSubMachineGunDrozd
-  description: A modern SMG manufactured by Nanotrasen’s Small Arms Division. It features an exceptional rate of fire in burst mode, useful for holding defensive angles or engaging hostiles at longer ranges. Feeds from .35 SMG magazines.
+  description: A modern SMG manufactured by Nanotrasen’s Small Arms Division. It features an exceptional rate of fire in burst mode, useful for holding defensive angles or engaging hostiles at longer ranges. Feeds from 9x19mm SMG magazines.
   components:
     - type: Sprite
       sprite: Objects/Weapons/Guns/SMGs/drozd.rsi
@@ -282,7 +282,7 @@
   name: WT550 autorifle # Goobstation
   parent: [ BaseWeaponSubMachineGun, BaseSecurityContraband]
   id: WeaponSubMachineGunWt550
-  description: A truly unique firearm, the WT550 was designed by Nanotrasen's Small Arms Division as a compact, cheap, and mass produced submachine gun fully controllable with one hand. It contains an exotic internal recoil buffer and feeds from special top-mounted .35 magazines.
+  description: A truly unique firearm, the WT550 was designed by Nanotrasen's Small Arms Division as a compact, cheap, and mass produced submachine gun fully controllable with one hand. It contains an exotic internal recoil buffer and feeds from special top-mounted 9x19mm magazines.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/SMGs/wt550.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -194,7 +194,7 @@
   name: Kardashev-Mosin
   parent: [BaseWeaponSniper, BaseGunWieldable, BaseMajorContraband]
   id: WeaponSniperMosin
-  description: A true relic, the Kardashev-Mosin has served in nearly every armed conflict since its creation 670 years ago. The bolt-action design of the rifle remains virtually identical to its original design, whether used for hunting, sniping, or endless trench warfare. Loads 10 rounds of .30 rifle.
+  description: A true relic, the Kardashev-Mosin has served in nearly every armed conflict since its creation 670 years ago. The bolt-action design of the rifle remains virtually identical to its original design, whether used for hunting, sniping, or endless trench warfare. Loads 10 rounds of 7.62x51mm.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
@@ -225,7 +225,7 @@
   name: Hristov
   parent: [BaseWeaponSniperMagazine, BaseGunWieldable, BaseSyndicateContraband]
   id: WeaponSniperHristov
-  description: A portable anti-materiel rifle. Fires armor piercing 14.5mm shells. Uses .60 anti-materiel ammo.
+  description: A portable anti-materiel rifle. Fires armor piercing 14.5x114mm shells.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/heavy_sniper.rsi
@@ -260,7 +260,7 @@
   name: musket
   parent: [ BaseWeaponSniper, BaseGunWieldable, BaseMajorContraband ]
   id: Musket
-  description: This should've been in a museum long before you were born. Uses .60 anti-materiel ammo.
+  description: This should've been in a museum long before you were born. Uses 14.5x114mm ammo.
   components:
   - type: Sharp
   - type: Item
@@ -299,7 +299,7 @@
   name: flintlock pistol
   parent: [BaseWeaponSniper, BaseMajorContraband]
   id: WeaponPistolFlintlock
-  description: A pirate's companion. Yarrr! Uses .45 magnum ammo.
+  description: A pirate's companion. Yarrr! Uses .44 magnum ammo.
   components:
   - type: Gun
     minAngle: 0

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Boxes/high_caliber_box.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Boxes/high_caliber_box.yml
@@ -12,7 +12,7 @@
   abstract: true
   parent: [ BaseItem, BaseSyndicateContraband ]
   id: BaseMagazineBoxHighCaliber
-  name: ammunition box (.50 anti-materiel)
+  name: ammunition box (.50 BMG anti-materiel)
   components:
   - type: BallisticAmmoProvider
     mayTransfer: true
@@ -46,7 +46,7 @@
 - type: entity
   parent: BaseMagazineBoxHighCaliber
   id: MagazineBoxHighCaliberExplosive
-  name: ammunition box (.50 high-explosive incendiary)
+  name: ammunition box (.50 BMG high-explosive incendiary)
   components:
   - type: BallisticAmmoProvider
     capacity: 30

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magnum.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magnum.yml
@@ -71,7 +71,7 @@
 - type: entity
   id: MagazineBoxMagnumNeurotoxin
   parent: BaseMagazineBoxMagnum
-  name: ammunition box (.45 magnum neurotoxin)
+  name: ammunition box (.44 magnum neurotoxin)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeMagnumNeurotoxin

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless.yml
@@ -5,7 +5,7 @@
 
 - type: entity
   id: CartridgeCaselessRifleSAPHE
-  name: cartridge (9.5mm SAP-HE)
+  name: cartridge (9.5x18mm SAP-HE)
   parent: BaseCartridgeCaselessRifle
   components:
   - type: CartridgeAmmo

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/high_caliber_cartridge.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/high_caliber_cartridge.yml
@@ -9,7 +9,7 @@
 - type: entity
   parent: [ BaseCartridge, BaseMajorContraband ]
   id: CartridgeHighCaliber
-  name: cartridge (.50 anti-materiel)
+  name: cartridge (.50 BMG anti-materiel)
   components:
   - type: Tag
     tags:
@@ -30,7 +30,7 @@
 - type: entity
   parent: [ BaseCartridge, BaseMajorContraband ]
   id: CartridgeHighCaliberExplosive
-  name: cartridge (.50 high-explosive incendiary)
+  name: cartridge (.50 BMG high-explosive incendiary)
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/m7s.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/m7s.yml
@@ -5,7 +5,7 @@
 
 - type: entity
   id: CartridgeLowCaliber
-  name: cartridge (5x23mm)
+  name: cartridge (5.7x28mm FMJ)
   parent: BaseCartridge
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
@@ -54,7 +54,7 @@
 
 - type: entity
   id: CartridgeMagnumNeurotoxin
-  name: shell (.45 subsonic neurotoxin)
+  name: shell (.44 subsonic neurotoxin)
   parent: BaseCartridgeMagnum
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/smartgun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/smartgun.yml
@@ -9,8 +9,8 @@
 - type: entity
   parent: [ BaseCartridge, BaseSecurityContraband ]
   id: CartridgeSmart
-  name: cartridge (.160 smart)
-  description: A .160 smart bullet with a small charge of booster propellant at the bottom.
+  name: cartridge (13x35mm gyrojet)
+  description: A solid-fuel rocket in pocket size. Corrects its flight path based on the target selected on ignition. Being self-propelled, it has little to no recoil and can be fired out of a small barrel without complications.
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless.yml
@@ -8,7 +8,7 @@
 
 - type: entity
   id: MagazinePistolCaselessRifleEmpty
-  name: pistol magazine (9.5mm any)
+  name: pistol magazine (9.5x18mm any)
   parent: BaseMagazinePistolCaselessRifle
   components:
   - type: BallisticAmmoProvider
@@ -24,7 +24,7 @@
 
 - type: entity
   id: MagazinePistolCaselessRifleSAPHE
-  name: "pistol magazine (9.5mm SAP-HE)"
+  name: "pistol magazine (9.5x18mm SAP-HE)"
   parent: BaseMagazinePistolCaselessRifle
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/high_caliber_magazine.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/high_caliber_magazine.yml
@@ -52,7 +52,7 @@
 
 - type: entity
   id: MagazineHighCaliber
-  name: "magazine (.50 anti-materiel)"
+  name: "magazine (.50 BMG anti-materiel)"
   parent: BaseMagazineHighCaliber
   components:
   - type: BallisticAmmoProvider
@@ -60,7 +60,7 @@
 
 - type: entity
   id: MagazineHighCaliberExplosive
-  name: "magazine (.50 high-explosive incendiary)"
+  name: "magazine (.50 BMG high-explosive incendiary)"
   parent: BaseMagazineHighCaliber
   components:
   - type: BallisticAmmoProvider
@@ -75,7 +75,7 @@
 
 - type: entity
   id: BaseMagazineAntiMateriel
-  name: "magazine (.60 caliber)"
+  name: "magazine (14.5x114mm FMJ)"
   parent: [ BaseItem, BaseSyndicateContraband ]
   abstract: true
   components:
@@ -109,7 +109,7 @@
 
 - type: entity
   id: MagazineAntiMaterielEmpty
-  name: "magazine (.60 empty)"
+  name: "magazine (14.5x114mm empty)"
   parent: BaseMagazineAntiMateriel
   components:
   - type: BallisticAmmoProvider
@@ -117,7 +117,7 @@
 
 - type: entity
   id: MagazineAntiMateriel
-  name: "magazine (.60 anti-materiel)"
+  name: "magazine (14.5x114mm anti-materiel)"
   parent: BaseMagazineAntiMateriel
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/m7s.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/m7s.yml
@@ -5,7 +5,7 @@
 
 - type: entity
   id: MagazineLowCaliberM7S
-  name: M7S magazine (5x23mm)
+  name: M7S magazine (5.7x28mm FMJ)
   parent: [ BaseItem, BaseSyndicateContraband ]
   components:
   - type: Tag
@@ -39,7 +39,7 @@
 
 - type: entity
   id: MagazineLowCaliberM7SEmpty # There's not much point in making this printable as it's the only weapon to use this caliber anyway
-  name: M7S magazine (5x23mm any)
+  name: M7S magazine (5.7x28mm any)
   parent: MagazineLowCaliberM7S
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -23,7 +23,7 @@
 
 - type: entity
   id: MagazinePistolNeurotoxin
-  name: pistol magazine (.45 neurotoxin)
+  name: pistol magazine (.44 neurotoxin)
   parent: [BaseMagazineMagnum, BaseCentcommContraband]
   components:
   - type: Tag

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/smartgun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Magazines/smartgun.yml
@@ -21,7 +21,7 @@
 
 - type: entity
   id: MagazineSmart
-  name: "magazine (.160 smart)"
+  name: "magazine (13x35mm gyrojet)"
   parent: [ BaseItem, BaseSecurityContraband ]
   components:
   - type: Tag

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless.yml
@@ -8,7 +8,7 @@
   categories: [ HideSpawnMenu ]
   parent: BaseBulletTrigger
   id: BulletCaselessRifleSAPHE
-  name: bullet (9.5mm SAP-HE)
+  name: bullet (9.5x18mm SAP-HE)
   components:
   - type: Projectile
     damage:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/m7s.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/m7s.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: BulletLowCaliber
-  name: bullet (5x23mm)
+  name: bullet (5.7x28mm FMJ)
   parent: BaseBullet
   components:
   - type: Projectile

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -10,7 +10,7 @@
 
 - type: entity
   id: BulletMagnumNeurotoxin
-  name: bullet (.45 subsonic neurotoxin)
+  name: bullet (.44 subsonic neurotoxin)
   categories: [ HideSpawnMenu ]
   parent: BaseBulletPractice
   components:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/smartgun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/smartgun.yml
@@ -5,7 +5,7 @@
 
 - type: entity
   id: BulletSmart
-  name: bullet (.160 smart)
+  name: bullet (13x35mm gyrojet)
   parent: BaseBullet
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/magnum.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/magnum.yml
@@ -7,7 +7,7 @@
 
 - type: entity
   id: SpeedLoaderMatebaAP
-  name: "centcomm speed loader (.45 magnum armor-piercing)"
+  name: "centcomm speed loader (.44 magnum armor-piercing)"
   parent: [SpeedLoaderMagnumAP, BaseCentcommContraband]
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -114,7 +114,7 @@
   categories: [ HideSpawnMenu ]
   parent: BaseBullet
   id: BulletHighCaliber
-  name: bullet (.50 anti-materiel)
+  name: bullet (.50 BMG anti-materiel)
   components:
   - type: Projectile
     damage:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifle.yml
@@ -70,7 +70,7 @@
   name: M-90
   parent: [BaseWeaponRifle, BaseSyndicateContraband]
   id: WeaponRifleM90
-  description: A revision of the M-90gl that removes the inbuilt grenade launcher. Uses .20 rifle ammo.
+  description: A revision of the M-90gl that removes the inbuilt grenade launcher. Uses 5.56x45mm ammo.
   components:
   - type: Sprite
     sprite: _Goobstation/Objects/Weapons/Guns/Rifles/m90.rsi
@@ -116,7 +116,7 @@
   name: Annie
   parent: [BaseCentcommContraband, BaseWeaponRifle]
   id: WeaponRifleAnnie
-  description: A beast designed to shoulder the weight of impossible missions. Uses .30 rifle ammo.
+  description: A beast designed to shoulder the weight of impossible missions. Uses 7.62x51mm ammo.
   components:
   - type: Sprite
     sprite: _Goobstation/Objects/Weapons/Guns/Rifles/annie.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/SMGs/smartgun.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/SMGs/smartgun.yml
@@ -12,7 +12,7 @@
   name: Abielle Smart-SMG
   parent: [BaseWeaponSubMachineGun, BaseSecurityContraband]
   id: WeaponSubMachineSmart
-  description: An experiment in smart-weapon technology that guides bullets towards the target the gun was aimed at when fired. While the tracking functions work fine, the gun is prone to insanely wide spread thanks to its practically non-existant barrel.
+  description: An experiment in smart-weapon technology that guides bullets towards the target the gun was aimed at when fired. While the tracking functions work fine, the gun is prone to insanely wide spread thanks to its practically nonexistent barrel.
   components:
   - type: Sprite
     sprite: _Goobstation/Objects/Weapons/Guns/SMGs/smartgun.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -9,7 +9,7 @@
   name: M7S "Ventilator" submachine gun
   parent: [BaseWeaponSubMachineGun, BaseGunWieldable, BaseSyndicateContraband]
   id: WeaponSubMachineGunM7S
-  description: You may or may not be green, but you are still very very mean. Takes proprietary side-loading 5x23mm rifle magazines.
+  description: You may or may not be green, but you are still very very mean. Takes proprietary side-loading 5.7x28mm rifle magazines.
   components:
   - type: Sprite
     sprite: _Goobstation/Objects/Weapons/Guns/SMGs/M7S.rsi


### PR DESCRIPTION
## About the PR
Replaced nearly every existing cartridge with its real-world counterpart (or, closest to it)
NOTE: WHILE THIS IS HEAVILY A WORK IN PROGRESS AND COMPLETELY UNTESTED, IT DOES RUN AND I NEED FEEDBACK

Full list:
.22 LR
5.7x28mm FMJ
9.5x18mm HP
9x19mm FMJ
.44 magnum FMJ
13x35mm gyrojet
5.56x45mm FMJ
7.62x51mm FMJ
.50 BMG
14.5x114mm

## Why / Balance
Personal preference.
It's easier to memorise actual cartridges that exist in real life, and makes it easier for new players to understand what caliber does what. It also looks sick as fuck.

## Media
Coming soontm

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Calibers have been renamed to their real-life counterparts.
- tweak: Guns now have tweaked descriptions.
