### PR TITLE
engi borg suffer

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -752,7 +752,7 @@
 - type: entity
   id: BorgModuleRCD
   parent: [ BaseBorgModuleEngineering, BaseProviderBorgModule ]
-  name: engineering cyborg module
+  name: RCD module # Goob
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
@@ -51,6 +51,7 @@
   - BorgModuleAdvancedTool
   - BorgModuleAdvancedChemical
   - BorgModuleAdvancedMining
+  - BorgModuleRCD
 
 - type: latheRecipePack
   id: MechParts

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -297,6 +297,7 @@
     - PowerDrill
     - JawsOfLife
     - BorgModuleAdvancedTool
+    - BorgModuleRCD #added from roundstart
     - SignallerAdvanced # Moved from explosives research
   # Goobstation R&D Console rework start
   position: 2,-5

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/robotics.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/robotics.yml
@@ -77,6 +77,11 @@
   id: BorgModuleLollypop
   result: BorgModuleLollypop
 
+- type: latheRecipe
+  parent: BaseGoldBorgModuleRecipe
+  id: BorgModuleRCD
+  result: BorgModuleRCD
+
 # AI
 - type: latheRecipe
   id: AiRemoteBrain
@@ -87,3 +92,6 @@
     Glass: 400
     Gold: 400
     Silver: 200
+
+
+

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -70,7 +70,7 @@
   defaultModules:
   - BorgModuleTool
   - BorgModuleConstruction
-  - BorgModuleRCD
+  # - BorgModuleRCD - roundstart mass producable recharging RCD is bad, make sci unlock it
   - BorgModuleCable
 
   lawset: Engineer # DeltaV: Custom lawset


### PR DESCRIPTION
RCDs are absurdly strong, this is coming from their number 1 abuser
:cl: Armok
- tweak: RCD mod moved from roundstart engi borgs to tech tree.
