### PR TITLE
Disease Buff

### DIFF
--- a/Resources/Prototypes/_Goobstation/Disease/Behaviors/annoyance.yml
+++ b/Resources/Prototypes/_Goobstation/Disease/Behaviors/annoyance.yml
@@ -129,7 +129,7 @@
     components:
     - type: PermanentBlindness
   - type: DiseaseProgressCondition
-    MinProgress: 0.5
+    minProgress: 0.5
 
 - type: entity
   id: DiseaseBehaviorPainNumbness
@@ -155,7 +155,7 @@
     components:
     - type: Deaf
   - type: DiseaseProgressCondition
-    MinProgress: 0.6
+    minProgress: 0.6
 
 - type: entity
   id: DiseaseBehaviorAnxiety
@@ -225,7 +225,7 @@
     components:
     - type: BlackAndWhiteOverlay
   - type: DiseaseProgressCondition
-    MinProgress: 0.5
+    minProgress: 0.5
 
 - type: entity
   id: DiseaseBehaviorBS
@@ -243,7 +243,7 @@
       rangeMin: 0.2
       rangeMax: 2
   - type: DiseaseProgressCondition
-    MinProgress: 0.5
+    minProgress: 0.5
 
 - type: entity
   id: DiseaseBehaviorDisorientation
@@ -260,4 +260,4 @@
       walkSpeedModifier: -1
       sprintSpeedModifier: -1
   - type: DiseaseProgressCondition
-    MinProgress: 0.8
+    minProgress: 0.8

--- a/Resources/Prototypes/_Goobstation/Disease/Behaviors/annoyance.yml
+++ b/Resources/Prototypes/_Goobstation/Disease/Behaviors/annoyance.yml
@@ -5,7 +5,7 @@
   description: Makes you periodically vomit.
   components:
   - type: DiseaseEffect
-    complexity: 12 # can make you constantly hungry
+    complexity: 8 # can make you constantly hungry
   - type: DiseaseReagentEffect
     timeScale: false
     effects:
@@ -54,6 +54,8 @@
     delayMax: 12
   - type: DiseaseFlashEffect
     timeScale: false
+  - type: DiseaseProgressCondition
+    minProgress: 0.5
 
 - type: entity
   id: DiseaseBehaviorGravitosisA
@@ -114,3 +116,148 @@
   - type: DiseaseGrantComponentEffect
     components:
     - type: OwOAccent
+
+- type: entity
+  id: DiseaseBehaviorBlindness
+  parent: DiseaseBehaviorBase
+  name: Blindness
+  description: Rare disease symptom that causes complete blindness.
+  components:
+  - type: DiseaseEffect
+    complexity: 12
+  - type: DiseaseGrantComponentEffect
+    components:
+    - type: PermanentBlindness
+  - type: DiseaseProgressCondition
+    MinProgress: 0.5
+
+- type: entity
+  id: DiseaseBehaviorPainNumbness
+  parent: DiseaseBehaviorBase
+  name: Analgesia
+  description: Rare disease symptom that causes you to become insensitive to pain.
+  components:
+  - type: DiseaseEffect
+    complexity: 12
+  - type: DiseaseGrantComponentEffect
+    components:
+    - type: PainNumbness
+
+- type: entity
+  id: DiseaseBehaviorDeaf
+  parent: DiseaseBehaviorBase
+  name: Deaf
+  description: Rare disease symptom that causes complete deaf.
+  components:
+  - type: DiseaseEffect
+    complexity: 14 # VERY annoying
+  - type: DiseaseGrantComponentEffect
+    components:
+    - type: Deaf
+  - type: DiseaseProgressCondition
+    MinProgress: 0.6
+
+- type: entity
+  id: DiseaseBehaviorAnxiety
+  parent: DiseaseBehaviorBase
+  name: Anxiety
+  description: Causes anxiety and fear of hugs
+  components:
+  - type: DiseaseEffect
+    complexity: 2
+  - type: DiseaseGrantComponentEffect
+    components:
+    - type: SocialAnxiety
+
+- type: entity
+  id: DiseaseBehaviorDrowsiness
+  parent: DiseaseBehaviorBase
+  name: Drowsiness
+  description: Causes a strong desire to sleep
+  components:
+  - type: DiseaseEffect
+    complexity: 10
+  - type: DiseaseReagentEffect
+    timeScale: true
+    effects:
+    - !type:ModifyStatusEffect
+      effectProto: StatusEffectDrowsiness
+      time: 30
+      type: Add
+      refresh: false
+  - type: DiseaseEmoteEffect
+    emote: Yawn
+  - type: DiseasePeriodicCondition
+    delayMin: 15
+    delayMax: 60
+
+- type: entity
+  id: DiseaseBehaviorEuphoria
+  parent: DiseaseBehaviorBase
+  name: Euphoria
+  description: Symptom that causes happiness!
+  components:
+  - type: DiseaseEffect
+    complexity: 5
+  - type: DiseaseReagentEffect
+    timeScale: false
+    effects:
+    - !type:ModifyStatusEffect
+      effectProto: StatusEffectSeeingRainbow
+      time: 20
+      type: Add
+      refresh: true
+  - type: DiseasePeriodicCondition
+    delayMin: 10
+    delayMax: 50
+  - type: DiseaseEmoteEffect
+    emote: Laugh
+
+- type: entity
+  id: DiseaseBehaviorApathy
+  parent: DiseaseBehaviorBase
+  name: Apathy
+  description: Symptom causing the loss of world color diversity
+  components:
+  - type: DiseaseEffect
+    complexity: 5
+  - type: DiseaseGrantComponentEffect
+    components:
+    - type: BlackAndWhiteOverlay
+  - type: DiseaseProgressCondition
+    MinProgress: 0.5
+
+- type: entity
+  id: DiseaseBehaviorBS
+  parent: DiseaseBehaviorBase
+  name: Bluespace Instability
+  description: Extremely rare symptom that causes you to teleport erratically.
+  components:
+  - type: DiseaseEffect
+    complexity: 40 #there is a chance of ending up in a wall or in space
+  - type: DiseaseGrantComponentEffect
+    components:
+    - type: ChaoticJump
+      jumpMinInterval: 0
+      jumpMaxInterval: 60
+      rangeMin: 0.2
+      rangeMax: 2
+  - type: DiseaseProgressCondition
+    MinProgress: 0.5
+
+- type: entity
+  id: DiseaseBehaviorDisorientation
+  parent: DiseaseBehaviorBase
+  name: Disorientation
+  description: Rare symptom that causes disorientation in space in the final stages
+  components:
+  - type: DiseaseEffect
+    complexity: 40
+  - type: DiseaseReagentEffect
+    timeScale: false
+    effects:
+    - !type:MovespeedModifier #Literally inverts movement. If you move forward, you'll move backward, and so on.
+      walkSpeedModifier: -1
+      sprintSpeedModifier: -1
+  - type: DiseaseProgressCondition
+    MinProgress: 0.8

--- a/Resources/Prototypes/_Goobstation/Disease/Behaviors/damage.yml
+++ b/Resources/Prototypes/_Goobstation/Disease/Behaviors/damage.yml
@@ -63,7 +63,7 @@
           Poison: 1.5
           Bloodloss: 5
   - type: DiseaseProgressCondition
-    MinProgress: 0.8
+    minProgress: 0.8
 
 - type: entity
   id: DiseaseBehaviorPulmonaryEdema
@@ -81,7 +81,7 @@
         types:
           Asphyxiation: 3
   - type: DiseaseProgressCondition
-    MinProgress: 0.5
+    minProgress: 0.5
 
 - type: entity
   id: DiseaseBehaviorInternalBleeding
@@ -101,7 +101,7 @@
     - !type:ModifyBloodLevel
       amount: -8
   - type: DiseaseProgressCondition
-    MinProgress: 0.8
+    minProgress: 0.8
 
 - type: entity
   id: DiseaseBehaviorAnemia
@@ -121,7 +121,7 @@
     - !type:ModifyBloodLevel
       amount: -3
   - type: DiseaseProgressCondition
-    MinProgress: 0.9
+    minProgress: 0.9
 
 - type: entity
   id: DiseaseBehaviorOrganFailure
@@ -140,7 +140,7 @@
         types:
           Bloodloss: 200
   - type: DiseaseProgressCondition
-    MinProgress: 1
+    minProgress: 1
 
 # this is broken and hits the owning entity but i'm leaving it here so someone can fix it
 - type: entity

--- a/Resources/Prototypes/_Goobstation/Disease/Behaviors/damage.yml
+++ b/Resources/Prototypes/_Goobstation/Disease/Behaviors/damage.yml
@@ -44,7 +44,103 @@
       useTargeting: false
       damage:
         types:
-          Blunt: 0.3
+          Blunt: 0.5
+
+- type: entity
+  id: DiseaseBehaviorNecrosis
+  parent: DiseaseBehaviorBase
+  name: Necrosis
+  description: In the final stages, it deals heavy poison and blood loss damage over time.
+  components:
+  - type: DiseaseEffect
+    complexity: 40
+  - type: DiseaseReagentEffect
+    effects:
+    - !type:HealthChange
+      useTargeting: false
+      damage:
+        types:
+          Poison: 1.5
+          Bloodloss: 5
+  - type: DiseaseProgressCondition
+    MinProgress: 0.8
+
+- type: entity
+  id: DiseaseBehaviorPulmonaryEdema
+  parent: DiseaseBehaviorBase
+  name: Pulmonary edema
+  description: Deals asphyxiation damage over time.
+  components:
+  - type: DiseaseEffect
+    complexity: 14
+  - type: DiseaseReagentEffect
+    effects:
+    - !type:HealthChange
+      useTargeting: false
+      damage:
+        types:
+          Asphyxiation: 3
+  - type: DiseaseProgressCondition
+    MinProgress: 0.5
+
+- type: entity
+  id: DiseaseBehaviorInternalBleeding
+  parent: DiseaseBehaviorBase
+  name: Internal bleeding
+  description: In the final stages, deals piercing damage over time and reduces the amount of blood in the body.
+  components:
+  - type: DiseaseEffect
+    complexity: 14
+  - type: DiseaseReagentEffect
+    effects:
+    - !type:HealthChange
+      useTargeting: false
+      damage:
+        types:
+          Piercing: 0.5
+    - !type:ModifyBloodLevel
+      amount: -8
+  - type: DiseaseProgressCondition
+    MinProgress: 0.8
+
+- type: entity
+  id: DiseaseBehaviorAnemia
+  parent: DiseaseBehaviorBase
+  name: Anemia
+  description: In the final stages, deals heavy asphyxiation damage over time.
+  components:
+  - type: DiseaseEffect
+    complexity: 40
+  - type: DiseaseReagentEffect
+    effects:
+    - !type:HealthChange
+      useTargeting: false
+      damage:
+        types:
+          Asphyxiation: 8
+    - !type:ModifyBloodLevel
+      amount: -3
+  - type: DiseaseProgressCondition
+    MinProgress: 0.9
+
+- type: entity
+  id: DiseaseBehaviorOrganFailure
+  parent: DiseaseBehaviorBase
+  name: Organ Failure
+  description: In the final stage, there is a chance of instant death
+  components:
+  - type: DiseaseEffect
+    complexity: 40
+  - type: DiseaseReagentEffect
+    effects:
+    - !type:HealthChange
+      useTargeting: false
+      probability: 0.01
+      damage:
+        types:
+          Bloodloss: 200
+  - type: DiseaseProgressCondition
+    MinProgress: 1
 
 # this is broken and hits the owning entity but i'm leaving it here so someone can fix it
 - type: entity

--- a/Resources/Prototypes/_Goobstation/Disease/Behaviors/spread.yml
+++ b/Resources/Prototypes/_Goobstation/Disease/Behaviors/spread.yml
@@ -71,7 +71,7 @@
         types:
           Piercing: 4
   - type: DiseaseProgressCondition
-    MinProgress: 0.5
+    minProgress: 0.5
 
 - type: entity
   id: DiseaseBehaviorSneeze
@@ -122,7 +122,7 @@
         types:
           Slash: 5
   - type: DiseaseProgressCondition
-    MinProgress: 0.7
+    minProgress: 0.7
 
 
 - type: entity
@@ -152,4 +152,4 @@
         types:
           Slash: 20
   - type: DiseaseProgressCondition
-    MinProgress: 0.9
+    minProgress: 0.9

--- a/Resources/Prototypes/_Goobstation/Disease/Behaviors/spread.yml
+++ b/Resources/Prototypes/_Goobstation/Disease/Behaviors/spread.yml
@@ -7,7 +7,7 @@
   - type: DiseaseEffect
     complexity: 6
   - type: DiseasePeriodicCondition
-    delayMin: 5
+    delayMin: 2
     delayMax: 20
   - type: DiseaseEmoteEffect
     emote: Cough
@@ -19,3 +19,137 @@
       power: 1
       chance: 0.5
       spreadType: Aerial
+
+- type: entity
+  id: DiseaseBehaviorHonk
+  parent: DiseaseBehaviorBase
+  name: HONK!
+  description: HONK! VERY infective.
+  components:
+  - type: DiseaseEffect
+    complexity: 14
+  - type: DiseasePeriodicCondition
+    delayMin: 1
+    delayMax: 20
+  - type: DiseaseEmoteEffect
+    emote: Honk
+  - type: DiseaseSpreadEffect
+    arc: 360
+    range: 2
+    timeScale: false
+    spreadParams:
+      power: 0.5
+      chance: 0.33
+      spreadType: Aerial
+
+- type: entity
+  id: DiseaseBehaviorPneumonia
+  parent: DiseaseBehaviorBase
+  name: Pneumonia
+  description: Makes you cough. Painful to cough.
+  components:
+  - type: DiseaseEffect
+    complexity: 20
+  - type: DiseasePeriodicCondition
+    delayMin: 0
+    delayMax: 20
+  - type: DiseaseEmoteEffect
+    emote: Cough
+  - type: DiseaseSpreadEffect
+    arc: 180
+    range: 3.5
+    timeScale: false
+    spreadParams:
+      power: 1
+      chance: 0.5
+      spreadType: Aerial
+  - type: DiseaseReagentEffect
+    effects:
+    - !type:HealthChange
+      useTargeting: false
+      damage:
+        types:
+          Piercing: 4
+  - type: DiseaseProgressCondition
+    MinProgress: 0.5
+
+- type: entity
+  id: DiseaseBehaviorSneeze
+  parent: DiseaseBehaviorBase
+  name: Sneeze
+  description: Makes you sneeze. VERY infective.
+  components:
+  - type: DiseaseEffect
+    complexity: 20 #very infective
+  - type: DiseasePeriodicCondition
+    delayMin: 5
+    delayMax: 20
+  - type: DiseaseEmoteEffect
+    emote: Cough
+  - type: DiseaseSpreadEffect
+    arc: 180
+    range: 5
+    timeScale: false
+    spreadParams:
+      power: 1.5
+      chance: 0.7
+      spreadType: Aerial
+
+- type: entity
+  id: DiseaseBehaviorSkinLesion
+  parent: DiseaseBehaviorBase
+  name: Skin lesion
+  description: Deals slash damage. Infective.
+  components:
+  - type: DiseaseEffect
+    complexity: 20
+  - type: DiseasePeriodicCondition
+    delayMin: 4
+    delayMax: 60
+  - type: DiseaseSpreadEffect
+    arc: 360
+    range: 2
+    timeScale: false
+    spreadParams:
+      power: 1
+      chance: 0.6
+      spreadType: Aerial
+  - type: DiseaseReagentEffect
+    effects:
+    - !type:HealthChange
+      useTargeting: false
+      damage:
+        types:
+          Slash: 5
+  - type: DiseaseProgressCondition
+    MinProgress: 0.7
+
+
+- type: entity
+  id: DiseaseBehaviorAbscesses
+  parent: DiseaseBehaviorBase
+  name: Abscesses
+  description: In the final stages, it deals heavy slash damage. Infective.
+  components:
+  - type: DiseaseEffect
+    complexity: 40
+  - type: DiseasePeriodicCondition
+    delayMin: 20
+    delayMax: 180
+  - type: DiseaseSpreadEffect
+    arc: 360
+    range: 3.5
+    timeScale: false
+    spreadParams:
+      power: 1
+      chance: 0.8
+      spreadType: Aerial
+  - type: DiseaseReagentEffect
+    effects:
+    - !type:HealthChange
+      useTargeting: false
+      damage:
+        types:
+          Slash: 20
+  - type: DiseaseProgressCondition
+    MinProgress: 0.9

--- a/Resources/Prototypes/_Goobstation/Disease/Behaviors/weights.yml
+++ b/Resources/Prototypes/_Goobstation/Disease/Behaviors/weights.yml
@@ -10,7 +10,7 @@
     DiseaseBehaviorTemperature: 1.5
     DiseaseBehaviorCold: 1
     DiseaseBehaviorFightImmunity: 0.5
-    DiseaseBehaviorCough: 2
+    DiseaseBehaviorCough: 5
     DiseaseBehaviorHyperactive: 0.5
     DiseaseBehaviorHealing: 0.5
     DiseaseBehaviorRapidMutation: 0.5
@@ -18,3 +18,22 @@
     # DiseaseBehaviorGravitosisA: 0.025
     # DiseaseBehaviorGravitosisB: 0.0125
     # DiseaseBehaviorGravitosisC: 0.0125
+    DiseaseBehaviorHonk: 0.33
+    DiseaseBehaviorOwO: 0.01
+    DiseaseBehaviorBlindness: 0.33
+    DiseaseBehaviorPainNumbness: 0.5
+    DiseaseBehaviorDeaf: 0.25
+    DiseaseBehaviorAnxiety: 0.5
+    DiseaseBehaviorDrowsiness: 0.5
+    DiseaseBehaviorEuphoria: 0.5
+    DiseaseBehaviorBS: 0.05
+    DiseaseBehaviorDisorientation: 0.05
+    DiseaseBehaviorApathy: 0.33
+    DiseaseBehaviorNecrosis: 0.1
+    DiseaseBehaviorPulmonaryEdema: 1
+    DiseaseBehaviorInternalBleeding: 0.5
+    DiseaseBehaviorPneumonia: 0.5
+    DiseaseBehaviorSneeze: 0.5
+    DiseaseBehaviorAbscesses: 0.1
+    DiseaseBehaviorAnemia: 0.5
+    DiseaseBehaviorOrganFailure: 0.05

--- a/Resources/Prototypes/_Goobstation/Disease/animals.yml
+++ b/Resources/Prototypes/_Goobstation/Disease/animals.yml
@@ -13,13 +13,13 @@
   - type: GhostTakeoverAvailable
   - type: GrantDisease
     baseDisease: DiseaseBaseMouse
-    complexity: 30
+    complexity: 40
     possibleTypes:
     - Bacterial
     - Viral
   - type: DiseaseOnHit
     spreadParams:
-      chance: 0.2 # higher chance for plague mice
+      chance: 0.33 # higher chance for plague mice
       power: 1
       spreadType: Blood
 


### PR DESCRIPTION
## About the PR
19 new disease symptoms have been added.

## Why / Balance
Right now, the diseases are extremely boring and weak, and I hope this PR will make them more FATAL. In the future, im plan to add more ways to get sick and more fun symptoms.

Minor changes to the Plague Mouse: the chance of infection has been increased to 33%, and the severity of the disease has been raised from 30 points to 40.

### Symptoms:
annoying:
- OwOify: Extremely rare; makes you do... UwU.
- Blindness: When the disease progresses to 50%, the person goes blind.
- Analgesia: A rare symptom that disables damage display; it will be harder to tell if you’re sick or not.
- Deaf: Rare; when the disease progresses to 60%, it causes deafness, which is very annoying and confusing.
- Anxiety: Nothing interesting; just adds the Social Anxiety trait.
- Drowsiness: Causes drowsiness.
- Euphoria: Makes you laugh from time to time; causes a drug-like effect.
- Apathy: Nothing interesting; turns the entire screen gray.
- Bluespace Instability: Extremely rare; at a random moment, teleports you a short distance.
- Disorientation: Rare; peak annoying - LITERALLY inverts your movements in the final stage of infection (80%).(that is, when moving forward, you will move backward)

damage:
- Necrosis: When the disease is 80% complete, it deals 1.5 poison damage and 5 blood loss damage (Yes, the character passively regenerates most of the blood loss damage)
- Pulmonary edema: Deals asphyxiation damage
- Internal bleeding: When the disease is 80% complete, it deals piercing damage and significantly reduces the amount of blood in the body.
- Anemia: When the disease is 90% complete, it deals significant Asphyxiation damage.
- Organ Failure: When the disease is 100% complete, there is a 1% chance every second to die instantly.

spread:
- HONK!: Causes the player to honk; has a 33% chance to infect others
- Pneumonia: Causes more frequent coughing; deals Piercing damage with each cough; activates when the disease is 50% complete
- Sneeze: A more contagious version of the cough; appears to be a normal cough, but has a larger infection radius and a higher chance of infecting others
- Skin lesion: When the disease is 70% complete, deals Slash damage every 10 seconds and can infect nearby people
- Abscesses: When the disease is 90% complete, deals 20 Slash damage every 20–180 seconds and has a high chance of infecting everyone nearby

In essence, the disease has become significantly more dangerous in its later stages; that is, it starts out just as mild, but by the end, things get really bad.

## Technical details
only YML

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: 19 new diseases symptoms
- tweak: Plague Mouse: infection chance 20% -> 33%
