### PR TITLE
Autocryo system

### DIFF
--- a/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
+++ b/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
@@ -110,7 +110,7 @@ public sealed partial class GoobCVars
     /// </summary>
     public static readonly CVarDef<float> RoundEndNoEorgPopupTime =
         CVarDef.Create("game.round_end_eorg_popup_time", 5f, CVar.SERVER | CVar.REPLICATED);
-  
+
     /// Easy mode for biomass requirements on cloning. If true, 30% less biomass is required to clone mobs.
     /// </summary>
     public static readonly CVarDef<bool> CloneBiomassEasyMode =
@@ -668,4 +668,20 @@ public sealed partial class GoobCVars
     /// </summary>
     public static readonly CVarDef<float> GpsUpdateRate =
         CVarDef.Create("gps.update_rate", 1f, CVar.SERVER | CVar.REPLICATED);
+
+    #region AutoCryo
+
+    /// <summary>
+    ///     Whether SSD players will automatically cryo after being SSD for too long.
+    /// </summary>
+    public static readonly CVarDef<bool> AutoCryoEnabled =
+        CVarDef.Create("ic.auto_cryo_enabled", true, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Time in seconds after going SSD before a player automatically cryos themself.
+    /// </summary>
+    public static readonly CVarDef<float> AutoCryoTime =
+        CVarDef.Create("ic.auto_cryo_time", 600f, CVar.SERVERONLY);
+
+    #endregion
 }

--- a/Content.Goobstation.Server/NPC/HTN/PrimitiveTasks/Operators/Specific/EnterCryostorageOperator.cs
+++ b/Content.Goobstation.Server/NPC/HTN/PrimitiveTasks/Operators/Specific/EnterCryostorageOperator.cs
@@ -1,0 +1,43 @@
+using Content.Server.NPC;
+using Content.Server.NPC.HTN;
+using Content.Server.NPC.HTN.PrimitiveTasks;
+using Content.Shared.Bed.Cryostorage;
+using Robust.Shared.Containers;
+
+namespace Content.Goobstation.Server.NPC.HTN.PrimitiveTasks.Operators.Specific;
+
+public sealed partial class EnterCryostorageOperator : HTNOperator
+{
+    [Dependency] private readonly IEntityManager _entManager = default!;
+    private SharedContainerSystem _container = default!;
+
+    [DataField(required: true)]
+    public string TargetKey = string.Empty;
+
+    public override void Initialize(IEntitySystemManager sysManager)
+    {
+        base.Initialize(sysManager);
+        _container = sysManager.GetEntitySystem<SharedContainerSystem>();
+    }
+
+    public override HTNOperatorStatus Update(NPCBlackboard blackboard, float frameTime)
+    {
+        var owner = blackboard.GetValue<EntityUid>(NPCBlackboard.Owner);
+
+        if (!blackboard.TryGetValue<EntityUid>(TargetKey, out var target, _entManager) ||
+            !_entManager.TryGetComponent<CryostorageComponent>(target, out var cryo))
+        {
+            return HTNOperatorStatus.Failed;
+        }
+
+        if (!_container.TryGetContainer(target, cryo.ContainerId, out var container))
+            return HTNOperatorStatus.Failed;
+
+        if (container.Contains(owner))
+            return HTNOperatorStatus.Finished;
+
+        return _container.Insert(owner, container)
+            ? HTNOperatorStatus.Finished
+            : HTNOperatorStatus.Failed;
+    }
+}

--- a/Content.Goobstation.Server/SSDTimer/AutoCryoActiveComponent.cs
+++ b/Content.Goobstation.Server/SSDTimer/AutoCryoActiveComponent.cs
@@ -1,0 +1,6 @@
+namespace Content.Goobstation.Server.SSDTimer;
+
+[RegisterComponent]
+public sealed partial class AutoCryoActiveComponent : Component
+{
+}

--- a/Content.Goobstation.Server/SSDTimer/AutoCryoSystem.cs
+++ b/Content.Goobstation.Server/SSDTimer/AutoCryoSystem.cs
@@ -1,0 +1,144 @@
+using Content.Goobstation.Common.CCVar;
+using Content.Server.NPC;
+using Content.Server.NPC.HTN;
+using Content.Server.NPC.Systems;
+using Content.Shared.Bed.Cryostorage;
+using Content.Shared.CCVar;
+using Content.Shared.Ghost;
+using Content.Shared.Humanoid;
+using Content.Shared.Mind;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Roles.Jobs;
+using Content.Shared.SSDIndicator;
+using Robust.Shared.Configuration;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.Goobstation.Server.SSDTimer;
+
+public sealed class AutoCryoSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly NPCSystem _npc = default!;
+    [Dependency] private readonly SharedJobSystem _jobs = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+
+    private static readonly ProtoId<HTNCompoundPrototype> AutoCryoCompound = "AutoCryoCompound";
+    private float _scanInterval = 5f;
+    private bool _enabled;
+    private float _autoCryoTime;
+
+    private float _icSsdSleepTime;
+    private TimeSpan _nextScan;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AutoCryoActiveComponent, PlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeLocalEvent<AutoCryoActiveComponent, ComponentShutdown>(OnShutdown);
+
+        Subs.CVar(_cfg, GoobCVars.AutoCryoEnabled, v => _enabled = v, true);
+        Subs.CVar(_cfg, GoobCVars.AutoCryoTime, v => _autoCryoTime = v, true);
+        Subs.CVar(_cfg, CCVars.ICSSDSleepTime, v => _icSsdSleepTime = v, true);
+    }
+
+    private void OnPlayerAttached(Entity<AutoCryoActiveComponent> ent, ref PlayerAttachedEvent args)
+    {
+        StopAutoCryo(ent);
+    }
+
+    private void OnShutdown(Entity<AutoCryoActiveComponent> ent, ref ComponentShutdown args)
+    {
+        RemComp<HTNComponent>(ent);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (!_enabled)
+            return;
+
+        var curTime = _timing.CurTime;
+        if (curTime < _nextScan)
+            return;
+
+        _nextScan = curTime + TimeSpan.FromSeconds(_scanInterval);
+
+        var threshold = TimeSpan.FromSeconds(_autoCryoTime);
+        var query = EntityQueryEnumerator<SSDIndicatorComponent>();
+        while (query.MoveNext(out var uid, out var ssd))
+        {
+            if (!ssd.IsSSD)
+                continue;
+
+            if (HasComp<CryostorageContainedComponent>(uid))
+                continue;
+
+            if (HasComp<AutoCryoActiveComponent>(uid))
+                continue;
+
+            if (ssd.FallAsleepTime == TimeSpan.Zero)
+                continue;
+
+            var ssdSince = curTime - (ssd.FallAsleepTime - TimeSpan.FromSeconds(_icSsdSleepTime));
+            if (ssdSince < threshold)
+                continue;
+
+            if (!IsEligible(uid))
+                continue;
+
+            StartAutoCryo(uid);
+        }
+    }
+
+    private bool IsEligible(EntityUid uid)
+    {
+        if (TerminatingOrDeleted(uid))
+            return false;
+
+        if (!HasComp<HumanoidAppearanceComponent>(uid))
+            return false;
+
+        if (!HasComp<CanEnterCryostorageComponent>(uid))
+            return false;
+
+        if (!_mobState.IsAlive(uid))
+            return false;
+
+        if (_mind.TryGetMind(uid, out var _, out var mind))
+        {
+            if (mind.VisitingEntity is { } visiting
+                && TryComp<GhostComponent>(visiting, out var ghost)
+                && ghost.CanReturnToBody)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private void StartAutoCryo(EntityUid uid)
+    {
+        EnsureComp<AutoCryoActiveComponent>(uid);
+
+        var htn = EnsureComp<HTNComponent>(uid);
+        htn.RootTask = new HTNCompoundTask { Task = AutoCryoCompound };
+        htn.Blackboard.SetValue(NPCBlackboard.NavInteract, true);
+        htn.Blackboard.SetValue(NPCBlackboard.Owner, uid);
+        htn.Blackboard.SetValue("CryoSearchRange", 500f);
+
+        _npc.WakeNPC(uid, htn);
+    }
+
+    private void StopAutoCryo(EntityUid uid)
+    {
+        RemComp<HTNComponent>(uid);
+        RemComp<AutoCryoActiveComponent>(uid);
+    }
+}

--- a/Content.Goobstation.Shared/SSDTimer/SSDTimerSystem.cs
+++ b/Content.Goobstation.Shared/SSDTimer/SSDTimerSystem.cs
@@ -10,26 +10,26 @@ public sealed class SSDTimerSystem : EntitySystem
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
-	
-	private float _icSsdSleepTime;
+
+    private float _icSsdSleepTime;
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<SSDIndicatorComponent, ExaminedEvent>(OnExamined);
-		
+
         _cfg.OnValueChanged(CCVars.ICSSDSleepTime, obj => _icSsdSleepTime = obj, true);
 
     }
-	
+
     private void OnExamined(EntityUid uid, SSDIndicatorComponent component, ExaminedEvent args)
     {
         if (!args.IsInDetailsRange || !component.IsSSD)
             return;
 
-		var timeFellAsleep = component.FallAsleepTime - TimeSpan.FromSeconds(_icSsdSleepTime);
-		var time = _timing.CurTime - timeFellAsleep;
-		args.PushMarkup(Loc.GetString("comp-ssd-person-examined", ("ent", uid), ("time", (int) time.TotalMinutes)));
+        var timeFellAsleep = component.FallAsleepTime - TimeSpan.FromSeconds(_icSsdSleepTime);
+        var time = _timing.CurTime - timeFellAsleep;
+        args.PushMarkup(Loc.GetString("comp-ssd-person-examined", ("ent", uid), ("time", (int) time.TotalMinutes)));
     }
 }

--- a/Resources/Prototypes/_Goobstation/HTN/auto_cryo.yml
+++ b/Resources/Prototypes/_Goobstation/HTN/auto_cryo.yml
@@ -1,0 +1,25 @@
+- type: htnCompound
+  id: AutoCryoCompound
+  branches:
+    - tasks:
+        - !type:HTNPrimitiveTask
+          operator: !type:PickAccessibleComponentOperator
+            component: Cryostorage
+            rangeKey: CryoSearchRange
+            targetKey: TargetCoordinates
+            target: Target
+            pathfindKey: TargetPathfind
+        - !type:HTNPrimitiveTask
+          operator: !type:MoveToOperator
+            pathfindInPlanning: true
+            removeKeyOnFinish: false
+            targetKey: TargetCoordinates
+            pathfindKey: TargetPathfind
+            rangeKey: InteractRange
+        - !type:HTNPrimitiveTask
+          preconditions:
+            - !type:TargetInRangePrecondition
+              targetKey: Target
+              rangeKey: InteractRange
+          operator: !type:EnterCryostorageOperator
+            targetKey: Target


### PR DESCRIPTION
## About the PR
Always hated that you had to manually cryo people that were SSD, after seeing the SSD timer pr, and 
being inspired by deadlock, where after you disconnect you automatically walk back to spawn,
i decided to make this slop

not done, need to add the ability for pathfinding to support pathing through doors if you have access (will def be easy, trust :face_holding_back_tears: )
which i will do tomorrow prolly

[Screencast_20260427_000412.webm](https://github.com/user-attachments/assets/b7c32d6a-f913-4ab3-b9c0-20872bf2b8b9)

**Changelog**
:cl: Durk
- add: Players will now automatically cryo themselves after being SSD for 10 minutes.
- add: AI can now pathfind through airlocks.


