### PR TITLE
Change food and drink valuation

### DIFF
--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -231,10 +231,10 @@ public sealed class NPCUtilitySystem : EntitySystem
                     return 0f;
 
                 // no mouse don't eat the uranium-235
-                if (avoidBadFood && (HasComp<BadFoodComponent>(targetUid) || TotalFoodUtilityConditioned(targetUid, owner).IsToxic))
+                if (avoidBadFood && (HasComp<BadFoodComponent>(targetUid) || TotalFoodUtilityConditioned(targetUid, owner).IsToxic)) // Goobstation edit
                     return 0f;
 
-                var nutrition = TotalFoodUtilityConditioned(targetUid, owner).TotalNutrition;
+                var nutrition = TotalFoodUtilityConditioned(targetUid, owner).TotalNutrition; // Goobstation edit
                 if (nutrition <= 1.0f)
                     return 0f;
 
@@ -251,13 +251,13 @@ public sealed class NPCUtilitySystem : EntitySystem
                     return 0f;
 
                 // no janicow don't drink the blood puddle
-                if (HasComp<BadDrinkComponent>(targetUid) || TotalFoodUtilityConditioned(targetUid, owner).IsToxic)
+                if (HasComp<BadDrinkComponent>(targetUid) || TotalFoodUtilityConditioned(targetUid, owner).IsToxic) // Goobstation edit
                     return 0f;
 
                 // needs to have something that will satiate thirst, mice wont try to drink 100% pure mutagen.
                 // We don't check if the solution is metabolizable cause all drinks should be currently.
                 // If that changes then simply use the other overflow.
-                var hydration = TotalFoodUtilityConditioned(targetUid, owner).TotalHydration;
+                var hydration = TotalFoodUtilityConditioned(targetUid, owner).TotalHydration; // Goobstation edit
                 if (hydration <= 1.0f)
                     return 0f;
 

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -67,6 +67,15 @@ using Content.Shared.Foldable;
 using Content.Shared.Wieldable;
 using Content.Shared.Wieldable.Components;
 
+using Content.Goobstation.Maths.FixedPoint; // Goobstation start
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.EntityEffects.Effects;
+using Content.Shared.EntityEffects;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Systems;
+using Content.Shared.Chemistry;
+using Content.Server.Body.Components; // Goobstation end
+
 namespace Content.Server.NPC.Systems;
 
 /// <summary>
@@ -92,7 +101,9 @@ public sealed class NPCUtilitySystem : EntitySystem
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private readonly MobThresholdSystem _thresholdSystem = default!;
     [Dependency] private readonly TurretTargetSettingsSystem _turretTargetSettings = default!;
-    [Dependency] private readonly SharedWieldableSystem _wieldable = default!; // Goobstation
+    [Dependency] private readonly SharedWieldableSystem _wieldable = default!; // Goobstation start
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly SharedBodySystem _body = default!; // Goobstation end
 
     private EntityQuery<PuddleComponent> _puddleQuery;
     private EntityQuery<TransformComponent> _xformQuery;
@@ -220,10 +231,10 @@ public sealed class NPCUtilitySystem : EntitySystem
                     return 0f;
 
                 // no mouse don't eat the uranium-235
-                if (avoidBadFood && HasComp<BadFoodComponent>(targetUid))
+                if (avoidBadFood && (HasComp<BadFoodComponent>(targetUid) || TotalFoodUtilityConditioned(targetUid, owner).IsToxic))
                     return 0f;
 
-                var nutrition = _ingestion.TotalNutrition(targetUid, owner);
+                var nutrition = TotalFoodUtilityConditioned(targetUid, owner).TotalNutrition;
                 if (nutrition <= 1.0f)
                     return 0f;
 
@@ -240,13 +251,13 @@ public sealed class NPCUtilitySystem : EntitySystem
                     return 0f;
 
                 // no janicow don't drink the blood puddle
-                if (HasComp<BadDrinkComponent>(targetUid))
+                if (HasComp<BadDrinkComponent>(targetUid) || TotalFoodUtilityConditioned(targetUid, owner).IsToxic)
                     return 0f;
 
                 // needs to have something that will satiate thirst, mice wont try to drink 100% pure mutagen.
                 // We don't check if the solution is metabolizable cause all drinks should be currently.
                 // If that changes then simply use the other overflow.
-                var hydration = _ingestion.TotalHydration(targetUid);
+                var hydration = TotalFoodUtilityConditioned(targetUid, owner).TotalHydration;
                 if (hydration <= 1.0f)
                     return 0f;
 
@@ -629,6 +640,81 @@ public sealed class NPCUtilitySystem : EntitySystem
                 throw new NotImplementedException();
         }
     }
+
+    // Goobstation start
+    /// <summary>
+    /// Gets the total metabolizable nutrition, hydration and toxicity from an ingested entity recursively, may return lesser numbers with cyclic metabolism graphs.
+    /// </summary>
+    /// <param name="consumer">The consumer entity</param>
+    /// <param name="ingestable">The consumed entity</param>
+    /// <returns>The amount of nutrition the consumable is worth</returns>
+    private FoodUtilityParams TotalFoodUtilityConditioned(Entity<EdibleComponent?> ingestable, EntityUid consumer)
+    {
+        var utilityParams = new FoodUtilityParams(0f, 0f, false);
+        if (!Resolve(ingestable, ref ingestable.Comp))
+            return utilityParams;
+
+        if (!_solutions.TryGetSolution(ingestable.Owner, ingestable.Comp.Solution, out _, out var solution))
+            return utilityParams;
+
+        Queue<ReagentQuantity> queue = [];
+        HashSet<ReagentPrototype> alreadychecked = [];
+
+        foreach (var quantity in solution.Contents)
+            queue.Enqueue(quantity);
+
+        FixedPoint2 quantityPerSipMultiplier = 1;
+        if (ingestable.Comp.TransferAmount is not null
+            && solution.Volume > ingestable.Comp.TransferAmount)
+            quantityPerSipMultiplier *= (FixedPoint2) (ingestable.Comp.TransferAmount / solution.Volume);
+
+        while (queue.Any())
+        {
+            var quantity = queue.Dequeue();
+            var reagent = _proto.Index<ReagentPrototype>(quantity.Reagent.Prototype);
+
+            if (!alreadychecked.Add(reagent))
+                continue;
+
+            if (reagent.Metabolisms == null)
+                continue;
+
+            foreach (var (metabolism, entry) in reagent.Metabolisms)
+            {
+                foreach (var effect in entry.Effects)
+                {
+                    Entity<MetabolizerComponent>? metabolizingOrgan = null;
+                    if (TryComp<BodyComponent>(consumer, out var body)
+                        && _body.TryGetBodyOrganEntityComps<MetabolizerComponent>(consumer, out var metabolizers)
+                        && metabolizers is not null)
+                        metabolizingOrgan = metabolizers.First(met => (met.Comp1.MetabolismGroups ?? []).Any(group => group.Id == metabolism));
+
+                    var quantityPerSip = quantity.Quantity * quantityPerSipMultiplier;
+                    var args = new EntityEffectReagentArgs(consumer, _entityManager, metabolizingOrgan, solution, quantityPerSip, reagent, ReactionMethod.Ingestion, 1f);
+                    if (effect.Conditions is not null
+                        && !effect.Conditions.All(x => x.Condition(args)))
+                        continue;
+
+                    if (effect is SatiateHunger hunger)
+                        utilityParams.TotalNutrition += hunger.NutritionFactor * quantity.Quantity.Float();
+
+                    if (effect is SatiateThirst thirst)
+                        utilityParams.TotalHydration += thirst.HydrationFactor * quantity.Quantity.Float();
+
+                    if (effect is HealthChange damage
+                        && damage.Damage.AnyPositive())
+                        utilityParams.IsToxic = true;
+
+                    if (effect is AdjustReagent newReagent
+                        && newReagent.Reagent is not null
+                        && newReagent.Amount > 0f)
+                        queue.Enqueue(new ReagentQuantity(newReagent.Reagent, quantity.Quantity /* (newReagent.Amount / entry.MetabolismRate)*/));
+                }
+            }
+        }
+
+        return utilityParams;
+    } // Goobstation end
 }
 
 public readonly record struct UtilityResult(Dictionary<EntityUid, float> Entities)
@@ -659,3 +745,5 @@ public readonly record struct UtilityResult(Dictionary<EntityUid, float> Entitie
         return Entities.MinBy(x => x.Value).Key;
     }
 }
+
+public record struct FoodUtilityParams(float TotalNutrition, float TotalHydration, bool IsToxic); // Goobstation edit

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -663,11 +663,6 @@ public sealed class NPCUtilitySystem : EntitySystem
         foreach (var quantity in solution.Contents)
             queue.Enqueue(quantity);
 
-        FixedPoint2 quantityPerSipMultiplier = 1;
-        if (ingestable.Comp.TransferAmount is not null
-            && solution.Volume > ingestable.Comp.TransferAmount)
-            quantityPerSipMultiplier *= (FixedPoint2) (ingestable.Comp.TransferAmount / solution.Volume);
-
         while (queue.Any())
         {
             var quantity = queue.Dequeue();
@@ -689,8 +684,7 @@ public sealed class NPCUtilitySystem : EntitySystem
                         && metabolizers is not null)
                         metabolizingOrgan = metabolizers.First(met => (met.Comp1.MetabolismGroups ?? []).Any(group => group.Id == metabolism));
 
-                    var quantityPerSip = quantity.Quantity * quantityPerSipMultiplier;
-                    var args = new EntityEffectReagentArgs(consumer, _entityManager, metabolizingOrgan, solution, quantityPerSip, reagent, ReactionMethod.Ingestion, 1f);
+                    var args = new EntityEffectReagentArgs(consumer, _entityManager, metabolizingOrgan, solution, quantity.Quantity, reagent, ReactionMethod.Ingestion, 1f);
                     if (effect.Conditions is not null
                         && !effect.Conditions.All(x => x.Condition(args)))
                         continue;
@@ -708,7 +702,7 @@ public sealed class NPCUtilitySystem : EntitySystem
                     if (effect is AdjustReagent newReagent
                         && newReagent.Reagent is not null
                         && newReagent.Amount > 0f)
-                        queue.Enqueue(new ReagentQuantity(newReagent.Reagent, quantity.Quantity /* (newReagent.Amount / entry.MetabolismRate)*/));
+                        queue.Enqueue(new ReagentQuantity(newReagent.Reagent, quantity.Quantity * (newReagent.Amount / entry.MetabolismRate)));
                 }
             }
         }

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -312,7 +312,7 @@
     locVolume: "examinable-solution-on-examine-volume-puddle"
   - type: DrawableSolution
     solution: puddle
-  - type: BadDrink
+  # - type: BadDrink # Goobstation
   - type: IgnoresFingerprints
   - type: Tag
     tags:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
The utility of food and drinks for AI has been changed, reagents are now checked recursively, automatic toxicity checking has also been added, this allows mice, slimes and other AI to eat uncooked proteins, drink blood and not consume toxic substances like mutagen if they are in the food.

## Why / Balance
There is less need to label food and drinks as badfood. Slimes that eat slime, raw eggs, and blood are more logical than slimes that eat only slime. Mice drinking blood from the station and reproducing from it look funny.

## Technical details
It would be better to implement TotalFoodUtilityConditioned in Goob namespace, but MetabolizerComponent is part of Content.Server.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Changed the utility of food and drinks for AI, this allows slimes, mice and another animals to eat uncooked eggs, drink blood if they can digest them and avoid toxic reagents. 

