### PR TITLE
Increase nukie commander playtimes requirements

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -144,10 +144,10 @@
     time: 90000 # 25 hours - Goobstation
   - !type:DepartmentTimeRequirement
     department: Security
-    time: 36000 # 10h Goobstation
+    time: 54000 # 15h Goobstation
   - !type:DepartmentTimeRequirement
     department: Command
-    time: 18000 # 5h Goobstation
+    time: 36000 # 10h Goobstation
 # should be changed to nukie playtime when thats tracked (wyci)
   - !type:SpeciesRequirement
     inverted: true

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -141,7 +141,7 @@
   objective: roles-antag-nuclear-operative-commander-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 90000 # 25 hours - Goobstation
+    time: 108000 # 30 hours - Goobstation
   - !type:DepartmentTimeRequirement
     department: Security
     time: 54000 # 15h Goobstation

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -141,10 +141,10 @@
   objective: roles-antag-nuclear-operative-commander-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 108000 # 30 hours - Goobstation
+    time: 144000 # 40 hours - Goobstation
   - !type:DepartmentTimeRequirement
     department: Security
-    time: 54000 # 15h Goobstation
+    time: 72000 # 20h Goobstation
   - !type:DepartmentTimeRequirement
     department: Command
     time: 36000 # 10h Goobstation


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
25 > 40 hours playtime req
10 > 20 hours sec playtime req
5 > 10 hours command playtime req
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
ive seen so many commanders who genuinely do not understand their role and also just have no idea how to play the game. if you are playing commander, you should be robust and know how to lead a team.
## Technical details
<!-- Summary of code changes for easier review. -->
yaml
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Beanyboi69
- tweak: Increased the playtime requirements for Nuclear Operative Commanders.

