### PR TITLE
Fix capoeira kick up

### DIFF
--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.Capoeira.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.Capoeira.cs
@@ -90,8 +90,7 @@ public abstract partial class SharedMartialArtsSystem
             || target != ent.Owner)
             return;
 
-        _status.TryRemoveStatusEffect(ent, "KnockedDown");
-        _standingState.Stand(ent);
+        RemCompDeferred<KnockedDownComponent>(ent);
         //_stamina.TryTakeStamina(ent, args.StaminaToHeal);
         ent.Comp.LastAttacks.Clear();
     }


### PR DESCRIPTION
## About the PR
Fixed capoeira kick up bug. Kick up was not removing KnockedDownComponent bcs of upstream <3
Nobody fixed that in months W

## Why / Balance
Bug (cool)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Capoeira kick up move is working now.
