### PR TITLE
give sci chemical analysis goggles

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
@@ -184,6 +184,7 @@
     - CircuitFloorsStatic
     - MedicalBoardsStatic
     - MedicalBoardsStaticGoob
+    - ChemistryStatic
     - ToolsStatic
     - PartsStatic
     - LatheMiscStatic


### PR DESCRIPTION
## About the PR
gives scifab chemical analysis goggles

## Why / Balance
sci gets basically all other chem stuff but not the actual glasses for some reason. there is literally no reason you should have to go over to the medfab and print chem goggles whenever theres a reagent anom or if you're doing xenobio. also, chemistry is just science and is being hijacked by the medical department .

## Technical details
<!-- Summary of code changes for easier review. -->
adds `ChemistryStatic` to sci techfab

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: rivermyth
- tweak: The science techfab can now print chemical analysis goggles.