### PR TITLE
Fix Verb inspections unbuckle

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -144,6 +144,7 @@ public abstract partial class SharedBuckleSystem
 
         SubscribeLocalEvent<BuckleComponent, StartPullAttemptEvent>(OnPullAttempt);
         SubscribeLocalEvent<BuckleComponent, BeingPulledAttemptEvent>(OnBeingPulledAttempt);
+        SubscribeLocalEvent<BuckleComponent, PullAttemptEvent>(OnBucklePullAttempt); // Goobstation
         SubscribeLocalEvent<BuckleComponent, PullStartedMessage>(OnPullStarted);
         SubscribeLocalEvent<BuckleComponent, UnbuckleAlertEvent>(OnUnbuckleAlert);
 
@@ -188,22 +189,38 @@ public abstract partial class SharedBuckleSystem
             return;
         }
 
-        // Goobstation - doafter for unbuckle by others
+        // Goobstation - cancel pull entirely if others are not allowed to unbuckle (e.g. clowncar)
         if (args.Puller != ent.Owner
             && TryComp<StrapComponent>(ent.Comp.BuckledTo, out var strap)
-            && strap.UnbuckleDoafterTime > 0)
+            && !strap.AllowOthersToUnbuckle)
         {
             args.Cancel();
-            var doAfter = new DoAfterArgs(EntityManager, args.Puller, TimeSpan.FromSeconds(strap.UnbuckleDoafterTime), new UnbuckleDoAfterEvent(), ent.Owner, target: ent.Owner)
-            {
-                BreakOnMove = true,
-                BreakOnDamage = true,
-            };
-            _doAfter.TryStartDoAfter(doAfter);
-            return;
         }
-        // Goobstation
+        // Goobstation - when do-after is required, do NOT cancel here; CanPull succeeds and
+        // OnBucklePullAttempt starts the do-after only on actual pull initiation, not on CanPull checks
     }
+
+    // Goobstation - start unbuckle do-after only on actual pull initiation, not on CanPull checks
+    private void OnBucklePullAttempt(Entity<BuckleComponent> ent, ref PullAttemptEvent args)
+    {
+        if (args.Cancelled || !ent.Comp.Buckled || args.PullerUid == ent.Owner)
+            return;
+
+        if (!TryComp<StrapComponent>(ent.Comp.BuckledTo, out var strap) || strap.UnbuckleDoafterTime <= 0)
+            return;
+
+        if (!CanUnbuckle(ent!, args.PullerUid, false))
+            return;
+
+        args.Cancelled = true;
+        var doAfter = new DoAfterArgs(EntityManager, args.PullerUid, TimeSpan.FromSeconds(strap.UnbuckleDoafterTime), new UnbuckleDoAfterEvent(), ent.Owner, target: ent.Owner)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = true,
+        };
+        _doAfter.TryStartDoAfter(doAfter);
+    }
+    // Goobstation
 
     private void OnPullStarted(Entity<BuckleComponent> ent, ref PullStartedMessage args)
     {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Fix inspections unbuckle, surgery rejoice !
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fix #6398
## Technical details
<!-- Summary of code changes for easier review. -->

OnBeingPulledAttempt — do-after removed. Now only does two things:
- Cancel if CanUnbuckle returns false (entity sleeping, out of range, etc.)
- Cancel if AllowOthersToUnbuckle = false (clowncar)


OnBucklePullAttempt subscribed to PullAttemptEvent, starts the do-after only on an actual pull initiation.
PullAttemptEvent is raised inside TryStartPull after CanPull() succeeds, unlike BeingPulledAttemptEvent which is raised inside CanPull() itself, meaning it also fires during passive verb-building checks.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
None
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
It would be far preferable to test some specific scenario, as this involves an element from the upstream.
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Baptr0b0t
- fix: right-clicking a buckled entity no longer unbuckles it.