### PR TITLE
Nightvision and Infrared goggles fix

### DIFF
--- a/Resources/Prototypes/_White/Entities/Clothing/Eyes/goggles.yml
+++ b/Resources/Prototypes/_White/Entities/Clothing/Eyes/goggles.yml
@@ -20,6 +20,9 @@
     flashDurationMultiplier: 2
     isEquipment: true
   - type: IdentityBlocker
+  - type: ClothingGrantComponent
+    component:
+    - type: FlashVulnerable
 
 - type: entity
   parent: [ClothingEyesBase,BaseSyndicateContraband]
@@ -39,12 +42,29 @@
   - type: ShowHealthBars
     damageContainers:
     - Biological
+  - type: ClothingGrantComponent
+    component:
+    - type: FlashVulnerable
 
 - type: entity
-  parent: ClothingEyesNightVisionGogglesSyndie
+  parent: [ClothingEyesBase,BaseSyndicateContraband]
+  name: syndicate night vision goggles
+  description: A high-tech pair of night vision goggles. Has medical analysis technology.
   id: ClothingEyesNightVisionGogglesNukie
   suffix: "NukeOps"
   components:
+  - type: Sprite
+    sprite: _White/Clothing/Eyes/Goggles/snightvision.rsi
+  - type: Clothing
+    sprite: _White/Clothing/Eyes/Goggles/snightvision.rsi
+  - type: NightVision
+    flashDurationMultiplier: 2
+    isEquipment: true
+  - type: IdentityBlocker
+    coverage: EYES
+  - type: ShowHealthBars
+    damageContainers:
+    - Biological
   - type: ShowSyndicateIcons
 
 # Thermal Vision Goggles
@@ -66,6 +86,9 @@
     toggleAction: PulseThermalVision
   - type: IdentityBlocker
     coverage: EYES
+  - type: ClothingGrantComponent
+    component:
+    - type: FlashVulnerable
 
 - type: entity
   parent: [ClothingEyesBase, BaseSyndicateContraband]
@@ -83,12 +106,27 @@
     toggleAction: ToggleThermalVision
   - type: IdentityBlocker
     coverage: EYES
+  - type: ClothingGrantComponent
+    component:
+    - type: FlashVulnerable
 
 - type: entity
-  parent: ClothingEyesThermalVisionGogglesSyndie
+  parent: [ClothingEyesBase, BaseSyndicateContraband]
   id: ClothingEyesThermalVisionGogglesNukie
+  name: thermal vision goggles
+  description: A high-tech pair of thermal goggles.
   suffix: "NukeOps"
   components:
   - type: ShowSyndicateIcons
   - type: ShowJobIcons
   - type: ShowMindShieldIcons
+  - type: Sprite
+    sprite: _White/Clothing/Eyes/Goggles/sthermals.rsi
+  - type: Clothing
+    sprite: _White/Clothing/Eyes/Goggles/sthermals.rsi
+  - type: ThermalVision
+    flashDurationMultiplier: 2
+    isEquipment: true
+    toggleAction: ToggleThermalVision
+  - type: IdentityBlocker
+    coverage: EYES


### PR DESCRIPTION
NV and IR goggles give flash vulnrability.
Nukie variants do not.
:cl: Armok
- fix: NV and IR goggles give flash vulnrability while worn, nukie versions do not.

