### PR TITLE
Chain sword Buff

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
@@ -852,7 +852,7 @@
     slots:
     - belt
   - type: TimedToggleOnPray
-    duration: 10
+    duration: 20
     soundActivate:
       collection: GeneratorTug
       params:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
@@ -856,21 +856,19 @@
     soundActivate:
       collection: GeneratorTug
       params:
-        volume: 3
+        volume: 5
     soundDeactivate:
       path: /Audio/_Goobstation/Weapons/ChainSword/chainEnd.ogg
       params:
-        volume: 3
+        volume: 5
   - type: ItemToggleActiveSound
     activeSound:
       path: /Audio/Weapons/chainsawidle.ogg
       params:
-        volume: 3
+        volume: 5
   - type: ComponentToggler
     components:
     - type: Sharp
-    - type: DisarmMalus
-      malus: 0.6
     - type: Execution
       doAfterDuration: 4.0
     - type: BoneSaw # Shitmed
@@ -880,6 +878,7 @@
         path: /Audio/Weapons/chainsawwield.ogg
       endSound:
         path: /Audio/Weapons/chainsaw.ogg
+    - type: Unremoveable
   - type: Item
     size: Large
   - type: ItemToggleMeleeWeapon
@@ -899,13 +898,13 @@
     autoAttack: true
     heavyStaminaCost: 10
     wideAnimationRotation: -135
-    attackRate: 1.2
+    attackRate: 1.4
     damage:
       types:
         Blunt: 7
         Holy: 5
   - type: UseDelay
-    delay: 180.0
+    delay: 100.0
   - type: Appearance
   - type: ToggleableVisuals
     spriteLayer: blade
@@ -917,3 +916,5 @@
   - type: Tag
     tags:
     - InquisitorChainSword
+  - type: AlternatePrayable
+    prayDoAfterDuration: 1.5

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
@@ -904,7 +904,7 @@
         Blunt: 7
         Holy: 5
   - type: UseDelay
-    delay: 100.0
+    delay: 120.0
   - type: Appearance
   - type: ToggleableVisuals
     spriteLayer: blade


### PR DESCRIPTION
## About the PR
Chaplain Chain sword Buff
The activation speed has been reduced from 5 to 1.5.
The cooldown between activations has been reduced from 3 minutes to 2 minutes.
The duration has been increased from 10 seconds to 20 seconds
While active, the sword cannot be dropped.
The attack speed has been slightly increased.

## Why / Balance
Due to its long activation time, the sword cannot be activated in combat, as any damage taken resets the activation. The long cooldown prevented the sword from being used more than once per battle. I HOPE these buffs will at least make the sword somewhat viable in combat.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


**Changelog**
:cl: RedTerror
- tweak: Chaplain Chain sword Buff: activation speed 5s -> 1.5s, cooldown 3 minutes -> 2 minutes, duration 10s -> 20s.
- tweak:  Chaplain Chain sword cannot be dropped while active
