### PR TITLE
i hate custom door remote

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -195,7 +195,7 @@
     - id: ClothingHeadsetAltCommand
     - id: ClothingOuterArmorCaptainCarapace
     - id: CommsComputerCircuitboard
-    - id: DoorRemoteCommand
+    - id: DoorRemoteCommand #Goob
     - id: MedalCase
     - id: NukeDisk
     - id: PinpointerNuclear

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -195,7 +195,7 @@
     - id: ClothingHeadsetAltCommand
     - id: ClothingOuterArmorCaptainCarapace
     - id: CommsComputerCircuitboard
-    - id: DoorRemoteCustom
+    - id: DoorRemoteCommand
     - id: MedalCase
     - id: NukeDisk
     - id: PinpointerNuclear


### PR DESCRIPTION

## Why / Balance
gives captain too much power (tends to shut down antags/bad things happening a bit too much)
becomes useless the moment an antag steals it (bad) and the moment you get theiving glove'd of your id (also really fucking bad), too unreliable overall because of these reasons
dilutes position as head of COMMAND primarily and head of station secondarily

## Technical details
yml


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**

:cl:
- tweak: Captians now have their old command door remote back
