### PR TITLE
Fix crit/dead/unconscious/stunned escape pulling

### DIFF
--- a/Content.Goobstation.Shared/GrabIntent/GrabIntentSystem.cs
+++ b/Content.Goobstation.Shared/GrabIntent/GrabIntentSystem.cs
@@ -128,7 +128,7 @@ public sealed partial class GrabIntentSystem : EntitySystem
         if (!TryComp<PullableComponent>(uid, out var pullable) || !pullable.BeingPulled)
             return;
 
-        if (component.GrabStage == GrabStage.Soft)
+        if (component.GrabStage == GrabStage.Soft && _blocker.CanInteract(uid, null))
             _pulling.TryStopPull(uid, pullable, uid);
 
         if (!_blocker.CanMove(args.Entity))

--- a/Content.Goobstation.Shared/GrabReleaseBind/GrabReleaseBindSystem.cs
+++ b/Content.Goobstation.Shared/GrabReleaseBind/GrabReleaseBindSystem.cs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Shared.ActionBlocker;
 using Content.Shared.Input;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
@@ -17,6 +18,7 @@ namespace Content.Goobstation.Shared.GrabReleaseBind;
 public sealed class GrabReleaseBindSystem : EntitySystem
 {
     [Dependency] private readonly PullingSystem _pullingSystem = default!;
+    [Dependency] private readonly ActionBlockerSystem _blocker = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -32,6 +34,10 @@ public sealed class GrabReleaseBindSystem : EntitySystem
         if (session?.AttachedEntity == null || !TryComp<PullableComponent>(session.AttachedEntity, out var pullable))
             return;
 
-        _pullingSystem.TryStopPull(session.AttachedEntity.Value, pullable, session.AttachedEntity.Value);
+        var uid = session.AttachedEntity.Value;
+        if (!_blocker.CanInteract(uid, null))
+            return;
+
+        _pullingSystem.TryStopPull(uid, pullable, uid);
     }
 }

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -359,6 +359,9 @@ public sealed class PullingSystem : EntitySystem
         if (args.Handled)
             return;
 
+        if (!_blocker.CanInteract(ent, null))
+            return;
+
         args.Handled = TryStopPull(ent, ent, ent);
     }
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Added verification for escape pulling (WASD, Keyboard (B), Alert click)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fix #6545

## Technical details
<!-- Summary of code changes for easier review. -->
_blocker.CanInteract(uid, null) check if entity is stunned, sleeping, crit...

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
None
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None 
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Baptr0b0t
- fix: Fixed able to escape grabs while crit/dead/unconscious/stunned