### PR TITLE
Rattling some Bones

### DIFF
--- a/Resources/Prototypes/Roles/Antags/ninja.yml
+++ b/Resources/Prototypes/Roles/Antags/ninja.yml
@@ -83,6 +83,11 @@
   setPreference: false
   objective: roles-antag-space-ninja-objective
   guides: [ SpaceNinja ]
+  requirements:
+  - !type:SpeciesRequirement
+    inverted: true
+    species:
+    - Plasmaman
 
 #Ninja Gear
 - type: startingGear

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -126,6 +126,10 @@
   - !type:RoleTimeRequirement
     role: JobChemist
     time: 18000 # 5h Goobstation
+  - !type:SpeciesRequirement
+    inverted: true
+    species:
+    - Plasmaman
   guides: [ NuclearOperatives ]
 
 - type: antag
@@ -143,6 +147,10 @@
   - !type:DepartmentTimeRequirement
     department: Command
     time: 18000 # 5h Goobstation
+  - !type:SpeciesRequirement
+    inverted: true
+    species:
+    - Plasmaman
   # should be changed to nukie playtime when thats tracked (wyci)
   guides: [ NuclearOperatives ]
 

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -105,6 +105,10 @@
   - !type:DepartmentTimeRequirement
     department: Security
     time: 36000 # 10h Goobstation
+  - !type:SpeciesRequirement
+    inverted: true
+    species:
+    - Plasmaman
   guides: [ NuclearOperatives ]
 
 - type: antag

--- a/Resources/Prototypes/Roles/Antags/thief.yml
+++ b/Resources/Prototypes/Roles/Antags/thief.yml
@@ -96,5 +96,5 @@
     back:
     - ThiefBeacon
     - SatchelThief
-    - ClothingHandsChameleonThief
+    # - ClothingHandsChameleonThief - Goobedit, since thieves have intrinsic pickpocketing now we don't need these
     - PinpointerThief # Goob edit

--- a/Resources/Prototypes/Roles/Antags/zombie.yml
+++ b/Resources/Prototypes/Roles/Antags/zombie.yml
@@ -20,6 +20,7 @@
     inverted: true
     species:
     - IPC
+    - Plasmaman
   guides: [ Zombies ]
 
 - type: antag
@@ -33,4 +34,5 @@
     inverted: true
     species:
     - IPC
+    - Plasmaman
   guides: [ Zombies ]

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Clothing/Hands/base_clothinghands.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Clothing/Hands/base_clothinghands.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: ClothingHandsGlovesSyntheticBase
+  parent: ClothingHandsButcherable
   id: ClothingHandsGlovesEnviroglovesBase
   components:
   - type: Armor

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Clothing/Hands/envirogloves.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Clothing/Hands/envirogloves.yml
@@ -24,8 +24,6 @@
       gloves:
       - state: equipped-HAND
         color: "#913b00"
-  - type: Fiber
-    fiberColor: fibers-orange
 
 - type: entity
   parent: ClothingHandsGlovesEnviroglovesBase
@@ -140,11 +138,15 @@
   suffix: Loadouts, Colorable
 
 - type: entity
-  parent: ClothingHandsGlovesEnviroglovesWhite
+  parent: [ClothingHandsGlovesEnviroglovesBase, BaseSecurityContraband]
   id: ClothingHandsGlovesEnviroglovesDetective
   name: forensic envirogloves
   description: Covers up those scandalous boney fingerprints.
   components:
+  - type: Sprite
+    sprite: Clothing/Hands/Gloves/forensic.rsi
+  - type: Clothing
+    sprite: Clothing/Hands/Gloves/forensic.rsi
   - type: FingerprintMask
   - type: GuideHelp
     guides:
@@ -356,6 +358,11 @@
   - type: Fiber
     fiberMaterial: fibers-leather
     fiberColor: fibers-blue
+  - type: DamageOnInteractProtection # Botanist death nettle moment
+    damageProtection:
+      flatReductions:
+        Heat: 10
+        Caustic: 5
 
 - type: entity
   parent: ClothingHandsGlovesEnviroglovesBase
@@ -445,6 +452,12 @@
   id: ClothingHandsGlovesEnviroglovesCaptain
   name: captain's envirogloves
   description: Covers up those scandalous, bony hands in a fancy way.
+  components:
+  - type: FingerprintMask
+  - type: Insulated
+  - type: Fiber
+  fiberMaterial: fibers-durathread
+  fiberColor: fibers-regal-blue #Goobstation - Captain enviroglove parity
 
 - type: entity
   parent: ClothingHandsGlovesEnviroglovesBase

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Clothing/Uniform/envirosuits.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Clothing/Uniform/envirosuits.yml
@@ -96,9 +96,6 @@
     sprite: _EinsteinEngines/Clothing/Uniforms/Envirosuits/clown.rsi
   - type: Clothing
     sprite: _EinsteinEngines/Clothing/Uniforms/Envirosuits/clown.rsi
-  - type: Tag
-    tags:
-    - ClownSuit
 
 - type: entity
   parent: ClothingUniformEnvirosuitBase

--- a/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
@@ -22,4 +22,5 @@
     inverted: true
     species:
     - IPC
+    - Plasmaman
   guides: [ Changelings ]

--- a/Resources/Prototypes/_Goobstation/Roles/Antags/devil.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Antags/devil.yml
@@ -20,6 +20,10 @@
   - !type:RoleTimeRequirement
     role: JobLawyer
     time: 3600 # 1 Hour
+  - !type:SpeciesRequirement
+    inverted: true
+    species:
+    - Plasmaman
 
 - type: startingGear
   id: DevilStartingGear

--- a/Resources/Prototypes/_Goobstation/Wizard/wizard.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/wizard.yml
@@ -36,6 +36,10 @@
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 126000 # 35h
+  - !type:SpeciesRequirement
+    inverted: true
+    species:
+    - Plasmaman
   guides: [ Wizard ]
 
 - type: antag

--- a/Resources/Prototypes/_Goobstation/_Pirates/antagdef.yml
+++ b/Resources/Prototypes/_Goobstation/_Pirates/antagdef.yml
@@ -11,6 +11,13 @@
   antagonist: true
   setPreference: false
   objective: roles-antag-syndicate-agent-objective
+  requirements:
+  - !type:OverallPlaytimeRequirement
+      time: 36000 #10 hrs
+  - !type:SpeciesRequirement
+    inverted: true
+    species:
+    - Plasmaman
 
 - type: entity
   parent: BaseMindRoleAntag


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
Made some fixes for:
#4310 
#4309 

The solutions were as follows:
All gloves were just fixed to have parity with their normal equivalents
Chameleon thief gloves are entirely removed from thief kit as thieves have built in pickpocketing now
Clown envirosuit now spawns as expected
Plasmamen are no longer able to roll as Ninja, Wizard, Pirate, Devil, Nukie or Ling.

## Why / Balance
Mostly little yaml tweaks required
No need for thieves to have 2 sources of thievery
Nukie envirosuits exist but I'm unsure if there's a way to set the nukie starting gear in a species specific way without having nukie loadouts (wyci)

## Technical details
All YAML BABY

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- remove: Plasmamen can no longer roll Ninja, Wizard, Pirate, Devil, Nukie or Ling.
- fix: Captain Envirogloves are now insulated and produce the correct fibers
- fix: Det Envirogloves now use forensic glove sprite, no longer leave fibers
- fix: Botanist Envirogloves now have proper protection against heat and caustic
- fix: Clown now spawns with their Envirosuit if they are a plasmaman
- remove: Removes thieves chameleon gloves from thieves roundstart kit

