### PR TITLE
Fixes UniqueChemstream reagent condition for multiver

### DIFF
--- a/Content.Goobstation.Server/EntityEffects/EffectConditions/UniqueBloodstreamChemThreshold.cs
+++ b/Content.Goobstation.Server/EntityEffects/EffectConditions/UniqueBloodstreamChemThreshold.cs
@@ -28,7 +28,7 @@ public sealed partial class UniqueBloodstreamChemThreshold : EntityEffectConditi
         if (args.EntityManager.TryGetComponent<BloodstreamComponent>(args.TargetEntity, out var blood))
         {
             if (args.EntityManager.System<SharedSolutionContainerSystem>().ResolveSolution(args.TargetEntity, blood.ChemicalSolutionName, ref blood.ChemicalSolution, out var chemSolution))
-                return chemSolution.Contents.Count >= Min && chemSolution.Contents.Count <= Max; // Omu; atleast / atmost 2" includes 2.
+                return chemSolution.Contents.Count >= Min && chemSolution.Contents.Count <= Max;
             return false;
         }
         throw new NotImplementedException();

--- a/Content.Goobstation.Server/EntityEffects/EffectConditions/UniqueBloodstreamChemThreshold.cs
+++ b/Content.Goobstation.Server/EntityEffects/EffectConditions/UniqueBloodstreamChemThreshold.cs
@@ -28,7 +28,7 @@ public sealed partial class UniqueBloodstreamChemThreshold : EntityEffectConditi
         if (args.EntityManager.TryGetComponent<BloodstreamComponent>(args.TargetEntity, out var blood))
         {
             if (args.EntityManager.System<SharedSolutionContainerSystem>().ResolveSolution(args.TargetEntity, blood.ChemicalSolutionName, ref blood.ChemicalSolution, out var chemSolution))
-                return chemSolution.Contents.Count > Min && chemSolution.Contents.Count < Max;
+                return chemSolution.Contents.Count >= Min && chemSolution.Contents.Count <= Max; // Omu; atleast / atmost 2" includes 2.
             return false;
         }
         throw new NotImplementedException();

--- a/Content.Goobstation.Shared/EntityEffects/EffectConditions/UniqueBloodstreamChemThreshold.cs
+++ b/Content.Goobstation.Shared/EntityEffects/EffectConditions/UniqueBloodstreamChemThreshold.cs
@@ -27,7 +27,7 @@ public sealed partial class UniqueBloodstreamChemThreshold : EntityEffectConditi
         if (args.EntityManager.TryGetComponent<BloodstreamComponent>(args.TargetEntity, out var blood))
         {
             if (args.EntityManager.System<SharedSolutionContainerSystem>().ResolveSolution(args.TargetEntity, blood.ChemicalSolutionName, ref blood.ChemicalSolution, out var chemSolution))
-                return chemSolution.Contents.Count >= Min && chemSolution.Contents.Count <= Max; // Omu; "Atleast/most 2" includes 2.
+                return chemSolution.Contents.Count >= Min && chemSolution.Contents.Count <= Max;
             return false;
         }
         throw new NotImplementedException();

--- a/Content.Goobstation.Shared/EntityEffects/EffectConditions/UniqueBloodstreamChemThreshold.cs
+++ b/Content.Goobstation.Shared/EntityEffects/EffectConditions/UniqueBloodstreamChemThreshold.cs
@@ -27,7 +27,7 @@ public sealed partial class UniqueBloodstreamChemThreshold : EntityEffectConditi
         if (args.EntityManager.TryGetComponent<BloodstreamComponent>(args.TargetEntity, out var blood))
         {
             if (args.EntityManager.System<SharedSolutionContainerSystem>().ResolveSolution(args.TargetEntity, blood.ChemicalSolutionName, ref blood.ChemicalSolution, out var chemSolution))
-                return chemSolution.Contents.Count > Min && chemSolution.Contents.Count < Max;
+                return chemSolution.Contents.Count >= Min && chemSolution.Contents.Count <= Max; // Omu; "Atleast/most 2" includes 2.
             return false;
         }
         throw new NotImplementedException();

--- a/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
@@ -499,7 +499,7 @@
         amount: -3
         conditions:
         - !type:UniqueBloodstreamChemThreshold
-          max: 3 # the gist is, 2 and below this sucks, 3 and above it's great; mix with water etc for good results
+          max: 2 # Omu fixed intent
       - !type:AdjustReagent
         group: Poison
         amount: -3
@@ -513,7 +513,7 @@
       - !type:HealthChange
         conditions:
         - !type:UniqueBloodstreamChemThreshold
-          min: 2
+          min: 3 # Omu fixed intent
         damage:
           types:
             Poison: -3

--- a/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
@@ -499,7 +499,7 @@
         amount: -3
         conditions:
         - !type:UniqueBloodstreamChemThreshold
-          max: 2 # Omu fixed intent
+          max: 2
       - !type:AdjustReagent
         group: Poison
         amount: -3
@@ -513,7 +513,7 @@
       - !type:HealthChange
         conditions:
         - !type:UniqueBloodstreamChemThreshold
-          min: 3 # Omu fixed intent
+          min: 3
         damage:
           types:
             Poison: -3


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
The actual check is looking for `< or >` than, but the guidebook words it as `<= or >=`, this makes the range it checks inclusive of its bounds.


## Why / Balance
`At most 3` includes `3`,
`At least 2` includes `2`.

## Technical details
makes the range operands < and > into <= and >=.
tweaks multiver's values to stay functionally the same.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Archee
- fix: Multivers guidebook entry now correctly shows how many chemicals are needed to trigger its effects.
