### PR TITLE
gemini fixes

### DIFF
--- a/Content.Goobstation.Server/CloneProjector/CloneProjectorSystem.Clone.cs
+++ b/Content.Goobstation.Server/CloneProjector/CloneProjectorSystem.Clone.cs
@@ -92,11 +92,11 @@ public partial class CloneProjectorSystem
         if (!projector.Comp.DoStun)
             return;
 
-        if (HasComp<WearingCloneProjectorComponent>(host))
-        {
-            _stun.TryUpdateParalyzeDuration(host, projector.Comp.StunDuration);
-            _damageable.TryChangeDamage(host, projector.Comp.DamageOnDestroyed, true, targetPart: TargetBodyPart.Groin);
-        }
+        if (!HasComp<WearingCloneProjectorComponent>(host))
+            return;
+
+        _stun.TryUpdateParalyzeDuration(host, projector.Comp.StunDuration);
+        _damageable.TryChangeDamage(host, projector.Comp.DamageOnDestroyed, true, targetPart: TargetBodyPart.Groin);
     }
     private void OnExamined(Entity<HolographicCloneComponent> clone, ref ExaminedEvent args)
     {

--- a/Content.Goobstation.Server/CloneProjector/CloneProjectorSystem.Clone.cs
+++ b/Content.Goobstation.Server/CloneProjector/CloneProjectorSystem.Clone.cs
@@ -4,11 +4,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Goobstation.Common.Temperature;
 using Content.Goobstation.Shared.CloneProjector.Clone;
+using Content.Goobstation.Shared.Temperature;
 using Content.Server.Emp;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds.Components;
 using Content.Shared._Shitmed.Targeting;
 using Content.Shared.Body.Systems;
+using Content.Shared.Damage;
 using Content.Shared.Examine;
 using Content.Shared.Mobs;
 using Content.Shared.Popups;
@@ -26,6 +29,35 @@ public partial class CloneProjectorSystem
         SubscribeLocalEvent<HolographicCloneComponent, MobStateChangedEvent>(OnCloneStateChanged);
         SubscribeLocalEvent<HolographicCloneComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<HolographicCloneComponent, EmpPulseEvent>(OnEmpPulse);
+
+        SubscribeLocalEvent<HolographicCloneComponent, DamageModifyEvent>(OnCloneDamageModify);
+        SubscribeLocalEvent<HolographicCloneComponent, TemperatureImmunityEvent>(OnTemperatureImmunityCheck);
+    }
+
+    // make clone immune to harmful temperature changes while stored away, to prevent death loops and such.
+    // emergency cooling/heating when stored inside device i guess, idfk who cares
+    private void OnTemperatureImmunityCheck(Entity<HolographicCloneComponent> clone, ref TemperatureImmunityEvent args)
+    {
+        if (clone.Comp.HostProjector is not { } projector
+            || IsCloneDeployed(projector))
+            return;
+
+        var thresholdEv = new GetTemperatureThresholdsEvent();
+        RaiseLocalEvent(clone, ref thresholdEv);
+
+        var freezeT = thresholdEv.ColdDamageThreshold;
+        var meltT = thresholdEv.HeatDamageThreshold;
+
+        args.CurrentTemperature = Math.Clamp(args.CurrentTemperature, freezeT, meltT);
+    }
+
+    // to prevent clone from taking damage while stored away
+    private void OnCloneDamageModify(Entity<HolographicCloneComponent> clone, ref DamageModifyEvent args)
+    {
+        if (clone.Comp.HostProjector is not { } projector
+            || IsCloneDeployed(projector))
+            return;
+        args.Damage *= 0;
     }
 
     private void OnInit(Entity<HolographicCloneComponent> clone, ref MapInitEvent args)

--- a/Content.Goobstation.Server/CloneProjector/CloneProjectorSystem.Clone.cs
+++ b/Content.Goobstation.Server/CloneProjector/CloneProjectorSystem.Clone.cs
@@ -60,8 +60,11 @@ public partial class CloneProjectorSystem
         if (!projector.Comp.DoStun)
             return;
 
-        _stun.TryUpdateParalyzeDuration(host, projector.Comp.StunDuration);
-        _damageable.TryChangeDamage(host, projector.Comp.DamageOnDestroyed, true, targetPart: TargetBodyPart.Groin);
+        if (HasComp<WearingCloneProjectorComponent>(host))
+        {
+            _stun.TryUpdateParalyzeDuration(host, projector.Comp.StunDuration);
+            _damageable.TryChangeDamage(host, projector.Comp.DamageOnDestroyed, true, targetPart: TargetBodyPart.Groin);
+        }
     }
     private void OnExamined(Entity<HolographicCloneComponent> clone, ref ExaminedEvent args)
     {

--- a/Content.Goobstation.Server/CloneProjector/CloneProjectorSystem.cs
+++ b/Content.Goobstation.Server/CloneProjector/CloneProjectorSystem.cs
@@ -328,6 +328,14 @@ public sealed partial class CloneProjectorSystem : SharedCloneProjectorSystem
         return true;
     }
 
+    private bool IsCloneDeployed(CloneProjectorComponent projector)
+    {
+        if (projector.CloneUid is not { } clone)
+            return false;
+
+        return !_container.IsEntityOrParentInContainer(clone);
+    }
+
     private bool TryDeployClone(CloneProjectorComponent projector)
     {
         if (projector.CloneUid is not { } clone

--- a/Content.Goobstation.Server/CloneProjector/CloneProjectorSystem.cs
+++ b/Content.Goobstation.Server/CloneProjector/CloneProjectorSystem.cs
@@ -304,7 +304,7 @@ public sealed partial class CloneProjectorSystem : SharedCloneProjectorSystem
     public bool TryInsertClone(Entity<CloneProjectorComponent> projector, bool doCooldown = false)
     {
         if (projector.Comp.CloneUid is not { } clone
-            || _container.IsEntityOrParentInContainer(clone))
+            || !IsCloneDeployed(projector))
             return false;
 
         CleanClone(clone);
@@ -339,7 +339,7 @@ public sealed partial class CloneProjectorSystem : SharedCloneProjectorSystem
     private bool TryDeployClone(CloneProjectorComponent projector)
     {
         if (projector.CloneUid is not { } clone
-            || !_container.IsEntityOrParentInContainer(clone))
+            || IsCloneDeployed(projector))
             return false;
 
         return _container.TryRemoveFromContainer(clone);


### PR DESCRIPTION
## About the PR
gemini now invulnerable while stored in the projector, projector now clamps the gemini's body temperature to safe levels, gemini no longer magically damages host on death if the host already took the projector off
will close #4536
will close #6304
will close #4948

## Why / Balance
[#4536 #6304 #4948](https://private-user-images.githubusercontent.com/154002422/508560072-ddab2ab0-d43a-4a80-bb91-6ebf401e6c3d.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzYyODIxMDYsIm5iZiI6MTc3NjI4MTgwNiwicGF0aCI6Ii8xNTQwMDI0MjIvNTA4NTYwMDcyLWRkYWIyYWIwLWQ0M2EtNGE4MC1iYjkxLTZlYmY0MDFlNmMzZC5tcDQ_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwNDE1JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDQxNVQxOTM2NDZaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT02ODllMTMyMWNmMmM5ZTRkYjZmMzNiYjkwZTQ4NmE1Mjk0MDUyNDJjNWZiZWNhMTNlYzkxYTQ1ZTkxMDcxMWEwJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZyZXNwb25zZS1jb250ZW50LXR5cGU9dmlkZW8lMkZtcDQifQ.tYyCrL9d60tdbx30pdwTlcTgeIaCA3pPp0hNAOEsrV0)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: rivermyth
- fix: Gemini is now invulnerable whilst stored inside of the projector.
- fix: Gemini's death will no longer magically damage its host after the projector has already been removed.
- tweak: Gemini's body temperature is now automatically cooled to safe levels while inside the projector.