### PR TITLE
Added stackable entity effect spawns

### DIFF
--- a/Content.Server/EntityEffects/EntityEffectSystem.cs
+++ b/Content.Server/EntityEffects/EntityEffectSystem.cs
@@ -45,6 +45,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Content.Server.Stack; // Goobstation
 
 using TemperatureCondition = Content.Shared.EntityEffects.EffectConditions.Temperature; // disambiguate the namespace
 using PolymorphEffect = Content.Shared.EntityEffects.Effects.Polymorph;
@@ -82,6 +83,7 @@ public sealed class EntityEffectSystem : EntitySystem
     [Dependency] private readonly VomitSystem _vomit = default!;
     [Dependency] private readonly TurfSystem _turf = default!; //todo Goobstation? The only thing im using this for is meant to be in RT? Fix if you havent
     [Dependency] private readonly ZombieSystem _zombie = default!; // Goob - zombie cure
+    [Dependency] private readonly StackSystem _stack = default!; // Goobstation
 
     public override void Initialize()
     {
@@ -587,12 +589,14 @@ public sealed class EntityEffectSystem : EntitySystem
 
     private void OnExecuteCreateEntityReactionEffect(ref ExecuteEntityEffectEvent<CreateEntityReactionEffect> args)
     {
-        var transform = Comp<TransformComponent>(args.Args.TargetEntity);
+        // var transform = Comp<TransformComponent>(args.Args.TargetEntity); Goobstation
         var quantity = (int)args.Effect.Number;
         if (args.Args is EntityEffectReagentArgs reagentArgs)
             quantity *= reagentArgs.Quantity.Int();
 
-        for (var i = 0; i < quantity; i++)
+        _stack.SpawnMultiple(args.Effect.Entity, quantity, args.Args.TargetEntity); // Goobstation, also should spawn inside containers (tested on plastic creation reaction inside backpack)
+
+        /*for (var i = 0; i < quantity; i++) Goobstation
         {
             var uid = Spawn(args.Effect.Entity, _xform.GetMapCoordinates(args.Args.TargetEntity, xform: transform));
             _xform.AttachToGridOrMap(uid);
@@ -604,7 +608,7 @@ public sealed class EntityEffectSystem : EntitySystem
             // --> if it doesn't fit, iterate through parent storage until it attaches to the grid (again, DON'T attach to players).
             // if the reaction happens INSIDE a stomach? the bloodstream? I have no idea how to handle that.
             // presumably having cheese materialize inside of your blood would have "disadvantages".
-        }
+        }*/
     }
 
     private void OnExecuteCreateGas(ref ExecuteEntityEffectEvent<CreateGas> args)
@@ -635,7 +639,7 @@ public sealed class EntityEffectSystem : EntitySystem
         {
             RemComp<ZombifyOnDeathComponent>(args.Args.TargetEntity);
             RemComp<PendingZombieComponent>(args.Args.TargetEntity);
-            
+
             _popup.PopupEntity(
                 Loc.GetString("zombie-cured-popup"),
                 args.Args.TargetEntity,

--- a/Content.Server/Stack/StackSystem.cs
+++ b/Content.Server/Stack/StackSystem.cs
@@ -180,7 +180,9 @@ namespace Content.Server.Stack
         private List<int> CalculateSpawns(string entityPrototype, int amount)
         {
             var proto = _prototypeManager.Index<EntityPrototype>(entityPrototype);
-            proto.TryGetComponent<StackComponent>(out var stack, EntityManager.ComponentFactory);
+            if (proto.TryGetComponent<StackComponent>(out var stack, EntityManager.ComponentFactory)) // Goobstation if added
+                amount *= stack.Count; // Goobstation, 10 stacks by 10 units = 100 units
+
             var maxCountPerStack = GetMaxCount(stack);
             var amounts = new List<int>();
             while (amount > 0)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Changed CreateEntityReactionEffect and CalculateSpawns a bit, so slime extracts and chemical reactions should spawn items by maximal possible stacks.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Less meaningless clicks - better.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Now slime extracts and chemical reactions spawn items by maximal possible stacks.