### PR TITLE
Fix right click unbuckling people

### DIFF
--- a/Content.Shared/Buckle/Components/BuckleComponent.cs
+++ b/Content.Shared/Buckle/Components/BuckleComponent.cs
@@ -253,7 +253,16 @@ public readonly record struct UnbuckledEvent(Entity<StrapComponent> Strap, Entit
 
 // WD EDIT START
 [Serializable, NetSerializable]
-public sealed partial class UnbuckleDoAfterEvent : SimpleDoAfterEvent;
+public sealed partial class UnbuckleDoAfterEvent : SimpleDoAfterEvent
+{
+    public readonly bool PullIntent = false;
+
+    public UnbuckleDoAfterEvent(bool pullIntent = false)
+    {
+        PullIntent = pullIntent;
+    }
+
+}
 // WD EDIT END
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Buckle/Components/BuckleComponent.cs
+++ b/Content.Shared/Buckle/Components/BuckleComponent.cs
@@ -255,12 +255,12 @@ public readonly record struct UnbuckledEvent(Entity<StrapComponent> Strap, Entit
 [Serializable, NetSerializable]
 public sealed partial class UnbuckleDoAfterEvent : SimpleDoAfterEvent
 {
-    public readonly bool PullIntent = false;
+    public readonly bool PullIntent = false; // goobstation - start unbuckle fix
 
     public UnbuckleDoAfterEvent(bool pullIntent = false)
     {
         PullIntent = pullIntent;
-    }
+    } // goobstation - end unbuckle fix
 
 }
 // WD EDIT END

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -313,10 +313,10 @@ public abstract partial class SharedBuckleSystem
             return;
 
         Unbuckle((uid, component), strap, args.User); // Goobstation
-        if (args.PullIntent)
+        if (args.PullIntent) // Goobstation - unbuckle fix start
         {
             _pullingSystem.TryStartPull(args.User, uid);
-        }
+        } // Goobstation - unbuckle fix end
     }
     // WD EDIT END
 

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -146,7 +146,7 @@ public abstract partial class SharedBuckleSystem
         SubscribeLocalEvent<BuckleComponent, EntGotInsertedIntoContainerMessage>(OnInserted);
 
         SubscribeLocalEvent<BuckleComponent, StartPullAttemptEvent>(OnPullAttempt);
-        SubscribeLocalEvent<BuckleComponent, PullAttemptEvent>(OnBeingPulledAttempt);
+        SubscribeLocalEvent<BuckleComponent, PullAttemptEvent>(OnBeingPulledAttempt); // goobstation edit - unbuckle fix
         SubscribeLocalEvent<BuckleComponent, PullStartedMessage>(OnPullStarted);
         SubscribeLocalEvent<BuckleComponent, UnbuckleAlertEvent>(OnUnbuckleAlert);
 
@@ -180,11 +180,11 @@ public abstract partial class SharedBuckleSystem
             args.Cancel();
     }
 
-    private void OnBeingPulledAttempt(Entity<BuckleComponent> ent, ref PullAttemptEvent args)
+    private void OnBeingPulledAttempt(Entity<BuckleComponent> ent, ref PullAttemptEvent args) // the second arg is also goobstation
     {
         if (args.Cancelled || !ent.Comp.Buckled)
             return;
-
+        // goobstation - unbuckle fix start
         if (!CanUnbuckle(ent!, args.PullerUid, false))
         {
             args.Cancelled = true;
@@ -205,7 +205,7 @@ public abstract partial class SharedBuckleSystem
             _doAfter.TryStartDoAfter(doAfter);
             return;
         }
-        // Goobstation
+        // Goobstation - end
     }
 
     private void OnPullStarted(Entity<BuckleComponent> ent, ref PullStartedMessage args)

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -112,6 +112,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Movement.Events;
+using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.Popups;
 using Content.Shared.Pulling.Events;
@@ -126,6 +127,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using Content.Shared.Movement.Pulling.Components;
 
 namespace Content.Shared.Buckle;
 
@@ -134,6 +136,7 @@ public abstract partial class SharedBuckleSystem
     public static ProtoId<AlertCategoryPrototype> BuckledAlertCategory = "Buckled";
 
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly PullingSystem _pullingSystem = default!; // goobstation
 
     private void InitializeBuckle()
     {
@@ -143,7 +146,7 @@ public abstract partial class SharedBuckleSystem
         SubscribeLocalEvent<BuckleComponent, EntGotInsertedIntoContainerMessage>(OnInserted);
 
         SubscribeLocalEvent<BuckleComponent, StartPullAttemptEvent>(OnPullAttempt);
-        SubscribeLocalEvent<BuckleComponent, BeingPulledAttemptEvent>(OnBeingPulledAttempt);
+        SubscribeLocalEvent<BuckleComponent, PullAttemptEvent>(OnBeingPulledAttempt);
         SubscribeLocalEvent<BuckleComponent, PullStartedMessage>(OnPullStarted);
         SubscribeLocalEvent<BuckleComponent, UnbuckleAlertEvent>(OnUnbuckleAlert);
 
@@ -177,24 +180,24 @@ public abstract partial class SharedBuckleSystem
             args.Cancel();
     }
 
-    private void OnBeingPulledAttempt(Entity<BuckleComponent> ent, ref BeingPulledAttemptEvent args)
+    private void OnBeingPulledAttempt(Entity<BuckleComponent> ent, ref PullAttemptEvent args)
     {
         if (args.Cancelled || !ent.Comp.Buckled)
             return;
 
-        if (!CanUnbuckle(ent!, args.Puller, false))
+        if (!CanUnbuckle(ent!, args.PullerUid, false))
         {
-            args.Cancel();
+            args.Cancelled = true;
             return;
         }
 
         // Goobstation - doafter for unbuckle by others
-        if (args.Puller != ent.Owner
+        if (args.PullerUid != ent.Owner
             && TryComp<StrapComponent>(ent.Comp.BuckledTo, out var strap)
             && strap.UnbuckleDoafterTime > 0)
         {
-            args.Cancel();
-            var doAfter = new DoAfterArgs(EntityManager, args.Puller, TimeSpan.FromSeconds(strap.UnbuckleDoafterTime), new UnbuckleDoAfterEvent(), ent.Owner, target: ent.Owner)
+            args.Cancelled = true;
+            var doAfter = new DoAfterArgs(EntityManager, args.PullerUid, TimeSpan.FromSeconds(strap.UnbuckleDoafterTime), new UnbuckleDoAfterEvent(true), ent.Owner, target: ent.Owner)
             {
                 BreakOnMove = true,
                 BreakOnDamage = true,
@@ -310,6 +313,10 @@ public abstract partial class SharedBuckleSystem
             return;
 
         Unbuckle((uid, component), strap, args.User); // Goobstation
+        if (args.PullIntent)
+        {
+            _pullingSystem.TryStartPull(args.User, uid);
+        }
     }
     // WD EDIT END
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Opening right click (context (?)) menu no longer unbuckles people.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Annoying
Closes https://github.com/Goob-Station/Goob-Station/issues/6398
## Technical details
<!-- Summary of code changes for easier review. -->
Changes the event that the unbuckle doafter listens for, also adds pull intent to the doafter event to make regular unbuckling not pull people.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Elperosn
- fix: Right clicking other players no longer unbuckles them.

