### PR TITLE
Readd sprint to mass effects

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -499,6 +499,7 @@
     damagePenalty: 0.2
   - type: ExaminableCharacter # WWDP
   - type: Sprinter # Goobstation
+  - type: SprintingAffectedByScale # Goobstation: port EE height/width sliders
   - type: MindControllable # Goobstation
   - type: VisibleContraband # Goobstation
 


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
This needs to exist - if it's too extreme it needs to be nerfed or edited correctly or another compromise to be met. Otherwise deal with it. 

## Why / Balance
Minimum size is a pain in the ass, with mass contests nerfed overall, this didn't need removed.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Mass again affects sprint


