### PR TITLE
Added knockdown if two entities spriting collide.

### DIFF
--- a/Content.Goobstation.Server/Sprinting/SprintingSystem.cs
+++ b/Content.Goobstation.Server/Sprinting/SprintingSystem.cs
@@ -5,8 +5,40 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Goobstation.Shared.Sprinting;
+using Content.Server.Stunnable;
+using Robust.Shared.Physics.Events;
 
 namespace Content.Goobstation.Server.Sprinting;
 
 public sealed class SprintingSystem : SharedSprintingSystem
-{}
+{
+
+    [Dependency] private readonly StunSystem _stunSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<SprinterComponent, StartCollideEvent>(OnCollide);
+    }
+
+    private void OnCollide(EntityUid uid, SprinterComponent sprinter, ref StartCollideEvent args)
+    {
+        var otherUid = args.OtherEntity;
+
+        if (uid.Id < otherUid.Id)
+            return;
+
+        if (!sprinter.IsSprinting)
+        {
+            return;
+        }
+
+        if (!TryComp(otherUid, out SprinterComponent? otherSprinter) || !otherSprinter.IsSprinting)
+        {
+            return;
+        }
+
+        _stunSystem.TryKnockdown(uid, sprinter.KnockdownDurationOnCollision, false);
+        _stunSystem.TryKnockdown(otherUid, otherSprinter.KnockdownDurationOnCollision, false);
+    }
+}

--- a/Content.Goobstation.Shared/Sprinting/SprinterComponent.cs
+++ b/Content.Goobstation.Shared/Sprinting/SprinterComponent.cs
@@ -122,6 +122,12 @@ public sealed partial class SprinterComponent : Component
             { "Blunt", 10 },
         }
     };
+
+    /// <summary>
+    ///     For how long does entity get knocked down on collision with another sprinting entity?
+    /// </summary>
+    [DataField]
+    public TimeSpan KnockdownDurationOnCollision = TimeSpan.FromSeconds(2f);
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

If two entities collide, they both get knocked down for 2 seconds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Just another something to make sprinting a bit more than just burning stamina to move faster.

## Technical details
<!-- Summary of code changes for easier review. -->

Subscribed to the collision event on server-side sprintersystem and added a handler that performs the checks.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/ea1eb776-6486-4494-a829-a8fc20f5e1bb


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: Hagvan
Sprinting into each other causes a knockdown.
