### PR TITLE
add assistant access

### DIFF
--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -54,6 +54,7 @@ public sealed partial class IdCardConsoleComponent : Component
     [DataField, AutoNetworkedField]
     public List<ProtoId<AccessLevelPrototype>> AccessLevels = new()
     {
+        "Assistant", // Goobstation
         "Armory",
         "Atmospherics",
         "Bar",

--- a/Resources/Locale/en-US/_Goobstation/access/accesslevel.ftl
+++ b/Resources/Locale/en-US/_Goobstation/access/accesslevel.ftl
@@ -1,1 +1,2 @@
 id-card-access-level-xenomorph = Xenomorph
+id-card-access-level-assistant = Assistant

--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -54,6 +54,7 @@
         - Belt
     - type: AccessOverrider
       accessLevels:
+      - Assistant # Goobstation
       - Armory
       - Atmospherics
       - Bar
@@ -125,6 +126,11 @@
     sprite: Objects/Tools/universal_access_configurator.rsi
   - type: AccessOverrider
     accessLevels:
+    # <Goobstation>
+    - Assistant
+    - BlueshieldOfficer
+    - NanotrasenRepresentative
+    # </Goobstation>
     - Armory
     - Atmospherics
     - Bar
@@ -162,8 +168,6 @@
     - CentralCommand
     - NuclearOperative
     - SyndicateAgent
-    - NanotrasenRepresentative # goobstation
-    - BlueshieldOfficer # goobstation
     - Wizard
     - Xenoborg
     - GenpopEnter

--- a/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/assistant.yml
@@ -93,6 +93,7 @@
     until: 24600
     disarmMalus: true
   access:
+  - Assistant # Goobstation
   - Maintenance
 
 - type: startingGear

--- a/Resources/Prototypes/_Goobstation/Access/assistant.yml
+++ b/Resources/Prototypes/_Goobstation/Access/assistant.yml
@@ -1,0 +1,4 @@
+# Only given to assistants, no other job even captain
+- type: accessLevel
+  id: Assistant
+  name: id-card-access-level-assistant


### PR DESCRIPTION
## About the PR
assistant ids (not hop cap etc only assistant) now have assistant access

access configurators and id computers can work with it too so its not 100% foolproof
and a tiders id is very, very, very easy to find

## Why / Balance
better tider bases

**Changelog**
:cl:
- add: Assistants now get a unique Assistant access level.