### PR TITLE
Hunger thirst rebalance

### DIFF
--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -49,7 +49,7 @@ public sealed partial class HungerComponent : Component
     /// </summary>
     /// <remarks>Any time this is modified, <see cref="HungerSystem.SetAuthoritativeHungerValue"/> should be called.</remarks>
     [DataField("baseDecayRate"), ViewVariables(VVAccess.ReadWrite)]
-    public float BaseDecayRate = 0.01666666666f;
+    public float BaseDecayRate = 0.04166666666f; // Goobstation changed to 150/3600
 
     /// <summary>
     /// The actual amount at which <see cref="LastAuthoritativeHungerValue"/> decays.

--- a/Content.Shared/Nutrition/Components/ThirstComponent.cs
+++ b/Content.Shared/Nutrition/Components/ThirstComponent.cs
@@ -31,7 +31,7 @@ public sealed partial class ThirstComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("baseDecayRate")]
     [AutoNetworkedField]
-    public float BaseDecayRate = 0.1f;
+    public float BaseDecayRate = 0.125f; // Goobstation changed to 450/3600
 
     [ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -227,7 +227,7 @@
       Peckish: 125
       Starving: 50
       Dead: 0
-    baseDecayRate: 0.01666666666
+    # baseDecayRate: 0.01666666666 Goobstation
   - type: Thirst
     thresholds:
       OverHydrated: 600
@@ -235,7 +235,7 @@
       Thirsty: 300
       Parched: 150
       Dead: 0
-    baseDecayRate: 0.1
+    # baseDecayRate: 0.1 Goobstation
   - type: DamageStateVisuals
     states:
       Alive:
@@ -463,7 +463,7 @@
       Peckish: 100
       Starving: 50
       Dead: 0
-    baseDecayRate: 0.01666666666
+    # baseDecayRate: 0.01666666666 Goobstation
   - type: Thirst
     thresholds:
       OverHydrated: 600
@@ -471,7 +471,7 @@
       Thirsty: 300
       Parched: 150
       Dead: 0
-    baseDecayRate: 0.1
+    # baseDecayRate: 0.1 Goobstation
   - type: DamageStateVisuals
     states:
       Alive:

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -53,9 +53,9 @@
   - type: HumanoidAppearance
     species: Diona
   - type: Hunger
-    baseDecayRate: 0.0083
+    baseDecayRate: 0.020833 # Goobstation base rate changed, 2 times lower than base
   - type: Thirst
-    baseDecayRate: 0.0083
+    baseDecayRate: 0.0625 # Goobsatation base rate changed, 2 times lower than base
   - type: Icon
     sprite: Mobs/Species/Diona/parts.rsi
     state: full

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
@@ -12,7 +12,7 @@
   - type: Hunger
   # - type: Carriable # ShibaStation - disabled because broken, for now.
   - type: Thirst
-    baseDecayRate: 0.2
+    baseDecayRate: 0.25 # Goobstation base rate changed, 2 times more than base
   - type: Icon
     sprite: _Goobstation/Mobs/Species/Feroxi/parts.rsi #RedTerror Goob Resprite
     state: full

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
@@ -45,7 +45,7 @@
   - type: HumanoidAppearance
     species: Rodentia
   - type: Hunger
-    baseDecayRate: 0.0467 # 33% faster than usual
+    baseDecayRate: 0.054166 # Goobstation base rate changed, 33% faster than base
   - type: Thirst # // Goob Station //
   - type: Carriable # Carrying system from nyanotrasen.
   - type: Inventory


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Base hunger decay increased from 0.01666 to 0.04166
Base thirst decay increased from 0.1 to 0.125
That should lead to first moodle in 45 minutes on average and to first slowdown debuff in 70 minutes on average if you eat your nutribrick after first moodle

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Let's assume that, on average, 1 round lasts from 1 to 2 hours.
Default hunger is 110–150.
Old hunger rate is 0.01666...
First moodle at 100 hunger.
Second moodle and slowdown debuff at 50 hunger (also a 0.8 modifier to the hunger rate).

1/0.01666... = 60 seconds (1 minute for 1 hunger).
1u vitamin/nutriment/protein = 6 hunger = 6 minutes.
5u = 30 minutes.
Nutribrick = 15 nutriment = 90 hunger = 90 minutes (i.e., you can eat nothing else in a round).
(if https://github.com/Goob-Station/Goob-Station/pull/6689 were accepted)
Snack/burger = 10 nutriment = 60 hunger = 60 minutes.

Minimal time to first debuff:
10/0.01666... + 50/(0.8 * 0.01666) = 4350 seconds = 72.5 minutes (in some rounds, you don't need to eat at all, even if you are unlucky).
Maximal time to first debuff:
50/0.01666... + 50/(0.8 * 0.01666) = 6750 seconds = 112.5 minutes (if you are lucky enough, you can never eat in an almost 2-hour round without any debuffs).

Let's assume that we need to force at least half of the station to eat something other than a nutribrick after an hour of the round.
In the worst case, you would have 110 (default) + 90 (nutribrick), i.e., max cap, so we need to have a debuff from overfed to starving in 1 hour (3600 seconds).
Roughly, it would be a rate of 150/3600 = 0.041666...
I would ignore the dead state. I assume that the slowdown debuff is enough to motivate eating. The whole station dying from starvation and eating their crewmates to survive sounds fun, but it is not fun to play as a ghost, so I don't think that damage is needed.

Okay, now let's reevaluate the numbers.
1/0.041666... = 24 seconds per 1 hunger.
1u vitamin/nutriment/protein = 6 hunger = 144 seconds (2.4 minutes).
5u = 30 hunger = 12 minutes.
Nutribrick = 15 nutriment = 36 minutes.
Snack/burger = 10 nutriment = 24 minutes.

Minimal time to first debuff:
10/0.041666... + 50/(0.8 * 0.041666) = 1740 seconds = 29 minutes.
Maximal time to first debuff:
50/0.041666... + 50/(0.8 * 0.041666) = 2700 seconds = 45 minutes.

Let's assume that the nutribrick is eaten the moment the first moodle appears.
Minimal time to first moodle after nutribrick:
10/0.041666... + 40/(1.2 * 0.041666...) + 50/0.041666... = 2240 seconds = 37 minutes.
Minimal time to first debuff after nutribrick:
10/0.041666... + 40/(1.2 * 0.041666...) + 50/0.041666... + 50/(0.8 * 0.041666...) = 3740 seconds = 62 minutes.
Maximal time to first moodle after nutribrick:
50/0.041666... + 40/(1.2 * 0.041666...) + 50/0.041666... = 3200 seconds = 53 minutes.
Maximal time to first debuff after nutribrick:
50/0.041666... + 40/(1.2 * 0.041666...) + 50/0.041666... + 50/(0.8 * 0.041666...) = 4700 seconds = 78 minutes.
Average time to first moodle after nutribrick:
(2240 + 3200)/2 = 2720 seconds = 45 minutes.
Average time to first debuff after nutribrick:
(3740 + 4700)/2 = 4220 seconds = 70 minutes.

The thirst rate was adjusted to be nearly equal to the hunger rate, because if it were lower, it would be strange, but if it were higher, it would be too annoying.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Base hunger decay increased from 0.01666 to 0.04166. Base thirst decay increased from 0.1 to 0.125. That should lead to first moodle in 45 minutes on average and to first slowdown debuff in 70 minutes on average if you eat your nutribrick after first moodle.
