### PR TITLE
low blood alert to health analyzer

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
@@ -300,6 +300,15 @@ namespace Content.Client.HealthAnalyzer.UI
 
             ConditionsListContainer.RemoveAllChildren();
 
+            // Goob start - low blood alert
+            if (msg.BloodLevelLow)
+                ConditionsListContainer.AddChild(new RichTextLabel
+                {
+                    Text = Loc.GetString("condition-body-low-blood", ("entity", Identity.Name(_target.Value, _entityManager))),
+                    Margin = new Thickness(0, 4),
+                });
+            // Goob end
+
             if (msg.Unrevivable == true)
                 ConditionsListContainer.AddChild(new RichTextLabel
                 {

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -385,11 +385,15 @@ public sealed class HealthAnalyzerSystem : EntitySystem
             bodyTemperature = temp.CurrentTemperature;
 
         var bloodAmount = float.NaN;
+        var bloodLow = false; // Goobstation
 
         if (TryComp<BloodstreamComponent>(target, out var bloodstream) &&
             _solutionContainerSystem.ResolveSolution(target, bloodstream.BloodSolutionName,
                 ref bloodstream.BloodSolution, out var bloodSolution))
+        {
             bloodAmount = bloodSolution.FillFraction;
+            bloodLow = bloodAmount < bloodstream.BloodlossThreshold; // Goobstation
+        }
 
         var bodyStatus = _woundSystem.GetDamageableStatesOnBody(target);
         Dictionary<TargetBodyPart, bool> bleeding; // Goobstation - removed unnecessary allocation
@@ -419,6 +423,7 @@ public sealed class HealthAnalyzerSystem : EntitySystem
                     vitalDamage, // Goobstation
                     traumas,
                     pain,
+                    bloodLow, // Goobstation
                     part != null ? GetNetEntity(part) : null
                 ));
                 break;

--- a/Content.Shared/_Shitmed/Medical/HealthAnalyzer/HealthAnalyzerMessages.cs
+++ b/Content.Shared/_Shitmed/Medical/HealthAnalyzer/HealthAnalyzerMessages.cs
@@ -55,6 +55,7 @@ public sealed class HealthAnalyzerBodyMessage : HealthAnalyzerBaseMessage
     public readonly NetEntity? SelectedPart;
     public readonly Dictionary<NetEntity, List<WoundableTraumaData>> Traumas;
     public readonly Dictionary<NetEntity, FixedPoint2> NervePainFeels;
+    public readonly bool BloodLevelLow; // Goobstation
 
     public HealthAnalyzerBodyMessage(
         NetEntity? targetEntity,
@@ -67,6 +68,7 @@ public sealed class HealthAnalyzerBodyMessage : HealthAnalyzerBaseMessage
         FixedPoint2 vitalDamage,  // Goobstation
         Dictionary<NetEntity, List<WoundableTraumaData>> traumas,
         Dictionary<NetEntity, FixedPoint2> nervePainFeels,
+        bool bloodLevelLow, // Goobstation
         NetEntity? selectedPart = null)
         : base(targetEntity, temperature, bloodLevel, scanMode, HealthAnalyzerMode.Body, body, bleeding, vitalDamage)  // Goobstation
     {
@@ -74,6 +76,7 @@ public sealed class HealthAnalyzerBodyMessage : HealthAnalyzerBaseMessage
         SelectedPart = selectedPart;
         Traumas = traumas;
         NervePainFeels = nervePainFeels;
+        BloodLevelLow = bloodLevelLow; // Goobstation
     }
 }
 

--- a/Resources/Locale/en-US/_Shitmed/medical/components/health-analyzer.ftl
+++ b/Resources/Locale/en-US/_Shitmed/medical/components/health-analyzer.ftl
@@ -10,6 +10,8 @@ condition-body-pain-decreased = • The {$woundable}'s nerves are numbed.
 condition-body-pain-increased = • The {$woundable}'s nerves are abnormally sensitive.
 condition-body-unrevivable = • {$entity} has a particularly weak constitution. They cannot withstand the shock of a defibrillator.
 condition-body-bleeding = • {$entity} is bleeding.
+# Goobstation - low blood alert
+condition-body-low-blood = • {$entity} has a [color=red]dangerously low[/color] blood level.
 
 condition-organ-damage-Normal = • The {$organ} is mostly good.
 condition-organ-damage-Damaged = • The {$organ} is damaged.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
added a low blood alert to the health analyzer which appears when the patient's blood is below the bloodloss threshold
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
quality of life change specifically towards newer players/med interns. also it's convenient not having to glance at the blood level
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
the alert is red so it grabs your attention
<img width="797" height="517" alt="image" src="https://github.com/user-attachments/assets/9c0d612a-1e64-4a18-bc5d-bd42975176fd" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] slooooooooop
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: shoebill
- add: Added a low blood alert to the health analyzer.
