### PR TITLE
Port Foliage Vision from Trauma.

### DIFF
--- a/Content.Goobstation.Client/Foliage/FoliageVisionSystem.cs
+++ b/Content.Goobstation.Client/Foliage/FoliageVisionSystem.cs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Client.GameObjects;
+using Robust.Client.Player;
+using Robust.Shared.Player;
+using Content.Goobstation.Shared.Foliage;
+
+namespace Content.Goobstation.Client.Foliage;
+
+public sealed class FoliageVisionSystem : EntitySystem
+{
+    private const int HighDrawDepth = 10;
+    private const int LowDrawDepth = -5;
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+    private bool _enabled;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<FoliageIgnoringVisionComponent, LocalPlayerAttachedEvent>((_, _, args) => OnLocalPlayerAttached(args));
+        SubscribeLocalEvent<FoliageIgnoringVisionComponent, LocalPlayerDetachedEvent>((_, _, args) => OnLocalPlayerDetached(args));
+        SubscribeLocalEvent<FoliageIgnoringVisionComponent, ComponentStartup>((uid, _, args) => OnPlayerComponentStartup(uid, args));
+        SubscribeLocalEvent<FoliageIgnoringVisionComponent, ComponentShutdown>((uid, _, args) => OnPlayerComponentShutdown(uid, args));
+        SubscribeLocalEvent<HideableFoliageComponent, ComponentStartup>((uid, _, args) => OnKudzuComponentStartup(uid, args));
+        SubscribeLocalEvent<HideableFoliageComponent, ComponentShutdown>((uid, _, args) => OnKudzuComponentShutdown(uid, args));
+    }
+
+    // Attaches detaches
+    private void OnLocalPlayerAttached(LocalPlayerAttachedEvent args)
+    {
+        UpdatePlayerFoliageIgnoringVision();
+    }
+
+    private void OnLocalPlayerDetached(LocalPlayerDetachedEvent args)
+    {
+        UpdatePlayerFoliageIgnoringVision();
+    }
+
+    // Player Startup/Shutdown
+    private void OnPlayerComponentStartup(EntityUid uid, ComponentStartup args)
+    {
+        if (uid == _player.LocalEntity)
+            UpdatePlayerFoliageIgnoringVision();
+    }
+
+    private void OnPlayerComponentShutdown(EntityUid uid, ComponentShutdown args)
+    {
+        if (uid == _player.LocalEntity)
+            UpdatePlayerFoliageIgnoringVision();
+    }
+
+    // Kudzu Startup/Shutdown
+    private void OnKudzuComponentStartup(EntityUid uid, ComponentStartup args)
+    {
+        UpdateFoliageDrawDepth(uid);
+    }
+
+    private void OnKudzuComponentShutdown(EntityUid uid, ComponentShutdown args)
+    {
+        UpdateFoliageDrawDepth(uid);
+    }
+
+    private void RefreshEveryPieceOfFoliage()
+    {
+        var query = EntityQueryEnumerator<HideableFoliageComponent, SpriteComponent>();
+
+        while (query.MoveNext(out var uid, out _, out var sprite))
+        {
+            UpdateFoliageDrawDepth(uid, sprite);
+        }
+    }
+
+    private void UpdateFoliageDrawDepth(EntityUid uid, SpriteComponent? sprite = null)
+    {
+        if (!Resolve(uid, ref sprite, false))
+            return;
+
+        var drawDepth = _enabled
+            ? DrawDepth.Default + LowDrawDepth
+            : DrawDepth.Default + HighDrawDepth;
+        _sprite.SetDrawDepth((uid, sprite), drawDepth);
+    }
+
+    private void UpdatePlayerFoliageIgnoringVision()
+    {
+        var previousEnabled = _enabled;
+        var attached = _player.LocalEntity;
+        var shouldHaveFoliageIgnoringVision = attached != null && HasComp<FoliageIgnoringVisionComponent>(attached.Value);
+        _enabled = shouldHaveFoliageIgnoringVision;
+        if (previousEnabled != _enabled)
+            RefreshEveryPieceOfFoliage();
+    }
+}

--- a/Content.Goobstation.Shared/Foliage/FoliageIgnoringVisionComponent.cs
+++ b/Content.Goobstation.Shared/Foliage/FoliageIgnoringVisionComponent.cs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.GameStates;
+
+namespace Content.Goobstation.Shared.Foliage;
+
+/// <summary>
+/// Makes "Foliage" with the IsFoliage Component render lower for the entity with this Component.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class FoliageIgnoringVisionComponent : Component;

--- a/Content.Goobstation.Shared/Foliage/HideableFoliageComponent.cs
+++ b/Content.Goobstation.Shared/Foliage/HideableFoliageComponent.cs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.GameStates;
+
+namespace Content.Goobstation.Shared.Foliage;
+
+/// <summary>
+/// Counts as foliage, and therefore gets a lower layer if the entity seeing them has the FoliageIgnoringVision Component.
+/// </summary>
+[RegisterComponent,NetworkedComponent]
+public sealed partial class HideableFoliageComponent : Component;

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -142,6 +142,7 @@
     understands:
     - TauCetiBasic
     - RootSpeak
+  - type: FoliageIgnoringVision # Goobstation - Dynamic Foliage Layer Changes
   - type: BodyEmotes
     soundsId: DionaBodyEmotes
   - type: IgnoreKudzu

--- a/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/kudzu.yml
@@ -65,6 +65,7 @@
       sprite: Objects/Misc/kudzu.rsi
       state: kudzu_11
       drawdepth: Overdoors
+    - type: IsFoliage # Goobstation - Dynamic Foliage Layer Changes
     - type: KudzuVisuals
     - type: Clickable
     - type: Fixtures


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Added Components so that Foliage (eg. Kudzu) is now drawn on a lower layer.
This is a Direct Port of the Code I wrote for Trauma station. If any changes are wanted please tell.

## Why / Balance
Diona are already able to move rapidly through Kudzu, it would only make sense for them to also interact and see better in it. 
It could also relatively easily be expanded to other similar entities that block tile vision and interaction.

## Technical details
Added components that give mobs Vision and that give entities the abilitiy to have their layed depth modified
Added a system that brings it all together. (Currently hardcoded, if you need that changed I can do that and read into it.)

## Media
[kudzuvisionexample.webm](https://github.com/user-attachments/assets/dcb31977-e177-464a-bb08-d1f477ae9c1f)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Vanadiom
- add: Diona can now see far better through the dense foliage of kudzu!
