### PR TITLE
[FIX] another ntr point glitch

### DIFF
--- a/Resources/Prototypes/_Goobstation/Devil/contract.yml
+++ b/Resources/Prototypes/_Goobstation/Devil/contract.yml
@@ -60,6 +60,8 @@
     tags:
     - Document
     - Paper
+  - type: ScannableForPoints
+    points: 0
 
 - type: entity
   id: PaperDevilContractBlank


### PR DESCRIPTION
<img width="421" height="170" alt="image" src="https://github.com/user-attachments/assets/8e60c338-07d0-46b6-ac79-0a734f650ee9" />

devil contracts are le infinite point farm

didnt test btw

**Changelog**
:cl: LuciferEOS
- fix: Devil contracts now are worth 0 points for the NTR.
