### PR TITLE
Fix: Blocked trash spawn for PassiveConsumableSystem when not deleting

### DIFF
--- a/Content.Goobstation.Shared/PassiveConsumable/PassiveConsumableSystem.cs
+++ b/Content.Goobstation.Shared/PassiveConsumable/PassiveConsumableSystem.cs
@@ -83,10 +83,11 @@ public sealed class PassiveConsumableSystem : EntitySystem
 
         foreach (var (uid, edible, user, delete) in finished)
         {
-            _ingestion.SpawnTrash((uid, edible), user);
-
             if (delete)
+            {
+                _ingestion.SpawnTrash((uid, edible), user);
                 QueueDel(uid);
+            }
         }
     }
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
In PassiveConsumableSystem, moved trash spawn logic to prevent DeleteOnEmpty=false entities from spawning trash indefinitely. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This only affects "FoodSnackLollypopCaptain" since it is the only entity with DeleteOnEmpty=false.
FoodSnackLollypopCaptain has a volume of 5 and PassiveConsumableSystem consumes 0.1 every 3 seconds by default. FoodSnackLollypopCaptain will be consumed after 2.5 minutes and will spawn a stick every three seconds until the round ends. 
If captain leaves in the lollypop at round start, there will be 2,350 sticks littered by captain at 2 hours of round time. 

## Technical details
<!-- Summary of code changes for easier review. -->
Updated Update() in PassiveConsumableSystem.cs.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/48cd0c3f-cab7-433a-b8c9-617fd54d7d4d

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Captain's lollypop will no longer spawn infinite trash.
