### PR TITLE
fix natural regen, bring back buffed slime regen

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -521,6 +521,7 @@
         Blunt: 0.50 #per second, scales with pressure and other constants.
         Heat: 0.1
   - type: PassiveDamage # Slight passive regen. Assuming one damage type, comes out to about 4 damage a minute.
+    splitBehavior: SplitEnsureAllDamagedAndOrganic # Goob
     allowedStates:
      - Alive
     damageCap: 20 #this looks at vital damage, not total damage, ideally it should look at damage/part but i dont care enough to fix it

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -132,15 +132,15 @@
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: Slime
-#  - type: PassiveDamage # Around 8 damage a minute healed
-#    allowedStates:
-#    - Alive
-#    damageCap: 65
-#    damage:
-#      types:
-#        Heat: -0.14
-#      groups:
-#        Brute: -0.14
+  - type: PassiveDamage # Around 8 damage a minute healed
+    allowedStates:
+    - Alive
+    damageCap: 65
+    damage:
+      types:
+        Heat: -0.14
+      groups:
+        Brute: -0.14
   #  - type: DamageVisuals
   #    damageOverlayGroups:
   #      Brute:

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -167,6 +167,7 @@
   - type: PassiveDamage
     # Augment normal health regen to be able to tank some Poison damage
     # This allows Vox to take their mask off temporarily to eat something without needing a trip to medbay afterwards.
+    splitBehavior: SplitEnsureAllDamagedAndOrganic # Goob
     allowedStates:
     - Alive
     damageCap: 20
@@ -290,7 +291,7 @@
           32:
             sprite: Mobs/Species/Vox/displacement.rsi
             state: shoes
-      outerClothing: # Goob 
+      outerClothing: # Goob
         sizeMaps:
           32:
             sprite: Mobs/Species/Vox/displacement.rsi
@@ -358,7 +359,7 @@
   - type: Carriable # Goobstation
   - type: CPRTraining # Goobstation - Just give to everyone! This ain't MRP.
   - type: GrabIntent # wilted rose
-  - type: Grabbable 
+  - type: Grabbable
   # Goobstation end
   - type: Hands
     leftHandDisplacement:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
fixed natural regen (brought back by @DeusMaldPr) not working as intended
<img width="771" height="212" alt="image" src="https://github.com/user-attachments/assets/651a0de8-c2b8-4760-8ea6-74e7df4d4e37" />

also brought back slimes buffed regen (bounty)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
why not

## Technical details
<!-- Summary of code changes for easier review. -->
yaml.

btw manual .contains in related wizden code is funny
<img width="588" height="134" alt="image" src="https://github.com/user-attachments/assets/ead911e3-cec2-452e-aa80-98ce773dc285" />

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="504" height="595" alt="image" src="https://github.com/user-attachments/assets/4700689f-ecf4-4f5c-b5bf-62c1d3d7a6f3" />
<img width="623" height="605" alt="image" src="https://github.com/user-attachments/assets/8422e913-9cec-4a91-af84-65dae455b99b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] Tested, works
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!---->
:cl:
- fix: Fixed natural regen (below 20 damage) being like 10 times less effective as it should've been.
- tweak: Slimes now have double natural regen speed again, and regenerate up to **65** damage.