### PR TITLE
Fix StepTriggerComp thinking deleted mice are stepping on it.

### DIFF
--- a/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
+++ b/Content.Shared/StepTrigger/Systems/StepTriggerSystem.cs
@@ -292,7 +292,7 @@ public sealed class StepTriggerSystem : EntitySystem
         if (!TryComp<StepTriggerComponent>(component.StepTrigger, out var step))
             return;
 
-        if (step.Colliding.Remove(uid) || step.CurrentlySteppedOn.Remove(uid))
+        if (step.Colliding.Remove(uid) | step.CurrentlySteppedOn.Remove(uid)) // bitwise cause we remove from both.
             Dirty(component.StepTrigger, step);
     }
 


### PR DESCRIPTION
## About the PR

tldr; Steptriggercomp tries to update its comp state but its storing deleted entities with no metadata comp and robust throws.

or, mice -> step on mouse trap -> gib -> delete -> not removed from currentlysteppedon

well, mice or anything really.

wait! we have a onterminating event! surely that should save us.

Yes, on the first part. this is a logical `OR` meaning we only remove the first. You can see this using vv and i did.

fix by having bitwise so both removes run.

## Why / Balance


## Technical details



## Media
<img width="1124" height="303" alt="image" src="https://github.com/user-attachments/assets/17754149-97a5-4649-afcb-5c4da0aaa84a" />

<img width="1363" height="852" alt="image" src="https://github.com/user-attachments/assets/6e2662c3-921a-4500-a623-7524bc5c092a" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**

not player facing unless your server is ass.
