### PR TITLE
lollypop fix

### DIFF
--- a/Content.Goobstation.Server/Lollypop/LollypopComponent.cs
+++ b/Content.Goobstation.Server/Lollypop/LollypopComponent.cs
@@ -7,19 +7,13 @@ namespace Content.Goobstation.Server.Lollypop;
 public sealed partial class LollypopComponent : Component
 {
     [DataField]
-    public FixedPoint2 Ammount = FixedPoint2.New(0.1);
+    public FixedPoint2 Amount = FixedPoint2.New(0.10);
 
     [DataField]
     public EntityUid? HeldBy = null;
 
     [DataField]
     public SlotFlags CheckSlot = SlotFlags.MASK;
-
-    [DataField]
-    public TimeSpan NextBite = TimeSpan.Zero;
-
-    [DataField]
-    public TimeSpan BiteInterval = TimeSpan.FromSeconds(3);
 
     [DataField]
     public bool DeleteOnEmpty = true; // for unique lollipops that don't get turned into trash when empty

--- a/Content.Goobstation.Server/Lollypop/LollypopComponent.cs
+++ b/Content.Goobstation.Server/Lollypop/LollypopComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Goobstation.Server.Lollypop;
 public sealed partial class LollypopComponent : Component
 {
     [DataField]
-    public FixedPoint2 Amount = FixedPoint2.New(0.10);
+    public FixedPoint2 Amount = FixedPoint2.New(0.1);
 
     [DataField]
     public EntityUid? HeldBy = null;

--- a/Content.Goobstation.Server/Lollypop/LollypopSystem.cs
+++ b/Content.Goobstation.Server/Lollypop/LollypopSystem.cs
@@ -78,8 +78,9 @@ public sealed class LollypopSystem : EntitySystem
         if (!_solutionContainer.TryGetSolution(ent.Owner, edible.Solution, out var soln, out var solution))
             return;
 
-        var split = _solutionContainer.SplitSolution(soln.Value, ent.Comp.Amount);
-
+        var transferAmount = FixedPoint2.Min( ent.Comp.Ammount, solution.Volume);
+        var split = _solutionContainer.SplitSolution(soln.Value, transferAmount);
+        
         // Get the stomach with the highest available solution volume
         var highestAvailable = FixedPoint2.Zero;
         Entity<StomachComponent>? stomachToUse = null;

--- a/Content.Goobstation.Server/Lollypop/LollypopSystem.cs
+++ b/Content.Goobstation.Server/Lollypop/LollypopSystem.cs
@@ -2,16 +2,13 @@ using Content.Server.Popups;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Goobstation.Maths.FixedPoint;
-using Content.Server.Body.Components;
 using Content.Server.Body.Systems;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Systems;
 using Content.Shared.Chemistry;
 using Content.Shared.Clothing;
-using Content.Shared.Nutrition;
 using Content.Shared.Nutrition.Components;
 using Content.Shared.Nutrition.EntitySystems;
-using Robust.Shared.Timing;
 
 namespace Content.Goobstation.Server.Lollypop;
 
@@ -25,7 +22,9 @@ public sealed class LollypopSystem : EntitySystem
     [Dependency] private readonly ReactiveSystem _reaction = default!;
     [Dependency] private readonly BodySystem _body = default!;
     [Dependency] private readonly FlavorProfileSystem _flavorProfile = default!;
-    [Dependency] private readonly IGameTiming _time = default!;
+
+    private float _updateCooldown = 3f;
+    private float _nextUpdate;
 
     public override void Initialize()
     {
@@ -35,32 +34,25 @@ public sealed class LollypopSystem : EntitySystem
 
     public override void Update(float frameTime)
     {
-        var query = EntityManager.EntityQueryEnumerator<LollypopComponent, ClothingComponent, EdibleComponent>();
-        List<(EntityUid Uid, EdibleComponent Edible, EntityUid User)>? fullyEaten = null;
+        _nextUpdate += frameTime;
 
+        if (_nextUpdate < _updateCooldown)
+            return;
+
+        var query = EntityManager.EntityQueryEnumerator<LollypopComponent, ClothingComponent, EdibleComponent>();
         while (query.MoveNext(out var queryUid, out var lollypop, out var clothing, out var edible))
         {
             if (clothing.InSlotFlag != lollypop.CheckSlot)
                 continue;
 
-            if(lollypop.NextBite > _time.CurTime && lollypop.NextBite != TimeSpan.Zero)
-                continue;
-
-            Eat((queryUid, lollypop), edible, ref fullyEaten);
-            lollypop.NextBite = _time.CurTime + lollypop.BiteInterval;
+            Eat((queryUid, lollypop), edible);
         }
-
-        if (fullyEaten != null)
-        {
-            foreach (var (uid, edible, user) in fullyEaten)
-                _ingestion.SpawnTrash((uid, edible), user);
-        }
+        _nextUpdate -= _updateCooldown;
     }
 
     private void OnEquipt(Entity<LollypopComponent> ent, ref ClothingGotEquippedEvent args)
     {
         ent.Comp.HeldBy = args.Wearer;
-        ent.Comp.NextBite = _time.CurTime + ent.Comp.BiteInterval;
 
         // add popup of taste
         if (!TryComp<EdibleComponent>(ent.Owner, out var edible))
@@ -75,24 +67,18 @@ public sealed class LollypopSystem : EntitySystem
     private void OnUnequipt(Entity<LollypopComponent> ent, ref ClothingGotUnequippedEvent args)
     {
         ent.Comp.HeldBy = null;
-        ent.Comp.NextBite = TimeSpan.Zero;
     }
 
-    private void Eat(Entity<LollypopComponent> ent, EdibleComponent edible, ref List<(EntityUid Uid, EdibleComponent Edible, EntityUid User)>? fullyEaten)
+    private void Eat(Entity<LollypopComponent> ent, EdibleComponent edible)
     {
-        if(ent.Comp.HeldBy == null)
+        if (ent.Comp.HeldBy == null ||
+            !_body.TryGetBodyOrganEntityComps<StomachComponent>(ent.Comp.HeldBy.Value, out var stomachs))
             return;
 
-        if (!TryComp<BodyComponent>(ent.Comp.HeldBy, out var body))
-            return;
-        if (!_body.TryGetBodyOrganEntityComps<StomachComponent>((ent.Comp.HeldBy.Value, body), out var stomachs))
-            return;
         if (!_solutionContainer.TryGetSolution(ent.Owner, edible.Solution, out var soln, out var solution))
             return;
 
-        var transferAmount = FixedPoint2.Min( ent.Comp.Ammount, solution.Volume);
-
-        var split = _solutionContainer.SplitSolution(soln.Value, transferAmount);
+        var split = _solutionContainer.SplitSolution(soln.Value, ent.Comp.Amount);
 
         // Get the stomach with the highest available solution volume
         var highestAvailable = FixedPoint2.Zero;
@@ -120,17 +106,15 @@ public sealed class LollypopSystem : EntitySystem
         }
 
         _reaction.DoEntityReaction(ent.Comp.HeldBy.Value, solution, ReactionMethod.Ingestion);
-        _stomach.TryTransferSolution(stomachToUse!.Value.Owner, split, stomachToUse);
+        _stomach.TryTransferSolution(stomachToUse.Value.Owner, split, stomachToUse);
 
         if (soln.Value.Comp.Solution.Volume > FixedPoint2.Zero )
-            return; // end if there is solution left
+            return;
 
         if (ent.Comp.DeleteOnEmpty)
         {
-            fullyEaten ??= new List<(EntityUid, EdibleComponent, EntityUid)>();
-            fullyEaten.Add((ent.Owner, edible, ent.Comp.HeldBy!.Value));
+            QueueDel(ent);
+            _ingestion.SpawnTrash((ent.Owner, edible), ent.Comp.HeldBy.Value);
         }
-
-        ent.Comp.NextBite = TimeSpan.Zero; // lollypop is empty stop checking
     }
 }

--- a/Content.Goobstation.Server/Lollypop/LollypopSystem.cs
+++ b/Content.Goobstation.Server/Lollypop/LollypopSystem.cs
@@ -78,9 +78,9 @@ public sealed class LollypopSystem : EntitySystem
         if (!_solutionContainer.TryGetSolution(ent.Owner, edible.Solution, out var soln, out var solution))
             return;
 
-        var transferAmount = FixedPoint2.Min( ent.Comp.Ammount, solution.Volume);
+        var transferAmount = FixedPoint2.Min(ent.Comp.Amount, solution.Volume);
         var split = _solutionContainer.SplitSolution(soln.Value, transferAmount);
-        
+
         // Get the stomach with the highest available solution volume
         var highestAvailable = FixedPoint2.Zero;
         Entity<StomachComponent>? stomachToUse = null;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
lollypop `DeleteOnSpawn` is now properly handled.
lollypop consumption update cooldown is system-wide now (perf)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<img width="753" height="75" alt="изображение" src="https://github.com/user-attachments/assets/fe9608c6-37c3-47ee-8707-711a00ca4cd4" />

## Technical details
<!-- Summary of code changes for easier review. -->
killed consumption update for each individual lollypop to prevent entity query each tick. System now handles update cooldown.
killed `fullyEaten` list because it was pure slop. now the `Eat` method just `QueueDel` lollypop entity and spawns trash.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Lollypops in mouth now actually get deleted when empty.
