### PR TITLE
Added silo production of materials

### DIFF
--- a/Content.Goobstation.Shared/Materials/MaterialProducerComponent.cs
+++ b/Content.Goobstation.Shared/Materials/MaterialProducerComponent.cs
@@ -1,0 +1,34 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Content.Shared.Materials;
+
+namespace Content.Goobstation.Shared.Materials;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(fieldDeltas: true), AutoGenerateComponentPause]
+public sealed partial class MaterialProducerComponent : Component
+{
+    /// <summary>
+    /// How much and what type of materials should be produced.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Dictionary<ProtoId<MaterialPrototype>, int> MaterialsProduce = new();
+
+    /// <summary>
+    /// Should materials be produced when there is no electricity.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool IsWorkingWithoutElectricity = false;
+
+    /// <summary>
+    /// What is the time interval between production.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public TimeSpan ProductionDelay = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// When should the next batch of materials be produced.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField, AutoNetworkedField]
+    public TimeSpan NextProduceTime = TimeSpan.Zero;
+}

--- a/Content.Goobstation.Shared/Materials/MaterialProducerSystem.cs
+++ b/Content.Goobstation.Shared/Materials/MaterialProducerSystem.cs
@@ -1,0 +1,31 @@
+using Content.Shared.Materials;
+using Robust.Shared.Timing;
+using Content.Shared.Power.EntitySystems;
+using Content.Shared.Power.Components;
+
+namespace Content.Goobstation.Shared.Materials;
+
+public class MaterialProducer : EntitySystem
+{
+    [Dependency] private readonly SharedMaterialStorageSystem _materialStorage = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedPowerReceiverSystem _power = default!;
+
+    public override void Update(float frameTime)
+    {
+        var query = EntityQueryEnumerator<MaterialProducerComponent, MaterialStorageComponent>();
+        while (query.MoveNext(out var uid, out var producer, out var storage))
+        {
+            if (_timing.CurTime < producer.NextProduceTime)
+                continue;
+
+            producer.NextProduceTime = _timing.CurTime + producer.ProductionDelay;
+
+            if (!producer.IsWorkingWithoutElectricity
+                && !_power.IsPowered(uid))
+                continue;
+
+            _materialStorage.TryChangeMaterialAmount((uid, storage), producer.MaterialsProduce);
+        }
+    }
+}

--- a/Content.Shared/Materials/SharedMaterialStorageSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialStorageSystem.cs
@@ -218,6 +218,28 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
         return true;
     }
 
+    // Goobstation start
+    /// <summary>
+    /// Checks if the specified materials can be changed by the specified volumes.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <param name="materials"></param>
+    /// <returns>If the amount can be changed</returns>
+    public bool CanChangeMaterialAmount(Entity<MaterialStorageComponent?> entity, Dictionary<ProtoId<MaterialPrototype>, int> materials)
+    {
+        if (!Resolve(entity, ref entity.Comp))
+            return false;
+
+        foreach (var (material, amount) in materials)
+        {
+            if (!CanChangeMaterialAmount(entity, material, amount, entity.Comp))
+                return false;
+        }
+
+        return true;
+    }
+    // Goobstation end
+
     /// <summary>
     /// Changes the amount of a specific material in the storage.
     /// Still respects the filters in place.
@@ -296,6 +318,35 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
         Dirty(entity, entity.Comp);
         return true;
     }
+
+    // Goobstation start
+    /// <summary>
+    /// Changes the amount of a specific material in the storage.
+    /// Still respects the filters in place.
+    /// </summary>
+    /// <param name="entity"></param>
+    /// <param name="materials"></param>
+    /// <returns>If the amount can be changed</returns>
+    public bool TryChangeMaterialAmount(Entity<MaterialStorageComponent?> entity, Dictionary<ProtoId<MaterialPrototype>, int> materials)
+    {
+        if (!Resolve(entity, ref entity.Comp))
+            return false;
+
+        if (!CanChangeMaterialAmount(entity, materials))
+            return false;
+
+        foreach (var (material, amount) in materials)
+        {
+            if (!TryChangeMaterialAmount(entity, material, amount, entity.Comp, false))
+                return false;
+        }
+
+        if (entity.Comp.ConnectToSilo) // Goobstation
+            _silo.DirtySilo(entity);
+        Dirty(entity, entity.Comp);
+        return true;
+    }
+    // Goobstation end
 
     /// <summary>
     /// Tries to set the amount of material in the storage to a specific value.

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/material_silo.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/material_silo.yml
@@ -39,6 +39,19 @@
   - type: DeviceLinkSink
     ports:
       - FillbotAnyItem
+  - type: MaterialProducer
+    isWorkingWithoutElectricity: true
+    materialsProduce:
+      Steel: 150
+      Glass: 150
+      Plastic: 150
+      Cloth: 20
+      Gold: 20
+      Silver: 20
+      Plasma: 20
+      Uranium: 20
+      Diamond: 2
+
 
 - type: entity
   id: BaseSiloUtilizer


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Now silo produce: 1.5 steel, glass and plastic per minute (90 per hour), 0.2 cloth, gold, silver, plasma and uranium per minute (12 per hour), 0.02 diamonds per minute (1.2 per hour).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This change is intended for cases where cargo is a total skill issue. It should not replace miners or technicians (2 hours of waiting will bring less than a crate of gold). But it should allow you to get minimal resources for some buildings or instruments. I know that you can disassemble lockers for steel, melt light bulbs into glass, boil plastic in chemmaster, and get plasma, silver, and bluespace crystals from slimes. But it doesn't seem to me that this is what departments should be doing every 4th round (at least on the server I'm playing on).
90 plastic, steel and glass per hour is 1 crate, I think this should be enough, it can also be reduced to 60 per hour.
0.2 precious materials per minute is 1 in 5 minutes, this should be enough for single boards like a chemmaster, industrial ore processor and experimental anomaly vessel, perhaps even enough for hyperconvection and small amounts of advanced chemicals.
I'm not sure about cloth, it's used quite rarely, but sometimes it comes in handy for duracloth, fultons and suits, if HOP is kind. I think 12 per hour will be enough, although more is possible.
As for diamonds, I'm not sure if they should be there at all, but they are enough for 1 gygax per hour or 12 bluespace crystals with hyperconvection.

## Technical details
<!-- Summary of code changes for easier review. -->
I had to duplicate TryChangeMaterialAmount and CanChangeMaterialAmount, since the current versions cannot accept Dictionary<ProtoId< MaterialPrototype> , int> for some reason.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Now silo produce: 1.5 steel, glass and plastic per minute (90 per hour), 0.2 cloth, gold, silver, plasma and uranium per minute (12 per hour), 0.02 diamonds per minute (1.2 per hour).
