### PR TITLE
Generic Internal Resources System

### DIFF
--- a/Content.Goobstation.Client/Alert/EntitySystems/ValueRelatedAlertSystem.cs
+++ b/Content.Goobstation.Client/Alert/EntitySystems/ValueRelatedAlertSystem.cs
@@ -1,0 +1,34 @@
+using Content.Client.Alerts;
+using Content.Client.UserInterface.Systems.Alerts.Controls;
+using Content.Goobstation.Shared.Alert.Components;
+using Content.Goobstation.Shared.Alert.Events;
+using Robust.Client.GameObjects;
+
+namespace Content.Goobstation.Client.Alert.EntitySystems;
+public sealed class ValueRelatedAlertSystem : EntitySystem
+{
+    [Dependency] private readonly SpriteSystem _spriteSystem = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ValueRelatedAlertComponent, UpdateAlertSpriteEvent>(OnAlertSpriteUpdate);
+    }
+
+    private void OnAlertSpriteUpdate(Entity<ValueRelatedAlertComponent> alert, ref UpdateAlertSpriteEvent args)
+    {
+        var sprite = args.SpriteViewEnt;
+
+        var ev = new GetValueRelatedAlertValuesEvent(args.Alert);
+        RaiseLocalEvent(args.ViewerEnt, ref ev);
+
+        if (!ev.Handled || ev.MaxValue == null || ev.MaxValue == 0 || ev.CurrentValue == null)
+            return;
+
+        var normalized = (int) (ev.CurrentValue / ev.MaxValue * alert.Comp.MaxSeverity);
+        normalized = Math.Clamp(normalized, (int) ev.MinValue, alert.Comp.MaxSeverity);
+
+        var rsiString = (string.IsNullOrEmpty(alert.Comp.IconPrefix) ? "" : $"{alert.Comp.IconPrefix}_") + $"{normalized}";
+
+        _spriteSystem.LayerSetRsiState(sprite.Owner, AlertVisualLayers.Base, rsiString);
+    }
+}

--- a/Content.Goobstation.Server/InternalResources/Commands/AddInternalResourceCommand.cs
+++ b/Content.Goobstation.Server/InternalResources/Commands/AddInternalResourceCommand.cs
@@ -1,0 +1,59 @@
+using Content.Goobstation.Shared.InternalResources.Data;
+using Content.Goobstation.Shared.InternalResources.EntitySystems;
+using Content.Server.Administration;
+using Content.Shared.Actions.Components;
+using Content.Shared.Administration;
+using Content.Shared.Prototypes;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+using System;
+using System.Linq;
+
+
+namespace Content.Goobstation.Server.InternalResources.Commands;
+
+[AdminCommand(AdminFlags.Debug)]
+public sealed class AddInternalResourceCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly SharedInternalResourcesSystem _internalResources = default!;
+
+    public override string Command => "addinternalresource";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 2)
+        {
+            shell.WriteError(Loc.GetString("cmd-addinternalresource-invalid-args"));
+        }
+
+        if (!NetEntity.TryParse(args[0], out var targetUidNet) || !EntityManager.TryGetEntity(targetUidNet, out var targetEntity))
+        {
+            shell.WriteLine(Loc.GetString("shell-entity-uid-must-be-number"));
+            return;
+        }
+
+        if (!_prototypeManager.TryIndex<InternalResourcesPrototype>(args[1], out var proto))
+        {
+            shell.WriteError(Loc.GetString("cmd-addinternalresource-type-not-found", ("type", args[1])));
+            return;
+        }
+
+        _internalResources.EnsureInternalResources(targetEntity.Value, proto, out _);
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+        {
+            return CompletionResult.FromHint(Loc.GetString("cmd-addinternalresource-player-completion"));
+        }
+
+        if (args.Length != 2)
+            return CompletionResult.Empty;
+
+        var resourcesPrototypes = _prototypeManager.EnumeratePrototypes<InternalResourcesPrototype>().Select(p => p.ID); ;
+
+        return CompletionResult.FromHintOptions(resourcesPrototypes, Loc.GetString("cmd-addinternalresource-type-completion"));
+    }
+}

--- a/Content.Goobstation.Shared/Alert/Components/ValueRelatedAlertComponent.cs
+++ b/Content.Goobstation.Shared/Alert/Components/ValueRelatedAlertComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Goobstation.Shared.Alert.Components;
+
+/// <summary>
+/// Generic component for alerts that have needs to update when some value in some component changes.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ValueRelatedAlertComponent : Component
+{
+    [DataField]
+    public short MaxSeverity = 0;
+
+    [DataField]
+    public string IconPrefix = "";
+}

--- a/Content.Goobstation.Shared/Alert/Events/ValueRelatedAlertEvents.cs
+++ b/Content.Goobstation.Shared/Alert/Events/ValueRelatedAlertEvents.cs
@@ -1,0 +1,9 @@
+using Content.Shared.Alert;
+
+namespace Content.Goobstation.Shared.Alert.Events;
+
+[ByRefEvent]
+public record struct GetValueRelatedAlertValuesEvent(AlertPrototype Alert, float? MaxValue = null, float? CurrentValue = null, float MinValue = 0)
+{
+    public bool Handled => MaxValue.HasValue && CurrentValue.HasValue;
+}

--- a/Content.Goobstation.Shared/InternalResources/Components/InternalResourcesActionComponent.cs
+++ b/Content.Goobstation.Shared/InternalResources/Components/InternalResourcesActionComponent.cs
@@ -1,0 +1,18 @@
+using Content.Goobstation.Shared.InternalResources.Data;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Goobstation.Shared.InternalResources.Components;
+
+/// <summary>
+/// Component for action that need to use internal resources
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class InternalResourcesActionComponent : Component
+{
+    [DataField(required: true)]
+    public ProtoId<InternalResourcesPrototype> ResourceProto;
+
+    [DataField]
+    public float UseAmount = 0;
+}

--- a/Content.Goobstation.Shared/InternalResources/Components/InternalResourcesComponent.cs
+++ b/Content.Goobstation.Shared/InternalResources/Components/InternalResourcesComponent.cs
@@ -1,6 +1,7 @@
 using Content.Goobstation.Shared.InternalResources.Data;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Content.Goobstation.Shared.InternalResources.Components;
 
@@ -13,15 +14,25 @@ namespace Content.Goobstation.Shared.InternalResources.Components;
 public sealed partial class InternalResourcesComponent : Component
 {
     /// <summary>
-    /// List of prototypes for internal resources initialization
-    /// </summary>
-    [DataField(customTypeSerializer: typeof(PrototypeIdListSerializer<InternalResourcesPrototype>))]
-    public List<string> InternalResourcesTypes;
-
-    /// <summary>
     /// List of internal resources data that entity have
     /// </summary>
     [ViewVariables]
     [AutoNetworkedField]
     public List<InternalResourcesData> CurrentInternalResources = new();
+
+    public bool HasResourceData(string protoId, [NotNullWhen(true)] out InternalResourcesData? data)
+    {
+        data = null;
+
+        foreach (var type in CurrentInternalResources)
+        {
+            if (type.InternalResourcesType.Id == protoId)
+            {
+                data = type;
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/Content.Goobstation.Shared/InternalResources/Components/InternalResourcesComponent.cs
+++ b/Content.Goobstation.Shared/InternalResources/Components/InternalResourcesComponent.cs
@@ -1,0 +1,27 @@
+using Content.Goobstation.Shared.InternalResources.Data;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
+
+namespace Content.Goobstation.Shared.InternalResources.Components;
+
+/// <summary>
+/// Component that uses for generic internal resources like mana or changeling's chemicals
+/// </summary>
+
+[RegisterComponent, NetworkedComponent]
+[AutoGenerateComponentState]
+public sealed partial class InternalResourcesComponent : Component
+{
+    /// <summary>
+    /// List of prototypes for internal resources initialization
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(PrototypeIdListSerializer<InternalResourcesPrototype>))]
+    public List<string> InternalResourcesTypes;
+
+    /// <summary>
+    /// List of internal resources data that entity have
+    /// </summary>
+    [ViewVariables]
+    [AutoNetworkedField]
+    public List<InternalResourcesData> CurrentInternalResources = new();
+}

--- a/Content.Goobstation.Shared/InternalResources/Components/InternalResourcesComponent.cs
+++ b/Content.Goobstation.Shared/InternalResources/Components/InternalResourcesComponent.cs
@@ -26,7 +26,7 @@ public sealed partial class InternalResourcesComponent : Component
 
         foreach (var type in CurrentInternalResources)
         {
-            if (type.InternalResourcesType.Id == protoId)
+            if (type.InternalResourcesType == protoId)
             {
                 data = type;
                 return true;

--- a/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesData.cs
+++ b/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesData.cs
@@ -1,3 +1,4 @@
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
@@ -27,13 +28,17 @@ public sealed partial class InternalResourcesData
     [DataField]
     public float RegenerationRate = 1f;
 
-    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<InternalResourcesPrototype>))]
-    public string? InternalResourcesType;
+    /// <summary>
+    /// Prototype with visual information of internal resources
+    /// </summary>
+    [DataField(required: true)]
+    public ProtoId<InternalResourcesPrototype> InternalResourcesType;
 
-    public InternalResourcesData(float maxAmount, float regenerationRate, float startingAmount)
+    public InternalResourcesData(float maxAmount, float regenerationRate, float startingAmount, string protoId)
     {
         CurrentAmount = startingAmount;
         MaxAmount = maxAmount;
         RegenerationRate = regenerationRate;
+        InternalResourcesType = protoId;
     }
 }

--- a/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesData.cs
+++ b/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesData.cs
@@ -1,0 +1,39 @@
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Goobstation.Shared.InternalResources.Data;
+
+/// <summary>
+/// Data structure for storing and changing inner resource in entities
+/// </summary>
+[Serializable, NetSerializable]
+public sealed partial class InternalResourcesData
+{
+    /// <summary>
+    /// Current amount of resources
+    /// </summary>
+    [DataField]
+    public float CurrentAmount = 0;
+
+    /// <summary>
+    /// Maximum amount of resources
+    /// </summary>
+    [DataField]
+    public float MaxAmount = 100;
+
+    /// <summary>
+    /// Resources regeneration rate per update time
+    /// </summary>
+    [DataField]
+    public float RegenerationRate = 1f;
+
+    [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<InternalResourcesPrototype>))]
+    public string? InternalResourcesType;
+
+    public InternalResourcesData(float maxAmount, float regenerationRate, float startingAmount)
+    {
+        CurrentAmount = startingAmount;
+        MaxAmount = maxAmount;
+        RegenerationRate = regenerationRate;
+    }
+}

--- a/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesPrototype.cs
+++ b/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesPrototype.cs
@@ -16,29 +16,29 @@ public sealed class InternalResourcesPrototype : IPrototype
     public LocId Name;
 
     [DataField]
-    public LocId Description;
+    public LocId? Description;
 
     /// <summary>
     /// Alert prototype for inner resources visualising
     /// </summary>
-    [DataField]
+    [DataField("alert")]
     public ProtoId<AlertPrototype> AlertPrototype = "ChangelingChemicals";
 
     /// <summary>
     /// Base resources regeneration rate per update time
     /// </summary>
-    [DataField]
+    [DataField("regenerationRate")]
     public float BaseRegenerationRate = 1f;
 
     /// <summary>
     /// Base resources maximum amount
     /// </summary>
-    [DataField]
+    [DataField("maxAmount")]
     public float BaseMaxAmount = 100f;
 
     /// <summary>
     /// Base amount of resources when these internal resources is added to entity
     /// </summary>
-    [DataField]
+    [DataField("startingAmount")]
     public float BaseStartingAmount = 100f;
 }

--- a/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesPrototype.cs
+++ b/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesPrototype.cs
@@ -1,0 +1,44 @@
+using Content.Shared.Alert;
+using Robust.Shared.Prototypes;
+
+namespace Content.Goobstation.Shared.InternalResources.Data;
+
+/// <summary>
+/// Prototype for internal resources type. Mostly contain visualization and information data.
+/// </summary>
+[Prototype]
+public sealed class InternalResourcesPrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    [DataField(required: true)]
+    public LocId Name;
+
+    [DataField]
+    public LocId Description;
+
+    /// <summary>
+    /// Alert prototype for inner resources visualising
+    /// </summary>
+    [DataField]
+    public ProtoId<AlertPrototype>? AlertPrototype;
+
+    /// <summary>
+    /// Base resources regeneration rate per update time
+    /// </summary>
+    [DataField]
+    public float BaseRegenerationRate = 1f;
+
+    /// <summary>
+    /// Base resources maximum amount
+    /// </summary>
+    [DataField]
+    public float BaseMaxAmount = 100f;
+
+    /// <summary>
+    /// Base amount of resources when these internal resources is added to entity
+    /// </summary>
+    [DataField]
+    public float StartingAmount = 100f;
+}

--- a/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesPrototype.cs
+++ b/Content.Goobstation.Shared/InternalResources/Data/InternalResourcesPrototype.cs
@@ -22,7 +22,7 @@ public sealed class InternalResourcesPrototype : IPrototype
     /// Alert prototype for inner resources visualising
     /// </summary>
     [DataField]
-    public ProtoId<AlertPrototype>? AlertPrototype;
+    public ProtoId<AlertPrototype> AlertPrototype = "ChangelingChemicals";
 
     /// <summary>
     /// Base resources regeneration rate per update time
@@ -40,5 +40,5 @@ public sealed class InternalResourcesPrototype : IPrototype
     /// Base amount of resources when these internal resources is added to entity
     /// </summary>
     [DataField]
-    public float StartingAmount = 100f;
+    public float BaseStartingAmount = 100f;
 }

--- a/Content.Goobstation.Shared/InternalResources/EntitySystems/SharedInternalResourcesActionSystem.cs
+++ b/Content.Goobstation.Shared/InternalResources/EntitySystems/SharedInternalResourcesActionSystem.cs
@@ -1,0 +1,52 @@
+using Content.Goobstation.Shared.InternalResources.Components;
+using Content.Goobstation.Shared.InternalResources.Events;
+using Content.Shared.Actions.Events;
+using Content.Shared.Popups;
+using Robust.Shared.Prototypes;
+
+namespace Content.Goobstation.Shared.InternalResources.EntitySystems;
+
+public sealed partial class SharedInternalResourcesActionSystem : EntitySystem
+{
+    [Dependency] private readonly SharedInternalResourcesSystem _internalResources = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<InternalResourcesActionComponent, ActionAttemptEvent>(OnActionAttempt);
+        SubscribeLocalEvent<InternalResourcesActionComponent, ActionPerformedEvent>(OnActionPerformed);
+    }
+
+    private void OnActionAttempt(Entity<InternalResourcesActionComponent> action, ref ActionAttemptEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        var actionCost = GetActionCost(args.User, action.Comp.UseAmount);
+
+        if (!_internalResources.TryGetResourceType(args.User, action.Comp.ResourceProto, out var data) || data.CurrentAmount < actionCost)
+        {
+            var typeName = Loc.GetString(_prototypeManager.Index(action.Comp.ResourceProto).Name);
+
+            _popupSystem.PopupClient(Loc.GetString("internal-resources-action-no-resources", ("type", typeName)), args.User, args.User);
+            args.Cancelled = true;
+            return;
+        }
+    }
+
+    private void OnActionPerformed(Entity<InternalResourcesActionComponent> action, ref ActionPerformedEvent args)
+    {
+        var actionCost = GetActionCost(args.Performer, action.Comp.UseAmount);
+
+        _internalResources.TryUpdateResourcesAmount(args.Performer, action.Comp.ResourceProto, -actionCost);
+    }
+
+    private float GetActionCost(EntityUid user, float baseCost)
+    {
+        var modifierEv = new GetInternalResourcesCostModifierEvent(user);
+        RaiseLocalEvent(user);
+
+        return baseCost * modifierEv.Multiplier;
+    }
+}

--- a/Content.Goobstation.Shared/InternalResources/EntitySystems/SharedInternalResourcesSystem.cs
+++ b/Content.Goobstation.Shared/InternalResources/EntitySystems/SharedInternalResourcesSystem.cs
@@ -1,0 +1,125 @@
+using Content.Goobstation.Shared.InternalResources.Components;
+using Content.Goobstation.Shared.InternalResources.Data;
+using Content.Goobstation.Shared.InternalResources.Events;
+using Content.Shared.Alert;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Content.Goobstation.Shared.InternalResources.EntitySystems;
+public sealed class SharedInternalResourcesSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IPrototypeManager _protoMan = default!;
+    [Dependency] private readonly AlertsSystem _alertsSystem = default!;
+
+    private readonly TimeSpan _systemUpdateRate = TimeSpan.FromSeconds(1);
+    private TimeSpan _systemNextUpdate = TimeSpan.Zero;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<InternalResourcesComponent, InternalResourcesAmountChangedEvent>(OnInternalResourcesAmountChanged);
+    }
+
+    private void OnInternalResourcesAmountChanged(Entity<InternalResourcesComponent> entity, ref InternalResourcesAmountChangedEvent args)
+    {
+        UpdateAppearance(entity, args.Data.InternalResourcesType);
+    }
+
+
+    /// <summary>
+    /// Updates internal resources alert
+    /// </summary>
+    private void UpdateAppearance(Entity<InternalResourcesComponent> entity, ProtoId<InternalResourcesPrototype> protoId)
+    {
+        if (!_protoMan.TryIndex(protoId, out var proto))
+            return;
+
+        _alertsSystem.ShowAlert(entity, proto.AlertPrototype);
+    }
+
+    /// <summary>
+    /// Updates amount of given resources by float amount with given protoId
+    /// </summary>
+    public bool TryUpdateResourcesAmount(EntityUid uid, string protoId, float amount, InternalResourcesComponent? component)
+    {
+        if (!Resolve(uid, ref component) || amount == 0)
+            return false;
+
+        if (!component.HasResourceData(protoId, out var data))
+            return false;
+
+        return TryUpdateResourcesAmount(uid, data, amount, component);
+    }
+
+    /// <summary>
+    /// Updates amount of given resources by float amount with given internal resources data
+    /// </summary>
+    public bool TryUpdateResourcesAmount(EntityUid uid, InternalResourcesData data, float amount, InternalResourcesComponent? component)
+    {
+        if (!Resolve(uid, ref component) || amount == 0)
+            return false;
+
+        if (!component.CurrentInternalResources.Contains(data))
+            return false;
+
+        var attemptEv = new InternalResourcesAmountChangeAttemptEvent(uid, data, amount);
+        RaiseLocalEvent(uid, ref attemptEv);
+
+        if (attemptEv.Cancelled)
+            return false;
+
+        var currentAmount = data.CurrentAmount;
+        var newAmount = Math.Clamp(data.CurrentAmount, 0f, data.MaxAmount);
+
+        data.CurrentAmount = newAmount;
+
+        var afterEv = new InternalResourcesAmountChangedEvent(uid, data, currentAmount, newAmount, amount);
+        RaiseLocalEvent(uid, afterEv);
+
+        return true;
+
+    }
+
+    /// <summary>
+    /// Ensures that entity have InternalResourcesComponent and adds internal resources type to it.
+    /// </summary>
+    public bool TryAddInternalResources(EntityUid uid, string protoId, [NotNullWhen(true)] InternalResourcesData? data)
+    {
+        data = null;
+
+        if (!EnsureComp<InternalResourcesComponent>(uid, out var resourcesComp))
+            return false;
+
+        if (!_protoMan.TryIndex<InternalResourcesPrototype>(protoId, out var proto))
+        {
+            Log.Debug($"Failed to add {protoId} internal resource type to entity {ToPrettyString(uid):uid}. Internal resource prototype does not exist.");
+            return false;
+        }
+
+        if (resourcesComp.HasResourceData(protoId, out data))
+            return true;
+
+        data = new InternalResourcesData(proto.BaseMaxAmount, proto.BaseRegenerationRate, proto.BaseStartingAmount, protoId);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Handles internal resources regeneration
+    /// </summary>
+    public override void Update(float frameTime)
+    {
+        if (_systemNextUpdate > _gameTiming.CurTime)
+            return;
+
+        _systemNextUpdate += _systemUpdateRate;
+
+        var query = EntityQueryEnumerator<InternalResourcesComponent>();
+        while (query.MoveNext(out var uid, out var resourcesComp))
+        {
+            foreach (var resourceData in resourcesComp.CurrentInternalResources)
+                TryUpdateResourcesAmount(uid, resourceData, resourceData.RegenerationRate, resourcesComp);
+        }
+    }
+}

--- a/Content.Goobstation.Shared/InternalResources/EntitySystems/SharedInternalResourcesSystem.cs
+++ b/Content.Goobstation.Shared/InternalResources/EntitySystems/SharedInternalResourcesSystem.cs
@@ -32,7 +32,7 @@ public sealed class SharedInternalResourcesSystem : EntitySystem
     {
         foreach (var type in entity.Comp.CurrentInternalResources)
         {
-            if (type.InternalResourcesType != args.Alert.ID)
+            if (_protoMan.Index(type.InternalResourcesType).AlertPrototype != args.Alert.ID)
                 continue;
 
             args.CurrentValue = type.CurrentAmount;
@@ -56,7 +56,7 @@ public sealed class SharedInternalResourcesSystem : EntitySystem
     /// <summary>
     /// Updates amount of given resources by float amount with given protoId
     /// </summary>
-    public bool TryUpdateResourcesAmount(EntityUid uid, string protoId, float amount, InternalResourcesComponent? component)
+    public bool TryUpdateResourcesAmount(EntityUid uid, string protoId, float amount, InternalResourcesComponent? component = null)
     {
         if (!Resolve(uid, ref component) || amount == 0)
             return false;
@@ -70,7 +70,7 @@ public sealed class SharedInternalResourcesSystem : EntitySystem
     /// <summary>
     /// Updates amount of given resources by float amount with given internal resources data
     /// </summary>
-    public bool TryUpdateResourcesAmount(EntityUid uid, InternalResourcesData data, float amount, InternalResourcesComponent? component)
+    public bool TryUpdateResourcesAmount(EntityUid uid, InternalResourcesData data, float amount, InternalResourcesComponent? component = null)
     {
         if (!Resolve(uid, ref component) || amount == 0)
             return false;
@@ -138,6 +138,16 @@ public sealed class SharedInternalResourcesSystem : EntitySystem
         UpdateAppearance((uid, resourcesComp), proto.ID);
 
         return false;
+    }
+
+    /// <summary>
+    /// Check if user has internal resources type
+    /// </summary>
+    public bool TryGetResourceType(EntityUid uid, ProtoId<InternalResourcesPrototype> type, [NotNullWhen(true)] out InternalResourcesData? data, InternalResourcesComponent? component = null)
+    {
+        data = null;
+
+        return Resolve(uid, ref component) && component.HasResourceData(type, out data);
     }
 
     /// <summary>

--- a/Content.Goobstation.Shared/InternalResources/EntitySystems/SharedInternalResourcesSystem.cs
+++ b/Content.Goobstation.Shared/InternalResources/EntitySystems/SharedInternalResourcesSystem.cs
@@ -1,3 +1,4 @@
+using Content.Goobstation.Shared.Alert.Events;
 using Content.Goobstation.Shared.InternalResources.Components;
 using Content.Goobstation.Shared.InternalResources.Data;
 using Content.Goobstation.Shared.InternalResources.Events;
@@ -19,6 +20,7 @@ public sealed class SharedInternalResourcesSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<InternalResourcesComponent, InternalResourcesAmountChangedEvent>(OnInternalResourcesAmountChanged);
+        SubscribeLocalEvent<InternalResourcesComponent, GetValueRelatedAlertValuesEvent>(OnAlertGetValues);
     }
 
     private void OnInternalResourcesAmountChanged(Entity<InternalResourcesComponent> entity, ref InternalResourcesAmountChangedEvent args)
@@ -26,6 +28,19 @@ public sealed class SharedInternalResourcesSystem : EntitySystem
         UpdateAppearance(entity, args.Data.InternalResourcesType);
     }
 
+    private void OnAlertGetValues(Entity<InternalResourcesComponent> entity, ref GetValueRelatedAlertValuesEvent args)
+    {
+        foreach (var type in entity.Comp.CurrentInternalResources)
+        {
+            if (type.InternalResourcesType != args.Alert.ID)
+                continue;
+
+            args.CurrentValue = type.CurrentAmount;
+            args.MaxValue = type.MaxAmount;
+
+            return;
+        }
+    }
 
     /// <summary>
     /// Updates internal resources alert
@@ -70,26 +85,25 @@ public sealed class SharedInternalResourcesSystem : EntitySystem
             return false;
 
         var currentAmount = data.CurrentAmount;
-        var newAmount = Math.Clamp(data.CurrentAmount, 0f, data.MaxAmount);
+        var newAmount = Math.Clamp(data.CurrentAmount + amount, 0f, data.MaxAmount);
 
         data.CurrentAmount = newAmount;
 
         var afterEv = new InternalResourcesAmountChangedEvent(uid, data, currentAmount, newAmount, amount);
         RaiseLocalEvent(uid, afterEv);
 
+        Dirty(uid, component);
+
         return true;
 
     }
 
     /// <summary>
-    /// Ensures that entity have InternalResourcesComponent and adds internal resources type to it.
+    /// Tries to add internal resources type to entity by protoId.
     /// </summary>
-    public bool TryAddInternalResources(EntityUid uid, string protoId, [NotNullWhen(true)] InternalResourcesData? data)
+    public bool TryAddInternalResources(EntityUid uid, string protoId, [NotNullWhen(true)] out InternalResourcesData? data)
     {
         data = null;
-
-        if (!EnsureComp<InternalResourcesComponent>(uid, out var resourcesComp))
-            return false;
 
         if (!_protoMan.TryIndex<InternalResourcesPrototype>(protoId, out var proto))
         {
@@ -97,12 +111,33 @@ public sealed class SharedInternalResourcesSystem : EntitySystem
             return false;
         }
 
-        if (resourcesComp.HasResourceData(protoId, out data))
+        EnsureInternalResources(uid, proto, out data);
+
+        return data != null;
+    }
+
+    /// <summary>
+    /// Ensures that entity have InternalResourcesComponent and adds internal resources type to it.
+    /// Returns true if entity already had this internal resource type.
+    /// </summary>
+    public bool EnsureInternalResources(EntityUid uid, InternalResourcesPrototype proto, out InternalResourcesData? data)
+    {
+        data = null;
+
+        EnsureComp<InternalResourcesComponent>(uid, out var resourcesComp);
+
+        if (resourcesComp.HasResourceData(proto.ID, out data))
             return true;
 
-        data = new InternalResourcesData(proto.BaseMaxAmount, proto.BaseRegenerationRate, proto.BaseStartingAmount, protoId);
+        var startingAmount = Math.Clamp(proto.BaseStartingAmount, 0f, proto.BaseMaxAmount);
+        data = new InternalResourcesData(proto.BaseMaxAmount, proto.BaseRegenerationRate, startingAmount, proto.ID);
 
-        return true;
+        resourcesComp.CurrentInternalResources.Add(data);
+        Dirty(uid, resourcesComp);
+
+        UpdateAppearance((uid, resourcesComp), proto.ID);
+
+        return false;
     }
 
     /// <summary>

--- a/Content.Goobstation.Shared/InternalResources/Events/InternalResourcesActionEvents.cs
+++ b/Content.Goobstation.Shared/InternalResources/Events/InternalResourcesActionEvents.cs
@@ -1,0 +1,4 @@
+namespace Content.Goobstation.Shared.InternalResources.Events;
+
+[ByRefEvent]
+public record struct GetInternalResourcesCostModifierEvent(EntityUid Target, float Multiplier = 1);

--- a/Content.Goobstation.Shared/InternalResources/Events/InternalResourcesEvents.cs
+++ b/Content.Goobstation.Shared/InternalResources/Events/InternalResourcesEvents.cs
@@ -1,0 +1,14 @@
+using Content.Goobstation.Shared.InternalResources.Data;
+
+namespace Content.Goobstation.Shared.InternalResources.Events;
+
+[ByRefEvent]
+public sealed class InternalResourcesAmountChangeAttemptEvent(EntityUid uid, InternalResourcesData data, float amount) : CancellableEntityEventArgs
+{
+    public EntityUid EntityUid { get; } = uid;
+    public InternalResourcesData InternalResources { get; } = data;
+    public float ChangeAmount { get; } = amount;
+
+}
+
+public record struct InternalResourcesAmountChangedEvent(EntityUid Uid, InternalResourcesData Data, float PreviousAmount, float NewAmount, float Delta);

--- a/Resources/Locale/en-US/_Goobstation/internal-resources/actions/internal-resources-actions.ftl
+++ b/Resources/Locale/en-US/_Goobstation/internal-resources/actions/internal-resources-actions.ftl
@@ -1,2 +1,5 @@
 internal-resources-debug-name = debug resource
 internal-resources-debug-desc = debug resource desc
+
+internal-resources-chemicals-name = chemicals
+internal-resources-chemicals-desc = Chemicals that used for biological creatures genetic transformations.

--- a/Resources/Locale/en-US/_Goobstation/internal-resources/actions/internal-resources-actions.ftl
+++ b/Resources/Locale/en-US/_Goobstation/internal-resources/actions/internal-resources-actions.ftl
@@ -1,0 +1,2 @@
+internal-resources-debug-name = debug resource
+internal-resources-debug-desc = debug resource desc

--- a/Resources/Locale/en-US/_Goobstation/internal-resources/commands/addinternalresource.ftl
+++ b/Resources/Locale/en-US/_Goobstation/internal-resources/commands/addinternalresource.ftl
@@ -1,0 +1,9 @@
+cmd-addinternalresource-desc = Ensures internal resource type and component on entity.
+cmd-addinternalresource-help = addinternalresource <EntityUid> <InternalResourcePrototype>
+
+cmd-addinternalresource-invalid-args = Expected exactly 2 arguments.
+cmd-addinternalresource-type-not-found = Can't find matching internal resource prototype {$type}.
+cmd-addinternalresource-adding-failed = Failed to add internal resource to entity.
+
+cmd-addinternalresource-player-completion = <EntityUid>
+cmd-addinternalresource-type-completion = <InternalResourcePrototype>

--- a/Resources/Locale/en-US/_Goobstation/internal-resources/components/internal-resources-action.ftl
+++ b/Resources/Locale/en-US/_Goobstation/internal-resources/components/internal-resources-action.ftl
@@ -1,0 +1,1 @@
+internal-resources-action-no-resources = Not enough resources of {$type} type.

--- a/Resources/Prototypes/_Goobstation/Actions/debug.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/debug.yml
@@ -1,0 +1,14 @@
+- type: entity
+  parent: BaseAction
+  id: ActionDebug
+  name: DEBUG
+  description: DEBUG
+  components:
+  - type: Action
+    useDelay: 1
+    icon: { sprite: Objects/Fun/bikehorn.rsi, state: icon }
+  - type: InstantAction
+    event: !type:ScreamActionEvent
+  - type: InternalResourcesAction
+    resourceProto: DebugInteralResources
+    useAmount: 25

--- a/Resources/Prototypes/_Goobstation/Changeling/Alerts/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Alerts/changeling.yml
@@ -38,6 +38,8 @@
   id: AlertChangelingChemicalsSpriteView
   categories: [ HideSpawnMenu ]
   components:
+  - type: ValueRelatedAlert
+    maxSeverity: 18
   - type: Sprite
     sprite: /Textures/_Goobstation/Changeling/changeling_chemicals.rsi
     layers:

--- a/Resources/Prototypes/_Goobstation/InternalResources/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/InternalResources/changeling.yml
@@ -1,0 +1,8 @@
+- type: internalResources
+  id: ChangelingChemicals
+  name: internal-resources-chemicals-name
+  description: internal-resources-chemicals-desc
+  alert: ChangelingChemicals
+  maxAmount: 100
+  regenerationRate: 1
+  startingAmount: 50

--- a/Resources/Prototypes/_Goobstation/InternalResources/debug.yml
+++ b/Resources/Prototypes/_Goobstation/InternalResources/debug.yml
@@ -1,0 +1,8 @@
+- type: internalResources
+  id: DebugInteralResources
+  name: internal-resources-debug-name
+  description: internal-resources-debug-desc
+  alert: ChangelingChemicals
+  maxAmount: 100
+  regenerationRate: 1
+  startingAmount: 50


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
- Added generic Internal Resources System for stuff like wizard mana or changenling chemicals. Supports AlertPrototype for visualization.
- Added Internal Resources Action System for actions that require internal resources. Supports modifier event for multiplying action cost.
- Added generic ValueRelatedAlertComponent and system for alerts that depend on some max and current value (changeling chemicals, shadowling light detection).

## Why / Balance
Required for changeling clean up.

## Technical details
- InternalResourcesComponent that contains List of InternalResourceData. Data contains information about maximum and current resource amount, regeneration rate and ProtoId of InternalResourcePrototype. Prototype used for visual information.
- InternalResourcesActionComponent in SharedInternalResourcesActionSystem subscribes to ActionAttemptEvent to check if entity have required resource type and it's amount. OnActionPerformedEvent it reduced amount of resources in entity.

## Media
No media required.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

No player facing changes.
