### PR TITLE
Notoriety system

### DIFF
--- a/Content.Goobstation.Client/Wanted/NotorietySystem.cs
+++ b/Content.Goobstation.Client/Wanted/NotorietySystem.cs
@@ -1,0 +1,5 @@
+using Content.Goobstation.Shared.Wanted;
+
+namespace Content.Goobstation.Client.Wanted;
+
+public sealed class NotorietySystem : SharedNotorietySystem;

--- a/Content.Goobstation.Common/Wanted/CriminalStatusUpdatedEvent.cs
+++ b/Content.Goobstation.Common/Wanted/CriminalStatusUpdatedEvent.cs
@@ -1,17 +1,21 @@
-using Content.Shared.Security;
-
 namespace Content.Goobstation.Common.Wanted;
 
 /// <summary>
 /// Broadcast event raised whenever a crew member's criminal status is applied to their in-world entity.
 /// Fired after the HUD icon has already been updated.
+/// Status is stored as byte because Common cannot reference Content.Shared (where SecurityStatus lives).
+/// Cast to SecurityStatus in consumers.
 /// </summary>
 public sealed class CriminalStatusUpdatedEvent : EntityEventArgs
 {
     public readonly EntityUid Entity;
-    public readonly SecurityStatus Status;
 
-    public CriminalStatusUpdatedEvent(EntityUid entity, SecurityStatus status)
+    /// <summary>
+    /// The new security status as a byte. Cast to <c>SecurityStatus</c> in systems that need it.
+    /// </summary>
+    public readonly byte Status;
+
+    public CriminalStatusUpdatedEvent(EntityUid entity, byte status)
     {
         Entity = entity;
         Status = status;

--- a/Content.Goobstation.Common/Wanted/CriminalStatusUpdatedEvent.cs
+++ b/Content.Goobstation.Common/Wanted/CriminalStatusUpdatedEvent.cs
@@ -1,0 +1,19 @@
+using Content.Shared.Security;
+
+namespace Content.Goobstation.Common.Wanted;
+
+/// <summary>
+/// Broadcast event raised whenever a crew member's criminal status is applied to their in-world entity.
+/// Fired after the HUD icon has already been updated.
+/// </summary>
+public sealed class CriminalStatusUpdatedEvent : EntityEventArgs
+{
+    public readonly EntityUid Entity;
+    public readonly SecurityStatus Status;
+
+    public CriminalStatusUpdatedEvent(EntityUid entity, SecurityStatus status)
+    {
+        Entity = entity;
+        Status = status;
+    }
+}

--- a/Content.Goobstation.Common/Wanted/NotorietyComponent.cs
+++ b/Content.Goobstation.Common/Wanted/NotorietyComponent.cs
@@ -1,14 +1,11 @@
-// SPDX-FileCopyrightText: 2026 Goob-Station Contributors <https://github.com/Goob-Station/Goob-Station>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Goobstation.Common.Wanted;
 
 /// <summary>
 /// Tracks a crew member's notoriety — accumulated over time as they commit crimes and become marked as wanted.
-/// Notoriety persists even after criminal status is cleared, and decays slowly over time while the criminal lays low.
+/// Notoriety persists even after criminal status is cleared.
 /// High notoriety can trigger a station-wide manhunt event.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
@@ -29,9 +26,8 @@ public sealed partial class NotorietyComponent : Component
 
     /// <summary>
     /// Timestamp of the last escalation (status set to Wanted/Dangerous/Perma).
-    /// Used to calculate when notoriety should begin to decay.
     /// </summary>
-    [DataField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan LastEscalationTime = TimeSpan.Zero;
 
     /// <summary>

--- a/Content.Goobstation.Common/Wanted/NotorietyComponent.cs
+++ b/Content.Goobstation.Common/Wanted/NotorietyComponent.cs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Goob-Station Contributors <https://github.com/Goob-Station/Goob-Station>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.GameStates;
+
+namespace Content.Goobstation.Common.Wanted;
+
+/// <summary>
+/// Tracks a crew member's notoriety — accumulated over time as they commit crimes and become marked as wanted.
+/// Notoriety persists even after criminal status is cleared, and decays slowly over time while the criminal lays low.
+/// High notoriety can trigger a station-wide manhunt event.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class NotorietyComponent : Component
+{
+    public const int MaxLevel = 5;
+
+    /// <summary>
+    /// Credit bounties offered per notoriety tier (indexed by level 0–5).
+    /// </summary>
+    public static readonly int[] BountyByLevel = [0, 500, 1500, 3500, 7000, 12000];
+
+    /// <summary>
+    /// Current notoriety level. 0 = clean, 5 = most wanted.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public int Level = 0;
+
+    /// <summary>
+    /// Timestamp of the last escalation (status set to Wanted/Dangerous/Perma).
+    /// Used to calculate when notoriety should begin to decay.
+    /// </summary>
+    [DataField]
+    public TimeSpan LastEscalationTime = TimeSpan.Zero;
+
+    /// <summary>
+    /// Total number of notoriety escalations this entity has accumulated this round.
+    /// </summary>
+    [DataField]
+    public int TotalEscalations = 0;
+
+    /// <summary>
+    /// Credit bounty for the entity's current notoriety level.
+    /// </summary>
+    public int BountyAmount => Level is >= 0 and <= MaxLevel ? BountyByLevel[Level] : 0;
+}

--- a/Content.Goobstation.Server/StationEvents/Components/ManhuntRuleComponent.cs
+++ b/Content.Goobstation.Server/StationEvents/Components/ManhuntRuleComponent.cs
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 Goob-Station Contributors <https://github.com/Goob-Station/Goob-Station>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Goobstation.Server.StationEvents.Events;
+
+namespace Content.Goobstation.Server.StationEvents.Components;
+
+/// <summary>
+/// Configuration for the manhunt station event.
+/// The event scans all entities with a notoriety component and, if enough notorious
+/// criminals are present, broadcasts their names and bounties over station comms.
+/// </summary>
+[RegisterComponent]
+[Access(typeof(ManhuntRule))]
+public sealed partial class ManhuntRuleComponent : Component
+{
+    /// <summary>
+    /// Minimum notoriety level a criminal must have to be included in the announcement.
+    /// </summary>
+    [DataField]
+    public int MinNotorietyLevel = 3;
+
+    /// <summary>
+    /// Minimum sum of notoriety levels across all qualifying criminals required for the
+    /// event to fire. If the total is below this the event aborts immediately.
+    /// </summary>
+    [DataField]
+    public int MinTotalNotoriety = 8;
+
+    /// <summary>
+    /// Maximum number of criminals to list in the announcement, sorted by level descending.
+    /// </summary>
+    [DataField]
+    public int MaxListed = 5;
+}

--- a/Content.Goobstation.Server/StationEvents/Components/ManhuntRuleComponent.cs
+++ b/Content.Goobstation.Server/StationEvents/Components/ManhuntRuleComponent.cs
@@ -1,7 +1,3 @@
-// SPDX-FileCopyrightText: 2026 Goob-Station Contributors <https://github.com/Goob-Station/Goob-Station>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
 using Content.Goobstation.Server.StationEvents.Events;
 
 namespace Content.Goobstation.Server.StationEvents.Components;

--- a/Content.Goobstation.Server/StationEvents/Events/ManhuntRule.cs
+++ b/Content.Goobstation.Server/StationEvents/Events/ManhuntRule.cs
@@ -7,6 +7,7 @@ using Content.Goobstation.Common.Wanted;
 using Content.Goobstation.Server.StationEvents.Components;
 using Content.Server.StationEvents.Events;
 using Content.Shared.GameTicking.Components;
+using Robust.Shared.Player;
 
 namespace Content.Goobstation.Server.StationEvents.Events;
 
@@ -59,6 +60,7 @@ public sealed class ManhuntRule : StationEventSystem<ManhuntRuleComponent>
         var announcement = Loc.GetString("manhunt-announcement",
             ("criminals", sb.ToString().TrimEnd()));
 
-        ChatSystem.DispatchStationAnnouncement(uid, announcement, colorOverride: Color.OrangeRed);
+        var allPlayers = Filter.Empty().AddWhere(GameTicker.UserHasJoinedGame);
+        ChatSystem.DispatchFilteredAnnouncement(allPlayers, announcement, playSound: false, colorOverride: Color.OrangeRed);
     }
 }

--- a/Content.Goobstation.Server/StationEvents/Events/ManhuntRule.cs
+++ b/Content.Goobstation.Server/StationEvents/Events/ManhuntRule.cs
@@ -1,7 +1,3 @@
-// SPDX-FileCopyrightText: 2026 Goob-Station Contributors <https://github.com/Goob-Station/Goob-Station>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
 using System.Text;
 using Content.Goobstation.Common.Wanted;
 using Content.Goobstation.Server.StationEvents.Components;

--- a/Content.Goobstation.Server/StationEvents/Events/ManhuntRule.cs
+++ b/Content.Goobstation.Server/StationEvents/Events/ManhuntRule.cs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Goob-Station Contributors <https://github.com/Goob-Station/Goob-Station>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Text;
+using Content.Goobstation.Common.Wanted;
+using Content.Goobstation.Server.StationEvents.Components;
+using Content.Server.StationEvents.Events;
+using Content.Shared.GameTicking.Components;
+
+namespace Content.Goobstation.Server.StationEvents.Events;
+
+/// <summary>
+/// Station event that identifies all highly notorious criminals on the station and
+/// broadcasts a wanted announcement listing their names and bounties over station comms.
+/// Aborts silently if there are not enough notorious criminals to meet the threshold.
+/// </summary>
+public sealed class ManhuntRule : StationEventSystem<ManhuntRuleComponent>
+{
+    protected override void Started(EntityUid uid, ManhuntRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        // Gather all criminals that meet the minimum notoriety threshold.
+        var criminals = new List<(string Name, int Level, int Bounty)>();
+        var totalNotoriety = 0;
+
+        var query = EntityQueryEnumerator<NotorietyComponent>();
+        while (query.MoveNext(out var entity, out var notoriety))
+        {
+            totalNotoriety += notoriety.Level;
+
+            if (notoriety.Level >= component.MinNotorietyLevel)
+                criminals.Add((Name(entity), notoriety.Level, notoriety.BountyAmount));
+        }
+
+        // Abort if there are not enough notorious criminals to justify a manhunt.
+        if (criminals.Count == 0 || totalNotoriety < component.MinTotalNotoriety)
+        {
+            ForceEndSelf(uid, gameRule);
+            return;
+        }
+
+        // Sort by level descending and cap the list.
+        criminals.Sort((a, b) => b.Level.CompareTo(a.Level));
+        if (criminals.Count > component.MaxListed)
+            criminals.RemoveRange(component.MaxListed, criminals.Count - component.MaxListed);
+
+        // Build the criminal listing.
+        var sb = new StringBuilder();
+        foreach (var (name, level, bounty) in criminals)
+        {
+            sb.AppendLine(Loc.GetString("manhunt-criminal-entry",
+                ("name", name),
+                ("level", level),
+                ("bounty", bounty)));
+        }
+
+        var announcement = Loc.GetString("manhunt-announcement",
+            ("criminals", sb.ToString().TrimEnd()));
+
+        ChatSystem.DispatchStationAnnouncement(uid, announcement, colorOverride: Color.OrangeRed);
+    }
+}

--- a/Content.Goobstation.Server/StationEvents/Events/ManhuntRule.cs
+++ b/Content.Goobstation.Server/StationEvents/Events/ManhuntRule.cs
@@ -1,5 +1,5 @@
 using System.Text;
-using Content.Goobstation.Common.Wanted;
+using Content.Goobstation.Shared.Wanted;
 using Content.Goobstation.Server.StationEvents.Components;
 using Content.Server.StationEvents.Events;
 using Content.Shared.GameTicking.Components;

--- a/Content.Goobstation.Server/Wanted/NotorietySystem.cs
+++ b/Content.Goobstation.Server/Wanted/NotorietySystem.cs
@@ -4,23 +4,30 @@
 
 using Content.Goobstation.Common.Wanted;
 using Content.Shared.CriminalRecords.Systems;
+using Content.Shared.Examine;
 using Content.Shared.Security;
+using Content.Shared.Security.Components;
 using Robust.Shared.Timing;
 
 namespace Content.Goobstation.Server.Wanted;
 
 /// <summary>
 /// Manages the notoriety system — tracks escalating criminal history on entities,
-/// decays notoriety over time when criminals lay low, and provides bounty information
-/// to other systems (e.g. the manhunt station event).
+/// decays notoriety over time when criminals lay low, upgrades their HUD security icon
+/// when notoriety is high, and shows bounty info in the examine panel.
 /// </summary>
 public sealed class NotorietySystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
 
     /// <summary>
+    /// Notoriety level at which the HUD icon is upgraded from Wanted → Dangerous.
+    /// </summary>
+    private const int DangerousIconThreshold = 4;
+
+    /// <summary>
     /// How long a criminal must stay out of trouble before losing one notoriety level.
-    /// A level-5 criminal takes 5 × this interval (75 min) to fully clear their record.
+    /// A level-5 criminal takes 5 × this interval (75 min) to fully clear.
     /// </summary>
     private static readonly TimeSpan DecayInterval = TimeSpan.FromMinutes(15);
 
@@ -35,6 +42,7 @@ public sealed class NotorietySystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<CriminalStatusUpdatedEvent>(OnStatusUpdated);
+        SubscribeLocalEvent<NotorietyComponent, ExaminedEvent>(OnExamined);
     }
 
     public override void Update(float frameTime)
@@ -68,6 +76,25 @@ public sealed class NotorietySystem : EntitySystem
         comp.LastEscalationTime = _timing.CurTime;
         comp.TotalEscalations++;
         Dirty(args.Entity, comp);
+
+        // If this entity is only Wanted (not already Dangerous) but their notoriety
+        // is high, upgrade the HUD icon so security knows they're a serious threat.
+        if (comp.Level >= DangerousIconThreshold
+            && TryComp<CriminalRecordComponent>(args.Entity, out var crimRecord)
+            && crimRecord.StatusIcon == "SecurityIconWanted")
+        {
+            crimRecord.StatusIcon = "SecurityIconDangerous";
+            Dirty(args.Entity, crimRecord);
+        }
+    }
+
+    private void OnExamined(Entity<NotorietyComponent> ent, ref ExaminedEvent args)
+    {
+        if (ent.Comp.Level <= 0)
+            return;
+
+        args.PushMarkup(Loc.GetString("notoriety-examine-bounty",
+            ("credits", ent.Comp.BountyAmount)));
     }
 
     // ── Decay ────────────────────────────────────────────────────────────────

--- a/Content.Goobstation.Server/Wanted/NotorietySystem.cs
+++ b/Content.Goobstation.Server/Wanted/NotorietySystem.cs
@@ -1,13 +1,12 @@
 using Content.Goobstation.Common.Wanted;
-using Content.Shared.CriminalRecords.Systems;
-using Content.Shared.Examine;
+using Content.Goobstation.Shared.Wanted;
 using Content.Shared.Security;
 using Content.Shared.Security.Components;
 using Robust.Shared.Timing;
 
 namespace Content.Goobstation.Server.Wanted;
 
-public sealed class NotorietySystem : EntitySystem
+public sealed class NotorietySystem : SharedNotorietySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
 
@@ -17,7 +16,6 @@ public sealed class NotorietySystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<CriminalStatusUpdatedEvent>(OnStatusUpdated);
-        SubscribeLocalEvent<NotorietyComponent, ExaminedEvent>(OnExamined);
     }
 
     private void OnStatusUpdated(CriminalStatusUpdatedEvent args)
@@ -41,24 +39,5 @@ public sealed class NotorietySystem : EntitySystem
             crimRecord.StatusIcon = "SecurityIconDangerous";
             Dirty(args.Entity, crimRecord);
         }
-    }
-
-    private void OnExamined(Entity<NotorietyComponent> ent, ref ExaminedEvent args)
-    {
-        if (ent.Comp.Level <= 0)
-            return;
-
-        args.PushMarkup(Loc.GetString("notoriety-examine-bounty",
-            ("credits", ent.Comp.BountyAmount)));
-    }
-
-    public int GetLevel(EntityUid uid)
-    {
-        return TryComp<NotorietyComponent>(uid, out var comp) ? comp.Level : 0;
-    }
-
-    public int GetBounty(EntityUid uid)
-    {
-        return TryComp<NotorietyComponent>(uid, out var comp) ? comp.BountyAmount : 0;
     }
 }

--- a/Content.Goobstation.Server/Wanted/NotorietySystem.cs
+++ b/Content.Goobstation.Server/Wanted/NotorietySystem.cs
@@ -74,11 +74,10 @@ public sealed class NotorietySystem : EntitySystem
         comp.TotalEscalations++;
         Dirty(args.Entity, comp);
 
-        // If this entity is only Wanted (not already Dangerous) but their notoriety
-        // is high, upgrade the HUD icon so security knows they're a serious threat.
+        // Upgrade the HUD icon to Dangerous for high-notoriety criminals so security
+        // can immediately see they are a serious threat, regardless of their recorded status.
         if (comp.Level >= DangerousIconThreshold
-            && TryComp<CriminalRecordComponent>(args.Entity, out var crimRecord)
-            && crimRecord.StatusIcon == "SecurityIconWanted")
+            && TryComp<CriminalRecordComponent>(args.Entity, out var crimRecord))
         {
             crimRecord.StatusIcon = "SecurityIconDangerous";
             Dirty(args.Entity, crimRecord);

--- a/Content.Goobstation.Server/Wanted/NotorietySystem.cs
+++ b/Content.Goobstation.Server/Wanted/NotorietySystem.cs
@@ -1,7 +1,3 @@
-// SPDX-FileCopyrightText: 2026 Goob-Station Contributors <https://github.com/Goob-Station/Goob-Station>
-//
-// SPDX-License-Identifier: AGPL-3.0-or-later
-
 using Content.Goobstation.Common.Wanted;
 using Content.Shared.CriminalRecords.Systems;
 using Content.Shared.Examine;
@@ -11,32 +7,11 @@ using Robust.Shared.Timing;
 
 namespace Content.Goobstation.Server.Wanted;
 
-/// <summary>
-/// Manages the notoriety system — tracks escalating criminal history on entities,
-/// decays notoriety over time when criminals lay low, upgrades their HUD security icon
-/// when notoriety is high, and shows bounty info in the examine panel.
-/// </summary>
 public sealed class NotorietySystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
 
-    /// <summary>
-    /// Notoriety level at which the HUD icon is upgraded from Wanted → Dangerous.
-    /// </summary>
     private const int DangerousIconThreshold = 4;
-
-    /// <summary>
-    /// How long a criminal must stay out of trouble before losing one notoriety level.
-    /// A level-5 criminal takes 5 × this interval (75 min) to fully clear.
-    /// </summary>
-    private static readonly TimeSpan DecayInterval = TimeSpan.FromMinutes(15);
-
-    /// <summary>
-    /// How often the decay pass runs. Keeps the Update loop cheap.
-    /// </summary>
-    private static readonly TimeSpan DecayCheckInterval = TimeSpan.FromMinutes(1);
-
-    private TimeSpan _nextDecayCheck = TimeSpan.Zero;
 
     public override void Initialize()
     {
@@ -45,22 +20,8 @@ public sealed class NotorietySystem : EntitySystem
         SubscribeLocalEvent<NotorietyComponent, ExaminedEvent>(OnExamined);
     }
 
-    public override void Update(float frameTime)
-    {
-        base.Update(frameTime);
-
-        if (_timing.CurTime < _nextDecayCheck)
-            return;
-
-        _nextDecayCheck = _timing.CurTime + DecayCheckInterval;
-        DecayAll();
-    }
-
-    // ── Event handlers ────────────────────────────────────────────────────────
-
     private void OnStatusUpdated(CriminalStatusUpdatedEvent args)
     {
-        // Only escalate for serious criminal statuses; clearing resets nothing.
         if (args.Status is not (SecurityStatus.Wanted or SecurityStatus.Dangerous or SecurityStatus.Perma))
             return;
 
@@ -74,8 +35,6 @@ public sealed class NotorietySystem : EntitySystem
         comp.TotalEscalations++;
         Dirty(args.Entity, comp);
 
-        // Upgrade the HUD icon to Dangerous for high-notoriety criminals so security
-        // can immediately see they are a serious threat, regardless of their recorded status.
         if (comp.Level >= DangerousIconThreshold
             && TryComp<CriminalRecordComponent>(args.Entity, out var crimRecord))
         {
@@ -93,40 +52,11 @@ public sealed class NotorietySystem : EntitySystem
             ("credits", ent.Comp.BountyAmount)));
     }
 
-    // ── Decay ────────────────────────────────────────────────────────────────
-
-    private void DecayAll()
-    {
-        var query = EntityQueryEnumerator<NotorietyComponent>();
-        while (query.MoveNext(out var uid, out var comp))
-        {
-            if (comp.Level <= 0)
-                continue;
-
-            var timeSinceLastEscalation = _timing.CurTime - comp.LastEscalationTime;
-            if (timeSinceLastEscalation < DecayInterval)
-                continue;
-
-            comp.Level--;
-            // Reset the timer so the next level also takes a full interval to decay.
-            comp.LastEscalationTime = _timing.CurTime;
-            Dirty(uid, comp);
-        }
-    }
-
-    // ── Public API ───────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Returns the current notoriety level of an entity, or 0 if none exists.
-    /// </summary>
     public int GetLevel(EntityUid uid)
     {
         return TryComp<NotorietyComponent>(uid, out var comp) ? comp.Level : 0;
     }
 
-    /// <summary>
-    /// Returns the credit bounty for the entity's current notoriety level.
-    /// </summary>
     public int GetBounty(EntityUid uid)
     {
         return TryComp<NotorietyComponent>(uid, out var comp) ? comp.BountyAmount : 0;

--- a/Content.Goobstation.Server/Wanted/NotorietySystem.cs
+++ b/Content.Goobstation.Server/Wanted/NotorietySystem.cs
@@ -64,9 +64,6 @@ public sealed class NotorietySystem : EntitySystem
         if (args.Status is not (SecurityStatus.Wanted or SecurityStatus.Dangerous or SecurityStatus.Perma))
             return;
 
-        if (!EntityManager.IsValid(args.Entity))
-            return;
-
         var comp = EnsureComp<NotorietyComponent>(args.Entity);
 
         if (comp.Level >= NotorietyComponent.MaxLevel)

--- a/Content.Goobstation.Server/Wanted/NotorietySystem.cs
+++ b/Content.Goobstation.Server/Wanted/NotorietySystem.cs
@@ -20,7 +20,8 @@ public sealed class NotorietySystem : SharedNotorietySystem
 
     private void OnStatusUpdated(CriminalStatusUpdatedEvent args)
     {
-        if (args.Status is not (SecurityStatus.Wanted or SecurityStatus.Dangerous or SecurityStatus.Perma))
+        var status = (SecurityStatus) args.Status;
+        if (status is not (SecurityStatus.Wanted or SecurityStatus.Dangerous or SecurityStatus.Perma))
             return;
 
         var comp = EnsureComp<NotorietyComponent>(args.Entity);

--- a/Content.Goobstation.Server/Wanted/NotorietySystem.cs
+++ b/Content.Goobstation.Server/Wanted/NotorietySystem.cs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 Goob-Station Contributors <https://github.com/Goob-Station/Goob-Station>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Goobstation.Common.Wanted;
+using Content.Shared.CriminalRecords.Systems;
+using Content.Shared.Security;
+using Robust.Shared.Timing;
+
+namespace Content.Goobstation.Server.Wanted;
+
+/// <summary>
+/// Manages the notoriety system — tracks escalating criminal history on entities and provides
+/// bounty information to other systems.
+/// </summary>
+public sealed class NotorietySystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<CriminalStatusUpdatedEvent>(OnStatusUpdated);
+    }
+
+    private void OnStatusUpdated(CriminalStatusUpdatedEvent args)
+    {
+        // Only escalate when assigned a serious criminal status, not when cleared.
+        if (args.Status is not (SecurityStatus.Wanted or SecurityStatus.Dangerous or SecurityStatus.Perma))
+            return;
+
+        if (!IsValid(args.Entity))
+            return;
+
+        var comp = EnsureComp<NotorietyComponent>(args.Entity);
+
+        if (comp.Level >= NotorietyComponent.MaxLevel)
+            return;
+
+        comp.Level++;
+        comp.LastEscalationTime = _timing.CurTime;
+        comp.TotalEscalations++;
+        Dirty(args.Entity, comp);
+    }
+
+    /// <summary>
+    /// Returns the current notoriety level of an entity, or 0 if none exists.
+    /// </summary>
+    public int GetLevel(EntityUid uid)
+    {
+        return TryComp<NotorietyComponent>(uid, out var comp) ? comp.Level : 0;
+    }
+
+    /// <summary>
+    /// Returns the credit bounty for the entity's current notoriety level.
+    /// </summary>
+    public int GetBounty(EntityUid uid)
+    {
+        return TryComp<NotorietyComponent>(uid, out var comp) ? comp.BountyAmount : 0;
+    }
+}

--- a/Content.Goobstation.Server/Wanted/NotorietySystem.cs
+++ b/Content.Goobstation.Server/Wanted/NotorietySystem.cs
@@ -10,12 +10,26 @@ using Robust.Shared.Timing;
 namespace Content.Goobstation.Server.Wanted;
 
 /// <summary>
-/// Manages the notoriety system — tracks escalating criminal history on entities and provides
-/// bounty information to other systems.
+/// Manages the notoriety system — tracks escalating criminal history on entities,
+/// decays notoriety over time when criminals lay low, and provides bounty information
+/// to other systems (e.g. the manhunt station event).
 /// </summary>
 public sealed class NotorietySystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
+
+    /// <summary>
+    /// How long a criminal must stay out of trouble before losing one notoriety level.
+    /// A level-5 criminal takes 5 × this interval (75 min) to fully clear their record.
+    /// </summary>
+    private static readonly TimeSpan DecayInterval = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// How often the decay pass runs. Keeps the Update loop cheap.
+    /// </summary>
+    private static readonly TimeSpan DecayCheckInterval = TimeSpan.FromMinutes(1);
+
+    private TimeSpan _nextDecayCheck = TimeSpan.Zero;
 
     public override void Initialize()
     {
@@ -23,9 +37,22 @@ public sealed class NotorietySystem : EntitySystem
         SubscribeLocalEvent<CriminalStatusUpdatedEvent>(OnStatusUpdated);
     }
 
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_timing.CurTime < _nextDecayCheck)
+            return;
+
+        _nextDecayCheck = _timing.CurTime + DecayCheckInterval;
+        DecayAll();
+    }
+
+    // ── Event handlers ────────────────────────────────────────────────────────
+
     private void OnStatusUpdated(CriminalStatusUpdatedEvent args)
     {
-        // Only escalate when assigned a serious criminal status, not when cleared.
+        // Only escalate for serious criminal statuses; clearing resets nothing.
         if (args.Status is not (SecurityStatus.Wanted or SecurityStatus.Dangerous or SecurityStatus.Perma))
             return;
 
@@ -42,6 +69,29 @@ public sealed class NotorietySystem : EntitySystem
         comp.TotalEscalations++;
         Dirty(args.Entity, comp);
     }
+
+    // ── Decay ────────────────────────────────────────────────────────────────
+
+    private void DecayAll()
+    {
+        var query = EntityQueryEnumerator<NotorietyComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (comp.Level <= 0)
+                continue;
+
+            var timeSinceLastEscalation = _timing.CurTime - comp.LastEscalationTime;
+            if (timeSinceLastEscalation < DecayInterval)
+                continue;
+
+            comp.Level--;
+            // Reset the timer so the next level also takes a full interval to decay.
+            comp.LastEscalationTime = _timing.CurTime;
+            Dirty(uid, comp);
+        }
+    }
+
+    // ── Public API ───────────────────────────────────────────────────────────
 
     /// <summary>
     /// Returns the current notoriety level of an entity, or 0 if none exists.

--- a/Content.Goobstation.Server/Wanted/NotorietySystem.cs
+++ b/Content.Goobstation.Server/Wanted/NotorietySystem.cs
@@ -64,7 +64,7 @@ public sealed class NotorietySystem : EntitySystem
         if (args.Status is not (SecurityStatus.Wanted or SecurityStatus.Dangerous or SecurityStatus.Perma))
             return;
 
-        if (!IsValid(args.Entity))
+        if (!EntityManager.IsValid(args.Entity))
             return;
 
         var comp = EnsureComp<NotorietyComponent>(args.Entity);

--- a/Content.Goobstation.Shared/Wanted/NotorietyComponent.cs
+++ b/Content.Goobstation.Shared/Wanted/NotorietyComponent.cs
@@ -1,14 +1,14 @@
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
-namespace Content.Goobstation.Common.Wanted;
+namespace Content.Goobstation.Shared.Wanted;
 
 /// <summary>
 /// Tracks a crew member's notoriety — accumulated over time as they commit crimes and become marked as wanted.
 /// Notoriety persists even after criminal status is cleared.
 /// High notoriety can trigger a station-wide manhunt event.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class NotorietyComponent : Component
 {
     public const int MaxLevel = 5;
@@ -27,13 +27,13 @@ public sealed partial class NotorietyComponent : Component
     /// <summary>
     /// Timestamp of the last escalation (status set to Wanted/Dangerous/Perma).
     /// </summary>
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan LastEscalationTime = TimeSpan.Zero;
 
     /// <summary>
     /// Total number of notoriety escalations this entity has accumulated this round.
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField]
     public int TotalEscalations = 0;
 
     /// <summary>

--- a/Content.Goobstation.Shared/Wanted/SharedNotorietySystem.cs
+++ b/Content.Goobstation.Shared/Wanted/SharedNotorietySystem.cs
@@ -1,0 +1,32 @@
+using Content.Goobstation.Common.Wanted;
+using Content.Shared.Examine;
+
+namespace Content.Goobstation.Shared.Wanted;
+
+public abstract class SharedNotorietySystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<NotorietyComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(Entity<NotorietyComponent> ent, ref ExaminedEvent args)
+    {
+        if (ent.Comp.Level <= 0)
+            return;
+
+        args.PushMarkup(Loc.GetString("notoriety-examine-bounty",
+            ("credits", ent.Comp.BountyAmount)));
+    }
+
+    public int GetLevel(EntityUid uid)
+    {
+        return TryComp<NotorietyComponent>(uid, out var comp) ? comp.Level : 0;
+    }
+
+    public int GetBounty(EntityUid uid)
+    {
+        return TryComp<NotorietyComponent>(uid, out var comp) ? comp.BountyAmount : 0;
+    }
+}

--- a/Content.Shared/CriminalRecords/Systems/SharedCriminalRecordsSystem.cs
+++ b/Content.Shared/CriminalRecords/Systems/SharedCriminalRecordsSystem.cs
@@ -7,6 +7,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Goobstation.Common.Wanted; // Goobstation - notoriety
 using Content.Shared.IdentityManagement;
 using Content.Shared.IdentityManagement.Components;
 using Content.Shared.Security;
@@ -87,23 +88,3 @@ public record struct CriminalHistoryAddedEvent(CrimeHistory History);
 
 [ByRefEvent]
 public record struct CriminalHistoryRemovedEvent(CrimeHistory History);
-
-// Goobstation - Notoriety system
-/// <summary>
-/// Broadcast event raised whenever a crew member's criminal status is applied to their in-world entity.
-/// Fired after the HUD icon has already been updated.
-/// </summary>
-public sealed class CriminalStatusUpdatedEvent : EntityEventArgs
-{
-    /// <summary>The entity whose criminal status changed.</summary>
-    public readonly EntityUid Entity;
-
-    /// <summary>The new security status applied to the entity.</summary>
-    public readonly SecurityStatus Status;
-
-    public CriminalStatusUpdatedEvent(EntityUid entity, SecurityStatus status)
-    {
-        Entity = entity;
-        Status = status;
-    }
-}

--- a/Content.Shared/CriminalRecords/Systems/SharedCriminalRecordsSystem.cs
+++ b/Content.Shared/CriminalRecords/Systems/SharedCriminalRecordsSystem.cs
@@ -38,7 +38,7 @@ public abstract class SharedCriminalRecordsSystem : EntitySystem
                 SetCriminalIcon(name, status, uid);
 
             // Goobstation - notify notoriety system of the status change on this entity
-            RaiseLocalEvent(new CriminalStatusUpdatedEvent(uid, status));
+            RaiseLocalEvent(new CriminalStatusUpdatedEvent(uid, (byte) status));
         }
     }
 

--- a/Content.Shared/CriminalRecords/Systems/SharedCriminalRecordsSystem.cs
+++ b/Content.Shared/CriminalRecords/Systems/SharedCriminalRecordsSystem.cs
@@ -35,6 +35,9 @@ public abstract class SharedCriminalRecordsSystem : EntitySystem
                 RemComp<CriminalRecordComponent>(uid);
             else
                 SetCriminalIcon(name, status, uid);
+
+            // Goobstation - notify notoriety system of the status change on this entity
+            RaiseLocalEvent(new CriminalStatusUpdatedEvent(uid, status));
         }
     }
 
@@ -84,3 +87,23 @@ public record struct CriminalHistoryAddedEvent(CrimeHistory History);
 
 [ByRefEvent]
 public record struct CriminalHistoryRemovedEvent(CrimeHistory History);
+
+// Goobstation - Notoriety system
+/// <summary>
+/// Broadcast event raised whenever a crew member's criminal status is applied to their in-world entity.
+/// Fired after the HUD icon has already been updated.
+/// </summary>
+public sealed class CriminalStatusUpdatedEvent : EntityEventArgs
+{
+    /// <summary>The entity whose criminal status changed.</summary>
+    public readonly EntityUid Entity;
+
+    /// <summary>The new security status applied to the entity.</summary>
+    public readonly SecurityStatus Status;
+
+    public CriminalStatusUpdatedEvent(EntityUid entity, SecurityStatus status)
+    {
+        Entity = entity;
+        Status = status;
+    }
+}

--- a/Resources/Locale/en-US/_Goobstation/wanted/notoriety.ftl
+++ b/Resources/Locale/en-US/_Goobstation/wanted/notoriety.ftl
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2026 Goob-Station Contributors <https://github.com/Goob-Station/Goob-Station>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+## Notoriety level names (shown in examine and records)
+notoriety-level-0 = No notoriety
+notoriety-level-1 = Minor offender
+notoriety-level-2 = Known criminal
+notoriety-level-3 = Dangerous criminal
+notoriety-level-4 = High-value target
+notoriety-level-5 = Most wanted
+
+## Examine text
+notoriety-examine-bounty = A bounty of [color=yellow]{ $credits } credits[/color] has been placed on this person's head.

--- a/Resources/Locale/en-US/_Goobstation/wanted/notoriety.ftl
+++ b/Resources/Locale/en-US/_Goobstation/wanted/notoriety.ftl
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2026 Goob-Station Contributors <https://github.com/Goob-Station/Goob-Station>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 ## Notoriety level names (shown in examine and records)
 notoriety-level-0 = No notoriety
 notoriety-level-1 = Minor offender

--- a/Resources/Locale/en-US/_Goobstation/wanted/notoriety.ftl
+++ b/Resources/Locale/en-US/_Goobstation/wanted/notoriety.ftl
@@ -12,3 +12,14 @@ notoriety-level-5 = Most wanted
 
 ## Examine text
 notoriety-examine-bounty = A bounty of [color=yellow]{ $credits } credits[/color] has been placed on this person's head.
+
+## Manhunt station event
+manhunt-announcement =
+    SECURITY ALERT: Station Command has authorized open bounties on the following individuals.
+    All crew are advised to report sightings immediately.
+
+    { $criminals }
+
+    NanoTrasen will reimburse the listed credit amounts upon confirmed apprehension.
+
+manhunt-criminal-entry = - { $name } | Notoriety { $level } | Bounty: { $bounty } cr

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -38,7 +38,7 @@
     chaosScore: 80
   - type: ManhuntRule
     minNotorietyLevel: 3
-    minTotalNotoriety: 8
+    minTotalNotoriety: 4
     maxListed: 5
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -11,7 +11,38 @@
 # SPDX-FileCopyrightText: 2025 loltart <159829224+loltart@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 loltart <lo1tartyt@gmail.com>
 #
+# SPDX-FileCopyrightText: 2026 Goob-Station Contributors <https://github.com/Goob-Station/Goob-Station>
+#
 # SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Manhunt — broadcasts open bounties on the most notorious criminals currently on the station.
+# Only fires when enough accumulated notoriety is present (handled in ManhuntRule.cs).
+- type: entity
+  parent: BaseGameRule
+  id: ManhuntMidround
+  components:
+  - type: StationEvent
+    weight: 6
+    earliestStart: 20
+    minimumPlayers: 10
+    maxOccurrences: 3
+    reoccurrenceDelay: 25
+    duration: 1
+    isSelectable: true
+    chaos:
+      Hostile: 20
+    eventType: HostilesSpawn
+    startAudio:
+      path: /Audio/Announcements/alert.ogg
+  - type: GameRule
+    chaosScore: 80
+  - type: ManhuntRule
+    minNotorietyLevel: 3
+    minTotalNotoriety: 8
+    maxListed: 5
+  - type: Tag
+    tags:
+      - MidroundAntag
 
 - type: entity
   parent: Traitor

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -11,10 +11,6 @@
 # SPDX-FileCopyrightText: 2025 loltart <159829224+loltart@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 loltart <lo1tartyt@gmail.com>
 #
-# SPDX-FileCopyrightText: 2026 Goob-Station Contributors <https://github.com/Goob-Station/Goob-Station>
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
 # Manhunt — broadcasts open bounties on the most notorious criminals currently on the station.
 # Only fires when enough accumulated notoriety is present (handled in ManhuntRule.cs).
 - type: entity

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -33,7 +33,7 @@
       Hostile: 20
     eventType: HostilesSpawn
     startAudio:
-      path: /Audio/Announcements/alert.ogg
+      path: /Audio/Announcements/attention.ogg
   - type: GameRule
     chaosScore: 80
   - type: ManhuntRule


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Adds a notoriety system that tracks criminal history across a round. Getting marked as Wanted/Dangerous/Perma bumps your notoriety level (0–5). Notoriety doesn't clear when your status does, it decays slowly on its own over time.

## Why / Balance
Criminal records currently have no memory. Someone can rack up a history of arrests, get discharged, and walk around with a clean HUD icon. This gives security a persistent threat indicator and rewards actually staying out of trouble as a criminal.

Decay is intentionally slow (15 min per level) so a level-5 criminal can't just hide for one shift and come back clean.

## Technical details
- `NotorietyComponent`
- `CriminalStatusUpdatedEvent` broadcast added to `SharedCriminalRecordsSystem.UpdateCriminalIdentity`, fired after the HUD icon is set
- Level 4+ overrides the HUD icon to `SecurityIconDangerous` even if the criminal record status is only "Wanted"
- Decay runs in a throttled `Update` loop (checks once/min, decays once per 15 min of clean time)
- Examine text shows active bounty amount (500–12000 cr by tier) to anyone who looks
- `ManhuntMidround` station event scans for criminals with notoriety ≥ 3 and broadcasts their names + bounties over comms; aborts silently if the station total is below threshold

## Media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Criminals now accumulate notoriety as they get marked wanted. It fades if they lay low.
- add: High-notoriety criminals show the Dangerous HUD icon to security even if only marked Wanted.
- add: Examining a notorious criminal shows the active credit bounty on their head.
- add: New midround event: station command broadcasts open bounties on the most wanted criminals currently aboard.