### PR TITLE
Add playtime requirements to some midround roles

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Markers/Spawners/ghost_roles.yml
@@ -19,6 +19,10 @@
     - MindRoleGhostRoleSilicon
     raffle:
       settings: default
+    requirements:
+    - !type:RoleTimeRequirement
+      role: JobBorg
+      time: 3600 #1 hour
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:
@@ -40,6 +44,10 @@
     - MindRoleGhostRoleSoloAntagonist
     raffle:
       settings: default
+    requirements:
+    - !type:RoleTimeRequirement
+      role: JobPassenger
+      time: 36000 #10 hours
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:
@@ -61,6 +69,10 @@
     - MindRoleGhostRoleSoloAntagonist
     raffle:
       settings: default
+    requirements:
+    - !type:RoleTimeRequirement
+      role: JobClown
+      time: 3600 #1 hour
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:
@@ -82,6 +94,10 @@
     - MindRoleGhostRoleFreeAgent
     raffle:
       settings: default
+    requirements:
+    - !type:DepartmentTimeRequirement
+      department: Engineering
+      time: 54000 #15 hrs
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:
@@ -103,6 +119,10 @@
     - MindRoleGhostRoleSoloAntagonist
     raffle:
       settings: default
+    requirements:
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 18000 #5 hours
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:
@@ -125,6 +145,10 @@
     - MindRoleGhostRoleSoloAntagonist
     raffle:
       settings: default
+    requirements:
+    - !type:RoleTimeRequirement
+      role: JobMime
+      time: 3600 #1 hour
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:
@@ -146,6 +170,10 @@
     - MindRoleGhostRoleNeutral
     raffle:
       settings: default
+    requirements:
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 18000 #5 hours
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:
@@ -167,6 +195,10 @@
     - MindRoleGhostRoleFreeAgent
     raffle:
       settings: default
+    requirements:
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 18000 #5 hours
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:
@@ -188,6 +220,10 @@
     - MindRoleGhostRoleTeamAntagonist
     raffle:
       settings: default
+    requirements:
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 18000 #5 hours
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
- Admins asked me to add a playtime requirement to siguloth knights because they kept singuloosing (even though they are crew-aligned)
- Derelict syndicate borg requirement is because of parity with the same requirement on a normal derelict cyborg
- Greytire requirement (even though it's removed) is 10h on assistaint to ensure that only real tiders can play this role :godo:
- Tunnel clown requires 1h on clown, because well, it's basically a clown but angry and scary one
- Mime assassin has mime requirements for same reasons as tunnel clown
- The rest require secutiry time since they are mostly combat focused

🆑 Rouden
- tweak: Singulo knights, Derelict syndicate borgs, Greytides, Tunnel clowns, Mime assassin, and some other midround roles now have playtime requirements.