### PR TITLE
Fixed mothroach variant head sprites

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/NPCs/animals.yml
@@ -942,6 +942,12 @@
       state: mothroach
   - type: FaxableObject
     insertingState: inserting_mothroach_mustard
+  - type: Clothing
+    quickEquip: false
+    sprite: _Goobstation/Mobs/Animals/mustard_mothroach.rsi
+    equippedPrefix: 0
+    slots:
+    - HEAD
 
 - type: entity
   name: leopard mothroach
@@ -956,6 +962,12 @@
       state: mothroach
   - type: FaxableObject
     insertingState: inserting_mothroach_leopard
+  - type: Clothing
+    quickEquip: false
+    sprite: _Goobstation/Mobs/Animals/leopard_mothroach.rsi
+    equippedPrefix: 0
+    slots:
+    - HEAD
 
 - type: entity
   name: cecropia mothroach
@@ -970,6 +982,12 @@
       state: mothroach
   - type: FaxableObject
     insertingState: inserting_mothroach_cecropia
+  - type: Clothing
+    quickEquip: false
+    sprite: _Goobstation/Mobs/Animals/cecropia_mothroach.rsi
+    equippedPrefix: 0
+    slots:
+    - HEAD
 
 - type: entity
   name: lunar mothroach
@@ -984,3 +1002,9 @@
       state: mothroach
   - type: FaxableObject
     insertingState: inserting_mothroach_lunar
+  - type: Clothing
+    quickEquip: false
+    sprite: _Goobstation/Mobs/Animals/lunar_mothroach.rsi
+    equippedPrefix: 0
+    slots:
+    - HEAD


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
I fixed mothroach variants not showing the correct sprite when equipped to the head slot.

## Why / Balance
Consistency.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img alt="image" src="https://github.com/user-attachments/assets/7d212e9e-dee2-4708-878f-36bf85332a0f" /> <img alt="image" src="https://github.com/user-attachments/assets/5191b08a-6c4f-493f-9395-0307e1bbc4b8" /> <img alt="image" src="https://github.com/user-attachments/assets/7f0ac208-2582-4279-8edd-4a38d7982b17" /> <img alt="image" src="https://github.com/user-attachments/assets/53c0ae31-21dc-493b-8ff9-bb3a2d3d14c4" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: seyriix
- fix: Mothroach variants now show the correct sprite when equipped.
