### PR TITLE
Unchuddify chaplain slop + ontag chaplain

### DIFF
--- a/Content.Goobstation.Shared/Boomerang/BoomerangSystem.cs
+++ b/Content.Goobstation.Shared/Boomerang/BoomerangSystem.cs
@@ -12,8 +12,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using System.Numerics;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Throwing;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Map;
 
 namespace Content.Goobstation.Shared.Boomerang;
@@ -21,6 +24,8 @@ namespace Content.Goobstation.Shared.Boomerang;
 public sealed class BoomerangSystem : EntitySystem
 {
     [Dependency] private readonly ThrowingSystem _throwingSystem = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
 
     private List<(EntityUid, EntityCoordinates, float, EntityUid?)> _toThrow = new();
@@ -30,6 +35,23 @@ public sealed class BoomerangSystem : EntitySystem
         base.Initialize();
         SubscribeLocalEvent<BoomerangComponent, LandEvent>(OnLanded);
         SubscribeLocalEvent<BoomerangComponent, ThrownEvent>(OnThrown);
+        SubscribeLocalEvent<BoomerangComponent, ThrowDoHitEvent>(OnHit);
+    }
+
+    private void OnHit(Entity<BoomerangComponent> ent, ref ThrowDoHitEvent args)
+    {
+        if (!TryComp(args.Thrown, out PhysicsComponent? body) || args.Component.Thrower is not { } thrower)
+            return;
+
+        var ourCoords = _transform.GetMapCoordinates(args.Thrown);
+        var throwerCoords = _transform.GetMapCoordinates(thrower);
+
+        if (ourCoords.MapId != throwerCoords.MapId)
+            return;
+
+        var vec = (throwerCoords.Position - ourCoords.Position).Normalized() * body.LinearVelocity.Length();
+
+        _physics.SetLinearVelocity(args.Thrown, vec, body: body);
     }
 
     public override void Update(float frameTime)
@@ -38,8 +60,11 @@ public sealed class BoomerangSystem : EntitySystem
 
         foreach (var (uid, coords, speed, thrower) in _toThrow)
         {
-            if (!TerminatingOrDeleted(uid) && (thrower == null || !TerminatingOrDeleted(thrower)))
-                _throwingSystem.TryThrow(uid, coords, speed, user: thrower, recoil: false, playSound: false);
+            if (TerminatingOrDeleted(uid) || thrower != null && TerminatingOrDeleted(thrower))
+                continue;
+
+            _physics.SetLinearVelocity(uid, Vector2.Zero);
+            _throwingSystem.TryThrow(uid, coords, speed, user: thrower, recoil: false, playSound: false);
         }
 
         _toThrow.Clear();

--- a/Content.Goobstation.Shared/Grab/GrabbingItemSystem.cs
+++ b/Content.Goobstation.Shared/Grab/GrabbingItemSystem.cs
@@ -31,10 +31,8 @@ public sealed class GrabbingItemSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<GrabbingItemComponent, MeleeHitEvent>(OnMeleeHitEvent);
-        SubscribeLocalEvent<GrabbingItemComponent, AttemptMeleeEvent>(OnMeleeAttempt);
         SubscribeLocalEvent<GrabbingItemComponent, HeldRelayedEvent<FindGrabbingItemEvent>>(OnGetGrabbingItem);
         SubscribeLocalEvent<GrabbingItemComponent, HeldRelayedEvent<StopGrabbingItemPullEvent>>(OnPullStopped);
-        SubscribeLocalEvent<GrabbingItemComponent, BeforeThrowEvent>(OnBeforeThrow);
     }
 
     private void OnPullStopped(Entity<GrabbingItemComponent> ent, ref HeldRelayedEvent<StopGrabbingItemPullEvent> args)
@@ -52,36 +50,6 @@ public sealed class GrabbingItemSystem : EntitySystem
             return;
 
         args.Args.GrabbingItem = ent;
-    }
-
-    private void OnBeforeThrow(Entity<GrabbingItemComponent> ent, ref BeforeThrowEvent args)
-    {
-        if (ent.Comp.ActivelyGrabbingEntity == null)
-            return;
-
-        args.Cancelled = true;
-
-        _grabbing.ThrowGrabbedEntity(args.PlayerUid, args.Direction);
-    }
-
-    private void OnMeleeAttempt(Entity<GrabbingItemComponent> ent, ref AttemptMeleeEvent args)
-    {
-        if (args.Cancelled)
-            return;
-
-        var grabbed = ent.Comp.ActivelyGrabbingEntity;
-
-        if (grabbed == null)
-            return;
-
-        if (!args.IsHeavyAttack && (!TryComp(args.User, out GrabIntentComponent? grabIntent) ||
-            grabIntent.GrabStage < GrabStage.Suffocate))
-            return;
-
-        args.Cancelled = true;
-        args.Message = Loc.GetString("grabbing-item-attack-fail",
-            ("item", Identity.Entity(ent.Owner, EntityManager)),
-            ("grabbed", Identity.Entity(grabbed.Value, EntityManager)));
     }
 
     private void OnMeleeHitEvent(Entity<GrabbingItemComponent> ent, ref MeleeHitEvent args)

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -823,7 +823,6 @@
       playerRatio: 10
       blacklist:
         components:
-        - BibleUser
         - ZombieImmune
         - AntagImmune
       briefing:

--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -54,7 +54,6 @@
       allowNonHumans: true
       multiAntagSetting: NotExclusive
       startingGear: ThiefGear
-      jobBlacklist: [ Chaplain ] # GOOBSTATION
       blacklist:
         components:
         - CommandStaff

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -497,7 +497,6 @@
     - prefRoles: [ InitialInfected ]
       max: 4
       playerRatio: 15
-      jobBlacklist: [ Chaplain ] # Goobstation
       blacklist:
         components:
         - CommandStaff # Goobstation

--- a/Resources/Prototypes/_EinsteinEngines/Gamerules/shadowling.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Gamerules/shadowling.yml
@@ -10,7 +10,6 @@
     - prefRoles: [ Shadowling ]
       playerRatio: 30
       chaosScore: 500
-      jobBlacklist: [ Chaplain ] # GOOBSTATION
       blacklist:
         components:
         - CommandStaff

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hoods.yml
@@ -62,7 +62,7 @@
     sprite: _Goobstation/Heretic/Clothing/Head/toy_hood.rsi
 
 - type: entity
-  parent: ClothingHeadBase
+  parent: ClothingHeadHatHelmetTemplar
   id: ClothingHeadHatHoodSchemaMonk
   categories: [ HideSpawnMenu ]
   name: hood of a monastic vestments
@@ -78,21 +78,3 @@
   - type: HideLayerClothing
     slots:
     - Hair
-  - type: Armor
-    coverage:
-    - Head
-    modifiers:
-      coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
-        Heat: 0.5
-        Caustic: 0.5
-    traumaDeductions:
-      Dismemberment: 0.5
-      OrganDamage: 0.5
-      BoneDamage: 0.5
-      VeinsDamage: 0.0
-      NerveDamage: 0.0
-  - type: FireProtection
-    reduction: 0.1

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/specific.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/specific.yml
@@ -165,7 +165,7 @@
       head: ClothingHeadHatHoodHereticCostume
 
 - type: entity
-  parent: ClothingOuterBaseToggleable
+  parent: [ClothingOuterArmorTemplar, ClothingOuterBaseToggleable]
   id: ClothingOuterSchemaMonk
   name: monastic vestments
   description: A sign of complete renunciation of the world and the acceptance of heroism. It is worn by those who have chosen the path of prayer and struggle for the human soul. In the silence of the cosmos, it seems especially appropriate.
@@ -177,25 +177,3 @@
   - type: ToggleableClothing
     clothingPrototypes:
       head: ClothingHeadHatHoodSchemaMonk
-  - type: Armor
-    coverage:
-    - Chest
-    - Groin
-    - Arm
-    - Hand
-    - Leg
-    - Foot
-    - Tail
-    modifiers:
-      coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
-        Heat: 0.5
-        Caustic: 0.5
-    traumaDeductions:
-      Dismemberment: 0.5
-      OrganDamage: 0.5
-      BoneDamage: 0.5
-      VeinsDamage: 0.0
-      NerveDamage: 0.0

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -67,7 +67,6 @@
       max: 4
       playerRatio: 12
       chaosScore: 200
-      jobBlacklist: [ Chaplain ] # GOOBSTATION
       blacklist:
         components:
         - CommandStaff

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -278,7 +278,6 @@
     definitions:
     - prefRoles: [ Blob ]
       allowNonHumans: true
-      jobBlacklist: [ Chaplain ] # Goobstation
       blacklist:
         components:
         - CommandStaff

--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -68,7 +68,6 @@
       max: 2
       playerRatio: 20
       lateJoinAdditional: true
-      jobBlacklist: [ Chaplain ] # GOOBSTATION
       blacklist:
         components:
         - CommandStaff

--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -38,7 +38,6 @@
       playerRatio: 15
       chaosScore: 250
       lateJoinAdditional: true
-      jobBlacklist: [ Chaplain, ] # GOOBSTATION
       blacklist:
         components:
         - CommandStaff

--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -38,6 +38,7 @@
       playerRatio: 15
       chaosScore: 250
       lateJoinAdditional: true
+      jobBlacklist: [ Chaplain ] # GOOBSTATION
       blacklist:
         components:
         - CommandStaff
@@ -67,6 +68,7 @@
       max: 2
       playerRatio: 20
       lateJoinAdditional: true
+      jobBlacklist: [ Chaplain ] # GOOBSTATION
       blacklist:
         components:
         - CommandStaff


### PR DESCRIPTION
## About the PR
Fixed new armor for chaplain. Now it has same resistances as other chap armor. No 50% pierce for chaplain.
Fedora fixed (trauma ported: https://github.com/Trauma-Station/Trauma-Station/pull/1956). Changed boomerang system - now it bounces from target when it hits (mjollnir and boomerang are fixed too) before it was hitting target multiple times.
Godhand reworked. Now you cant throw after grab when you used it. You also can hit when your target is choke grabbed.
Chaplains can be most of antags except cosmic cultist, devil and heretic now.

## Why / Balance
New armor is not good for balance at all. 50% resistance for brute and heat with wound resistances </3
Godhand throw too evil.
Fedora was bugged.
And there is no reason to not allow chaplain to be antag at all. ~Heretic chaplain is ss13 parity and can be funny (RP OPPORTUNITY)~ (chat dont think so)

## Media

https://github.com/user-attachments/assets/c595f57f-bf70-4665-b5f3-281e20ebe4fa

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed monastic vestments resistances.
- fix: Fixed boomerangs hitting targets multiple times.
- remove: Removed godhand throw.
- add: Chaplains can be most of antags except cosmic cultist, devil and heretic now.
