### PR TITLE
you can no longer self-revive while devoured [BOUNTY]

### DIFF
--- a/Content.Goobstation.Common/Devour/PreventSelfRevivalComponent.cs
+++ b/Content.Goobstation.Common/Devour/PreventSelfRevivalComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Goobstation.Common.Devour;
+
+/// <summary>
+/// Used to mark an entity as being unable to self-revive (e.g preventing Changelings from using their stasis)
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class PreventSelfRevivalComponent : Component
+{
+}

--- a/Content.Goobstation.Server/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingSystem.Abilities.cs
@@ -71,6 +71,7 @@ using Content.Shared.Traits.Assorted;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Content.Shared.Actions.Components;
+using Content.Goobstation.Shared.Devour.Events;
 
 namespace Content.Goobstation.Server.Changeling;
 
@@ -405,6 +406,13 @@ public sealed partial class ChangelingSystem
     }
     private void OnExitStasis(EntityUid uid, ChangelingIdentityComponent comp, ref ExitStasisEvent args)
     {
+        // check if we're allowed to revive
+        var reviveEv = new PreventSelfRevivalEvent(uid);
+        RaiseLocalEvent(uid, ref reviveEv);
+
+        if (reviveEv.Cancelled)
+            return;
+
         if (!comp.IsInStasis)
         {
             _popup.PopupEntity(Loc.GetString("changeling-stasis-exit-fail"), uid, uid);

--- a/Content.Goobstation.Server/Devil/CheatDeath/CheatDeathSystem.cs
+++ b/Content.Goobstation.Server/Devil/CheatDeath/CheatDeathSystem.cs
@@ -6,6 +6,7 @@
 
 using Content.Goobstation.Common.DelayedDeath;
 using Content.Goobstation.Shared.CheatDeath;
+using Content.Goobstation.Shared.Devour.Events;
 using Content.Server._Shitmed.DelayedDeath;
 using Content.Server.Actions;
 using Content.Server.Administration.Systems;
@@ -87,6 +88,13 @@ public sealed partial class CheatDeathSystem : EntitySystem
 
             return;
         }
+
+        // check if we're allowed to revive
+        var reviveEv = new PreventSelfRevivalEvent(ent);
+        RaiseLocalEvent(ent, ref reviveEv);
+
+        if (reviveEv.Cancelled)
+            return;
 
         // If the entity is out of revives, or if they are unrevivable, return.
         if (ent.Comp.ReviveAmount <= 0 || HasComp<UnrevivableComponent>(ent))

--- a/Content.Goobstation.Server/SlaughterDemon/SlaughterDemonSystem.cs
+++ b/Content.Goobstation.Server/SlaughterDemon/SlaughterDemonSystem.cs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Goobstation.Common.Devour;
 using Content.Goobstation.Shared.SlaughterDemon;
 using Content.Goobstation.Shared.SlaughterDemon.Systems;
 using Content.Server.Administration.Systems;
@@ -39,6 +40,10 @@ public sealed class SlaughterDemonSystem : SharedSlaughterDemonSystem
             return;
 
         _container.EmptyContainer(devour.Container);
+
+        // Allow everyone to self revive again (if they have the ability to)
+        foreach (var entity in ent.Comp.ConsumedMobs)
+            RemComp<PreventSelfRevivalComponent>(entity);
 
         // heal them if they were in the laughter demon
         if (!ent.Comp.IsLaughter)

--- a/Content.Goobstation.Shared/Devour/Events/PreventSelfRevivalEvents.cs
+++ b/Content.Goobstation.Shared/Devour/Events/PreventSelfRevivalEvents.cs
@@ -1,0 +1,8 @@
+namespace Content.Goobstation.Shared.Devour.Events;
+
+[ByRefEvent]
+public record struct PreventSelfRevivalEvent(
+    EntityUid Target,
+    String PopupText = "self-revive-fail",
+    bool Handled = false,
+    bool Cancelled = false);

--- a/Content.Goobstation.Shared/Devour/Systems/PreventSelfRevivalSystem.cs
+++ b/Content.Goobstation.Shared/Devour/Systems/PreventSelfRevivalSystem.cs
@@ -1,0 +1,26 @@
+using Content.Goobstation.Common.Devour;
+using Content.Goobstation.Shared.Devour.Events;
+using Content.Shared.Popups;
+
+namespace Content.Goobstation.Shared.Devour.Systems;
+
+public sealed class PreventSelfRevivalSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PreventSelfRevivalComponent, PreventSelfRevivalEvent>(OnAttemptSelfRevive);
+    }
+
+    private void OnAttemptSelfRevive(Entity<PreventSelfRevivalComponent> ent, ref PreventSelfRevivalEvent args)
+    {
+        if (args.Handled || args.Cancelled)
+            return;
+
+        _popup.PopupEntity(Loc.GetString(args.PopupText), args.Target, args.Target, PopupType.SmallCaution);
+        args.Cancelled = true;
+    }
+}

--- a/Content.Goobstation.Shared/SlaughterDemon/Systems/SharedSlaughterDemonSystem.cs
+++ b/Content.Goobstation.Shared/SlaughterDemon/Systems/SharedSlaughterDemonSystem.cs
@@ -1,3 +1,4 @@
+using Content.Goobstation.Common.Devour;
 using Content.Shared.Actions;
 using Content.Shared.Item;
 using Content.Shared.Mobs;
@@ -121,6 +122,9 @@ public abstract class SharedSlaughterDemonSystem : EntitySystem
             return;
 
         _container.Insert(pullingEnt, slaughterDevour.Container);
+
+        // Stop them from being able to self-revive
+        EnsureComp<PreventSelfRevivalComponent>(pullingEnt);
 
         // Kill them for sure, just in case
         if (_mobStateQuery.TryComp(pullingEnt, out var mobState))

--- a/Content.Shared/Devour/DevourSystem.cs
+++ b/Content.Shared/Devour/DevourSystem.cs
@@ -1,3 +1,4 @@
+using Content.Goobstation.Common.Devour;
 using Content.Shared.Actions;
 using Content.Shared.Body.Events;
 using Content.Shared.Body.Systems;
@@ -115,6 +116,14 @@ public sealed class DevourSystem : EntitySystem
         if (args.Args.Target != null && _whitelistSystem.IsWhitelistPass(ent.Comp.StomachStorageWhitelist, (EntityUid)args.Args.Target))
         {
             _containerSystem.Insert(args.Args.Target.Value, ent.Comp.Stomach);
+
+            // Goobstation start
+
+            if (HasComp<MobStateComponent>(args.Args.Target.Value)) // can be cases where objects are also whitelisted, which wont need this
+                EnsureComp<PreventSelfRevivalComponent>(args.Args.Target.Value);
+
+            // Goobstation end
+
         }
         //TODO: Figure out a better way of removing structures via devour that still entails standing still and waiting for a DoAfter. Somehow.
         //If it's not alive, it must be a structure.
@@ -131,6 +140,13 @@ public sealed class DevourSystem : EntitySystem
     {
         if (ent.Comp.StomachStorageWhitelist == null)
             return;
+
+        // Goobstation start
+
+        foreach (var entity in ent.Comp.Stomach.ContainedEntities)
+            RemComp<PreventSelfRevivalComponent>(entity);
+
+        // Goobstation end
 
         // For some reason we have two different systems that should handle gibbing,
         // and for some another reason GibbingSystem, which should empty all containers, doesn't get involved in this process

--- a/Resources/Locale/en-US/_Goobstation/devour/prevent-self-revive.ftl
+++ b/Resources/Locale/en-US/_Goobstation/devour/prevent-self-revive.ftl
@@ -1,0 +1,1 @@
+self-revive-fail = Can't revive in this state!


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
changelings and devils (or those with cheat death) will no longer be able to revive while devoured by a dragon or slaughter demon

## Why / Balance
bounty

## Technical details
c#

## Media

https://github.com/user-attachments/assets/71bddcdd-0602-417f-b2de-02c5d8bd5802

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Changelings and people with Cheat Death (e.g devils) will no longer be able to revive while devoured by a dragon or slaughter demon.
