### PR TITLE
Roundstart echem removal

### DIFF
--- a/Resources/Maps/.oasis.yml
+++ b/Resources/Maps/.oasis.yml
@@ -92724,7 +92724,7 @@ entities:
       parent: 10023
     - type: Physics
       canCollide: False
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 7800
     components:

--- a/Resources/Maps/_Goobstation/amber.yml
+++ b/Resources/Maps/_Goobstation/amber.yml
@@ -75669,7 +75669,7 @@ entities:
     - type: Transform
       pos: -28.661604,12.681278
       parent: 2
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 9065
     components:

--- a/Resources/Maps/_Goobstation/atlas.yml
+++ b/Resources/Maps/_Goobstation/atlas.yml
@@ -25107,7 +25107,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -44.5,-16.5
       parent: 2
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 3211
     components:

--- a/Resources/Maps/_Goobstation/bagel.yml
+++ b/Resources/Maps/_Goobstation/bagel.yml
@@ -71251,7 +71251,7 @@ entities:
       parent: 10858
     - type: Physics
       canCollide: False
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 9108
     components:

--- a/Resources/Maps/_Goobstation/barratry.yml
+++ b/Resources/Maps/_Goobstation/barratry.yml
@@ -49887,7 +49887,7 @@ entities:
     - type: Transform
       pos: 27.345951,23.492924
       parent: 2
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 5200
     components:

--- a/Resources/Maps/_Goobstation/box.yml
+++ b/Resources/Maps/_Goobstation/box.yml
@@ -81103,7 +81103,7 @@ entities:
       parent: 12763
     - type: Physics
       canCollide: False
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 10389
     components:

--- a/Resources/Maps/_Goobstation/chloris.yml
+++ b/Resources/Maps/_Goobstation/chloris.yml
@@ -132890,7 +132890,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 173.5,28.5
       parent: 2
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 10790
     components:

--- a/Resources/Maps/_Goobstation/cluster.yml
+++ b/Resources/Maps/_Goobstation/cluster.yml
@@ -34164,7 +34164,7 @@ entities:
       parent: 5189
     - type: Physics
       canCollide: False
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 4119
     components:

--- a/Resources/Maps/_Goobstation/cog.yml
+++ b/Resources/Maps/_Goobstation/cog.yml
@@ -97143,7 +97143,7 @@ entities:
     - type: Transform
       pos: 33.51501,-6.2675023
       parent: 2
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 15505
     components:

--- a/Resources/Maps/_Goobstation/delta.yml
+++ b/Resources/Maps/_Goobstation/delta.yml
@@ -132045,7 +132045,7 @@ entities:
       parent: 18033
     - type: Physics
       canCollide: False
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 14666
     components:

--- a/Resources/Maps/_Goobstation/fland.yml
+++ b/Resources/Maps/_Goobstation/fland.yml
@@ -111368,7 +111368,7 @@ entities:
       parent: 17127
     - type: Physics
       canCollide: False
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 17129
     components:

--- a/Resources/Maps/_Goobstation/kettle.yml
+++ b/Resources/Maps/_Goobstation/kettle.yml
@@ -79116,7 +79116,7 @@ entities:
       parent: 11943
     - type: Physics
       canCollide: False
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 9802
     components:

--- a/Resources/Maps/_Goobstation/leonid.yml
+++ b/Resources/Maps/_Goobstation/leonid.yml
@@ -114848,7 +114848,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -0.8063518,-47.42559
       parent: 2
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 16091
     components:

--- a/Resources/Maps/_Goobstation/marathon.yml
+++ b/Resources/Maps/_Goobstation/marathon.yml
@@ -63743,7 +63743,7 @@ entities:
     - type: Transform
       pos: -17.315872,-34.317642
       parent: 2
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 8308
     components:

--- a/Resources/Maps/_Goobstation/meta.yml
+++ b/Resources/Maps/_Goobstation/meta.yml
@@ -76617,7 +76617,7 @@ entities:
     - type: Transform
       pos: 66.5,28.5
       parent: 2
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 9547
     components:

--- a/Resources/Maps/_Goobstation/oasis.yml
+++ b/Resources/Maps/_Goobstation/oasis.yml
@@ -92791,7 +92791,7 @@ entities:
       parent: 10023
     - type: Physics
       canCollide: False
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 7800
     components:

--- a/Resources/Maps/_Goobstation/omega.yml
+++ b/Resources/Maps/_Goobstation/omega.yml
@@ -38678,7 +38678,7 @@ entities:
       parent: 5984
     - type: Physics
       canCollide: False
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 4963
     components:

--- a/Resources/Maps/_Goobstation/origin.yml
+++ b/Resources/Maps/_Goobstation/origin.yml
@@ -94491,7 +94491,7 @@ entities:
       parent: 14860
     - type: Physics
       canCollide: False
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 12399
     components:

--- a/Resources/Maps/_Goobstation/saltern.yml
+++ b/Resources/Maps/_Goobstation/saltern.yml
@@ -33837,7 +33837,7 @@ entities:
       parent: 5429
     - type: Physics
       canCollide: False
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 4447
     components:

--- a/Resources/Maps/_Goobstation/serpentcrest.yml
+++ b/Resources/Maps/_Goobstation/serpentcrest.yml
@@ -85039,7 +85039,7 @@ entities:
     - type: Transform
       pos: -46.72189,-33.300808
       parent: 2
-- proto: EnergyChemDispenser
+- proto: ChemDispenser
   entities:
   - uid: 595
     components:

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -21,24 +21,24 @@
     Jug: 8 #Goob edit - Energy Chem
     JugAluminium: 2
     JugCarbon: 4
-    JugChlorine: 1
+    JugChlorine: 2 #Goob edit
     JugCopper: 2
     JugEthanol: 2
-    JugFluorine: 1
+    JugFluorine: 2 #Goob edit
     JugHydrogen: 3
-    JugIodine: 1
+    JugIodine: 2 #Goob edit
     JugIron: 2
     JugLithium: 2
-    JugMercury: 1
+    JugMercury: 2 #Goob edit
     JugNitrogen: 3
     JugOxygen: 3
-    JugPhosphorus: 1
+    JugPhosphorus: 2 #Goob edit
     JugPotassium: 2
-    JugRadium: 1
+    JugRadium: 2 #Goob edit
     JugSilicon: 2
     JugSodium: 2
     JugSugar: 3
-    JugSulfur: 1
+    JugSulfur: 2 #Goob edit
   contrabandInventory:
     DrinkLithiumFlask: 1
     StrangePill: 3
@@ -50,29 +50,29 @@
 - type: vendingMachineInventory
   id: ChemVendInventorySyndicate
   startingInventory:
-    Jug: 4
+    Jug: 8 #Goob edit
     JugAluminium: 2
     JugCarbon: 4
-    JugChlorine: 1
+    JugChlorine: 2 #Goob edit
     JugCopper: 2
     JugEthanol: 2
-    JugFluorine: 1
+    JugFluorine: 2 #Goob edit
     JugHydrogen: 3
-    JugIodine: 1
+    JugIodine: 2 #Goob edit
     JugIron: 2
     JugLithium: 2
-    JugMercury: 1
+    JugMercury: 2 #Goob edit
     JugNitrogen: 3
     JugOxygen: 3
-    JugPhosphorus: 1
+    JugPhosphorus: 2 #Goob edit
     JugPotassium: 2
-    JugRadium: 1
+    JugRadium: 2 #Goob edit
     JugSilicon: 2
     JugSodium: 2
     JugSugar: 3
-    JugSulfur: 1
-    JugWeldingFuel: 1
-    PlasmaChemistryVial: 1
+    JugSulfur: 2 #Goob edit
+    JugWeldingFuel: 2 #Goob edit
+    PlasmaChemistryVial: 2 #Goob edit
   contrabandInventory:
     DrinkLithiumFlask: 1
     StrangePill: 3

--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -108,7 +108,6 @@
   - ChemMasterMachineCircuitboard
   - CondenserMachineCircuitBoard
   - HotplateMachineCircuitboard
-  - EnergyChemDispenserMachineCircuitboard #Goob edit - all things that get base med boards get E-Chem
 
 ## Dynamic
 
@@ -131,3 +130,4 @@
   - CryoPodMachineCircuitboard
   - BiomassReclaimerMachineCircuitboard
   - StasisOperatingTableCircuitboard # Corvax-Goob-StasisOperatingTable
+  - EnergyChemDispenserMachineCircuitboard #Goob

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -323,13 +323,14 @@
     sprite: _Goobstation/Structures/Machines/service_dispenser.rsi
     state: industrial
   discipline: CivilianServices
-  tier: 2
+  tier: 3
   cost: 7500
   recipeUnlocks:
   - ServiceEnergyChemMachineCircuitboard
   position: -4,7
   technologyPrerequisites:
   - MeatManipulation
+  - BluespaceChemistry
 
 
 # Tier 3
@@ -367,6 +368,7 @@
   - MedkitCombat # Goobstation - remove medkitcombat from static to research
   - VialBluespace # goob edit - bluespace vials
   - DrinkShakerBluespace # goob
+  - EnergyChemDispenserMachineCircuitboard #Goob
   # Goobstation R&D Console rework start
   position: 4,5
   technologyPrerequisites:

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/lathe.yml
@@ -211,6 +211,7 @@
     - Chemistry
     - Janitor
     - Equipment
+    - MedicalBoards #Goob
     # - ServiceWeapons
     - Surgery
     - SpecOpsGoogles

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/medical.yml
@@ -161,6 +161,12 @@
 - type: latheRecipe
   id: EnergyChemDispenserMachineCircuitboard
   parent: BaseGoldCircuitboardRecipe
+  materials:
+    Steel: 100
+    Glass: 500
+    Gold: 100
+    Plasma: 100
+    BSCrystal: 50
   result: EnergyChemDispenserMachineCircuitboard
   icon:
     sprite: Structures/dispensers.rsi

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1058,6 +1058,3 @@ GhostBarSpawner: null
 
 # 2026-01-18
 DVSmartFridgeMedical: SmartFridgeMedical
-
-# 2026-01-10 Goobstation Change Mapped Chem to Energy Chem by default
-ChemDispenser: EnergyChemDispenser


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Removed mapped roundstart echem dispensers
Put echem board under bluespace chem research and increased the cost of the board (0.5 BSC, 1 plasma)
Made civ echem require bluespace chem
Increased amount of jugs in chemvend
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Energy chem as a concept is very cool. However, it's current implementation is powercreep disguised as QOL. A station has pretty much infinite power, and this equals infinite chems. This would be less of an issue if echem was something you had to work for, which it isn't.
Chemists like to cope about "but le cargo never gets my le jugs" so I increased some jugs in the chemvend by one to account for less chems.
## Technical details
<!-- Summary of code changes for easier review. -->
Yaml slop
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="457" height="713" alt="{4A0D98C2-E94C-400D-AC1A-0AE83F3BDE1B}" src="https://github.com/user-attachments/assets/d3ec04dc-d021-459f-bac0-982248cbd068" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Beanyboi69
- add: Sci techfab can now access some advanced medical recipes such as the biomass reclaimer.
- remove: Removed mapped energy chem dispensers.
- tweak: Made the energy chem dispenser board more expensive.
- tweak: Energy food synthesizer research now requires bluespace chemistry research.
- tweak: Moved energy chem dispenser board into bluespace chemistry research and out of roundstart recipes.
- tweak: Increased the amount of some jugs in the chemvend.
- fix: Syndicate chemvend now has the proper amount of empty jugs (8).