### PR TITLE
Security Biosuit buff

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -105,9 +105,7 @@
   name: bio suit
   description: A suit that protects against tougher biological contamination, kitted out with additional armor.
   suffix: Security
-  parent:
-  - ClothingOuterBioGeneral
-  - BaseSecurityContraband
+  parent: [ClothingOuterBioGeneral, BaseSecurityContraband]
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Bio/security.rsi

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -130,7 +130,7 @@
     - Foot
     - Tail
   - type: ZombificationResistance
-    zombificationResistanceCoefficient: 0.3
+    zombificationResistanceCoefficient: 0.3 # Goobstation
 
 - type: entity
   parent: ClothingOuterBioGeneral

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -101,17 +101,26 @@
     sprite: Clothing/OuterClothing/Bio/scientist.rsi
 
 - type: entity
-  parent: [ClothingOuterBioGeneral, BaseSecurityContraband]
   id: ClothingOuterBioSecurity
   name: bio suit
+  description: A suit that protects against tougher biological contamination, kitted out with additional armor.
   suffix: Security
-  description: A suit that protects against biological contamination, kitted out with additional armor.
+  parent:
+  - ClothingOuterBioGeneral
+  - BaseSecurityContraband
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Bio/security.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Bio/security.rsi
   - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.8
+        Caustic: 0.2
     coverage:
     - Chest
     - Groin
@@ -120,15 +129,8 @@
     - Leg
     - Foot
     - Tail
-    modifiers:
-      coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.7
-        Heat: 0.8
-        Caustic: 0.2
   - type: ZombificationResistance
-    zombificationResistanceCoefficient: 0.4
+    zombificationResistanceCoefficient: 0.3
 
 - type: entity
   parent: ClothingOuterBioGeneral


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Increased security Biosuit Infection chance reduction from protecting against an average of 1-2 bites to around 5

First yaml so hopefully nothings wrong
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The main way of defending against zeds should not be steamrolled in one to two hits with something designed to protect against just that. Should hopefully be fine balance wise with it being less infection protection than virology biosuits and there only being 2-3 per station. Good for fighting off one zed early in, Two if your brave. Any more and your likely going to turn.
## Technical details
<!-- Summary of code changes for easier review. -->
Set the ZombificationResistance coefficients on security biosuit to 0.3 along with changing the examine text to explain its for tougher biohazards than normal suits. 
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Quick note, Broken into two parts due to crashes

https://github.com/user-attachments/assets/85179481-52ad-4ff8-be53-192501e69f05


https://github.com/user-attachments/assets/5bcb793a-0ad3-4ebe-bba2-a2258b819d7a



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->:cl: Dummy

• tweak: Decreased chances of infection on the security Biosuit to help defend against smaller biological hordes!
