### PR TITLE
Fix metal slimes being unobtainable

### DIFF
--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Mobs/NPCs/slimes_baby.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Mobs/NPCs/slimes_baby.yml
@@ -138,7 +138,7 @@
     potentialMutations:
     - MobSlimeXenobioBabyBlue
     - MobSlimeXenobioBabyPyrite
-    - MobSlimeXenobioBabySilver
+    - MobSlimeXenobioBabyMetal
 
 - type: entity
   parent: MobSlimeXenobioBaby

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Mobs/NPCs/slimes_baby.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Mobs/NPCs/slimes_baby.yml
@@ -12,7 +12,7 @@
     - MobSlimeXenobioBabyOrange
     - MobSlimeXenobioBabyPurple
     - MobSlimeXenobioBabyBlue
-    - MobSlimeXenobioBabyPyrite
+    - MobSlimeXenobioBabyMetal
 
 - type: entity
   parent: MobSlimeXenobioBaby
@@ -91,7 +91,7 @@
     producedExtract: YellowSlimeExtract
     potentialMutations:
     - MobSlimeXenobioBabyOrange
-    - MobSlimeXenobioBabyPyrite
+    - MobSlimeXenobioBabyMetal
     - MobSlimeXenobioBabyBluespace
 
 - type: entity


### PR DESCRIPTION
I've been copypasting a lot of YAML during the refactor to make slimer spawners not shit and accidentally made metal slimes not obtainable
fixed now though probably

fixes #6594

**Changelog**

:cl: Rouden
- fix: Fixed metal slimes being unobtainable.
