### PR TITLE
Headrev hours changed from 10 hours overall to 10 hours command

### DIFF
--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -18,7 +18,7 @@
   setPreference: true
   objective: roles-antag-rev-head-objective
   requirements:
-   - !type:DepartmentTimeRequirement # was  - !type:OverallPlaytimeRequirement, Goob change
+  - !type:DepartmentTimeRequirement # was  - !type:OverallPlaytimeRequirement, Goob change
       department: Command 
       time: 36000 # 10h
   guides: [ Revolutionaries ]

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -18,7 +18,7 @@
   setPreference: true
   objective: roles-antag-rev-head-objective
   requirements:
- - !type:DepartmentTimeRequirement # was  - !type:OverallPlaytimeRequirement, Goob change
+   - !type:DepartmentTimeRequirement # was  - !type:OverallPlaytimeRequirement, Goob change
       department: Command 
       time: 36000 # 10h
   guides: [ Revolutionaries ]

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -18,7 +18,8 @@
   setPreference: true
   objective: roles-antag-rev-head-objective
   requirements:
-    - !type:OverallPlaytimeRequirement
+ - !type:DepartmentTimeRequirement # was  - !type:OverallPlaytimeRequirement, Goob change
+      department: Command 
       time: 36000 # 10h
   guides: [ Revolutionaries ]
 


### PR DESCRIPTION
GOIDAMERGE THIS NOW!!!!

if you want actual reasoning: hmm today i will make the people who decide the entire flow of the round need 10 hours on tider to achieve YEA RIGHT

## Technical details
yml (lmao)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**

:cl:
- tweak: Headrev time requirements made into 10 hours command instead of 10 hours overall
