### PR TITLE
Fix feroxi displacement maps

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
@@ -202,3 +202,28 @@
       sprite: "_DV/Effects/creampie.rsi"
       state: "creampie_feroxi"
       visible: false
+  - type: Inventory
+    speciesId: feroxi
+    femaleDisplacements: # Goob-Feroxi-Resprite-Start
+      jumpsuit:
+        sizeMaps:
+          32:
+            sprite: _White/Mobs/Species/displacement.rsi
+            state: jumpsuit-female
+      shoes:
+        sizeMaps:
+          32:
+            sprite: _White/Mobs/Species/displacement.rsi
+            state: shoes
+    displacements:
+      jumpsuit:
+        sizeMaps:
+          32:
+            sprite: _White/Mobs/Species/displacement.rsi
+            state: jumpsuit
+      shoes:
+        sizeMaps:
+          32:
+            sprite: _White/Mobs/Species/displacement.rsi
+            state: shoes
+    # Goob-Feroxi-Resprite-End

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
@@ -202,9 +202,9 @@
       sprite: "_DV/Effects/creampie.rsi"
       state: "creampie_feroxi"
       visible: false
-  - type: Inventory
+  - type: Inventory # Goob-Feroxi-Resprite-Start
     speciesId: feroxi
-    femaleDisplacements: # Goob-Feroxi-Resprite-Start
+    femaleDisplacements:
       jumpsuit:
         sizeMaps:
           32:


### PR DESCRIPTION
## About the PR
fix feroxi displacement maps in lobby


## Media
<img width="231" height="324" alt="Screenshot 2026-05-10 152006" src="https://github.com/user-attachments/assets/2c0da991-0650-4b44-b0cb-557e5edf7858" />
<img width="222" height="315" alt="Screenshot 2026-05-10 152016" src="https://github.com/user-attachments/assets/952319d5-6c03-4709-919e-6c6c2ef53201" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: RedTerror
- fix: Feroxi are now displayed correctly in lobby
