### PR TITLE
fix ipc autodoc surgery

### DIFF
--- a/Content.Shared/_Shitmed/Autodoc/Systems/SharedAutodocSystem.cs
+++ b/Content.Shared/_Shitmed/Autodoc/Systems/SharedAutodocSystem.cs
@@ -6,6 +6,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Shared._EinsteinEngines.Silicon.Components;
 using Content.Shared._Shitmed.Autodoc.Components;
 using Content.Shared._Shitmed.Medical.Surgery;
 using Content.Shared._Shitmed.Medical.Surgery.Steps;
@@ -343,6 +344,8 @@ public abstract class SharedAutodocSystem : EntitySystem
 
     public bool IsAwake(EntityUid uid)
     {
+        if (TryComp(uid, out SiliconComponent? comp) && !comp.DoSiliconsDreamOfElectricSheep)
+            return false;
         return _mobState.IsAlive(uid) && !HasComp<SleepingComponent>(uid);
     }
 


### PR DESCRIPTION
## About the PR
makes autodoc work on awake silicons if they are considered incapable of sleeping

closes #6247

## Technical details
just always considers them to be asleep if they have `SiliconComponent` and its `DoSiliconsDreamOfElectricSheep` is set to `false`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: rivermyth
- fix: Autodoc Mk.XIV now works on IPCs without needing to cut the safety wire.