### PR TITLE
[bounty] remove both clowning modules from normal gameplay

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
@@ -49,7 +49,7 @@
   recipes:
   - BorgModuleAdvancedCleaning
   - BorgModuleAdvancedTool
-  - BorgModuleAdvancedClowning
+  # - BorgModuleAdvancedClowning # goobedit
   # - BorgModuleAdvancedChemical # Goob edit
   - BorgModuleAdvancedMining
 

--- a/Resources/Prototypes/Recipes/Lathes/robot_modules.yml
+++ b/Resources/Prototypes/Recipes/Lathes/robot_modules.yml
@@ -66,13 +66,3 @@
 # Science Modules
 
 # Service Modules
-
-- type: latheRecipe
-  parent: BaseGoldBorgModuleRecipe
-  id: BorgModuleAdvancedClowning
-  result: BorgModuleAdvancedClowning
-  materials:
-    Steel: 500
-    Glass: 500
-    Plastic: 250
-    Bananium: 375

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -307,7 +307,7 @@
   cost: 4000
   recipeUnlocks:
   - PushHorn
-  - BorgModuleAdvancedClowning
+  # - BorgModuleAdvancedClowning # goobedit
   # Goobstation R&D Console rework start
   position: 0,5
   technologyPrerequisites:

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -251,7 +251,7 @@
   - BorgModuleTool
   - BorgModuleMusique
   - BorgModuleService
-  - BorgModuleClowning
+  # - BorgModuleClowning # goobedit
   - BorgModuleGardening
   - BorgModuleHarvesting
   - BorgModuleLollypop # Goobstation


### PR DESCRIPTION
## About the PR
title

## Why / Balance
money https://discord.com/channels/1202734573247795300/1472050447412887572

## Media
tested works

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- remove: Removed both normal and advanced clowning modules.