### PR TITLE
Chaplain Grey Emperor's Glove Buff

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
@@ -535,7 +535,7 @@
   - type: MeleeWeapon
     canWideSwing: false
     range: 3
-    attackRate: 0.7
+    attackRate: 0.9
     damage:
       types:
         Holy: 14

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
@@ -478,8 +478,8 @@
   - type: Tool
     qualities:
     - Screwing
-    speedModifier: 1.2
-    useSound: /Audio/Items/drill_use.ogg
+    speedModifier: 1.5
+    useSound: /Audio/Effects/Emotes/snap3.ogg
   - type: ToolTileCompatible
   - type: Prying
     enabled: false
@@ -491,48 +491,59 @@
         sprite: _ShitChap/Objects/Weapons/Nullrod/uristhand.rsi
         state: icon
       useSound:
-        path: /Audio/Items/drill_use.ogg
+        path: /Audio/Effects/Emotes/snap3.ogg
       changeSound:
-        path: /Audio/Items/change_drill.ogg
+        path: /Audio/Effects/Emotes/snap2.ogg
     - behavior: Prying
       sprite:
         sprite: _ShitChap/Objects/Weapons/Nullrod/uristhand.rsi
         state: icon
       useSound:
-        path: /Audio/Items/jaws_pry.ogg
+        path: /Audio/Effects/Emotes/snap3.ogg
       changeSound:
-        path: /Audio/Items/change_drill.ogg
+        path: /Audio/Effects/Emotes/snap2.ogg
     - behavior: Anchoring
       sprite:
         sprite: _ShitChap/Objects/Weapons/Nullrod/uristhand.rsi
         state: icon
       useSound:
-        path: /Audio/Items/ratchet.ogg
+        path: /Audio/Effects/Emotes/snap3.ogg
       changeSound:
-        path: /Audio/Items/change_drill.ogg
+        path: /Audio/Effects/Emotes/snap2.ogg
     - behavior: Cutting
       sprite:
         sprite: _ShitChap/Objects/Weapons/Nullrod/uristhand.rsi
         state: icon
       useSound:
-        path: /Audio/Items/jaws_cut.ogg
+        path: /Audio/Effects/Emotes/snap3.ogg
       changeSound:
-        path: /Audio/Items/change_drill.ogg
+        path: /Audio/Effects/Emotes/snap2.ogg
     - behavior: Pulsing
       sprite:
         sprite: _ShitChap/Objects/Weapons/Nullrod/uristhand.rsi
         state: icon
       changeSound:
-        path: /Audio/Items/change_drill.ogg
+        path: /Audio/Effects/Emotes/snap2.ogg
+    - behavior: Welding
+      sprite:
+        sprite: _ShitChap/Objects/Weapons/Nullrod/uristhand.rsi
+        state: icon
+      useSound:
+        path: /Audio/Effects/Emotes/snap3.ogg
+      changeSound:
+        path: /Audio/Effects/Emotes/snap2.ogg
   - type: MeleeWeapon
     canWideSwing: false
-    attackRate: 0.9
+    range: 3
+    attackRate: 0.7
     damage:
       types:
         Holy: 14
-        Blunt: 9
+        Blunt: 14
     soundHit:
-      path: /Audio/Weapons/smash.ogg
+      path: /Audio/Effects/Emotes/snap3.ogg
+      params:
+        volume: 10
   - type: Unremoveable
   - type: Nullrod
     DamageOnUntrainedUse:


### PR DESCRIPTION
## About the PR
Chaplain Grey Emperor's Glove Buff
All weapon sounds have been replaced with finger snaps
An infinite welder has been added. This means you can now tear down walls, repair windows, and weld shut airlocks and crates—a Greytide player’s dream.
The attack radius has been increased to 3 tiles, but there is no area-of-effect attack (right-click). You still have to click on the enemy with the left mouse button to hit them.
Damage has been increased from 9 Blunt and 14 Holy to 14 Blunt and 14 Holy. 

## Why / Balance
Right now, the Grey Emperor's Glove is a weak weapon. Adding welding to the list of tools would make it much more useful. Increasing the radius to 3 tiles sounds crazy—but essentially, the player has to hit a moving target with the mouse, which is difficult to do with fast-moving targets. Although it depends on skill...

But yes, that definitely makes the weapon “unique.”

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl: RedTerror
- tweak: Chaplain Grey Emperor's Glove Buff: welding add to the list of tools. The attack range has been increased to 3 tiles, and attacks cannot be performed by right-clicking.
- tweak: All Grey Emperor's Glove sounds have been replaced with finger snaps


