### PR TITLE
fixed client crash when removing shadowCloak

### DIFF
--- a/Content.Shared/_Shitcode/Heretic/Systems/SharedShadowCloakSystem.cs
+++ b/Content.Shared/_Shitcode/Heretic/Systems/SharedShadowCloakSystem.cs
@@ -323,6 +323,9 @@ public abstract class SharedShadowCloakSystem : EntitySystem
 
     private void RemoveShadowCloak(Entity<ShadowCloakedComponent> ent)
     {
+        if (ent.Comp.LifeStage >= ComponentLifeStage.Stopping || TerminatingOrDeleted(ent))
+            return;
+
         _status.TryRemoveStatusEffect(ent, ent.Comp.ShadowCloakAlert, remComp: false);
         RemCompDeferred(ent.Owner, ent.Comp);
     }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Fixed a client crash occurring when ShadowCloak is removed from an entity that is already terminating (specific interactions like climbing).

## Why / Balance
Client crashes.

## Technical details
Added a check for LifeStage and TerminatingOrDeleted(ent) inside RemoveShadowCloak before attempting to remove the status.

## Media
(before this fix)
![bug_crash](https://github.com/user-attachments/assets/6e16758b-bedf-4843-b9fe-26ea4cda76bd)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed a client crash occurring when Shadow Cloak is removed on specific actions like climbing.
