### PR TITLE
Cargo tax + catalog addition

### DIFF
--- a/Content.Shared/Cargo/Components/StationBankAccountComponent.cs
+++ b/Content.Shared/Cargo/Components/StationBankAccountComponent.cs
@@ -21,7 +21,7 @@ public sealed partial class StationBankAccountComponent : Component
     /// When giving funds to a particular account, the proportion of funds they should receive compared to remaining accounts.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public double PrimaryCut = 0.50;
+    public double PrimaryCut = 0.90; //Goobstation, cargo uncucking
 
     /// <summary>
     /// When giving funds to a particular account from an override sell, the proportion of funds they should receive compared to remaining accounts.

--- a/Resources/Prototypes/_Goobstation/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Cargo/cargo_engineering.yml
@@ -22,3 +22,13 @@
   cost: 20000
   category: cargoproduct-category-name-engineering
   group: market
+
+- type: cargoProduct
+  id: CargoEngineeringGeneratorPacman
+  icon:
+    sprite: Structures/Power/Generation/portable_generator.rsi
+    state: portgen0
+  product: PortableGeneratorPacman # Not flatpack or in a crate to be a hassle to carry around so building is better.
+  cost: 3500 # Not meant to be bought for the slightest thing but still cheap enough in emergency.
+  category: cargoproduct-category-name-engineering
+  group: market

--- a/Resources/Prototypes/_Goobstation/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Cargo/cargo_materials.yml
@@ -3,7 +3,7 @@
   icon:
     sprite: Objects/Materials/Sheets/other.rsi
     state: generic_materials
-  product: CrateMaterialBasicResource
+  product: CrateMaterialBasicResourceBulk
   cost: 4980
   category: cargoproduct-category-name-materials
   group: market
@@ -13,7 +13,7 @@
   icon:
     sprite: Objects/Materials/Sheets/metal.rsi
     state: steel_3
-  product: CrateMaterialSteel
+  product: CrateMaterialSteelBulk
   cost: 5000
   category: cargoproduct-category-name-materials
   group: market

--- a/Resources/Prototypes/_Goobstation/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Cargo/cargo_materials.yml
@@ -1,0 +1,19 @@
+- type: cargoProduct
+  id: MaterialBasicBulk
+  icon:
+    sprite: Objects/Materials/Sheets/other.rsi
+    state: generic_materials
+  product: CrateMaterialBasicResource
+  cost: 4980
+  category: cargoproduct-category-name-materials
+  group: market
+
+- type: cargoProduct
+  id: MaterialSteelBulk
+  icon:
+    sprite: Objects/Materials/Sheets/metal.rsi
+    state: steel_3
+  product: CrateMaterialSteel
+  cost: 5000
+  category: cargoproduct-category-name-materials
+  group: market

--- a/Resources/Prototypes/_Goobstation/Catalog/materials.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/materials.yml
@@ -1,0 +1,25 @@
+- type: entity
+  id: CrateMaterialBasicResourceBulk
+  parent: CrateGenericSteel
+  name: bulk basic sheet crate
+  description: 90 sheets of steel, glass, and plastic, for when science is really screaming at you.
+  components:
+  - type: StorageFill
+    contents:
+    - id: SheetSteel
+      amount: 3
+    - id: SheetGlass
+      amount: 3
+    - id: SheetPlastic
+      amount: 3
+
+- type: entity
+  id: CrateMaterialSteelBulk
+  parent: CrateGenericSteel
+  name: bulk steel sheet crate
+  description: 300 sheets of steel, for your big construction or crafting needs.
+  components:
+  - type: StorageFill
+    contents:
+    - id: SheetSteel
+      amount: 10


### PR DESCRIPTION
## About the PR
- Base tax for non-lockbox sources, 50%->10%

- Bulk basic mat crate (90 of each basics)
Bulk steel mat crate (10x stack)

- PACMAN plasma gen crate for 3.5k, not flatpacked and pretty expensive so not insentivised to buy for fun.

## Why / Balance
Mald

- 50% base tax is slop, stops cargo from getting money to start/emergency, letting cargo grow with their starting money lends every departement more money in the end (money which isn't ever used anyway).
This mostly affected cargo where most players were new and didn't know about taxes (90% of them) which means most cargo were getting heavily cucked.

- No more crate spam and clogging ATS, make loading slightly faster so people stop complaining about cargo taking forever when they gotta carry shitsalv/miners.

- Shitty way for cargo to get emergency power in case of shitgee.

## Media

Bulk basics
<img width="725" height="394" alt="image" src="https://github.com/user-attachments/assets/b0a170c7-8eb1-4cb2-8644-b9a887516077" />

Bulk steel
<img width="679" height="385" alt="image" src="https://github.com/user-attachments/assets/2dcbc73a-74d0-42dc-ad00-ded5d9e9a03e" />

Generator
<img width="674" height="415" alt="image" src="https://github.com/user-attachments/assets/f91cdbbd-0ef4-406f-90a0-627c269733e2" />


:cl:
- add: Qol bulk material crates for cargo and plasma generator now available to buy.
- tweak: Cargo stroke a deal with the space IRS.