### PR TITLE
(Bounty) Remove ontags from the video game (pending rework)

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -98,13 +98,13 @@
   components:
   - type: SecretPlus
     # if you've come here due to "too many antags", lower chaos change for less midrounds and lower starting chaos for less roundstarts
-    minStartingChaos: 11 # scales per player
-    maxStartingChaos: 22
-    livingChaosChange: -0.018
-    deadChaosChange: 0.020
+    minStartingChaos: 1 # scales per player
+    maxStartingChaos: 1
+    livingChaosChange: -0.00018
+    deadChaosChange: 0.2
     # chance for greenshift as well as evilshift
-    chaosChangeVariationMin: 0.65
-    chaosChangeVariationMax: 1.3
+    chaosChangeVariationMin: 0.01
+    chaosChangeVariationMax: 0.1
     # often fires chud events so relatively low
     eventIntervalMin: 90
     eventIntervalMax: 400


### PR DESCRIPTION
Antagonists in Space Station 14 often function like a sudden storm in what could otherwise be a carefully tended garden of roleplay. The game’s core strength lies in its ability to simulate a living, breathing station where players inhabit roles, build relationships, and create emergent narratives through cooperation and conversation. When antagonists enter the picture, that delicate ecosystem shifts. Instead of slow-burning interpersonal storytelling, the focus pivots toward urgency, suspicion, and survival. The result is less time spent inhabiting characters and more time reacting to threats, which quietly erodes the immersive roleplay experience the game is uniquely positioned to deliver.

The presence of antagonists also introduces a competitive layer that clashes with the collaborative spirit of roleplay. Roleplay thrives on shared storytelling, where outcomes are not measured in victory or defeat but in the richness of the narrative. Antagonists, by design, operate with objectives that often require secrecy, disruption, or outright destruction. This creates a divide between players, turning what could be a unified storytelling effort into a fragmented contest. Instead of asking, “What would my character do?” players begin asking, “How do I win or stop the other side?” That subtle shift reframes the entire experience, pulling it away from narrative depth and toward mechanical success.

Moreover, antagonists tend to accelerate the pacing of rounds in a way that suffocates meaningful interaction. Good roleplay requires time: time to establish character dynamics, to explore motivations, and to let conflicts unfold naturally. Antagonist-driven events often compress this timeline, forcing players into rapid decision-making and high-stakes situations before relationships or storylines have had a chance to develop. It’s like trying to stage a theatrical play where the final act begins five minutes after the curtain rises. The spectacle might be intense, but the emotional foundation is thin, leaving roleplay feeling shallow or rushed.

Ultimately, removing antagonists or minimizing their influence would allow Space Station 14 to fully embrace its identity as a roleplay-first experience. Without the constant pressure of hidden threats or adversarial objectives, players could invest more deeply in their characters and the shared world. Conflicts could still exist, but they would emerge organically from character interactions rather than being imposed by game mechanics. In that environment, the station transforms from a battleground into a stage, where every player contributes to a collective story that is richer, slower, and far more memorable.

**Changelog**

:cl:
- remove: Removed ontags