### PR TITLE
shadowling123

### DIFF
--- a/Content.Goobstation.Shared/Shadowling/Components/Abilities/PreAscension/ShadowlingEnthrallComponent.cs
+++ b/Content.Goobstation.Shared/Shadowling/Components/Abilities/PreAscension/ShadowlingEnthrallComponent.cs
@@ -13,7 +13,7 @@ public sealed partial class ShadowlingEnthrallComponent : Component
     /// Indicates how long the enthrallment process takes.
     /// </summary>
     [DataField]
-    public TimeSpan EnthrallTime = TimeSpan.FromSeconds(5);
+    public TimeSpan EnthrallTime = TimeSpan.FromSeconds(4);
 
     [DataField]
     public EntProtoId EnthrallComponents = "ThrallAbilities";

--- a/Content.Goobstation.Shared/Shadowling/Components/Abilities/PreAscension/ShadowlingGlareComponent.cs
+++ b/Content.Goobstation.Shared/Shadowling/Components/Abilities/PreAscension/ShadowlingGlareComponent.cs
@@ -53,12 +53,6 @@ public sealed partial class ShadowlingGlareComponent : Component
     public float MinGlareDelay = 0.1f;
 
     [DataField]
-    public float MuteTime = 8f; //no callouts
-
-    [DataField]
-    public float SlowTime = 2f;
-
-    [DataField]
     public EntityUid GlareTarget;
 
     [DataField]

--- a/Content.Goobstation.Shared/Shadowling/Components/Abilities/PreAscension/ShadowlingGlareComponent.cs
+++ b/Content.Goobstation.Shared/Shadowling/Components/Abilities/PreAscension/ShadowlingGlareComponent.cs
@@ -38,7 +38,7 @@ public sealed partial class ShadowlingGlareComponent : Component
     public float MinGlareDistance = 1f;
 
     [DataField]
-    public float MaxGlareStunTime = 7f;
+    public float MaxGlareStunTime = 8f;
 
     // <summary>
     // Regarding time delay before activation
@@ -53,7 +53,7 @@ public sealed partial class ShadowlingGlareComponent : Component
     public float MinGlareDelay = 0.1f;
 
     [DataField]
-    public float MuteTime = 2f;
+    public float MuteTime = 8f; //no callouts
 
     [DataField]
     public float SlowTime = 2f;

--- a/Content.Goobstation.Shared/Shadowling/Systems/Abilities/PreAscension/ShadowlingGlareSystem.cs
+++ b/Content.Goobstation.Shared/Shadowling/Systems/Abilities/PreAscension/ShadowlingGlareSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Actions;
 using Content.Shared.Popups;
 using Content.Shared.StatusEffect;
 using Content.Shared.Stunnable;
+using Content.Shared.Speech.Muting;
 using Robust.Shared.Timing;
 
 namespace Content.Goobstation.Shared.Shadowling.Systems.Abilities.PreAscension;
@@ -83,13 +84,6 @@ public sealed class ShadowlingGlareSystem : EntitySystem
         var distance = (_transform.GetWorldPosition(user) - targetCoords).Length();
         comp.GlareTarget = target;
 
-        // Glare mutes and slows down the target no matter what.
-        if (TryComp<StatusEffectsComponent>(target, out var statComp))
-        {
-            _effects.TryAddStatusEffect(target, "Muted", TimeSpan.FromSeconds(comp.MuteTime), false, statComp);
-            _stun.TrySlowdown(target, TimeSpan.FromSeconds(comp.SlowTime), false, 0.5f, 0.5f, statComp);
-        }
-
         if (distance <= comp.MinGlareDistance)
         {
             comp.GlareStunTime = comp.MaxGlareStunTime;
@@ -102,6 +96,13 @@ public sealed class ShadowlingGlareSystem : EntitySystem
             comp.GlareTimeBeforeEffect = comp.MinGlareDelay + (comp.MaxGlareDelay - comp.MinGlareDelay) * Math.Clamp(distance / comp.MaxGlareDistance, 0, 1);
 
             comp.ActivateGlareTimer = true;
+        }
+
+        // Glare mutes and slows down the target no matter what.
+        if (TryComp<StatusEffectsComponent>(target, out var statComp))
+        {
+            _effects.TryAddStatusEffect<MutedComponent>(target, "Muted", TimeSpan.FromSeconds(comp.GlareStunTime), true);
+            _stun.TrySlowdown(target, TimeSpan.FromSeconds(comp.GlareStunTime), true, 0.5f, 0.5f, statComp);
         }
 
         var effectEnt = PredictedSpawnAtPosition(comp.EffectGlare, Transform(uid).Coordinates);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Buffed shadowling glare ability to a max of 8 seconds
Buffed shadowling entrall to 4 seconds
Also fixed glare not muting

## Why / Balance
Before you would have to do a pixel perfect glare, enthrall combo to get anyone + you could be interupted by anything and have to start again

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Shadowling glare stun has a max of 8 instead of 7
- tweak: Shadowling enthrall takes 4 seconds, down from 5
- fix: Fixed Shadowling glare not muting target
