### PR TITLE
Fix woundmed

### DIFF
--- a/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Queries.cs
+++ b/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Queries.cs
@@ -32,7 +32,10 @@ public sealed partial class WoundSystem
                 continue;
 
             foreach (var woundEntity in childWoundable.Wounds.ContainedEntities)
-                yield return (woundEntity, Comp<WoundComponent>(woundEntity));
+            {
+                if (TryComp<WoundComponent>(woundEntity, out var woundComp))
+                    yield return (woundEntity, woundComp);
+            }
 
         }
     }

--- a/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Queries.cs
+++ b/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Queries.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Content.Shared._Shitmed.Medical.Surgery.Pain.Components;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds.Components;
 using Content.Shared._Shitmed.Targeting;
@@ -252,7 +253,8 @@ public sealed partial class WoundSystem
             var nearestSeverity = WoundableSeverity.Severed;
             var damage = damageable.TotalDamage;
 
-            foreach (var (severity, threshold) in woundable.SortedThresholds!)
+            woundable.SortedThresholds ??= [.. woundable.Thresholds.OrderByDescending(kv => kv.Value)];
+            foreach (var (severity, threshold) in woundable.SortedThresholds)
             {
                 if (damage <= 0)
                 {
@@ -297,8 +299,9 @@ public sealed partial class WoundSystem
 
             var damageFeeling = woundable.WoundableIntegrity * nerve.PainFeels;
 
+            woundable.SortedThresholds ??= [.. woundable.Thresholds.OrderByDescending(kv => kv.Value)];
             var nearestSeverity = woundable.WoundableSeverity;
-            foreach (var (severity, value) in woundable.SortedThresholds!)
+            foreach (var (severity, value) in woundable.SortedThresholds)
             {
                 if (damageFeeling <= 0)
                 {

--- a/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Severity.cs
+++ b/Content.Shared/_Shitmed/Surgery/Wounds/Systems/WoundSystem.Severity.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Shared._Shitmed.Medical.Surgery.Wounds.Components;
 using Content.Shared._Shitmed.Targeting;
 using Content.Shared._Shitmed.Targeting.Events;
@@ -252,8 +253,9 @@ public sealed partial class WoundSystem
         if (!Resolve(woundable, ref component, false))
             return;
 
+        component.SortedThresholds ??= [.. component.Thresholds.OrderByDescending(kv => kv.Value)];
         var nearestSeverity = component.WoundableSeverity;
-        foreach (var (severity, value) in component.SortedThresholds!)
+        foreach (var (severity, value) in component.SortedThresholds)
         {
             if (component.WoundableIntegrity >= component.IntegrityCap)
             {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Fix shitmed
Disclaimer : It's untested (because I have no idea what causes these entities to appear).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
<img width="1891" height="283" alt="image" src="https://github.com/user-attachments/assets/125ec152-a911-4d24-961f-d642785aa0f7" />
<img width="1849" height="285" alt="image" src="https://github.com/user-attachments/assets/3e7e8db6-aa37-4102-8bf4-f8b9406a6022" />

## Technical details
<!-- Summary of code changes for easier review. -->
Null object -> non-null object
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="255" height="21" alt="image" src="https://github.com/user-attachments/assets/45d6858b-ee98-4d29-b86b-3b2631a40a01" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Baptr0b0t
- Fix: Fixed game reloading every second !