### PR TITLE
HOTFIX:  Holoparasite movement causing a rare server crash

### DIFF
--- a/Content.Server/Guardian/GuardianComponent.cs
+++ b/Content.Server/Guardian/GuardianComponent.cs
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: MIT
 
 using Robust.Shared.Audio;
+using Robust.Shared.Map; // Goobstation
 
 namespace Content.Server.Guardian
 {
@@ -63,11 +64,10 @@ namespace Content.Server.Guardian
         public SoundSpecifier DeathSound = new SoundPathSpecifier("/Audio/Voice/Human/malescream_guardian.ogg", AudioParams.Default.WithVariation(0.2f));
 
         /// <summary>
-        /// Whether the guardian is currently being repositioned to prevent infinite move event loops
-        /// </summary>
         /// Goobstation
-        [ViewVariables(VVAccess.ReadOnly)]
-        public bool IsRepositioning;
-
+        /// The guardian's last known position to prevent unnecessary position updates
+        /// </summary>
+        [ViewVariables]
+        public EntityCoordinates? LastPosition;
     }
 }

--- a/Content.Server/Guardian/GuardianComponent.cs
+++ b/Content.Server/Guardian/GuardianComponent.cs
@@ -62,5 +62,12 @@ namespace Content.Server.Guardian
         [DataField]
         public SoundSpecifier DeathSound = new SoundPathSpecifier("/Audio/Voice/Human/malescream_guardian.ogg", AudioParams.Default.WithVariation(0.2f));
 
+        /// <summary>
+        /// Whether the guardian is currently being repositioned to prevent infinite move event loops
+        /// </summary>
+        /// Goobstation
+        [ViewVariables(VVAccess.ReadOnly)]
+        public bool IsRepositioning;
+
     }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## About the PR
Added a bool to stop Holoparasite movement logic from being repeated if there is already one in progress.

## Why / Balance
This can cause server crashes (I dunno why this code is server-sided)

## Technical details
- Added a bool to check for movement in `Content.Server/Guardian/GuardianComponent.cs`
- Added a check for this bool in `Content.Server/Guardian/GuardianSystem.cs` in addition to logic to force the bool in the rare case it might throw an error to keep the server functional.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Richard Blonski
- fix: Holoparasite being able to crash the server

