### PR TITLE
Department modsuits now craftable

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -788,6 +788,7 @@
     # - ServiceWeapons
     - SpecOpsGoogles
     - PowerCells
+    - ModsuitSecurity
   - type: EmagLatheRecipes # Goobstation
     emagStaticPacks:
     - SyndicateAmmoLightStatic
@@ -877,6 +878,7 @@
     - MedicalBoardsStaticGoob
     - PowerCellsStatic
     - GrenadeTriggersStatic
+    - ModsuitMedical
     # Einstein Engines Packs
     - SyringeCase
     dynamicPacks:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -881,7 +881,6 @@
     - MedicalBoardsStaticGoob
     - PowerCellsStatic
     - GrenadeTriggersStatic
-    - ModsuitMedical
     # Einstein Engines Packs
     - SyringeCase
     dynamicPacks:
@@ -897,6 +896,7 @@
     - Janitor
     - Genetics
     - MedicalCloning
+    - ModsuitMedical 
     # Einstein Engines Packs
     - Translators # Language
     - TranslatorImplanters # Language

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -672,6 +672,9 @@
   - type: EmagLatheRecipes # Goobstation
     emagStaticPacks:
     - MechWeaponsSecurityStatic
+    - ModsuitEngineering
+    - ModsuitSecurity
+    - ModsuitMedical
     emagDynamicPacks:
     - MechWeaponsSalvage
     - MechWeaponsSecurityLight

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Robotics/modsuit_parts.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Robotics/modsuit_parts.yml
@@ -133,7 +133,7 @@
           shell-secured: { state: shell-secured }
 
 - type: entity
-  id: ModsuitPlatingExternal #sci fab
+  id: ModsuitPlatingExternal
   parent: PartModsuit
   name: MOD standard external plating
   description: A part used in MOD construction.
@@ -153,7 +153,7 @@
     - ModsuitPlatingExternal
 
 - type: entity
-  id: ModsuitPlatingParamedic #medfab
+  id: ModsuitPlatingParamedic
   parent: PartModsuit
   name: MOD standard paramedic 'sanitater' plating
   description: A part used in MOD construction.
@@ -173,7 +173,7 @@
     - ModsuitPlatingParamedic 
 
 - type: entity
-  id: ModsuitPlatingEngineer #engiefab
+  id: ModsuitPlatingEngineer
   parent: PartModsuit
   name: MOD standard engineer 'sapper' plating
   description: A part used in MOD construction.
@@ -193,7 +193,7 @@
     - ModsuitPlatingEngineer
 
 - type: entity
-  id: ModsuitPlatingSecurity #secfab
+  id: ModsuitPlatingSecurity
   parent: PartModsuit
   name: MOD standard security 'soldat' plating
   description: A part used in MOD construction.
@@ -213,7 +213,7 @@
     - ModsuitPlatingSecurity
 
 - type: entity
-  id: ModsuitPlatingHeadOfSecurity # Not obtainable
+  id: ModsuitPlatingHeadOfSecurity
   parent: PartModsuit
   name: MOD standard head of security 'bulwark' plating
   description: A part used in MOD construction.
@@ -233,7 +233,7 @@
     - ModsuitPlatingHeadOfSecurity 
 
 - type: entity
-  id: ModsuitPlatingCaptain # Not obtainable
+  id: ModsuitPlatingCaptain
   parent: PartModsuit
   name: MOD standard captain's magnate plating
   description: A part used in MOD construction.
@@ -253,7 +253,7 @@
     - ModsuitPlatingCaptain 
 
 - type: entity
-  id: ModsuitPlatingRD # Not obtainable
+  id: ModsuitPlatingRD
   parent: PartModsuit
   name: MOD standard RD's 'minerva' plating
   description: A part used in MOD construction.
@@ -273,7 +273,7 @@
     - ModsuitPlatingRD
 
 - type: entity
-  id: ModsuitPlatingAtmostech #engiefab
+  id: ModsuitPlatingAtmostech
   parent: PartModsuit
   name: MOD standard atmospheric technician's 'aeolus' plating
   description: A part used in MOD construction.

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Robotics/modsuit_parts.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Robotics/modsuit_parts.yml
@@ -133,7 +133,7 @@
           shell-secured: { state: shell-secured }
 
 - type: entity
-  id: ModsuitPlatingExternal
+  id: ModsuitPlatingExternal #sci fab
   parent: PartModsuit
   name: MOD standard external plating
   description: A part used in MOD construction.
@@ -153,7 +153,7 @@
     - ModsuitPlatingExternal
 
 - type: entity
-  id: ModsuitPlatingParamedic
+  id: ModsuitPlatingParamedic #medfab
   parent: PartModsuit
   name: MOD standard paramedic 'sanitater' plating
   description: A part used in MOD construction.
@@ -170,10 +170,10 @@
   - type: Tag
     tags:
     - ModsuitPart
-    - ModsuitPlatingExternal # Change this when they become obtainable
+    - ModsuitPlatingParamedic 
 
 - type: entity
-  id: ModsuitPlatingEngineer
+  id: ModsuitPlatingEngineer #engiefab
   parent: PartModsuit
   name: MOD standard engineer 'sapper' plating
   description: A part used in MOD construction.
@@ -190,10 +190,10 @@
   - type: Tag
     tags:
     - ModsuitPart
-    - ModsuitPlatingExternal # Change this when they become obtainable
+    - ModsuitPlatingEngineer
 
 - type: entity
-  id: ModsuitPlatingSecurity
+  id: ModsuitPlatingSecurity #secfab
   parent: PartModsuit
   name: MOD standard security 'soldat' plating
   description: A part used in MOD construction.
@@ -210,10 +210,10 @@
   - type: Tag
     tags:
     - ModsuitPart
-    - ModsuitPlatingExternal # Change this when they become obtainable
+    - ModsuitPlatingSecurity
 
 - type: entity
-  id: ModsuitPlatingHeadOfSecurity
+  id: ModsuitPlatingHeadOfSecurity # Not obtainable
   parent: PartModsuit
   name: MOD standard head of security 'bulwark' plating
   description: A part used in MOD construction.
@@ -230,10 +230,10 @@
   - type: Tag
     tags:
     - ModsuitPart
-    - ModsuitPlatingExternal # Change this when they become obtainable
+    - ModsuitPlatingHeadOfSecurity 
 
 - type: entity
-  id: ModsuitPlatingCaptain
+  id: ModsuitPlatingCaptain # Not obtainable
   parent: PartModsuit
   name: MOD standard captain's magnate plating
   description: A part used in MOD construction.
@@ -250,10 +250,10 @@
   - type: Tag
     tags:
     - ModsuitPart
-    - ModsuitPlatingExternal # Change this when they become obtainable
+    - ModsuitPlatingCaptain 
 
 - type: entity
-  id: ModsuitPlatingRD
+  id: ModsuitPlatingRD # Not obtainable
   parent: PartModsuit
   name: MOD standard RD's 'minerva' plating
   description: A part used in MOD construction.
@@ -270,10 +270,10 @@
   - type: Tag
     tags:
     - ModsuitPart
-    - ModsuitPlatingExternal # Change this when they become obtainable
+    - ModsuitPlatingRD
 
 - type: entity
-  id: ModsuitPlatingAtmostech
+  id: ModsuitPlatingAtmostech #engiefab
   parent: PartModsuit
   name: MOD standard atmospheric technician's 'aeolus' plating
   description: A part used in MOD construction.
@@ -290,7 +290,7 @@
   - type: Tag
     tags:
     - ModsuitPart
-    - ModsuitPlatingExternal # Change this when they become obtainable
+    - ModsuitPlatingAtmostech
 
 - type: entity
   id: ModsuitCoreStandard

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
@@ -75,6 +75,7 @@
     - BluespaceTheory
     - ScienceClothing
     - UpgradeKits
+    - ModsuitEngineering
   - type: EmagLatheRecipes
     emagStaticPacks:
     - NailgunEvilStatic

--- a/Resources/Prototypes/_Goobstation/Recipes/Construction/Graphs/clothing/modsuit.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Construction/Graphs/clothing/modsuit.yml
@@ -117,6 +117,89 @@
 
         - tool: Anchoring
           doAfter: 1
+    - to: security
+      steps:
+        - tag: ModsuitPlatingSecurity
+          name: construction-graph-tag-mod-plating
+          doAfter: 1
+          completed:
+          - !type:PlaySound
+            sound: /Audio/Items/screwdriver2.ogg
+
+        - tool: Anchoring
+          doAfter: 1
+
+    - to: headofsecurity
+      steps:
+        - tag: ModsuitPlatingHeadOfSecurity
+          name: construction-graph-tag-mod-plating
+          doAfter: 1
+          completed:
+          - !type:PlaySound
+            sound: /Audio/Items/screwdriver2.ogg
+
+        - tool: Anchoring
+          doAfter: 1
+
+    - to: paramedic
+      steps:
+        - tag: ModsuitPlatingParamedic
+          name: construction-graph-tag-mod-plating
+          doAfter: 1
+          completed:
+          - !type:PlaySound
+            sound: /Audio/Items/screwdriver2.ogg
+
+        - tool: Anchoring
+          doAfter: 1
+
+    - to: engineer
+      steps:
+        - tag: ModsuitPlatingEngineer
+          name: construction-graph-tag-mod-plating
+          doAfter: 1
+          completed:
+          - !type:PlaySound
+            sound: /Audio/Items/screwdriver2.ogg
+
+        - tool: Anchoring
+          doAfter: 1
+
+    - to: atmostech
+      steps:
+        - tag: ModsuitPlatingAtmostech
+          name: construction-graph-tag-mod-plating
+          doAfter: 1
+          completed:
+          - !type:PlaySound
+            sound: /Audio/Items/screwdriver2.ogg
+
+        - tool: Anchoring
+          doAfter: 1
+
+    - to: rd
+      steps:
+        - tag: ModsuitPlatingRD
+          name: construction-graph-tag-mod-plating
+          doAfter: 1
+          completed:
+          - !type:PlaySound
+            sound: /Audio/Items/screwdriver2.ogg
+
+        - tool: Anchoring
+          doAfter: 1
+
+    - to: captain
+      steps:
+        - tag: ModsuitPlatingCaptain
+          name: construction-graph-tag-mod-plating
+          doAfter: 1
+          completed:
+          - !type:PlaySound
+            sound: /Audio/Items/screwdriver2.ogg
+
+        - tool: Anchoring
+          doAfter: 1
 
   - node: standard
     entity: ClothingModsuitStandard

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/engineering.yml
@@ -38,3 +38,11 @@
   id: ConstructionBagOfHolding
   recipes:
   - ConstructionBagOfHolding
+
+- type: latheRecipePack
+  id: ModsuitEngineering
+  categories:
+   - Modsuit
+  recipes:
+   -  ModsuitPlatingEngineering
+   -  ModsuitPlatingAtmostech

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/engineering.yml
@@ -41,8 +41,6 @@
 
 - type: latheRecipePack
   id: ModsuitEngineering
-  categories:
-   - Modsuit
   recipes:
    -  ModsuitPlatingEngineering
    -  ModsuitPlatingAtmostech

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/medical.yml
@@ -98,7 +98,5 @@
 
 - type: latheRecipePack
   id: ModsuitMedical
-  categories:
-   - Modsuit
   recipes:
    -  ModsuitPlatingParamedic

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/medical.yml
@@ -95,3 +95,10 @@
   - CloningPodMachineCircuitboardRecipe
   - MedicalScannerMachineCircuitboardRecipe
   - CloningConsoleComputerCircuitboardRecipe
+
+- type: latheRecipePack
+  id: ModsuitMedical
+  categories:
+   - Modsuit
+  recipes:
+   -  ModsuitPlatingParamedic

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/security.yml
@@ -118,7 +118,5 @@
 
 - type: latheRecipePack
   id: ModsuitSecurity
-  categories:
-   - Modsuit
   recipes:
    -  ModsuitPlatingSecurity

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/Packs/security.yml
@@ -115,3 +115,10 @@
   recipes:
   - ClothingMaskMuzzleSecure
   - ClothingMaskMuzzleShock
+
+- type: latheRecipePack
+  id: ModsuitSecurity
+  categories:
+   - Modsuit
+  recipes:
+   -  ModsuitPlatingSecurity

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/engineering.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/engineering.yml
@@ -10,7 +10,6 @@
     Glass: 150
     Plasma: 50
 
-
 - type: latheRecipe
   id: ModsuitPlatingAtmostech
   result: ModsuitPlatingAtmostech

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/engineering.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/engineering.yml
@@ -1,4 +1,3 @@
-
   # Modsuits
 
 - type: latheRecipe

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/engineering.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/engineering.yml
@@ -1,0 +1,21 @@
+
+  # Modsuits
+
+- type: latheRecipe
+  id: ModsuitPlatingEngineering
+  result: ModsuitPlatingEngineer
+  completetime: 4
+  materials:
+    Steel: 300
+    Glass: 150
+    Plasma: 50
+
+
+- type: latheRecipe
+  id: ModsuitPlatingAtmostech
+  result: ModsuitPlatingAtmostech
+  completetime: 4
+  materials:
+    Steel: 300
+    Glass: 150
+    Plasma: 50

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/medical.yml
@@ -208,3 +208,14 @@
     Plastic: 100
     Steel: 150
     Glass: 150
+
+# Modsuits
+
+- type: latheRecipe
+  id: ModsuitPlatingParamedic
+  result: ModsuitPlatingParamedic
+  completetime: 4
+  materials:
+    Steel: 300
+    Glass: 150
+    Plasma: 50

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/security.yml
@@ -773,4 +773,15 @@
     Plastic: 250
     Cloth: 200
 
-  
+
+
+  # Modsuits
+
+- type: latheRecipe
+  id: ModsuitPlatingSecurity
+  result: ModsuitPlatingSecurity
+  completetime: 4
+  materials:
+    Steel: 300
+    Glass: 150
+    Plasma: 50

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/security.yml
@@ -773,8 +773,6 @@
     Plastic: 250
     Cloth: 200
 
-
-
   # Modsuits
 
 - type: latheRecipe

--- a/Resources/Prototypes/_Goobstation/Research/experimental.yml
+++ b/Resources/Prototypes/_Goobstation/Research/experimental.yml
@@ -47,6 +47,10 @@
   - ModsuitGauntlets
   - ModsuitShell
   - ModsuitPlatingExternal
+  - ModsuitPlatingSecurity
+  - ModsuitPlatingParamedic
+  - ModsuitPlatingEngineering
+  - ModsuitPlatingAtmostech
   position: -4,-1
   technologyPrerequisites:
   - MagnetsTech

--- a/Resources/Prototypes/_Goobstation/tags.yml
+++ b/Resources/Prototypes/_Goobstation/tags.yml
@@ -450,6 +450,27 @@
   id: ModsuitPlatingExternal
 
 - type: Tag
+  id: ModsuitPlatingParamedic
+
+- type: Tag
+  id: ModsuitPlatingEngineer
+
+- type: Tag
+  id: ModsuitPlatingSecurity
+
+- type: Tag
+  id: ModsuitPlatingAtmostech
+
+- type: Tag
+  id: ModsuitPlatingHeadOfSecurity
+
+- type: Tag
+  id: ModsuitPlatingCaptain
+
+- type: Tag
+  id: ModsuitPlatingRD
+
+- type: Tag
   id: ModsuitShell
 
 - type: Tag


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Made Security, Atmospherics, Engineering, and Paramedic modsuit plating craftable after research, requires departmental lathes to make
I.E. Security modsuit plating only craftable at security techfab, engineering only at engineering techfab, etc. etc. 

If you emag the robotics lathe you can make any departments modsuit plating- syndies will probobly only use this for security armor if anything at all, but could be useful for disguises or better MODsuits for thieves, if they want to go that route- I guess.

Allows for modsuits to be replaceable if one is lost and / or more are needed (warops?)

Did not add any recipes to make captain, RD, or HoS plating- still unobtainable if the original one is lost.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
No way to get the different plating for modsuits before- now obtainable + able to be used in making modsuits.

I kept all the costs for the plating the same as normal external plating- I figure that the cost of the rest of the modsuit components don't cause it to be too easy to print, as well as needing the cores from cargo.

## Technical details
<!-- Summary of code changes for easier review. -->
bunch of yaml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Now able to craft and assemble departmental MODsuits!
