### PR TITLE
Made automation more accessible

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
@@ -49,7 +49,7 @@
 
 - type: entity
   id: ChemMaster
-  parent: [ BaseMachinePowered, ConstructibleMachine ]
+  parent: [ BaseMachinePowered, ConstructibleMachine, BaseAutomatedMachine ] # Goob: Automation
   name: ChemMaster 4000
   description: An industrial grade chemical manipulator with pill and bottle production included.
   placement:

--- a/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
@@ -83,7 +83,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: entity
-  parent: BaseMachinePowered
+  parent: [ BaseMachinePowered, BaseAutomatedMachine ] # Goob: Automation
   id: FaxMachineBase
   name: long range fax machine
   description: Bluespace technologies on the application of bureaucracy.

--- a/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
@@ -12,7 +12,7 @@
 
 - type: entity
   id: MachineFlatpacker
-  parent: [ BaseMachinePowered, ConstructibleMachine, BaseSiloUtilizer ] # Goob edit
+  parent: [ BaseMachinePowered, ConstructibleMachine, BaseSiloUtilizer, BaseAutomatedMachine ] # Goob: Automation + silo
   name: Flatpacker 1001
   description: An industrial machine used for expediting machine construction across the station.
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -282,7 +282,7 @@
 
 - type: entity
   id: BaseLathe
-  parent: [ BaseMachinePowered, ConstructibleMachine ]
+  parent: [ BaseMachinePowered, ConstructibleMachine, BaseAutomatedMachine ] # Goob: Automation
   abstract: true
   name: lathe
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
@@ -109,7 +109,7 @@
 
 - type: entity
   id: KitchenMicrowave
-  parent: [ BaseMachinePowered, SmallConstructibleMachine ]
+  parent: [ BaseMachinePowered, SmallConstructibleMachine, BaseAutomatedMachine ] # Goob: Automation
   name: microwave
   description: It's magic.
   components:

--- a/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
@@ -36,7 +36,7 @@
 
 - type: entity
   id: KitchenReagentGrinder
-  parent: [ BaseMachinePowered, SmallConstructibleMachine ]
+  parent: [ BaseMachinePowered, SmallConstructibleMachine, BaseAutomatedMachine ] # Goob: Automation
   name: reagent grinder
   description: From BlenderTech. Will It Blend? Let's find out!
   suffix: grinder/juicer

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -516,7 +516,7 @@
     board: HellfireHeaterMachineCircuitBoard
 
 - type: entity
-  parent: [ BaseMachinePowered, SmallConstructibleMachine ]
+  parent: [ BaseMachinePowered, SmallConstructibleMachine, BaseAutomatedMachine ] # Goob: Automation
   id: BaseGasCondenser
   name: condenser
   description: Condenses gases into liquids. Now we just need some plumbing.

--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/units.yml
@@ -29,7 +29,7 @@
 - type: entity
   abstract: true
   id: DisposalUnitBase
-  parent: BaseMachinePowered
+  parent: [ BaseMachinePowered, BaseAutomatedMachine ] # Goob: Automation
   description: A pneumatic waste disposal unit.
   placement:
     mode: SnapgridCenter

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
@@ -32,7 +32,7 @@
 
 - type: entity
   id: RadiationCollector
-  parent: ConstructibleMachine # Goobstation
+  parent: [ ConstructibleMachine, BaseAutomatedMachine ] # Goob: Automation
   name: radiation collector
   suffix: Empty tank
   description: A machine that collects radiation and turns it into power. Requires plasma gas to function.

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -64,7 +64,7 @@
 
 - type: entity
   abstract: true
-  parent: BaseStructureDynamic
+  parent: [ BaseStructureDynamic, BaseAutomatedMachine ] # Goob: Automation
   id: GasCanister
   name: gas canister
   description: A canister that can contain any type of gas. It can be attached to connector ports using a wrench.

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -168,7 +168,6 @@
   - LatheUpgradeKitCryo
   # End DeltaV Additions
   # Begin Goobstation Additions
-  - UpgradeKitAutomation
   - RoboticArmCircuitboard
   - ConstructorCircuitboard
   - StorageBinCircuitboard

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/upgrade_kits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/upgrade_kits.yml
@@ -6,31 +6,6 @@
 
 - type: entity
   parent: BaseItem
-  id: UpgradeKitAutomation
-  name: automation upgrade kit
-  description: An upgrade kit with all the parts needed to upgrade a machine. This one allows extra automation options by linking robotic arms.
-  components:
-  - type: Sprite
-    sprite: _DV/Objects/Tools/lathe_upgrade_kit.rsi
-    state: icon
-  - type: UpgradeKit
-    whitelist:
-      components:
-      - AutomationSlots # automation needs code to support it, can't work on literally any machine
-    blacklist:
-      components:
-      - Automated
-      - UpgradedMachine
-    components:
-    - type: UpgradedMachine
-      upgrade: upgrade-kit-automation
-    - type: Automated
-    - type: DeviceNetwork
-      deviceNetId: Wireless
-      receiveFrequencyId: BasicDevice
-
-- type: entity
-  parent: BaseItem
   id: AutodocUpgradeKitBluespace
   name: autodoc bluespace upgrade kit
   description: An upgrade kit with all the parts needed to upgrade an Autodoc. This one allows it to operate through clothing.

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/engineering.yml
@@ -32,7 +32,6 @@
   recipes:
   - LatheUpgradeKitHyper
   - LatheUpgradeKitCryo
-  - UpgradeKitAutomation
   - AutodocUpgradeKitBluespace
 
 - type: latheRecipePack

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/upgrade_kits.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/upgrade_kits.yml
@@ -1,14 +1,5 @@
 - type: latheRecipe
   parent: BaseUpgradeKit
-  id: UpgradeKitAutomation
-  result: UpgradeKitAutomation
-  materials:
-    Glass: 500
-    Steel: 200
-    Silver: 300
-
-- type: latheRecipe
-  parent: BaseUpgradeKit
   id: AutodocUpgradeKitBluespace
   result: AutodocUpgradeKitBluespace
   materials:

--- a/Resources/Prototypes/_Shitmed/Entities/Structures/Machines/autodoc.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Structures/Machines/autodoc.yml
@@ -9,7 +9,7 @@
 # Autodocs
 
 - type: entity
-  parent: [ConstructibleMachine, BaseMachinePowered]
+  parent: [ ConstructibleMachine, BaseMachinePowered, BaseAutomatedMachine ] # Goob: Automation
   id: Autodoc
   name: Autodoc Mk.XIV
   description: A programmable robotic surgeon capable of automatically operating on patients.


### PR DESCRIPTION
## About the PR
Removed the automation upgrade and added automation ports to every machine that supports them built-in.

## Why / Balance
To make automation more useful and let people know it even exists

**Changelog**

:cl: Rouden
- remove: Removed automation upgrades.
- tweak: All machines that support automation now have automation ports built-in.
