### PR TITLE
Void heretic changes

### DIFF
--- a/Content.Shared/_Shitcode/Heretic/Heretic.Abilites.cs
+++ b/Content.Shared/_Shitcode/Heretic/Heretic.Abilites.cs
@@ -213,9 +213,6 @@ public sealed partial class HereticVoidPullEvent : InstantActionEvent
     };
 
     [DataField]
-    public TimeSpan StunTime = TimeSpan.FromSeconds(0.5);
-
-    [DataField]
     public TimeSpan KnockDownTime = TimeSpan.FromSeconds(3);
 
     [DataField]

--- a/Content.Shared/_Shitcode/Heretic/Systems/Abilities/SharedHereticAbilitySystem.Void.cs
+++ b/Content.Shared/_Shitcode/Heretic/Systems/Abilities/SharedHereticAbilitySystem.Void.cs
@@ -95,8 +95,7 @@ public abstract partial class SharedHereticAbilitySystem
                 targetPart: TargetBodyPart.All,
                 canMiss: false);
 
-            _stun.TryUpdateStunDuration(pookie, args.StunTime);
-            _stun.TryKnockdown(pookie.Owner, args.KnockDownTime, true);
+            _stun.TryKnockdown(pookie.Owner, args.KnockDownTime, true, drop: false);
 
             if (condition)
                 Voidcurse.DoCurse(pookie, 3);

--- a/Resources/Prototypes/_Goobstation/Actions/Heretic/path_void.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/Heretic/path_void.yml
@@ -75,7 +75,7 @@
     whitelist:
       components:
       - MobState
-    canTargetSelf: false
+    canTargetSelf: true
     event: !type:HereticVoidPrisonEvent
   - type: HereticAction
     requireMagicItem: true


### PR DESCRIPTION
## About the PR
Voidpull doesnt disarm and stun anymore. (deleted stun, bcs it causes disarm too)
You can use void prison on yourself now.

## Why / Balance
Mass AOE disarm on t2 is too evil.
Why we cant selfcast void prison :drools:

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: You can use void prison on yourself now.
- tweak: Voidpull doesnt disarm and stun anymore.
