### PR TITLE
Fix: Server crash in PowerMonitoringConsoleSystem during grid impacts

### DIFF
--- a/Content.Server/Power/EntitySystems/PowerMonitoringConsoleSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerMonitoringConsoleSystem.cs
@@ -852,8 +852,15 @@ internal sealed partial class PowerMonitoringConsoleSystem : SharedPowerMonitori
 
     private void UpdateCollectionChildMetaData(EntityUid child, EntityUid master)
     {
+
+        if (TerminatingOrDeleted(child) || TerminatingOrDeleted(master))
+            return;
+
+        if (!TryComp<TransformComponent>(child, out var xform))
+            return;
+
         var netEntity = GetNetEntity(child);
-        var xform = Transform(child);
+        var masterNet = GetNetEntity(master);
 
         var query = AllEntityQuery<PowerMonitoringConsoleComponent, TransformComponent>();
         while (query.MoveNext(out var ent, out var entConsole, out var entXform))
@@ -864,7 +871,7 @@ internal sealed partial class PowerMonitoringConsoleSystem : SharedPowerMonitori
             if (!entConsole.PowerMonitoringDeviceMetaData.TryGetValue(netEntity, out var metaData))
                 continue;
 
-            metaData.CollectionMaster = GetNetEntity(master);
+            metaData.CollectionMaster = masterNet;
             entConsole.PowerMonitoringDeviceMetaData[netEntity] = metaData;
 
             Dirty(ent, entConsole);


### PR DESCRIPTION
## About the PR
Fixed a critical server crash (KeyNotFoundException) in `PowerMonitoringConsoleSystem`.

## Why / Balance
The server would crash whenever a power-monitoring device (like a cable or solar panel) was destroyed exactly when the system was trying to update its metadata (common during shuttle impacts or explosions). This fix ensures the server stays alive.

## Technical details
- Added `TerminatingOrDeleted` checks for both `child` and `master` entities.
- Switched from `Transform(child)` to `TryComp<TransformComponent>(child, out var xform)` to safely handle missing components.
- Cached `GetNetEntity(master)` outside the loop for better performance.

## Media
Small bug fix for a backend crash, no visual changes.

## Requirements
- [x] I have read and am following the Pull Request and Changelog Guidelines.
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

**Changelog**
:cl:
- fix: Fixed a server crash occurring during grid impacts/explosions involving power cables.