### PR TITLE
make `UnZombify()` actually work, make ambuzol cure zombie infection

### DIFF
--- a/Content.Server/EntityEffects/EntityEffectSystem.cs
+++ b/Content.Server/EntityEffects/EntityEffectSystem.cs
@@ -630,10 +630,18 @@ public sealed class EntityEffectSystem : EntitySystem
             return;
 
         // Goob - cure notification
-        bool wasCured = HasComp<PendingZombieComponent>(args.Args.TargetEntity) || HasComp<ZombifyOnDeathComponent>(args.Args.TargetEntity);
-
-        RemComp<ZombifyOnDeathComponent>(args.Args.TargetEntity);
-        RemComp<PendingZombieComponent>(args.Args.TargetEntity);
+        if (HasComp<ZombifyOnDeathComponent>(args.Args.TargetEntity)
+            || HasComp<PendingZombieComponent>(args.Args.TargetEntity))
+        {
+            RemComp<ZombifyOnDeathComponent>(args.Args.TargetEntity);
+            RemComp<PendingZombieComponent>(args.Args.TargetEntity);
+            
+            _popup.PopupEntity(
+                Loc.GetString("zombie-cured-popup"),
+                args.Args.TargetEntity,
+                PopupType.Medium
+            );
+        }
 
         if (args.Effect.Innoculate)
         {
@@ -647,7 +655,11 @@ public sealed class EntityEffectSystem : EntitySystem
             && mobStateComp.CurrentState != Shared.Mobs.MobState.Alive)
         {
             if (_zombie.UnZombify(args.Args.TargetEntity, args.Args.TargetEntity, zombieComp))
-                wasCured = true;
+                _popup.PopupEntity(
+                    Loc.GetString("zombie-cured-popup"),
+                    args.Args.TargetEntity,
+                    PopupType.Medium
+                );
             else
                 _popup.PopupEntity(
                     Loc.GetString("zombie-cure-failed-popup"),
@@ -655,16 +667,6 @@ public sealed class EntityEffectSystem : EntitySystem
                     PopupType.Medium
                 );
         }
-
-        // Goob - zombie cure notification
-        if (!wasCured)
-            return;
-
-        _popup.PopupEntity(
-            Loc.GetString("zombie-cured-popup"),
-            args.Args.TargetEntity,
-            PopupType.Medium
-        );
     }
 
     private void OnExecuteEmote(ref ExecuteEntityEffectEvent<Emote> args)

--- a/Content.Server/EntityEffects/EntityEffectSystem.cs
+++ b/Content.Server/EntityEffects/EntityEffectSystem.cs
@@ -646,8 +646,14 @@ public sealed class EntityEffectSystem : EntitySystem
             && TryComp(args.Args.TargetEntity, out MobStateComponent? mobStateComp)
             && mobStateComp.CurrentState != Shared.Mobs.MobState.Alive)
         {
-            _zombie.UnZombify(args.Args.TargetEntity, args.Args.TargetEntity, zombieComp);
-            wasCured = true;
+            if (_zombie.UnZombify(args.Args.TargetEntity, args.Args.TargetEntity, zombieComp))
+                wasCured = true;
+            else
+                _popup.PopupEntity(
+                    Loc.GetString("zombie-cure-failed-popup"),
+                    args.Args.TargetEntity,
+                    PopupType.Medium
+                );
         }
 
         // Goob - zombie cure notification

--- a/Content.Server/EntityEffects/EntityEffectSystem.cs
+++ b/Content.Server/EntityEffects/EntityEffectSystem.cs
@@ -50,6 +50,8 @@ using Robust.Shared.Random;
 using TemperatureCondition = Content.Shared.EntityEffects.EffectConditions.Temperature; // disambiguate the namespace
 using PolymorphEffect = Content.Shared.EntityEffects.Effects.Polymorph;
 
+using Content.Shared.Mobs.Components; // Goob - zombie cure
+
 namespace Content.Server.EntityEffects;
 
 public sealed class EntityEffectSystem : EntitySystem
@@ -79,6 +81,7 @@ public sealed class EntityEffectSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _xform = default!;
     [Dependency] private readonly VomitSystem _vomit = default!;
     [Dependency] private readonly TurfSystem _turf = default!; //todo Goobstation? The only thing im using this for is meant to be in RT? Fix if you havent
+    [Dependency] private readonly ZombieSystem _zombie = default!; // Goob - zombie cure
 
     public override void Initialize()
     {
@@ -632,6 +635,15 @@ public sealed class EntityEffectSystem : EntitySystem
         if (args.Effect.Innoculate)
         {
             EnsureComp<ZombieImmuneComponent>(args.Args.TargetEntity);
+        }
+
+        // Goob - zombie cure
+        if (args.Effect.CureCriticalZombies
+            && TryComp(args.Args.TargetEntity, out ZombieComponent? zombieComp)
+            && TryComp(args.Args.TargetEntity, out MobStateComponent? mobStateComp)
+            && mobStateComp.CurrentState != Shared.Mobs.MobState.Alive)
+        {
+            _zombie.UnZombify(args.Args.TargetEntity, args.Args.TargetEntity, zombieComp);
         }
     }
 

--- a/Content.Server/EntityEffects/EntityEffectSystem.cs
+++ b/Content.Server/EntityEffects/EntityEffectSystem.cs
@@ -629,6 +629,9 @@ public sealed class EntityEffectSystem : EntitySystem
         if (HasComp<IncurableZombieComponent>(args.Args.TargetEntity))
             return;
 
+        // Goob - cure notification
+        bool wasCured = HasComp<PendingZombieComponent>(args.Args.TargetEntity) || HasComp<ZombifyOnDeathComponent>(args.Args.TargetEntity);
+
         RemComp<ZombifyOnDeathComponent>(args.Args.TargetEntity);
         RemComp<PendingZombieComponent>(args.Args.TargetEntity);
 
@@ -644,7 +647,18 @@ public sealed class EntityEffectSystem : EntitySystem
             && mobStateComp.CurrentState != Shared.Mobs.MobState.Alive)
         {
             _zombie.UnZombify(args.Args.TargetEntity, args.Args.TargetEntity, zombieComp);
+            wasCured = true;
         }
+
+        // Goob - zombie cure notification
+        if (!wasCured)
+            return;
+
+        _popup.PopupEntity(
+            Loc.GetString("zombie-cured-popup"),
+            args.Args.TargetEntity,
+            PopupType.Medium
+        );
     }
 
     private void OnExecuteEmote(ref ExecuteEntityEffectEvent<Emote> args)

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -103,6 +103,7 @@ using Content.Shared.Mech.Components;
 using Content.Shared.Rejuvenate; // Shitmed Change
 using Content.Shared.NPC.Prototypes;
 using Content.Shared.Mech.EntitySystems; // Goobstation
+using Content.Server.Cloning; // Goob - zedcure
 
 namespace Content.Server.Zombies;
 
@@ -129,6 +130,7 @@ public sealed partial class ZombieSystem
     [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly ISharedPlayerManager _player = default!;
     [Dependency] private readonly SharedMechSystem _mech = default!; // Goobstation
+    [Dependency] private readonly CloningSystem _cloning = default!; // Goob - zombie cure
 
     private static readonly ProtoId<TagPrototype> CannotSuicideTag = "CannotSuicide";
     private static readonly ProtoId<NpcFactionPrototype> ZombieFaction = "Zombie";
@@ -168,7 +170,19 @@ public sealed partial class ZombieSystem
 
         //you're a real zombie now, son.
         RaiseLocalEvent(target, new RejuvenateEvent(false, false)); // Shitmed Change
+
+        // Goob start
+        if (!_cloning.TryCloning(target, null, "Antag", out var clone))
+        {
+            Log.Error($"Unable to make a clone for zombification of entity {ToPrettyString(target)}");
+            return;
+        }
+        RemComp<PendingZombieComponent>(clone.Value);
+        // Goob end
+
         var zombiecomp = AddComp<ZombieComponent>(target);
+
+        zombiecomp.BeforeZombificationReferenceEnt = clone; // Goob - reference to cloned entity, for curing later
 
         //we need to basically remove all of these because zombies shouldn't
         //get diseases, breath, be thirst, be hungry, die in space, have offspring or be paraplegic.

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -173,16 +173,16 @@ public sealed partial class ZombieSystem
 
         // Goob start
         if (!_cloning.TryCloning(target, null, "Antag", out var clone))
-        {
             Log.Error($"Unable to make a clone for zombification of entity {ToPrettyString(target)}");
-            return;
-        }
-        RemComp<PendingZombieComponent>(clone.Value);
+        else
+            RemComp<PendingZombieComponent>(clone.Value);
         // Goob end
 
         var zombiecomp = AddComp<ZombieComponent>(target);
 
-        zombiecomp.BeforeZombificationReferenceEnt = clone; // Goob - reference to cloned entity, for curing later
+        // Goob - reference to cloned entity, for curing later
+        if (clone is not null)
+            zombiecomp.BeforeZombificationReferenceEnt = clone;
 
         //we need to basically remove all of these because zombies shouldn't
         //get diseases, breath, be thirst, be hungry, die in space, have offspring or be paraplegic.

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -405,9 +405,10 @@ namespace Content.Server.Zombies
         /// </summary>
         /// <param name="source">the entity having the ZombieComponent</param>
         /// <param name="target">the entity you want to unzombify (different from source in case of cloning, for example)</param>
-        /// <param name="zombieCOmp"></param>
+        /// <param name="zombieComp"></param>
         /// <remarks>
-        ///     goob note: this now restores the character pretty much completley, upstream is only skin/eye color
+        ///     goob note: this now restores the character pretty much completely*, upstream is only skin/eye color
+        ///     *not without sacrifices to sane code
         /// </remarks>
         public bool UnZombify(EntityUid source, EntityUid target, ZombieComponent? zombieComp) // This function is really stupid but it works
         {
@@ -454,7 +455,6 @@ namespace Content.Server.Zombies
             OverrideComp<PacifiedComponent>(target, reference);
             OverrideComp<ReplacementAccentComponent>(target, reference);
             OverrideComp<PryingComponent>(target, reference);
-
             if (TryComp(reference, out BloodstreamComponent? referenceBloodstream))
             {
                 EnsureComp<BloodstreamComponent>(target);

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -80,6 +80,25 @@ using Content.Shared._EinsteinEngines.Language;
 using Content.Shared._EinsteinEngines.Language.Components;
 using Content.Shared._EinsteinEngines.Language.Events;
 
+// Goob start - zombie cure
+using Content.Shared.Body.Components;
+using Content.Server.Temperature.Components;
+using Content.Server.Body.Components;
+using Content.Server.Atmos.Components;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Nutrition.AnimalHusbandry;
+using Content.Goobstation.Common.Traits;
+using Content.Shared.Interaction.Components;
+using Content.Shared.Weapons.Melee;
+using Content.Shared.Hands.Components;
+using Content.Shared.NPC.Components;
+using Content.Server.NPC.HTN;
+using Content.Shared.CombatMode.Pacification;
+using Content.Server.Speech.Components;
+using Content.Goobstation.Shared.Sprinting;
+using Content.Shared.Prying.Components;
+// Goob end
+
 namespace Content.Server.Zombies
 {
     public sealed partial class ZombieSystem : SharedZombieSystem
@@ -369,35 +388,110 @@ namespace Content.Server.Zombies
             }
         }
 
+        private void OverrideComp<T>(EntityUid target, EntityUid source) where T : IComponent // Goob, for below function
+        {
+            //Log.Error("Remove" + typeof(T).Name);
+            //RemComp<T>(target);
+            //if (!TryComp(source, out T? toCopy))
+            //    return;
+
+            //Log.Error("Copy" + typeof(T).Name);
+            //CopyComp<T>(source, target, toCopy);
+            if (!TryComp(source, out T? toCopy))
+            {
+                Log.Error("Remove" + typeof(T).Name);
+                RemComp<T>(target);
+                return;
+            }
+
+            Log.Error("Copy" + typeof(T).Name);
+            CopyComp<T>(source, target, toCopy);
+        }
+
+        // GOOB START - completely rewrote function to actually work now
         /// <summary>
         ///     This is the function to call if you want to unzombify an entity.
         /// </summary>
         /// <param name="source">the entity having the ZombieComponent</param>
         /// <param name="target">the entity you want to unzombify (different from source in case of cloning, for example)</param>
-        /// <param name="zombiecomp"></param>
+        /// <param name="zombieCOmp"></param>
         /// <remarks>
-        ///     this currently only restore the skin/eye color from before zombified
-        ///     TODO: completely rethink how zombies are done to allow reversal.
+        ///     goob note: this now restores the character pretty much completley, upstream is only skin/eye color
         /// </remarks>
-        public bool UnZombify(EntityUid source, EntityUid target, ZombieComponent? zombiecomp)
+        public bool UnZombify(EntityUid source, EntityUid target, ZombieComponent? zombieComp) // This function is really stupid but it works
         {
-            if (!Resolve(source, ref zombiecomp))
+            if (!Resolve(source, ref zombieComp))
                 return false;
 
-            foreach (var (layer, info) in zombiecomp.BeforeZombifiedCustomBaseLayers)
+            RemComp<ZombieComponent>(target);
+            if (zombieComp.BeforeZombificationReferenceEnt is not { } reference)
             {
-                _humanoidAppearance.SetBaseLayerColor(target, layer, info.Color);
-                _humanoidAppearance.SetBaseLayerId(target, layer, info.Id);
+                Log.Error($"Failed to properly reverse zombification of entity \"{ToPrettyString(target)}\"!");
+                return false;
             }
-            if (TryComp<HumanoidAppearanceComponent>(target, out var appcomp))
+
+            //OverrideComp<HumanoidAppearanceComponent>(target, referenceEnt.Value); // For some reason, this does not work properly in copying appearance
+            if (TryComp(target, out HumanoidAppearanceComponent? targetHumanoidAppearance)
+                && TryComp(reference, out HumanoidAppearanceComponent? referenceHumanoidAppearance))
             {
-                appcomp.EyeColor = zombiecomp.BeforeZombifiedEyeColor;
+                _humanoidAppearance.CloneAppearance(reference, target, referenceHumanoidAppearance, targetHumanoidAppearance);
             }
-            _humanoidAppearance.SetSkinColor(target, zombiecomp.BeforeZombifiedSkinColor, false);
-            _bloodstream.ChangeBloodReagent(target, zombiecomp.BeforeZombifiedBloodReagent);
+
+            // Override components that zombification tampers with reference clone components.
+            // - OverrideComp() just removes them if reference clone doesn't have them, otherwise copies component.
+            // - This is kind of ass but what can we do about it, at least this actually mostly fixes it unlike upstream UnZombify().
+            OverrideComp<DamageableComponent>(target, reference);
+            OverrideComp<TemperatureComponent>(target, reference);
+            OverrideComp<SprinterComponent>(target, reference);
+
+            OverrideComp<RespiratorComponent>(target, reference);
+            OverrideComp<BarotraumaComponent>(target, reference);
+            OverrideComp<HungerComponent>(target, reference);
+            OverrideComp<ThirstComponent>(target, reference);
+            OverrideComp<ReproductiveComponent>(target, reference);
+            OverrideComp<ReproductivePartnerComponent>(target, reference);
+            OverrideComp<LegsParalyzedComponent>(target, reference);
+            OverrideComp<ComplexInteractionComponent>(target, reference);
+
+            OverrideComp<MeleeWeaponComponent>(target, reference);
+
+            OverrideComp<EmoteOnDamageComponent>(target, reference);
+            OverrideComp<AutoEmoteComponent>(target, reference);
+            OverrideComp<HandsComponent>(target, reference);
+            OverrideComp<NpcFactionMemberComponent>(target, reference);
+            OverrideComp<HTNComponent>(target, reference);
+            OverrideComp<PacifiedComponent>(target, reference);
+            OverrideComp<ReplacementAccentComponent>(target, reference);
+            OverrideComp<PryingComponent>(target, reference);
+
+            if (TryComp(reference, out BloodstreamComponent? referenceBloodstream))
+            {
+                EnsureComp<BloodstreamComponent>(target);
+                _bloodstream.ChangeBloodReagent(target, referenceBloodstream.BloodReagent);
+                _bloodstream.SetBloodLossThreshold(target, referenceBloodstream.BloodlossThreshold);
+            }
+
+            // seems to fix no hand being selected
+            if (HasComp<HandsComponent>(target)
+                && _hands.TryGetEmptyHand(target, out string? emptyHand))
+            {
+                _hands.SetActiveHand(target, emptyHand);
+            }
+
+            // gotta make sure it tells them theyre no longer antag
+            var hasMind = _mind.TryGetMind(target, out var mindId, out var mind);
+            if (hasMind)
+                _role.MindRemoveRole(mindId, "MindRoleZombie");
+
+            _nameMod.RefreshNameModifiers(target);
+            _identity.QueueIdentityUpdate(target);
+
+            // free up the reference clone
+            QueueDel(reference);
 
             return true;
         }
+        // GOOB END
 
         private void OnZombieCloning(Entity<ZombieComponent> ent, ref CloningEvent args)
         {

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -390,21 +390,12 @@ namespace Content.Server.Zombies
 
         private void OverrideComp<T>(EntityUid target, EntityUid source) where T : IComponent // Goob, for below function
         {
-            //Log.Error("Remove" + typeof(T).Name);
-            //RemComp<T>(target);
-            //if (!TryComp(source, out T? toCopy))
-            //    return;
-
-            //Log.Error("Copy" + typeof(T).Name);
-            //CopyComp<T>(source, target, toCopy);
             if (!TryComp(source, out T? toCopy))
             {
-                Log.Error("Remove" + typeof(T).Name);
                 RemComp<T>(target);
                 return;
             }
 
-            Log.Error("Copy" + typeof(T).Name);
             CopyComp<T>(source, target, toCopy);
         }
 

--- a/Content.Shared/EntityEffects/Effects/CureZombieInfection.cs
+++ b/Content.Shared/EntityEffects/Effects/CureZombieInfection.cs
@@ -7,6 +7,9 @@ public sealed partial class CureZombieInfection : EventEntityEffect<CureZombieIn
     [DataField]
     public bool Innoculate;
 
+    [DataField]
+    public bool CureCriticalZombies; // Goob - whether it cures zombies in a critical state or under
+
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
     {
         if(Innoculate)

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -288,4 +288,7 @@ public sealed partial class ZombieComponent : Component
     /// </summary>
     [DataField("newBloodReagent", customTypeSerializer: typeof(PrototypeIdSerializer<ReagentPrototype>))]
     public string NewBloodReagent = "ZombieBlood";
+
+    [DataField]
+    public EntityUid? BeforeZombificationReferenceEnt; // Goob - reference clone of before zombified
 }

--- a/Resources/Locale/en-US/zombies/zombie.ftl
+++ b/Resources/Locale/en-US/zombies/zombie.ftl
@@ -20,3 +20,6 @@ zombie-role-rules = You are a [color={role-type-team-antagonist-color}][bold]{ro
 zombie-permadeath = This time, you're dead for real.
 
 zombification-resistance-coefficient-value = - [color=violet]Infection[/color] chance reduced by [color=lightblue]{$value}%[/color].
+
+# Goob
+zombie-cured-popup = The zombie infection vanishes without a trace!

--- a/Resources/Locale/en-US/zombies/zombie.ftl
+++ b/Resources/Locale/en-US/zombies/zombie.ftl
@@ -23,3 +23,4 @@ zombification-resistance-coefficient-value = - [color=violet]Infection[/color] c
 
 # Goob
 zombie-cured-popup = The zombie infection vanishes without a trace!
+zombie-cure-failed-popup = The cure fails to take hold!

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -909,6 +909,7 @@
     Medicine:
       effects:
         - !type:CureZombieInfection
+          cureCriticalZombies: true # Goob
           conditions:
             - !type:ReagentThreshold
               min: 10
@@ -926,6 +927,7 @@
       effects:
         - !type:CureZombieInfection
           innoculate: true
+          cureCriticalZombies: true # Goob
           conditions:
             - !type:ReagentThreshold
               min: 5


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
- makes the `UnZombify()` function actually do what it's meant to instead of just a hacky fix to make cloning work
- makes it so ambuzol & ambuzol plus can be used to cure critical and dead zombies, no more piles of corpses that you cant do anything with but clone

Meant to go alongside #6483

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
no more stupid round removal during zeds, will make zed rounds more interesting and not just annoying most likely.

## Technical details
<!-- Summary of code changes for easier review. -->
now makes a reference clone of character in nullspace before zombification, has reference to it stored in `ZombieComponent`. `UnZombify()` will try to override components that are tampered with by zombification based on the reference clone in order to restore their character to normal. this is Kind of shitcode but shrug, it Works...it seems. not really aware of a better way to do this

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: rivermyth
- tweak: Ambuzol can now cure dead zombies