### PR TITLE
FoldableClothingFix

### DIFF
--- a/Content.Shared/Foldable/FoldableSystem.cs
+++ b/Content.Shared/Foldable/FoldableSystem.cs
@@ -153,8 +153,8 @@ public sealed class FoldableSystem : EntitySystem
         if (_container.IsEntityInContainer(uid) && !fold.CanFoldInsideContainer)
             return false;
 
-        if (!TryComp(uid, out PhysicsComponent? body) ||
-            !_anchorable.TileFree(Transform(uid).Coordinates, body))
+        if (!fold.CanFoldInsideContainer && (!TryComp(uid, out PhysicsComponent? body) || //GoobStation - FoldableClothingFix
+            !_anchorable.TileFree(Transform(uid).Coordinates, body)))
             return false;
 
         var ev = new FoldAttemptEvent(fold);


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
Clothing with a foldable component can now be folded and unfolded on occupied tiles.

## Why / Balance
<img width="322" height="142" alt="image" src="https://github.com/user-attachments/assets/6d6f8e01-37a0-44b9-8873-e7cf8ef61762" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Fixed Clothing Folding on Occupied Tiles

