### PR TITLE
Make lavaland enviroment less punishing

### DIFF
--- a/Content.Shared/_Lavaland/Procedural/Prototypes/LavalandRuinPoolPrototype.cs
+++ b/Content.Shared/_Lavaland/Procedural/Prototypes/LavalandRuinPoolPrototype.cs
@@ -40,7 +40,7 @@ public sealed partial class LavalandRuinPoolPrototype : IPrototype
     /// Max distance that Ruins can generate.
     /// </summary>
     [DataField]
-    public int MaxDistance = 256; // TODO make this value higher after proper GPS UI is added
+    public int MaxDistance = 256;
 
     /// <summary>
     /// List of all grid ruins and their count.

--- a/Resources/Prototypes/_Lavaland/Procedural/lavaland_planets.yml
+++ b/Resources/Prototypes/_Lavaland/Procedural/lavaland_planets.yml
@@ -65,9 +65,12 @@
         max: 120
     - weather: Ashfall
       duration:
-        min: 120
-        max: 180
+        min: 90
+        max: 120
     - weather: AshfallLight
       duration:
         min: 30
         max: 30
+  - type: LightCycle
+    duration: 900 # 15 minutes
+    minLightLevel: 0.3 # You can barely see things moving at this light level

--- a/Resources/Prototypes/_Lavaland/Procedural/lavaland_planets.yml
+++ b/Resources/Prototypes/_Lavaland/Procedural/lavaland_planets.yml
@@ -72,5 +72,5 @@
         min: 30
         max: 30
   - type: LightCycle
-    duration: 900 # 15 minutes
-    minLightLevel: 0.3 # You can barely see things moving at this light level
+    duration: 1200 # 20 minutes
+    minLightLevel: 0.4 # You can barely see things moving at this light level

--- a/Resources/Prototypes/_Lavaland/Procedural/lavaland_ruin_pools.yml
+++ b/Resources/Prototypes/_Lavaland/Procedural/lavaland_ruin_pools.yml
@@ -26,6 +26,8 @@
 
 - type: lavalandRuinPool
   id: LavalandRuins
+  ruinDistance: 14
+  maxDistance: 172
   gridRuins:
     SyndicateBase: 1
     HierophantArena: 1
@@ -57,4 +59,4 @@
     Mug: 1
     Temple: 1
   dungeonRuins:
-    CommonRuin5x5: 60
+    CommonRuin5x5: 50


### PR DESCRIPTION
## About the PR
Lavaland light cycle is now 20 minutes instead of 30.
Lavaland storms are now 1,5-2 minutes instead of 2-3.
Lavaland ruins now spawn much closer to eachother.

## Why / Balance
All these changes make exploration less punishing, since these are the factors that shaft miners can't affect in any way

## Technical details
Shrimple YAML

**Changelog**

:cl: Rouden
- tweak: Lavaland light cycle is now 20 minutes instead of 30.
- tweak: Lavaland storms are now 1,5-2 minutes instead of 2-3.
- tweak: Lavaland ruins now spawn much closer to each other.
