### PR TITLE
Various bugfixes

### DIFF
--- a/Content.Goobstation.Common/Materials/MaterialReclaimerImmuneComponent.cs
+++ b/Content.Goobstation.Common/Materials/MaterialReclaimerImmuneComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Goobstation.Common.Materials;
+
+/// <summary>
+/// Prevents this entity from being processed by an emagged recycler.
+/// </summary>
+[RegisterComponent]
+public sealed partial class MaterialReclaimerImmuneComponent : Component;

--- a/Content.Goobstation.Shared/Content.Goobstation.Shared.csproj
+++ b/Content.Goobstation.Shared/Content.Goobstation.Shared.csproj
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
       <PackageReference Include="JetBrains.Annotations" />
     </ItemGroup>
 
-
+  
   <Import Project="..\RobustToolbox\MSBuild\Robust.Properties.targets" />
   <Import Project="..\RobustToolbox\MSBuild\Robust.CompNetworkGenerator.targets" />
 </Project>

--- a/Content.Goobstation.Shared/PhaseShift/PhaseShiftedComponent.cs
+++ b/Content.Goobstation.Shared/PhaseShift/PhaseShiftedComponent.cs
@@ -6,13 +6,13 @@ using Robust.Shared.Utility;
 
 namespace Content.Goobstation.Shared.PhaseShift;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class PhaseShiftedComponent : Component
 {
     [DataField]
     public EntProtoId StatusEffectId = "PhaseShifted";
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public float MovementSpeedBuff = 1.5f;
 
     [DataField]
@@ -34,7 +34,7 @@ public sealed partial class PhaseShiftedComponent : Component
     public SoundSpecifier PhaseOutSound =
         new SoundPathSpecifier(new ResPath("/Audio/_EinsteinEngines/Shadowling/veilout.ogg"));
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public bool SpawnEffects = true;
 
     public int StoredMask;

--- a/Content.Goobstation.Shared/Slasher/Systems/SlasherIncorporealSystem.cs
+++ b/Content.Goobstation.Shared/Slasher/Systems/SlasherIncorporealSystem.cs
@@ -243,23 +243,23 @@ public sealed class SlasherIncorporealSystem : EntitySystem
             _tags.RemoveTag(uid, FootstepSoundTag);
 
         // Mute and block vocal emotes.
-        _ = EnsureComp<MutedComponent>(uid);
+        EnsureComp<MutedComponent>(uid);
 
         // Disable FOV for full vision while incorporeal.
         _eye.SetDrawFov(uid, false);
 
         // Space immunity
-        _ = EnsureComp<MovementIgnoreGravityComponent>(uid);
-        _ = EnsureComp<SpecialPressureImmunityComponent>(uid);
-        _ = EnsureComp<SpecialBreathingImmunityComponent>(uid);
-        _ = EnsureComp<SpecialLowTempImmunityComponent>(uid);
-        _ = EnsureComp<SpecialHighTempImmunityComponent>(uid);
+        EnsureComp<MovementIgnoreGravityComponent>(uid);
+        EnsureComp<SpecialPressureImmunityComponent>(uid);
+        EnsureComp<SpecialBreathingImmunityComponent>(uid);
+        EnsureComp<SpecialLowTempImmunityComponent>(uid);
+        EnsureComp<SpecialHighTempImmunityComponent>(uid);
 
         // Supermatter immunity
-        _ = EnsureComp<SupermatterImmuneComponent>(uid);
+        EnsureComp<SupermatterImmuneComponent>(uid);
 
         // Recycler immunity
-        _ = EnsureComp<MaterialReclaimerImmuneComponent>(uid);
+        EnsureComp<MaterialReclaimerImmuneComponent>(uid);
 
         // Raise event for server systems to handle additional logic (like disabling lights)
         var enteredEv = new SlasherIncorporealEnteredEvent();
@@ -302,23 +302,23 @@ public sealed class SlasherIncorporealSystem : EntitySystem
         _tags.AddTag(uid, FootstepSoundTag);
 
         // Let them speak
-        _ = RemComp<MutedComponent>(uid);
+        RemComp<MutedComponent>(uid);
 
         // Restore FOV
         _eye.SetDrawFov(uid, true);
 
         // Remove space immunity
-        _ = RemComp<MovementIgnoreGravityComponent>(uid);
-        _ = RemComp<SpecialPressureImmunityComponent>(uid);
-        _ = RemComp<SpecialBreathingImmunityComponent>(uid);
-        _ = RemComp<SpecialLowTempImmunityComponent>(uid);
-        _ = RemComp<SpecialHighTempImmunityComponent>(uid);
+        RemComp<MovementIgnoreGravityComponent>(uid);
+        RemComp<SpecialPressureImmunityComponent>(uid);
+        RemComp<SpecialBreathingImmunityComponent>(uid);
+        RemComp<SpecialLowTempImmunityComponent>(uid);
+        RemComp<SpecialHighTempImmunityComponent>(uid);
 
         // Remove supermatter immunity
-        _ = RemComp<SupermatterImmuneComponent>(uid);
+        RemComp<SupermatterImmuneComponent>(uid);
 
         // Remove recycler immunity
-        _ = RemComp<MaterialReclaimerImmuneComponent>(uid);
+        RemComp<MaterialReclaimerImmuneComponent>(uid);
     }
 
     // Goida as shit.. I couldn't find a better way stop cooldowns

--- a/Content.Goobstation.Shared/Slasher/Systems/SlasherIncorporealSystem.cs
+++ b/Content.Goobstation.Shared/Slasher/Systems/SlasherIncorporealSystem.cs
@@ -40,6 +40,7 @@ using Content.Goobstation.Shared.Sprinting;
 using Content.Shared.Stunnable;
 using Content.Shared.Trigger;
 using Content.Shared.Trigger.Components.Triggers;
+using Content.Goobstation.Common.Materials;
 
 namespace Content.Goobstation.Shared.Slasher.Systems;
 
@@ -257,6 +258,9 @@ public sealed class SlasherIncorporealSystem : EntitySystem
         // Supermatter immunity
         _ = EnsureComp<SupermatterImmuneComponent>(uid);
 
+        // Recycler immunity
+        _ = EnsureComp<MaterialReclaimerImmuneComponent>(uid);
+
         // Raise event for server systems to handle additional logic (like disabling lights)
         var enteredEv = new SlasherIncorporealEnteredEvent();
         RaiseLocalEvent(uid, ref enteredEv);
@@ -312,6 +316,9 @@ public sealed class SlasherIncorporealSystem : EntitySystem
 
         // Remove supermatter immunity
         _ = RemComp<SupermatterImmuneComponent>(uid);
+
+        // Remove recycler immunity
+        _ = RemComp<MaterialReclaimerImmuneComponent>(uid);
     }
 
     // Goida as shit.. I couldn't find a better way stop cooldowns

--- a/Content.Server/_Shitcode/Wizard/Systems/SpellsSystem.cs
+++ b/Content.Server/_Shitcode/Wizard/Systems/SpellsSystem.cs
@@ -16,6 +16,7 @@ using Content.Goobstation.Common.Bloodstream;
 using Content.Goobstation.Maths.FixedPoint;
 using Content.Goobstation.Shared.Emoting;
 using Content.Goobstation.Shared.Teleportation.Systems;
+using Content.Goobstation.Shared.Religion;
 using Content.Server._Goobstation.Wizard.Components;
 using Content.Server.Antag;
 using Content.Server.Body.Systems;
@@ -112,6 +113,7 @@ public sealed class SpellsSystem : SharedSpellsSystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly PuddleSystem _puddle = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
+    [Dependency] private readonly DivineInterventionSystem _divineIntervention = default!;
 
     public override void Initialize()
     {
@@ -189,8 +191,12 @@ public sealed class SpellsSystem : SharedSpellsSystem
         var coords = TransformSystem.GetMapCoordinates(ev.Performer);
         foreach (var uid in Lookup.GetEntitiesInRange(coords, ev.Range))
         {
+            if (_divineIntervention.TouchSpellDenied(uid))
+                continue;
+
             _emp.TryEmpEffects(uid, ev.EnergyConsumption, ev.DisableDuration);
         }
+
 
         Spawn(ev.Effect, coords);
     }
@@ -242,6 +248,9 @@ public sealed class SpellsSystem : SharedSpellsSystem
                 continue;
 
             if (entity == ev.Performer)
+                continue;
+
+            if (_divineIntervention.TouchSpellDenied(entity))
                 continue;
 
             if (!_gravityWell.CanGravPulseAffect(entity))
@@ -687,6 +696,9 @@ public sealed class SpellsSystem : SharedSpellsSystem
         foreach (var (target, _) in Lookup.GetEntitiesInRange<FartComponent>(mapPos, ev.MaxRange))
         {
             if (target == ev.Performer)
+                continue;
+
+            if (_divineIntervention.TouchSpellDenied(target))
                 continue;
 
             if (!TryComp<FartComponent>(target, out var fart)

--- a/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialReclaimerSystem.cs
@@ -184,6 +184,10 @@ public abstract class SharedMaterialReclaimerSystem : EntitySystem
         if (HasComp<RecyclableOnUnlockComponent>(item) && _lockSystem.IsLocked(item))
             return false;
 
+        // Goobstation
+        if (HasComp<MaterialReclaimerImmuneComponent>(item))
+            return false;
+
         if (HasComp<MobStateComponent>(item) && !CanGib(uid, item, component)) // whitelist? We be gibbing, boy!
             return false;
 

--- a/Content.Shared/_Shitcode/Wizard/SpellEvents.cs
+++ b/Content.Shared/_Shitcode/Wizard/SpellEvents.cs
@@ -562,5 +562,5 @@ public sealed partial class RathenEvent : InstantActionEvent
     };
 
     [DataField]
-    public float LimbTearChance = 0.3f;
+    public float LimbTearChance = 0.2f;
 }

--- a/Resources/Prototypes/_Goobstation/Slasher/items.yml
+++ b/Resources/Prototypes/_Goobstation/Slasher/items.yml
@@ -16,7 +16,7 @@
     soundHit:
       path: /Audio/_Goobstation/Weapons/Melee/slashermachetehit.ogg
       params:
-        volume: -12
+        volume: -2
   - type: DamageOtherOnHit
     damage:
       types:

--- a/Resources/Prototypes/_Goobstation/Slasher/items.yml
+++ b/Resources/Prototypes/_Goobstation/Slasher/items.yml
@@ -16,7 +16,7 @@
     soundHit:
       path: /Audio/_Goobstation/Weapons/Melee/slashermachetehit.ogg
       params:
-        volume: -2
+        volume: -6
   - type: DamageOtherOnHit
     damage:
       types:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Changelog
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
Slasher changed the speed modifier in the phaseshiftedcomponent. It wasn't networked so it would cause client mispredicts when moving.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Repulse, Disable technology, and Rathen's Secret are now properly blocked by nullrods.
- fix: Slashers no longer get gibbed by emagged recyclers while incorporeal.
- fix: Slashers incorporeal form should feel better to use.
