### PR TITLE
[Tweak] Implanters de-metagaming

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -209,7 +209,7 @@
 
 - type: entity
   id: SadTromboneImplanter
-  name: sad trombone implanter
+  suffix: Sad Trombone
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -217,7 +217,7 @@
 
 - type: entity
   id: LightImplanter
-  name: light implanter
+  suffix: Light
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -225,7 +225,7 @@
 
 - type: entity
   id: BikeHornImplanter
-  name: bike horn implanter
+  suffix: Bike Horn
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -235,7 +235,7 @@
 
 - type: entity
   id: TrackingImplanter
-  name: tracking implanter
+  suffix: Tracking
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -245,7 +245,7 @@
 
 - type: entity
   id: StorageImplanter
-  name: storage implanter
+  suffix: Storage
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -253,7 +253,7 @@
 
 - type: entity
   id: FreedomImplanter
-  name: freedom implanter
+  suffix: Freedom
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -261,7 +261,7 @@
 
 - type: entity
   id: RadioImplanter
-  name: syndicate radio implanter
+  suffix: Syndicate Radio
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -269,7 +269,7 @@
 
 - type: entity
   id: UplinkImplanter
-  name: uplink implanter
+  suffix: Uplink
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -277,7 +277,7 @@
 
 - type: entity
   id: EmpImplanter
-  name: EMP implanter
+  suffix: EMP
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -285,7 +285,7 @@
 
 - type: entity
   id: ScramImplanter
-  name: scram implanter
+  suffix: Scram
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -293,7 +293,7 @@
 
 - type: entity
   id: DnaScramblerImplanter
-  name: DNA scrambler implanter
+  suffix: DNA scrambler
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -301,7 +301,7 @@
 
 - type: entity
   id: ChameleonControllerImplanter
-  name: chameleon controller implanter
+  suffix: Chameleon Controller
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -311,7 +311,7 @@
 
 - type: entity
   id: MicroBombImplanter
-  name: micro-bomb implanter
+  suffix: Micro-Bomb
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -319,7 +319,7 @@
 
 - type: entity
   id: MacroBombImplanter
-  name: macro-bomb implanter
+  suffix: Macro-Bomb
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -327,7 +327,7 @@
 
 - type: entity
   id: DeathRattleImplanter
-  name: death rattle implanter
+  suffix: Death Rattle
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -335,7 +335,7 @@
 
 - type: entity
   id: DeathAcidifierImplanter
-  name: death acidifier implanter
+  suffix: Death Acidifier
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -343,7 +343,7 @@
 
 - type: entity
   id: FakeMindShieldImplanter
-  name: fake mindshield implanter
+  suffix: Fake Mindshield
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -353,7 +353,7 @@
 
 - type: entity
   id: MindShieldImplanter
-  name: mindshield implanter
+  suffix: Mindshield
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -363,7 +363,7 @@
 
 - type: entity
   id: RadioImplanterCentcomm
-  name: centcomm radio implanter
+  suffix: Centcomm Radio
   parent: BaseImplantOnlyImplanterCentcomm # Goobstation
   components:
   - type: Implanter
@@ -371,8 +371,8 @@
 
 - type: entity
   id: DeathRattleImplanterCentcomm
-  name: centcomm death rattle implanter
-  parent: BaseImplantOnlyImplanter
+  suffix: Death Rattle
+  parent: BaseImplantOnlyImplanterCentcomm # Goobstation
   components:
   - type: Implanter
     implant: DeathRattleImplantCentcomm

--- a/Resources/Prototypes/_EinsteinEngines/Objects/Misc/translator_implanters.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Objects/Misc/translator_implanters.yml
@@ -9,13 +9,13 @@
   id: BaseTranslatorImplanter
   abstract: true
   parent: BaseImplantOnlyImplanter
-  name: basic translator implanter
+  name: translator implanter
 
 # Gives ability to understand TauCetiBasic.
 - type: entity
   id: BasicGalaticCommonTranslatorImplanter
   parent: BaseTranslatorImplanter
-  name: basic common translator implanter
+  suffix: Basic Common
   components:
   - type: Implanter
     implant: BasicTauCetiBasicTranslatorImplant
@@ -24,7 +24,7 @@
 - type: entity
   id: AdvancedGalaticCommonTranslatorImplanter
   parent: BaseTranslatorImplanter
-  name: advanced common translator implanter
+  suffix: Advanced Common
   components:
   - type: Implanter
     implant: TauCetiBasicTranslatorImplant
@@ -32,7 +32,7 @@
 - type: entity
   id: BubblishTranslatorImplanter
   parent: BaseTranslatorImplanter
-  name: bubblish translator implant
+  suffix: Bubblish
   components:
   - type: Implanter
     implant: BubblishTranslatorImplant
@@ -40,7 +40,7 @@
 - type: entity
   id: NekomimeticTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  name: nekomimetic translator implant
+  suffix: Nekomimetic
   components:
   - type: Implanter
     implant: NekomimeticTranslatorImplant
@@ -48,7 +48,7 @@
 - type: entity
   id: DraconicTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  name: unathi translator implant
+  suffix: Draconic
   components:
   - type: Implanter
     implant: DraconicTranslatorImplant
@@ -56,7 +56,7 @@
 - type: entity
   id: CanilunztTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  name: canilunzt translator implant
+  suffix: Canilunzt
   components:
   - type: Implanter
     implant: CanilunztTranslatorImplant
@@ -64,7 +64,7 @@
 - type: entity
   id: SolCommonTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  name: sol-common translator implant
+  suffix: Sol-Common
   components:
   - type: Implanter
     implant: SolCommonTranslatorImplant
@@ -72,7 +72,7 @@
 - type: entity
   id: NovuNedericTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  name: novu-nederic translator implant
+  suffix: Novu-Nederic
   components:
   - type: Implanter
     implant: NovuNedericTranslatorImplant
@@ -80,7 +80,7 @@
 - type: entity
   id: RootSpeakTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  name: root-speak translator implant
+  suffix: Root-Speak
   components:
   - type: Implanter
     implant: RootSpeakTranslatorImplant
@@ -88,7 +88,7 @@
 - type: entity
   id: MofficTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  name: moffic translator implant
+  suffix: Moffic
   components:
   - type: Implanter
     implant: MofficTranslatorImplant
@@ -96,7 +96,7 @@
 - type: entity
   id: ValyrianStandardTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  name: valyrian standard translator implant
+  suffix: Valyrian Standard
   components:
   - type: Implanter
     implant: ValyrianStandardTranslatorImplant
@@ -104,7 +104,7 @@
 - type: entity
   id: AzazibaTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  name: azaziba translator implant
+  suffix: Azaziba
   components:
   - type: Implanter
     implant: AzazibaTranslatorImplant
@@ -112,7 +112,7 @@
 - type: entity
   id: ChittinTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  name: chittin translator implant
+  suffix: Chittin
   components:
   - type: Implanter
     implant: ChittinTranslatorImplant
@@ -120,7 +120,7 @@
 - type: entity
   id: SiikMaasTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  name: siik'maas translator implant
+  suffix: Siik'Maas
   components:
   - type: Implanter
     implant: SiikMaasTranslatorImplant
@@ -128,7 +128,7 @@
 - type: entity
   id: MarishTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  name: marish translator implant
+  suffix: Marish
   components:
   - type: Implanter
     implant: MarishTranslatorImplant
@@ -136,7 +136,7 @@
 - type: entity
   id: SchechiTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  name: schechi translator implant
+  suffix: Schechi
   components:
   - type: Implanter
     implant: SchechiTranslatorImplant
@@ -144,7 +144,7 @@
 - type: entity
   id: NewKinPidginTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  name: ka'rakk translator implant
+  suffix: Ka'Rakk
   components:
   - type: Implanter
     implant: NewKinPidginTranslatorImplant

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/implanters.yml
@@ -99,7 +99,7 @@
 
 - type: entity
   id: BluespaceLifelineImplanter
-  name: bluespace lifeline implanter
+  suffix: Bluespace Lifeline
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -107,7 +107,7 @@
 
 - type: entity
   id: CommandTrackingImplanter
-  suffix: command tracker
+  suffix: Command Tracker
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -115,7 +115,7 @@
 
 - type: entity
   id: CentcommFreedomImplanter
-  name: freedom implant implanter
+  suffix: Freedom
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -123,7 +123,7 @@
 
 - type: entity
   id: CentcommStorageImplanter
-  name: storage implant implanter
+  suffix: Storage
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -131,7 +131,7 @@
 
 - type: entity
   id: CentcommMindShieldImplanter
-  name: mindshield implanter
+  suffix: Mindshield
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -139,7 +139,7 @@
 
 - type: entity
   id: CentcommNutrimentImplanter
-  name: nutriment pump implanter
+  suffix: Nutriment Pump
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -147,7 +147,7 @@
 
 - type: entity
   id: CentcommSpaceproofImplanter
-  name: space proofing implanter
+  suffix: Space Proofing
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -155,7 +155,7 @@
 
 - type: entity
   id: CentcommStypticStimulatorImplanter
-  name: styptic stimulator implanter
+  suffix: Styptic Stimulator
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -164,7 +164,7 @@
 - type: entity
   parent: BaseImplantOnlyImplanter
   id: PacifismImplanter
-  name: pacifism implant implanter
+  suffix: Pacifism
   components:
   - type: Implanter
     implant: PacifismImplant
@@ -172,14 +172,14 @@
 - type: entity
   parent: BaseImplantOnlyImplanterSyndi
   id: SmokeImplanter
-  name: smoke implant implanter
+  suffix: Smoke
   components:
   - type: Implanter
     implant: SmokeImplant
 
 - type: entity
   id: NutrimentImplanter
-  name: nutriment pump implanter
+  suffix: Nutriment Pump
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -187,7 +187,7 @@
 
 - type: entity
   id: StypticStimulatorImplanter
-  name: styptic stimulator implanter
+  suffix: Styptic Stimulator
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -196,7 +196,7 @@
 - type: entity
   parent: BaseImplantOnlyImplanterSyndi
   id: KravMagaImplanter
-  name: krav maga nanochip implanter
+  suffix: Krav Maga
   components:
   - type: Implanter
     implant: KravMagaImplant
@@ -204,14 +204,14 @@
 - type: entity
   parent: BaseImplantOnlyImplanterSyndi
   id: ClumsyImplanter
-  name: Clumsy Implanter
+  suffix: Clumsy
   components:
   - type: Implanter
     implant: ClumsyImplant
 
 - type: entity
   id: BinaryImplanter
-  name: binary decoder implanter
+  suffix: Binary Decoder
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -221,8 +221,7 @@
 
 - type: entity
   id: VaporizeImplanter
-  name: vaporize implant implanter
-  suffix: DO NOT MAP
+  suffix: Vaporize, DO NOT MAP
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -230,8 +229,7 @@
 
 - type: entity
   id: ShiftImplanter
-  name: shift implant implanter
-  suffix: DO NOT MAP
+  suffix: Shift, DO NOT MAP
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -239,8 +237,7 @@
 
 - type: entity
   id: BlinkImplanter
-  name: blink implant implanter
-  suffix: DO NOT MAP
+  suffix: Blink, DO NOT MAP
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -248,8 +245,7 @@
 
 - type: entity
   id: StopTimeImplanter
-  name: stop time implant implanter
-  suffix: DO NOT MAP
+  suffix: Time Stop, DO NOT MAP
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -257,7 +253,7 @@
 
 - type: entity
   id: NaniteMenderImplanter
-  suffix: nanite mender, DO NOT MAP
+  suffix: Nanite Mender, DO NOT MAP
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -266,25 +262,31 @@
 # Antag Planet
 
 - type: entity
-  id: AntagImplanterChangeling
-  name: changeling nanochip implanter
+  abstract: true
+  id: BaseAntagImplantOnlyImplanter
   parent: BaseImplantOnlyImplanterCentcomm
+  name: antag implanter
+
+- type: entity
+  id: AntagImplanterChangeling
+  suffix: Changeling
+  parent: BaseAntagImplantOnlyImplanter
   components:
   - type: Implanter
     implant: AntagImplantChangeling
 
 - type: entity
   id: AntagImplanterHeretic
-  name: heretic nanochip implanter
-  parent: BaseImplantOnlyImplanterCentcomm
+  suffix: Heretic
+  parent: BaseAntagImplantOnlyImplanter
   components:
   - type: Implanter
     implant: AntagImplantHeretic
 
 - type: entity
   id: AntagImplanterSpaceNinja
-  name: space ninja nanochip implanter
-  parent: BaseImplantOnlyImplanterCentcomm
+  suffix: Space Ninja
+  parent: BaseAntagImplantOnlyImplanter
   components:
   - type: Implanter
     implant: AntagImplantSpaceNinja
@@ -294,7 +296,7 @@
 - type: entity
   parent: BaseImplantOnlyImplanter
   id: XenoCompatibilityImplanter
-  name: xeno compatibility implanter
+  suffix: Xeno Compatibility
   components:
   - type: Implanter
     implant: XenoCompatibilityImplant

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/mindcontrol_implant.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/mindcontrol_implant.yml
@@ -8,7 +8,7 @@
 
 - type: entity
   id: MindcontrolImplanter
-  name: mind control implanter
+  suffix: Mind Control
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/subdermal_implants.yml
@@ -46,7 +46,7 @@
 - type: entity
   parent: BaseSubdermalImplant
   id: CommandTrackingImplant
-  name: Command tracking implant
+  name: command tracking implant
   description: This implant reserved for command has a tracking device attached to a private suit sensor network, as well as a condition monitor for the Command radio channel.
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_Goobstation/Objects/Misc/translator_implanters.yml
+++ b/Resources/Prototypes/_Goobstation/Objects/Misc/translator_implanters.yml
@@ -9,7 +9,7 @@
 - type: entity
   id: LibrarianTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  name: librarian translator implant
+  suffix: Librarian
   components:
   - type: Implanter
     implant: LibrarianTranslatorImplant
@@ -17,7 +17,7 @@
 - type: entity
   id: ChevalTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  name: Cheval translator implant
+  suffix: Cheval
   components:
   - type: Implanter
     implant: ChevalTranslatorImplant
@@ -26,7 +26,7 @@
 - type: entity
   id: BasicSpaceItalianTranslatorImplanter
   parent: BaseTranslatorImplanter
-  name: basic space italian translator implanter
+  suffix: Basic Space Italian
   components:
   - type: Implanter
     implant: BasicSpaceItalianTranslatorImplant
@@ -35,7 +35,7 @@
 - type: entity
   id: AdvancedSpaceItalianTranslatorImplanter
   parent: BaseTranslatorImplanter
-  name: advanced space italian translator implanter
+  suffix: Advanced Space Italian
   components:
   - type: Implanter
     implant: SpaceItalianTranslatorImplant


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
- Now implanters have label of containing implant. Label disappear after implanting and appears again after implant drawing.
- All implanters were renamed to just "implanters" to prevent metagaming.

## Why / Balance
I have no idea why this wizden change was reverted on goob. It was good anti-metagame change.
Resolves: #4470

## Media
<img width="331" height="880" alt="image" src="https://github.com/user-attachments/assets/6f5489ec-70c0-4c91-97ca-a5c6fafffb0b" />

<img width="376" height="149" alt="image" src="https://github.com/user-attachments/assets/fda5c8c0-dcdf-44ae-a48b-35667f920a7a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: All implanters now have generic names to prevent metagaming.
- tweak: All implanters now auto-label themself with containing implant's name. Label disappear after implanting and appears against after implant drawing.


