### PR TITLE
Fix Arachnid specific textures

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -175,6 +175,7 @@
         visible: false
   - type: Inventory
     templateId: arachnid
+    speciesId: arachnid #Goobedit - Fix Arachnid specific textures
   - type: IgnoreSpiderWeb # Goobstation
 
 - type: entity


### PR DESCRIPTION
## About the PR
Added speciesId for InventoryComponent to grab because it wasn't there for whatever reason.
Now arachnid specific sprites display correctly.
Tested, works.


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines]
- [X] I have added media to this PR or it does not require an ingame showcase.


**Changelog**

:cl:
- fix: Arachnid specific clothing sprites now display correctly.