### PR TITLE
Hotfix upgrade kits

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/upgrade_kits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/upgrade_kits.yml
@@ -32,8 +32,6 @@
   components:
   - type: AutomationSlots
   - type: Automated
-  - type: UpgradedMachine
-    upgrade: upgrade-kit-automation
   - type: DeviceNetwork
     deviceNetId: Wireless
     receiveFrequencyId: BasicDevice


### PR DESCRIPTION

**Changelog**

:cl: Rouden
- fix: Fixed lathe upgrades not being installable.
