### PR TITLE
Removed stealth on death for xeno hunter

### DIFF
--- a/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/hunter.yml
+++ b/Resources/Prototypes/_White/Entities/Mobs/Xenomorphs/hunter.yml
@@ -37,6 +37,7 @@
   - type: Stealth
     revealOnAttack: false
     revealOnDamage: false
+    enabledOnDeath: false # Removing Stealth on death, so you can do surgery
     enabled: false
     lastVisibility: 0.2
   - type: Jump


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
I made it so that when xenomorph hunters die, they lose stealth and become visible
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Well, I wanted to get some juicy xenomorph organs from a hunter I had killed, but the hunter being invisible made it so you can't do surgery AT ALL. Even though they are DEAD!
I figure if the xenomorph is dead, then they probably won't be needing their stealth. Hunters are the only xenomorph that spawns from gold slime (aside from face hugger), so they are the only natural source of xenomorph organs outside the xenomorphs spawning.

## Technical details
<!-- Summary of code changes for easier review. -->
Literally one line of yaml (100% NO SLOPCODE WORKING 2026)

## Media
### BEFORE: 
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="328" height="275" alt="BeforeXenoStealth" src="https://github.com/user-attachments/assets/7706fac7-9db6-4a83-99fa-e8eb06f6d2b1" />

### AFTER:
<img width="468" height="432" alt="AfterXenoStealth" src="https://github.com/user-attachments/assets/a4de5350-6f85-4f8a-8162-d3a116be734a" />

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Arraydeess
- tweak: Xenomorph Hunters now lose all stealth on death