### PR TITLE
Fix lavaland beacons appearing in the ghost warp menu

### DIFF
--- a/Resources/Locale/en-US/_Lavaland/navmap-beacons/station-beacons.ftl
+++ b/Resources/Locale/en-US/_Lavaland/navmap-beacons/station-beacons.ftl
@@ -1,3 +1,5 @@
+station-beacon-ruin-lavaland = Lavaland
+
 station-beacon-ruin-abductor = Alien Signal
 station-beacon-ruin-arrivals = Arrivals Shuttle Signal
 station-beacon-ruin-beach-biodome = Beach Biodome
@@ -7,5 +9,4 @@ station-beacon-ruin-hunter-shelter = Hunter Signal
 station-beacon-ruin-small-outpost = Small Outpost
 station-beacon-ruin-rouge-ai = Unknown Laboratory
 station-beacon-ruin-snow-biodome = Snow Biodome
-
 station-beacon-ruin-syndicate = Syndicate Signal

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Devices/station_beacon.yml
@@ -1,11 +1,94 @@
+# A default station beacon without warp point components.
 - type: entity
-  parent: DefaultStationBeacon
+  parent: BaseItem
+  id: DefaultStationBeaconNoWarpPoints
+  name: station beacon
+  description: A small device that transmits information to station maps. Can be configured.
+  placement:
+    mode: SnapgridCenter
+  suffix: General
+  components:
+  - type: Sprite
+    sprite: Objects/Devices/station_beacon.rsi
+    drawdepth: BelowFloor
+    layers:
+    - state: blink
+      map: ["base"]
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.NavMapBeaconVisuals.Enabled:
+        base:
+          True: {state: blink}
+          False: {state: icon}
+  - type: ConfigurableNavMapBeacon
+  - type: NavMapBeacon
+    defaultText: station-beacon-general
+    color: "#D4D4D496"
+  #- type: WarpPoint
+  #- type: WizardTeleportWarpPoint
+  - type: ActivatableUI
+    key: enum.NavMapBeaconUiKey.Key
+    singleUser: true
+  - type: UserInterface
+    interfaces:
+      enum.NavMapBeaconUiKey.Key:
+        type: NavMapBeaconBoundUserInterface
+  - type: Item
+    size: Small
+  - type: Visibility
+    layer: 1
+  - type: SubFloorHide
+  - type: Anchorable
+  - type: Construction
+    graph: StationBeaconPart
+    node: complete
+  - type: CollideOnAnchor
+  - type: Physics
+    canCollide: false
+    bodyType: static
+  - type: Transform
+    anchored: true
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger: # for nukes
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+          params:
+            volume: -8
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          SheetSteel1:
+            min: 1
+            max: 1
+        offset: 0
+      - !type:DoActsBehavior
+        acts: ["Breakage"]
+  - type: StaticPrice
+    price: 25
+
+# Station beacon type placed on lavaland ruins.
+- type: entity
+  parent: DefaultStationBeaconNoWarpPoints
   id: DefaultStationBeaconLavalandRuin
-  suffix: Command
+  suffix: Lavaland Ruin
   components:
   - type: NavMapBeacon
-    defaultText: station-beacon-command
-    color: "#FFFF00"
+    defaultText: station-beacon-ruin-lavaland
+    color: "#FFAA00"
 
 - type: entity
   parent: DefaultStationBeaconLavalandRuin


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Ghosts no longer have lavaland ruin warp points.

## Why / Balance
Was never intended, it makes warp points more annoying to use and can be useful only for metagaming and literally nothing else

**Changelog**

:cl: Rouden
- fix: Fixed lavaland ruin beacons having ghost warp points.
