### PR TITLE
Fix Biome noise cache breaking after restart

### DIFF
--- a/Content.Shared/Parallax/Biomes/SharedBiomeSystem.cs
+++ b/Content.Shared/Parallax/Biomes/SharedBiomeSystem.cs
@@ -10,6 +10,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using Content.Shared.Maps;
@@ -33,7 +34,7 @@ public abstract class SharedBiomeSystem : EntitySystem
     public const byte ChunkSize = 8; // Lavaland change - make it public
 
     // Goob - Cache Noise
-    private readonly Dictionary<(FastNoiseLite, int), FastNoiseLite> _noiseCache = new();
+    private readonly ConcurrentDictionary<(FastNoiseLite, int), FastNoiseLite> _noiseCache = new();
 
     protected void ClearNoiseCache()
     {


### PR DESCRIPTION
Based on the evidence that @Sarahon gave, sometimes biome noise cache can break because of a concurrent call to a normal dictioary that contains the noise maps. I've fixed that by changing the type from `Dictionary` to `ConcurrentDictionary`, so it should be alright now
unless there's something even worse than that that we didn't find yet