### PR TITLE
Fix arachnid specific textures

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -54,138 +54,139 @@
   id: BaseMobArachnid
   abstract: true
   components:
-  - type: Body
-    prototype: Arachnid
-    requiredLegs: 2 # It would be funny if arachnids could use their little back limbs to move around once they lose their legs, but just something to consider post-woundmed
-  - type: HumanoidAppearance
-    species: Arachnid
-  - type: Hunger
-  - type: Thirst
-  - type: Sericulture
-    productionLength: 2
-    entityProduced: MaterialWebSilk1
-    hungerCost: 4 # Should total to 25 total silk on full hunger
-  - type: Tag
-    tags:
-    - CanPilot
-    - FootstepSound
-    - DoorBumpOpener
-    - SpiderCraft
-    - AnomalyHost
-  - type: Butcherable
-    butcheringType: Spike
-    spawned:
-      - id: FoodMeatSpider
-        amount: 5
-  - type: Reactive
-    reactions:
-    - reagents: [Water]
-      methods: [Touch]
-      effects:
-      - !type:WearableReaction
-        slot: head
-        prototypeID: WaterDropletHat
-    - reagents: [Water, SpaceCleaner]
-      methods: [Touch]
-      effects:
-      - !type:WashCreamPieReaction
-  # Damage (Self)
-  - type: Bloodstream
-    bloodReagent: CopperBlood
-  # Damage (Others)
-  - type: MeleeWeapon
-    animation: WeaponArcBite
-    soundHit:
-      path: /Audio/Effects/bite.ogg
-    damage:
-      types:
-        Piercing: 5
-  # Visual & Audio
-#  - type: DamageVisuals
-#    damageOverlayGroups:
-#      Brute:
-#        sprite: _Shitmed/Mobs/Effects/brute_damage.rsi
-#        color: "#162581"
-#      Burn:
-#        sprite: _Shitmed/Mobs/Effects/burn_damage.rsi
-  - type: Speech
-    speechVerb: Arachnid
-    speechSounds: Arachnid
-    allowedEmotes: ['Click', 'Chitter']
-  - type: Vocal
-    sounds:
-      Male: UnisexArachnid
-      Female: UnisexArachnid
-      Unsexed: UnisexArachnid
-  - type: TypingIndicator
-    proto: spider
-  - type: LanguageKnowledge # Einstein Engines - Language
-    speaks:
-    - TauCetiBasic
-    - Chittin # Until they have a species-specific
-    understands:
-    - TauCetiBasic
-    - Chittin # Until they have a species-specific
-  - type: Sprite # I'd prefer if these maps were better. Insert map pun here.
-    layers:
-      - map: [ "enum.HumanoidVisualLayers.Chest" ]
-      - map: [ "enum.HumanoidVisualLayers.Groin" ]
-      - map: [ "enum.HumanoidVisualLayers.Head" ]
-      - map: [ "enum.HumanoidVisualLayers.Snout" ]
-      - map: [ "enum.HumanoidVisualLayers.Eyes" ]
-      - map: [ "enum.HumanoidVisualLayers.RArm" ]
-      - map: [ "enum.HumanoidVisualLayers.LArm" ]
-      - map: [ "enum.HumanoidVisualLayers.RLeg" ]
-      - map: [ "enum.HumanoidVisualLayers.LLeg" ]
-      - map: [ "enum.HumanoidVisualLayers.Underwear" ]
-      - map: [ "enum.HumanoidVisualLayers.Undershirt" ]
-      - map: ["jumpsuit"]
-      - map: ["enum.HumanoidVisualLayers.LFoot"]
-      - map: ["enum.HumanoidVisualLayers.RFoot"]
-      - map: ["enum.HumanoidVisualLayers.LHand"]
-      - map: ["enum.HumanoidVisualLayers.RHand"]
-      - map: [ "enum.HumanoidVisualLayers.Face" ]
-      - map: [ "gloves" ]
-      - map: [ "shoes" ]
-      - map: [ "id" ]
-      - map: [ "outerClothing" ]
-      - map: [ "belt" ] #Goobedit - Belts over outerwear
-      - map: [ "enum.HumanoidVisualLayers.Tail" ] # Mentioned in moth code: This needs renaming lol.
-      - map: [ "back" ]
-      - map: [ "neck" ]
-      - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
-      - map: [ "enum.HumanoidVisualLayers.Hair" ] # Do these need to be here? (arachnid hair arachnid hair)
-      - map: [ "enum.HumanoidVisualLayers.HeadSide" ]
-      - map: [ "ears" ]
-      - map: [ "eyes" ]
-      - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
-      - map: [ "maskalt" ]
-      - map: [ "mask" ]
-      - map: [ "head" ]
-      - map: [ "pocket1" ]
-      - map: [ "pocket2" ]
-      - map: ["enum.HumanoidVisualLayers.Handcuffs"]
-        color: "#ffffff"
-        sprite: Objects/Misc/handcuffs.rsi
-        state: body-overlay-2
-        visible: false
-      - map: [ "clownedon" ] # Dynamically generated
-        sprite: "Effects/creampie.rsi"
-        state: "creampie_arachnid"
-        visible: false
-  - type: Inventory
-    templateId: arachnid
-  - type: IgnoreSpiderWeb # Goobstation
+    - type: Body
+      prototype: Arachnid
+      requiredLegs: 2 # It would be funny if arachnids could use their little back limbs to move around once they lose their legs, but just something to consider post-woundmed
+    - type: HumanoidAppearance
+      species: Arachnid
+    - type: Hunger
+    - type: Thirst
+    - type: Sericulture
+      productionLength: 2
+      entityProduced: MaterialWebSilk1
+      hungerCost: 4 # Should total to 25 total silk on full hunger
+    - type: Tag
+      tags:
+        - CanPilot
+        - FootstepSound
+        - DoorBumpOpener
+        - SpiderCraft
+        - AnomalyHost
+    - type: Butcherable
+      butcheringType: Spike
+      spawned:
+        - id: FoodMeatSpider
+          amount: 5
+    - type: Reactive
+      reactions:
+        - reagents: [Water]
+          methods: [Touch]
+          effects:
+            - !type:WearableReaction
+              slot: head
+              prototypeID: WaterDropletHat
+        - reagents: [Water, SpaceCleaner]
+          methods: [Touch]
+          effects:
+            - !type:WashCreamPieReaction # Damage (Self)
+
+
+    - type: Bloodstream
+      bloodReagent: CopperBlood
+    # Damage (Others)
+    - type: MeleeWeapon
+      animation: WeaponArcBite
+      soundHit:
+        path: /Audio/Effects/bite.ogg
+      damage:
+        types:
+          Piercing: 5
+    # Visual & Audio
+    #  - type: DamageVisuals
+    #    damageOverlayGroups:
+    #      Brute:
+    #        sprite: _Shitmed/Mobs/Effects/brute_damage.rsi
+    #        color: "#162581"
+    #      Burn:
+    #        sprite: _Shitmed/Mobs/Effects/burn_damage.rsi
+    - type: Speech
+      speechVerb: Arachnid
+      speechSounds: Arachnid
+      allowedEmotes: ["Click", "Chitter"]
+    - type: Vocal
+      sounds:
+        Male: UnisexArachnid
+        Female: UnisexArachnid
+        Unsexed: UnisexArachnid
+    - type: TypingIndicator
+      proto: spider
+    - type: LanguageKnowledge # Einstein Engines - Language
+      speaks:
+        - TauCetiBasic
+        - Chittin # Until they have a species-specific
+      understands:
+        - TauCetiBasic
+        - Chittin # Until they have a species-specific
+    - type: Sprite # I'd prefer if these maps were better. Insert map pun here.
+      layers:
+        - map: ["enum.HumanoidVisualLayers.Chest"]
+        - map: ["enum.HumanoidVisualLayers.Groin"]
+        - map: ["enum.HumanoidVisualLayers.Head"]
+        - map: ["enum.HumanoidVisualLayers.Snout"]
+        - map: ["enum.HumanoidVisualLayers.Eyes"]
+        - map: ["enum.HumanoidVisualLayers.RArm"]
+        - map: ["enum.HumanoidVisualLayers.LArm"]
+        - map: ["enum.HumanoidVisualLayers.RLeg"]
+        - map: ["enum.HumanoidVisualLayers.LLeg"]
+        - map: ["enum.HumanoidVisualLayers.Underwear"]
+        - map: ["enum.HumanoidVisualLayers.Undershirt"]
+        - map: ["jumpsuit"]
+        - map: ["enum.HumanoidVisualLayers.LFoot"]
+        - map: ["enum.HumanoidVisualLayers.RFoot"]
+        - map: ["enum.HumanoidVisualLayers.LHand"]
+        - map: ["enum.HumanoidVisualLayers.RHand"]
+        - map: ["enum.HumanoidVisualLayers.Face"]
+        - map: ["gloves"]
+        - map: ["shoes"]
+        - map: ["id"]
+        - map: ["outerClothing"]
+        - map: ["belt"] #Goobedit - Belts over outerwear
+        - map: ["enum.HumanoidVisualLayers.Tail"] # Mentioned in moth code: This needs renaming lol.
+        - map: ["back"]
+        - map: ["neck"]
+        - map: ["enum.HumanoidVisualLayers.FacialHair"]
+        - map: ["enum.HumanoidVisualLayers.Hair"] # Do these need to be here? (arachnid hair arachnid hair)
+        - map: ["enum.HumanoidVisualLayers.HeadSide"]
+        - map: ["ears"]
+        - map: ["eyes"]
+        - map: ["enum.HumanoidVisualLayers.HeadTop"]
+        - map: ["maskalt"]
+        - map: ["eyes"]
+        - map: ["mask"]
+        - map: ["head"]
+        - map: ["pocket1"]
+        - map: ["pocket2"]
+        - map: ["enum.HumanoidVisualLayers.Handcuffs"]
+          color: "#ffffff"
+          sprite: Objects/Misc/handcuffs.rsi
+          state: body-overlay-2
+          visible: false
+        - map: ["clownedon"] # Dynamically generated
+          sprite: "Effects/creampie.rsi"
+          state: "creampie_arachnid"
+          visible: false
+    - type: Inventory
+      templateId: arachnid
+      speciesId: arachnid #Goobedit - Fix Arachnid specific textures
+    - type: IgnoreSpiderWeb # Goobstation
 
 - type: entity
   parent: BaseSpeciesDummy
   id: MobArachnidDummy
-  categories: [ HideSpawnMenu ]
+  categories: [HideSpawnMenu]
   components:
-  - type: HumanoidAppearance
-    species: Arachnid
-  - type: Inventory
-    speciesId: arachnid
-
-
+    - type: HumanoidAppearance
+      species: Arachnid
+    - type: Inventory
+      speciesId: arachnid
 #>88w88<


### PR DESCRIPTION
## About the PR
Added speciesId for InventoryComponent to grab because it wasn't there for whatever reason.
Now arachnid specific sprites display correctly.
Tested, works


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines]
- [X] I have added media to this PR or it does not require an ingame showcase.


**Changelog**

:cl:
- fix: Arachnid specific clothing sprites now display correctly.