### PR TITLE
Revert "[Tweak] Implanters de-metagaming"

### DIFF
--- a/Content.Shared/Implants/SharedImplanterSystem.cs
+++ b/Content.Shared/Implants/SharedImplanterSystem.cs
@@ -31,12 +31,10 @@ using Content.Shared.Forensics;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Implants.Components;
 using Content.Shared.Interaction.Events;
-using Content.Shared.Labels.EntitySystems;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
 using Content.Shared.Whitelist;
 using Robust.Shared.Containers;
-using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
@@ -53,8 +51,6 @@ public abstract class SharedImplanterSystem : EntitySystem
     [Dependency] private readonly DamageableSystem _damageableSystem = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _uiSystem = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
-    [Dependency] private readonly INetManager _netMan = default!; // Goobstation - Labeled implants
-    [Dependency] private readonly LabelSystem _label = default!; // Goobstation - Labeled implants
 
     public override void Initialize()
     {
@@ -62,7 +58,6 @@ public abstract class SharedImplanterSystem : EntitySystem
 
         SubscribeLocalEvent<ImplanterComponent, ComponentInit>(OnImplanterInit);
         SubscribeLocalEvent<ImplanterComponent, EntInsertedIntoContainerMessage>(OnEntInserted);
-        SubscribeLocalEvent<ImplanterComponent, EntRemovedFromContainerMessage>(OnEntRemoved);
         SubscribeLocalEvent<ImplanterComponent, ExaminedEvent>(OnExamine);
 
         SubscribeLocalEvent<ImplanterComponent, UseInHandEvent>(OnUseInHand);
@@ -86,17 +81,6 @@ public abstract class SharedImplanterSystem : EntitySystem
     {
         var implantData = Comp<MetaDataComponent>(args.Entity);
         component.ImplantData = (implantData.EntityName, implantData.EntityDescription);
-
-        // Goobstation - Labeled implants
-        if (_netMan.IsServer)
-            _label.Label(uid, implantData.EntityName);
-    }
-
-    // Goobstation - Labeled implants - Remove label on implant inject
-    private void OnEntRemoved(EntityUid uid, ImplanterComponent component, EntRemovedFromContainerMessage args)
-    {
-        if (_netMan.IsServer)
-            _label.Label(uid, null);
     }
 
     private void OnExamine(EntityUid uid, ImplanterComponent component, ExaminedEvent args)

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -209,7 +209,7 @@
 
 - type: entity
   id: SadTromboneImplanter
-  suffix: Sad Trombone
+  name: sad trombone implanter
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -217,7 +217,7 @@
 
 - type: entity
   id: LightImplanter
-  suffix: Light
+  name: light implanter
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -225,7 +225,7 @@
 
 - type: entity
   id: BikeHornImplanter
-  suffix: Bike Horn
+  name: bike horn implanter
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -235,7 +235,7 @@
 
 - type: entity
   id: TrackingImplanter
-  suffix: Tracking
+  name: tracking implanter
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -245,7 +245,7 @@
 
 - type: entity
   id: StorageImplanter
-  suffix: Storage
+  name: storage implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -253,7 +253,7 @@
 
 - type: entity
   id: FreedomImplanter
-  suffix: Freedom
+  name: freedom implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -261,7 +261,7 @@
 
 - type: entity
   id: RadioImplanter
-  suffix: Syndicate Radio
+  name: syndicate radio implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -269,7 +269,7 @@
 
 - type: entity
   id: UplinkImplanter
-  suffix: Uplink
+  name: uplink implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -277,7 +277,7 @@
 
 - type: entity
   id: EmpImplanter
-  suffix: EMP
+  name: EMP implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -285,7 +285,7 @@
 
 - type: entity
   id: ScramImplanter
-  suffix: Scram
+  name: scram implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -293,7 +293,7 @@
 
 - type: entity
   id: DnaScramblerImplanter
-  suffix: DNA scrambler
+  name: DNA scrambler implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -301,7 +301,7 @@
 
 - type: entity
   id: ChameleonControllerImplanter
-  suffix: Chameleon Controller
+  name: chameleon controller implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -311,7 +311,7 @@
 
 - type: entity
   id: MicroBombImplanter
-  suffix: Micro-Bomb
+  name: micro-bomb implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -319,7 +319,7 @@
 
 - type: entity
   id: MacroBombImplanter
-  suffix: Macro-Bomb
+  name: macro-bomb implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -327,7 +327,7 @@
 
 - type: entity
   id: DeathRattleImplanter
-  suffix: Death Rattle
+  name: death rattle implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
     - type: Implanter
@@ -335,7 +335,7 @@
 
 - type: entity
   id: DeathAcidifierImplanter
-  suffix: Death Acidifier
+  name: death acidifier implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -343,7 +343,7 @@
 
 - type: entity
   id: FakeMindShieldImplanter
-  suffix: Fake Mindshield
+  name: fake mindshield implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -353,7 +353,7 @@
 
 - type: entity
   id: MindShieldImplanter
-  suffix: Mindshield
+  name: mindshield implanter
   parent: BaseImplantOnlyImplanter
   components:
     - type: Implanter
@@ -363,7 +363,7 @@
 
 - type: entity
   id: RadioImplanterCentcomm
-  suffix: Centcomm Radio
+  name: centcomm radio implanter
   parent: BaseImplantOnlyImplanterCentcomm # Goobstation
   components:
   - type: Implanter
@@ -371,8 +371,8 @@
 
 - type: entity
   id: DeathRattleImplanterCentcomm
-  suffix: Death Rattle
-  parent: BaseImplantOnlyImplanterCentcomm # Goobstation
+  name: centcomm death rattle implanter
+  parent: BaseImplantOnlyImplanter
   components:
   - type: Implanter
     implant: DeathRattleImplantCentcomm

--- a/Resources/Prototypes/_EinsteinEngines/Objects/Misc/translator_implanters.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Objects/Misc/translator_implanters.yml
@@ -9,13 +9,13 @@
   id: BaseTranslatorImplanter
   abstract: true
   parent: BaseImplantOnlyImplanter
-  name: translator implanter
+  name: basic translator implanter
 
 # Gives ability to understand TauCetiBasic.
 - type: entity
   id: BasicGalaticCommonTranslatorImplanter
   parent: BaseTranslatorImplanter
-  suffix: Basic Common
+  name: basic common translator implanter
   components:
   - type: Implanter
     implant: BasicTauCetiBasicTranslatorImplant
@@ -24,7 +24,7 @@
 - type: entity
   id: AdvancedGalaticCommonTranslatorImplanter
   parent: BaseTranslatorImplanter
-  suffix: Advanced Common
+  name: advanced common translator implanter
   components:
   - type: Implanter
     implant: TauCetiBasicTranslatorImplant
@@ -32,7 +32,7 @@
 - type: entity
   id: BubblishTranslatorImplanter
   parent: BaseTranslatorImplanter
-  suffix: Bubblish
+  name: bubblish translator implant
   components:
   - type: Implanter
     implant: BubblishTranslatorImplant
@@ -40,7 +40,7 @@
 - type: entity
   id: NekomimeticTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  suffix: Nekomimetic
+  name: nekomimetic translator implant
   components:
   - type: Implanter
     implant: NekomimeticTranslatorImplant
@@ -48,7 +48,7 @@
 - type: entity
   id: DraconicTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  suffix: Draconic
+  name: unathi translator implant
   components:
   - type: Implanter
     implant: DraconicTranslatorImplant
@@ -56,7 +56,7 @@
 - type: entity
   id: CanilunztTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  suffix: Canilunzt
+  name: canilunzt translator implant
   components:
   - type: Implanter
     implant: CanilunztTranslatorImplant
@@ -64,7 +64,7 @@
 - type: entity
   id: SolCommonTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  suffix: Sol-Common
+  name: sol-common translator implant
   components:
   - type: Implanter
     implant: SolCommonTranslatorImplant
@@ -72,7 +72,7 @@
 - type: entity
   id: NovuNedericTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  suffix: Novu-Nederic
+  name: novu-nederic translator implant
   components:
   - type: Implanter
     implant: NovuNedericTranslatorImplant
@@ -80,7 +80,7 @@
 - type: entity
   id: RootSpeakTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  suffix: Root-Speak
+  name: root-speak translator implant
   components:
   - type: Implanter
     implant: RootSpeakTranslatorImplant
@@ -88,7 +88,7 @@
 - type: entity
   id: MofficTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  suffix: Moffic
+  name: moffic translator implant
   components:
   - type: Implanter
     implant: MofficTranslatorImplant
@@ -96,7 +96,7 @@
 - type: entity
   id: ValyrianStandardTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  suffix: Valyrian Standard
+  name: valyrian standard translator implant
   components:
   - type: Implanter
     implant: ValyrianStandardTranslatorImplant
@@ -104,7 +104,7 @@
 - type: entity
   id: AzazibaTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  suffix: Azaziba
+  name: azaziba translator implant
   components:
   - type: Implanter
     implant: AzazibaTranslatorImplant
@@ -112,7 +112,7 @@
 - type: entity
   id: ChittinTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  suffix: Chittin
+  name: chittin translator implant
   components:
   - type: Implanter
     implant: ChittinTranslatorImplant
@@ -120,7 +120,7 @@
 - type: entity
   id: SiikMaasTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  suffix: Siik'Maas
+  name: siik'maas translator implant
   components:
   - type: Implanter
     implant: SiikMaasTranslatorImplant
@@ -128,7 +128,7 @@
 - type: entity
   id: MarishTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  suffix: Marish
+  name: marish translator implant
   components:
   - type: Implanter
     implant: MarishTranslatorImplant
@@ -136,7 +136,7 @@
 - type: entity
   id: SchechiTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  suffix: Schechi
+  name: schechi translator implant
   components:
   - type: Implanter
     implant: SchechiTranslatorImplant
@@ -144,7 +144,7 @@
 - type: entity
   id: NewKinPidginTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  suffix: Ka'Rakk
+  name: ka'rakk translator implant
   components:
   - type: Implanter
     implant: NewKinPidginTranslatorImplant

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/implanters.yml
@@ -99,7 +99,7 @@
 
 - type: entity
   id: BluespaceLifelineImplanter
-  suffix: Bluespace Lifeline
+  name: bluespace lifeline implanter
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -107,7 +107,7 @@
 
 - type: entity
   id: CommandTrackingImplanter
-  suffix: Command Tracker
+  suffix: command tracker
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -115,7 +115,7 @@
 
 - type: entity
   id: CentcommFreedomImplanter
-  suffix: Freedom
+  name: freedom implant implanter
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -123,7 +123,7 @@
 
 - type: entity
   id: CentcommStorageImplanter
-  suffix: Storage
+  name: storage implant implanter
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -131,7 +131,7 @@
 
 - type: entity
   id: CentcommMindShieldImplanter
-  suffix: Mindshield
+  name: mindshield implanter
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -139,7 +139,7 @@
 
 - type: entity
   id: CentcommNutrimentImplanter
-  suffix: Nutriment Pump
+  name: nutriment pump implanter
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -147,7 +147,7 @@
 
 - type: entity
   id: CentcommSpaceproofImplanter
-  suffix: Space Proofing
+  name: space proofing implanter
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -155,7 +155,7 @@
 
 - type: entity
   id: CentcommStypticStimulatorImplanter
-  suffix: Styptic Stimulator
+  name: styptic stimulator implanter
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -164,7 +164,7 @@
 - type: entity
   parent: BaseImplantOnlyImplanter
   id: PacifismImplanter
-  suffix: Pacifism
+  name: pacifism implant implanter
   components:
   - type: Implanter
     implant: PacifismImplant
@@ -172,14 +172,14 @@
 - type: entity
   parent: BaseImplantOnlyImplanterSyndi
   id: SmokeImplanter
-  suffix: Smoke
+  name: smoke implant implanter
   components:
   - type: Implanter
     implant: SmokeImplant
 
 - type: entity
   id: NutrimentImplanter
-  suffix: Nutriment Pump
+  name: nutriment pump implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -187,7 +187,7 @@
 
 - type: entity
   id: StypticStimulatorImplanter
-  suffix: Styptic Stimulator
+  name: styptic stimulator implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -196,7 +196,7 @@
 - type: entity
   parent: BaseImplantOnlyImplanterSyndi
   id: KravMagaImplanter
-  suffix: Krav Maga
+  name: krav maga nanochip implanter
   components:
   - type: Implanter
     implant: KravMagaImplant
@@ -204,14 +204,14 @@
 - type: entity
   parent: BaseImplantOnlyImplanterSyndi
   id: ClumsyImplanter
-  suffix: Clumsy
+  name: Clumsy Implanter
   components:
   - type: Implanter
     implant: ClumsyImplant
 
 - type: entity
   id: BinaryImplanter
-  suffix: Binary Decoder
+  name: binary decoder implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter
@@ -221,7 +221,8 @@
 
 - type: entity
   id: VaporizeImplanter
-  suffix: Vaporize, DO NOT MAP
+  name: vaporize implant implanter
+  suffix: DO NOT MAP
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -229,7 +230,8 @@
 
 - type: entity
   id: ShiftImplanter
-  suffix: Shift, DO NOT MAP
+  name: shift implant implanter
+  suffix: DO NOT MAP
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -237,7 +239,8 @@
 
 - type: entity
   id: BlinkImplanter
-  suffix: Blink, DO NOT MAP
+  name: blink implant implanter
+  suffix: DO NOT MAP
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -245,7 +248,8 @@
 
 - type: entity
   id: StopTimeImplanter
-  suffix: Time Stop, DO NOT MAP
+  name: stop time implant implanter
+  suffix: DO NOT MAP
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -253,7 +257,7 @@
 
 - type: entity
   id: NaniteMenderImplanter
-  suffix: Nanite Mender, DO NOT MAP
+  suffix: nanite mender, DO NOT MAP
   parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
@@ -262,31 +266,25 @@
 # Antag Planet
 
 - type: entity
-  abstract: true
-  id: BaseAntagImplantOnlyImplanter
-  parent: BaseImplantOnlyImplanterCentcomm
-  name: antag implanter
-
-- type: entity
   id: AntagImplanterChangeling
-  suffix: Changeling
-  parent: BaseAntagImplantOnlyImplanter
+  name: changeling nanochip implanter
+  parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
     implant: AntagImplantChangeling
 
 - type: entity
   id: AntagImplanterHeretic
-  suffix: Heretic
-  parent: BaseAntagImplantOnlyImplanter
+  name: heretic nanochip implanter
+  parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
     implant: AntagImplantHeretic
 
 - type: entity
   id: AntagImplanterSpaceNinja
-  suffix: Space Ninja
-  parent: BaseAntagImplantOnlyImplanter
+  name: space ninja nanochip implanter
+  parent: BaseImplantOnlyImplanterCentcomm
   components:
   - type: Implanter
     implant: AntagImplantSpaceNinja
@@ -296,7 +294,7 @@
 - type: entity
   parent: BaseImplantOnlyImplanter
   id: XenoCompatibilityImplanter
-  suffix: Xeno Compatibility
+  name: xeno compatibility implanter
   components:
   - type: Implanter
     implant: XenoCompatibilityImplant

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/mindcontrol_implant.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/mindcontrol_implant.yml
@@ -8,7 +8,7 @@
 
 - type: entity
   id: MindcontrolImplanter
-  suffix: Mind Control
+  name: mind control implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:
   - type: Implanter

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/subdermal_implants.yml
@@ -46,7 +46,7 @@
 - type: entity
   parent: BaseSubdermalImplant
   id: CommandTrackingImplant
-  name: command tracking implant
+  name: Command tracking implant
   description: This implant reserved for command has a tracking device attached to a private suit sensor network, as well as a condition monitor for the Command radio channel.
   categories: [ HideSpawnMenu ]
   components:

--- a/Resources/Prototypes/_Goobstation/Objects/Misc/translator_implanters.yml
+++ b/Resources/Prototypes/_Goobstation/Objects/Misc/translator_implanters.yml
@@ -9,7 +9,7 @@
 - type: entity
   id: LibrarianTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  suffix: Librarian
+  name: librarian translator implant
   components:
   - type: Implanter
     implant: LibrarianTranslatorImplant
@@ -17,7 +17,7 @@
 - type: entity
   id: ChevalTranslatorImplanter
   parent: [ BaseTranslatorImplanter ]
-  suffix: Cheval
+  name: Cheval translator implant
   components:
   - type: Implanter
     implant: ChevalTranslatorImplant
@@ -26,7 +26,7 @@
 - type: entity
   id: BasicSpaceItalianTranslatorImplanter
   parent: BaseTranslatorImplanter
-  suffix: Basic Space Italian
+  name: basic space italian translator implanter
   components:
   - type: Implanter
     implant: BasicSpaceItalianTranslatorImplant
@@ -35,7 +35,7 @@
 - type: entity
   id: AdvancedSpaceItalianTranslatorImplanter
   parent: BaseTranslatorImplanter
-  suffix: Advanced Space Italian
+  name: advanced space italian translator implanter
   components:
   - type: Implanter
     implant: SpaceItalianTranslatorImplant


### PR DESCRIPTION
Reverts Goob-Station/Goob-Station#4473

Bad change. Stop being lazy and go throw the implanter into space or something. Sec shouldn't need to gamble for twenty minutes if you decide to not properly dispose of it. It's not metagaming if the item literally says the type of implant it has

Also causes this
<img width="1179" height="466" alt="image" src="https://github.com/user-attachments/assets/28ed6d4f-9c56-4f89-9e7c-055d23b89976" />
