### PR TITLE
extend intellicard to be compatible with other silicons

### DIFF
--- a/Content.Goobstation.Client/Silicon/IntellicardExtras/IntellicardExtras.cs
+++ b/Content.Goobstation.Client/Silicon/IntellicardExtras/IntellicardExtras.cs
@@ -1,0 +1,5 @@
+using Content.Goobstation.Shared.Silicon;
+
+namespace Content.Goobstation.Client.Silicons;
+
+public sealed partial class IntellicardExtras : SharedIntellicardExtrasSystem;

--- a/Content.Goobstation.Server/Silicon/IntellicardExtras/IntellicardExtras.cs
+++ b/Content.Goobstation.Server/Silicon/IntellicardExtras/IntellicardExtras.cs
@@ -1,0 +1,5 @@
+using Content.Goobstation.Shared.Silicon;
+
+namespace Content.Goobstation.Server.Silicons;
+
+public sealed partial class IntellicardExtras : SharedIntellicardExtrasSystem;

--- a/Content.Goobstation.Shared/Silicon/Components/IntellicardableMindComponent.cs
+++ b/Content.Goobstation.Shared/Silicon/Components/IntellicardableMindComponent.cs
@@ -5,5 +5,18 @@ namespace Content.Goobstation.Shared.Silicon.Components;
 /// <summary>
 /// Declares that this entity's MindContainerComponent can be transferred to/from via an intellicard.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
-public sealed partial class IntellicardableMindComponent : Component;
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class IntellicardableMindComponent : Component
+{
+    /// <summary>
+    /// How many times longer it takes to download than it does when downloading from an AI Core.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float DownloadTimeFactor = 0.3f;
+
+    /// <summary>
+    /// How many times longer it takes to download than it does when uploading to an AI Core.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float UploadTimeFactor = 0.8f;
+}

--- a/Content.Goobstation.Shared/Silicon/Components/IntellicardableMindComponent.cs
+++ b/Content.Goobstation.Shared/Silicon/Components/IntellicardableMindComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Goobstation.Shared.Silicon.Components;
+
+/// <summary>
+/// Declares that this entity's MindContainerComponent can be transferred to/from via an intellicard.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class IntellicardableMindComponent : Component;

--- a/Content.Goobstation.Shared/Silicon/IntellicardExtras/SharedIntellicardExtrasSystem.cs
+++ b/Content.Goobstation.Shared/Silicon/IntellicardExtras/SharedIntellicardExtrasSystem.cs
@@ -14,6 +14,7 @@ using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using static Content.Shared.Movement.Systems.SharedContentEyeSystem;
 
 namespace Content.Goobstation.Shared.Silicon;
 
@@ -24,13 +25,13 @@ public abstract partial class SharedIntellicardExtrasSystem : EntitySystem
 {
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly ItemSlotsSystem _slots = default!;
-    [Dependency] private readonly SharedContainerSystem _containers = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly NameModifierSystem _nameMod = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedEyeSystem _eye = default!;
 
     private static readonly EntProtoId DefaultAi = "StationAiBrain";
     private readonly ProtoId<ChatNotificationPrototype> _downloadChatNotificationPrototype = "IntellicardDownload";
@@ -48,7 +49,7 @@ public abstract partial class SharedIntellicardExtrasSystem : EntitySystem
         if (args.Handled || !args.CanReach || args.Target == null)
             return;
 
-        if (!HasComp<IntellicardableMindComponent>(args.Target))
+        if (!TryComp(args.Target, out IntellicardableMindComponent? intellicardableMind))
             return;
         if (!TryComp(args.Used, out StationAiHolderComponent? cardAiHolder))
             return;
@@ -63,7 +64,6 @@ public abstract partial class SharedIntellicardExtrasSystem : EntitySystem
         // otherwise a braindead ai clogs the card without any clear indicator.
         EntityUid? cardBrain = _slots.GetItemOrNull(ent.Owner, "station_ai_mind_slot");
         if (TryComp<MindContainerComponent>(cardBrain, out MindContainerComponent? cardMindContainer)
-            && cardMindContainer is { }
             && cardMindContainer.Mind is null)
         {
             _popup.PopupClient(Loc.GetString("intellicard-extras-contained-missing"), args.User, args.User, PopupType.MediumCaution);
@@ -88,7 +88,13 @@ public abstract partial class SharedIntellicardExtrasSystem : EntitySystem
             return;
         }
 
-        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, cardHasAi ? ent.Comp.UploadTime : ent.Comp.DownloadTime, new IntellicardDoAfterEvent(), args.Target, ent.Owner)
+        var doAfterArgs = new DoAfterArgs(
+            EntityManager,
+            args.User,
+            cardHasAi ? ent.Comp.UploadTime * intellicardableMind.UploadTimeFactor : ent.Comp.DownloadTime * intellicardableMind.DownloadTimeFactor,
+            new IntellicardDoAfterEvent(),
+            args.Target,
+            ent.Owner)
         {
             BreakOnDamage = true,
             BreakOnMove = true,
@@ -159,6 +165,9 @@ public abstract partial class SharedIntellicardExtrasSystem : EntitySystem
             _mind.UnVisit(targetMind);
 
             _audio.PlayPvs(cardAiHolder.Slot.InsertSound, cardUid);
+
+            // for some godforsaken reason the fov gets fucked
+            _eye.SetDrawFov(newCardBrain, true);
 
             args.Handled = true;
             return;

--- a/Content.Goobstation.Shared/Silicon/IntellicardExtras/SharedIntellicardExtrasSystem.cs
+++ b/Content.Goobstation.Shared/Silicon/IntellicardExtras/SharedIntellicardExtrasSystem.cs
@@ -1,0 +1,166 @@
+using Content.Goobstation.Shared.Silicon.Components;
+using Content.Shared.Chat.Prototypes;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.DoAfter;
+using Content.Shared.Intellicard;
+using Content.Shared.Interaction;
+using Content.Shared.Mind;
+using Content.Shared.Mind.Components;
+using Content.Shared.NameModifier.EntitySystems;
+using Content.Shared.Popups;
+using Content.Shared.Silicons.StationAi;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Containers;
+using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Goobstation.Shared.Silicon;
+
+[Serializable, NetSerializable]
+public sealed partial class IntellicardDoAfterEvent : SimpleDoAfterEvent;
+
+public abstract partial class SharedIntellicardExtrasSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly ItemSlotsSystem _slots = default!;
+    [Dependency] private readonly SharedContainerSystem _containers = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+    [Dependency] private readonly MetaDataSystem _metaData = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly NameModifierSystem _nameMod = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    private static readonly EntProtoId DefaultAi = "StationAiBrain";
+
+    private readonly ProtoId<ChatNotificationPrototype> _downloadChatNotificationPrototype = "IntellicardDownload";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<IntellicardComponent, AfterInteractEvent>(OnHolderInteract);
+        SubscribeLocalEvent<IntellicardableMindComponent, IntellicardDoAfterEvent>(OnIntellicardDoAfter);
+    }
+
+    private void OnHolderInteract(Entity<IntellicardComponent> ent, ref AfterInteractEvent args)
+    {
+        if (args.Handled || !args.CanReach || args.Target == null)
+            return;
+
+        if (!HasComp<IntellicardableMindComponent>(args.Target))
+            return;
+        if (!TryComp(args.Used, out StationAiHolderComponent? cardAiHolder))
+            return;
+
+        // this only exists after the borg has been inhabited at least once, stock positronic brains dont have it...
+        // so we need to create it if its not there already (arguably a bug because other brains do have it on spawn...)
+        if (!HasComp<MindContainerComponent>(args.Target))
+            AddComp<MindContainerComponent>(args.Target.Value);
+        TryComp(args.Target, out MindContainerComponent? targetMindContainer);
+
+        // because of the stupid ai holder thing, need to remove the brain if the ai mind is destroyed due to suicide or something
+        // otherwise a braindead ai clogs the card without any clear indicator.
+        EntityUid? cardBrain = _slots.GetItemOrNull(ent.Owner, "station_ai_mind_slot");
+        if (TryComp<MindContainerComponent>(cardBrain, out MindContainerComponent? cardMindContainer)
+            && cardMindContainer is { }
+            && cardMindContainer.Mind is null)
+        {
+            _popup.PopupClient(Loc.GetString("intellicard-extras-contained-missing"), args.User, args.User, PopupType.MediumCaution);
+            args.Handled = true;
+            return;
+        }
+
+        var cardHasAi = _slots.CanEject(ent.Owner, args.User, cardAiHolder.Slot);
+        var brainHasAi = targetMindContainer!.Mind is { };
+
+        if (cardHasAi && brainHasAi)
+        {
+            _popup.PopupClient(Loc.GetString("intellicard-extras-target-occupied"), args.User, args.User, PopupType.Medium);
+            args.Handled = true;
+            return;
+        }
+        if (!cardHasAi && !brainHasAi)
+        {
+            _popup.PopupClient(Loc.GetString("intellicard-extras-target-empty"), args.User, args.User, PopupType.Medium);
+            args.Handled = true;
+            return;
+        }
+
+        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, cardHasAi ? ent.Comp.UploadTime : ent.Comp.DownloadTime, new IntellicardDoAfterEvent(), args.Target, ent.Owner)
+        {
+            BreakOnDamage = true,
+            BreakOnMove = true,
+            NeedHand = true,
+            BreakOnDropItem = true,
+            MultiplyDelay = false
+        };
+
+        _doAfter.TryStartDoAfter(doAfterArgs);
+        args.Handled = true;
+    }
+
+    private void OnIntellicardDoAfter(Entity<IntellicardableMindComponent> ent, ref IntellicardDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled || args.Target is null || _net.IsClient)
+            return;
+
+        EntityUid targetUid = ent.Owner;
+        EntityUid cardUid = args.Target.Value;
+
+        if (!TryComp(cardUid, out StationAiHolderComponent? targetHolder))
+            return;
+
+        EntityUid? cardBrain = _slots.GetItemOrNull(cardUid, "station_ai_mind_slot");
+
+        TryComp<MindContainerComponent>(cardBrain, out MindContainerComponent? cardMindContainer);
+
+        if (!TryComp(cardUid, out StationAiHolderComponent? cardAiHolder))
+            return;
+
+        if (!TryComp(targetUid, out MindContainerComponent? targetMindContainer))
+            return;
+
+        // get mind status of both
+        var cardHasAi = _slots.CanEject(cardUid, args.User, cardAiHolder.Slot) && cardMindContainer is { } && cardMindContainer.Mind is { };
+        var targetHasAi = targetMindContainer.Mind is { };
+
+        // Card -> Brain
+        // upload the mind from the positronic brain inside the card's StationAiHolder into the target brain
+        if (cardHasAi && !targetHasAi)
+        {
+            if (cardMindContainer!.Mind is not { } cardMind)
+                return;
+
+            _metaData.SetEntityName(targetUid, _nameMod.GetBaseName(cardBrain!.Value));
+
+            _mind.TransferTo(cardMind, targetUid, ghostCheckOverride: true);
+            _mind.UnVisit(cardMind);
+
+            QueueDel(cardBrain); // free up the empty brain
+
+            _audio.PlayPvs(cardAiHolder.Slot.InsertSound, targetUid);
+
+            args.Handled = true;
+            return;
+        }
+
+        // Brain -> Card
+        // create positronic brain for StationAiHolder and then download the mind from the target brain
+        if (!cardHasAi && targetHasAi)
+        {
+            if (targetMindContainer.Mind is not { } targetMind)
+                return;
+            var newCardBrain = SpawnInContainerOrDrop(DefaultAi, cardUid, StationAiCoreComponent.Container);
+            _metaData.SetEntityName(newCardBrain, _nameMod.GetBaseName(targetUid));
+
+            _mind.TransferTo(targetMind, newCardBrain, ghostCheckOverride: true);
+            _mind.UnVisit(targetMind);
+
+            _audio.PlayPvs(cardAiHolder.Slot.InsertSound, cardUid);
+
+            args.Handled = true;
+            return;
+        }
+    }
+}

--- a/Content.Goobstation.Shared/Silicon/IntellicardExtras/SharedIntellicardExtrasSystem.cs
+++ b/Content.Goobstation.Shared/Silicon/IntellicardExtras/SharedIntellicardExtrasSystem.cs
@@ -31,8 +31,8 @@ public abstract partial class SharedIntellicardExtrasSystem : EntitySystem
     [Dependency] private readonly NameModifierSystem _nameMod = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly INetManager _net = default!;
-    private static readonly EntProtoId DefaultAi = "StationAiBrain";
 
+    private static readonly EntProtoId DefaultAi = "StationAiBrain";
     private readonly ProtoId<ChatNotificationPrototype> _downloadChatNotificationPrototype = "IntellicardDownload";
 
     public override void Initialize()

--- a/Content.Goobstation.Shared/Silicon/IntellicardExtras/SharedIntellicardExtrasSystem.cs
+++ b/Content.Goobstation.Shared/Silicon/IntellicardExtras/SharedIntellicardExtrasSystem.cs
@@ -67,6 +67,7 @@ public abstract partial class SharedIntellicardExtrasSystem : EntitySystem
             && cardMindContainer.Mind is null)
         {
             _popup.PopupClient(Loc.GetString("intellicard-extras-contained-missing"), args.User, args.User, PopupType.MediumCaution);
+            QueueDel(cardBrain);
             args.Handled = true;
             return;
         }

--- a/Resources/Locale/en-US/_Goobstation/intellicard/intellicard.ftl
+++ b/Resources/Locale/en-US/_Goobstation/intellicard/intellicard.ftl
@@ -1,0 +1,3 @@
+intellicard-extras-target-occupied = The targetted device is already occupied by another digital consciousness.
+intellicard-extras-target-empty = The targetted device has no digital consciousness to download.
+intellicard-extras-contained-missing = The targetted device could not be transferred to because the contained digital consciousness was in an irrecoverable state.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -258,6 +258,7 @@
     defaultChannel: Binary
     channels:
     - Binary
+  - type: IntellicardableMind # Goobstation - intellicard on more AIs
   - type: HealthExaminable
     examinableTypes:
     - Blunt

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -178,6 +178,7 @@
     defaultChannel: Binary
     channels:
     - Binary
+  - type: IntellicardableMind # Goobstation - intellicard on more AIs
   - type: DoAfter
   - type: Actions
   - type: Store

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -223,6 +223,7 @@
     - type: BlockMovement
     - type: Examiner
     - type: BorgBrain
+    - type: IntellicardableMind # Goobstation - intellicard on more AIs
     - type: IntrinsicRadioReceiver
     #- type: IntrinsicRadioTransmitter
     #  channels:

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -259,6 +259,7 @@
     defaultChannel: Binary
     channels:
     - Binary
+  - type: IntellicardableMind # Goobstation - intellicard on more AIs
   - type: DoAfter
   - type: Electrified
     enabled: false

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/gambling_machines.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/gambling_machines.yml
@@ -59,6 +59,7 @@
     defaultChannel: Binary
     channels:
     - Binary
+  - type: IntellicardableMind # Goobstation - intellicard on more AIs
   - type: Vocalizer
     minVocalizeInterval: 8m
     maxVocalizeInterval: 10m


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
enables the Intellicard to function on more silicons than just the ai core (pretty much all of them)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
fun gimmick that makes plenty sense due to the intellicard being a generic storage device for transferral of digital consciousnesses.

not really any balance implications since already if you have the intellicard you can just throw the station ai into space and if you have a borg's positronic brain you can just click wipe

## Technical details
<!-- Summary of code changes for easier review. -->
added `IntellicardableMindComponent` to mark additional things transferrable with the intellicard, attached it to a bunch of silicons like pAIs, positronic brains, and vending machines and such. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: rivermyth
- add: extended functionality of the intellicard
