### PR TITLE
turret buff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -1291,7 +1291,7 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 28
+        Heat: 20 #Goob 4 hits to kill > 5 hits
 
 - type: entity
   name : disabler bolt

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_ballistic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_ballistic.yml
@@ -33,13 +33,13 @@
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 250 # Goobstation
+        damage: 350 # Goobstation
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
       - !type:TriggerBehavior
   - type: Gun
-    fireRate: 2
+    fireRate: 5
     selectedMode: FullAuto
     availableModes:
     - FullAuto

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_base.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_base.yml
@@ -73,7 +73,7 @@
       task: TurretCompound
     blackboard:
       RotateSpeed: !type:Single
-        3.141
+        9 #Goob change
       SoundTargetInLOS: !type:SoundPathSpecifier
         path: /Audio/Effects/double_beep.ogg
   - type: MouseRotator


### PR DESCRIPTION
Make turrets significantly harder to cheese by increasing rotation speed.
Make AI turrets slightly less hard hitting as a result
Made disposable turret shoot faster
:cl:
- tweak: Turrets are harder to cheese with walls now, they rotate and lock on faster. Syndie disposable turret is less dogshit.

