### PR TITLE
Fix gear lost on polymorph + Transfer Appearance to species changes 

### DIFF
--- a/Content.Goobstation.Server/Xenobiology/Systems/XenobiologyMiscSystems.cs
+++ b/Content.Goobstation.Server/Xenobiology/Systems/XenobiologyMiscSystems.cs
@@ -22,7 +22,7 @@ using Robust.Shared.Map;
 namespace Content.Goobstation.Server.Xenobiology.Systems;
 
 // any other bs needed serverside
-public class XenobiologyMiscSystems : EntitySystem
+public sealed class XenobiologyMiscSystems : EntitySystem
 {
     public override void Initialize()
     {

--- a/Content.Goobstation.Server/Xenobiology/Systems/XenobiologyTransformingSystem.cs
+++ b/Content.Goobstation.Server/Xenobiology/Systems/XenobiologyTransformingSystem.cs
@@ -8,6 +8,7 @@
 
 using Content.Goobstation.Shared.EntityEffects;
 using Content.Server._Shitmed.StatusEffects;
+using Content.Server.Humanoid;
 using Content.Server.Polymorph.Components;
 using Content.Server.Polymorph.Systems;
 using Content.Shared.Humanoid;
@@ -17,8 +18,10 @@ using Robust.Shared.Prototypes;
 namespace Content.Goobstation.Server.Xenobiology.Systems;
 
 // Any Polymorphing etc needing to run serverside
-public class XenobiologyTransformingSystem : EntitySystem
+public sealed class XenobiologyTransformingSystem : EntitySystem
 {
+    [Dependency] private readonly HumanoidAppearanceSystem _humanoid = default!;
+
     public override void Initialize()
     {
         SubscribeLocalEvent<HumanoidAppearanceComponent, SpeciesChange>(OnSpeciesChange);
@@ -50,6 +53,9 @@ public class XenobiologyTransformingSystem : EntitySystem
         var @new = polymorphSystem.PolymorphEntity(uid, config);
         if (@new.HasValue)
         {
+            if (ev.TransferAppearance)
+                _humanoid.CloneAppearance(uid, @new.Value, keepSpecies: true);
+
             EntityManager.RemoveComponentDeferred<PolymorphedEntityComponent>(@new.Value);
         }
     }

--- a/Content.Goobstation.Shared/EntityEffects/RandomSpeciesChange.cs
+++ b/Content.Goobstation.Shared/EntityEffects/RandomSpeciesChange.cs
@@ -13,6 +13,7 @@ public sealed partial class RandomSpeciesChange : EntityEffect
 
     [DataField] public List<ProtoId<SpeciesPrototype>>? SpeciesWhitelist;
     [DataField] public List<ProtoId<SpeciesPrototype>>? SpeciesBlacklist;
+    [DataField] public bool TransferAppearance;
 
     public override void Effect(EntityEffectBaseArgs args)
     {
@@ -32,6 +33,7 @@ public sealed partial class RandomSpeciesChange : EntityEffect
         var sce = new SpeciesChange
         {
             NewSpecies = random.Pick(species.ToList()).ID,
+            TransferAppearance = TransferAppearance,
         };
 
         entityEffects.Effect(sce, args);

--- a/Content.Goobstation.Shared/EntityEffects/SpeciesChange.cs
+++ b/Content.Goobstation.Shared/EntityEffects/SpeciesChange.cs
@@ -21,9 +21,13 @@ public sealed partial class SpeciesChange : EventEntityEffect<SpeciesChange>
     [DataField(required: true)]
     public ProtoId<SpeciesPrototype> NewSpecies;
 
-    public SpeciesChange(ProtoId<SpeciesPrototype> newspecies)
+    [DataField]
+    public bool TransferAppearance;
+
+    public SpeciesChange(ProtoId<SpeciesPrototype> newspecies, bool transferAppearance = false)
     {
         NewSpecies = newspecies;
+        TransferAppearance = transferAppearance;
     }
 
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
@@ -31,7 +35,7 @@ public sealed partial class SpeciesChange : EventEntityEffect<SpeciesChange>
 
     public override void Effect(EntityEffectBaseArgs args)
     {
-        var ev = new SpeciesChange(NewSpecies);
+        var ev = new SpeciesChange(NewSpecies, TransferAppearance);
         args.EntityManager.EventBus.RaiseLocalEvent(args.TargetEntity, ev);
     }
 

--- a/Content.Server/Implants/SubdermalImplantSystem.cs
+++ b/Content.Server/Implants/SubdermalImplantSystem.cs
@@ -122,12 +122,14 @@ using Content.Shared.Polymorph;
 using Content.Shared.Store.Components;
 using Content.Shared.Teleportation;
 using Content.Shared.Stunnable;
+using Robust.Shared.Containers;
 
 namespace Content.Server.Implants;
 public sealed class SubdermalImplantSystem : SharedSubdermalImplantSystem
 {
     [Dependency] private readonly StoreSystem _store = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
     public override void Initialize()
     {
         base.Initialize();
@@ -147,6 +149,10 @@ public sealed class SubdermalImplantSystem : SharedSubdermalImplantSystem
         {
             if (!TryComp<SubdermalImplantComponent>(implant, out var sic))
                 continue;
+
+            // Permanent implants (e.g. bluespace lifeline) block normal container removal, force them out first so they transfer too.
+            if (sic.Permanent)
+                _container.Remove(implant, ent.Comp.ImplantContainer, force: true);
 
             ForceImplant(args.NewEntity, implant, sic);
         }

--- a/Content.Server/Inventory/ServerInventorySystem.cs
+++ b/Content.Server/Inventory/ServerInventorySystem.cs
@@ -20,6 +20,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Shared.Clothing.EntitySystems;
 using Content.Shared.Explosion;
 using Content.Shared.Inventory;
 
@@ -27,6 +28,8 @@ namespace Content.Server.Inventory
 {
     public sealed class ServerInventorySystem : InventorySystem
     {
+        [Dependency] private readonly ToggleableClothingSystem _toggleableClothing = default!;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -50,8 +53,9 @@ namespace Content.Server.Inventory
             if (!Resolve(source.Owner, ref source.Comp) || !Resolve(target.Owner, ref target.Comp))
                 return;
 
-            var enumerator = new InventorySlotEnumerator(source.Comp);
             // Goob edit start
+            _toggleableClothing.RetractModsuits(source);
+            var enumerator = new InventorySlotEnumerator(source.Comp);
             List<(EntityUid, SlotDefinition)> items = new();
             while (enumerator.NextItem(out var item, out var slot))
             {

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -402,7 +402,7 @@ public sealed partial class PolymorphSystem : EntitySystem
             {
                 if (TryComp(child, out InventoryComponent? inventory2))
                 {
-                    _inventory.TransferEntityInventories((uid, inventory1), (child, inventory2), false);
+                    _inventory.TransferEntityInventories((uid, inventory1), (child, inventory2), true);
                     foreach (var hand in _hands.EnumerateHeld(uid))
                     {
                         _hands.TryDrop(uid, hand, checkActionBlocker: false);

--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -588,6 +588,33 @@ public sealed class ToggleableClothingSystem : EntitySystem
         }
     }
 
+    // <Goobstation>
+    /// <summary>
+    ///     Retracts every deployed modsuit piece worn by wearer
+    /// </summary>
+    public void RetractModsuits(EntityUid wearer)
+    {
+        var cores = new List<Entity<ToggleableClothingComponent>>();
+        var slots = _inventorySystem.GetSlotEnumerator(wearer);
+        while (slots.NextItem(out var worn))
+        {
+            if (TryComp<ToggleableClothingComponent>(worn, out var toggleable)
+                && toggleable.Container != null
+                && toggleable.ReplaceCurrentClothing)
+                cores.Add((worn, toggleable));
+        }
+
+        foreach (var core in cores)
+        {
+            foreach (var (part, slot) in new Dictionary<EntityUid, string>(core.Comp.ClothingUids))
+            {
+                if (!string.IsNullOrEmpty(slot) && !core.Comp.Container.Contains(part))
+                    UnequipClothing(wearer, core, part, slot);
+            }
+        }
+    }
+    // </Goobstation>
+
     private bool CanToggleClothing(EntityUid user, Entity<ToggleableClothingComponent> toggleable, bool multiple)
     {
         var comp = toggleable.Comp;

--- a/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
+++ b/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
@@ -227,6 +227,8 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
             targetHumanoid.MarkingSet = new(sourceHumanoid.MarkingSet);
         }
 
+        SetBarkVoice(target, sourceHumanoid.BarkVoice, targetHumanoid); // Goobstation
+
         if (TryComp<GrammarComponent>(target, out var grammar))
             _grammarSystem.SetGender((target, grammar), sourceHumanoid.Gender);
 

--- a/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
+++ b/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
@@ -192,23 +192,40 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
     /// <param name="target">Target entity to apply the source entity's appearance to.</param>
     /// <param name="sourceHumanoid">Source entity's humanoid component.</param>
     /// <param name="targetHumanoid">Target entity's humanoid component.</param>
+    /// <param name="keepSpecies">Target keeps its own species; skin/markings the species can't have are dropped. Goobstation</param>
     public void CloneAppearance(EntityUid source, EntityUid target, HumanoidAppearanceComponent? sourceHumanoid = null,
-        HumanoidAppearanceComponent? targetHumanoid = null)
+        HumanoidAppearanceComponent? targetHumanoid = null, bool keepSpecies = false)
     {
         if (!Resolve(source, ref sourceHumanoid, false) || !Resolve(target, ref targetHumanoid, false))
             return;
 
-        targetHumanoid.Species = sourceHumanoid.Species;
-        targetHumanoid.SkinColor = sourceHumanoid.SkinColor;
         targetHumanoid.EyeColor = sourceHumanoid.EyeColor;
         targetHumanoid.Age = sourceHumanoid.Age;
         targetHumanoid.Height = sourceHumanoid.Height; // Goobstation: port EE height/width sliders
         targetHumanoid.Width = sourceHumanoid.Width; // Goobstation: port EE height/width sliders
-        SetSex(target, sourceHumanoid.Sex, false, targetHumanoid);
-        targetHumanoid.CustomBaseLayers = new(sourceHumanoid.CustomBaseLayers);
-        targetHumanoid.MarkingSet = new(sourceHumanoid.MarkingSet);
-
         targetHumanoid.Gender = sourceHumanoid.Gender;
+        SetSex(target, sourceHumanoid.Sex, false, targetHumanoid);
+
+        if (keepSpecies) // Goobstation: keep target species, coerce skin and drop markings it can't have
+        {
+            SetSkinColor(target, sourceHumanoid.SkinColor, false, true, targetHumanoid);
+
+            targetHumanoid.MarkingSet.Clear();
+            foreach (var (_, list) in sourceHumanoid.MarkingSet.Markings)
+                foreach (var marking in list)
+                    AddMarking(target, marking.MarkingId, marking.MarkingColors, false, humanoid: targetHumanoid);
+
+            targetHumanoid.MarkingSet.EnsureSpecies(targetHumanoid.Species, targetHumanoid.SkinColor, _markingManager, _proto);
+            targetHumanoid.MarkingSet.EnsureSexes(sourceHumanoid.Sex, _markingManager);
+            targetHumanoid.MarkingSet.EnsureDefault(targetHumanoid.SkinColor, targetHumanoid.EyeColor, _markingManager);
+        }
+        else
+        {
+            targetHumanoid.Species = sourceHumanoid.Species;
+            targetHumanoid.SkinColor = sourceHumanoid.SkinColor;
+            targetHumanoid.CustomBaseLayers = new(sourceHumanoid.CustomBaseLayers);
+            targetHumanoid.MarkingSet = new(sourceHumanoid.MarkingSet);
+        }
 
         if (TryComp<GrammarComponent>(target, out var grammar))
             _grammarSystem.SetGender((target, grammar), sourceHumanoid.Gender);

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -732,6 +732,7 @@
       effects:
       - !type:SpeciesChange
         newSpecies: BananaMen
+        transferAppearance: true
         conditions:
         - !type:ReagentThreshold
           min: 30

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Reagents/reagents.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Reagents/reagents.yml
@@ -179,6 +179,7 @@
         - !type:ReagentThreshold
           min: 10
         newSpecies: SlimePerson
+        transferAppearance: true
       - !type:AdjustReagent
         reagent: XenobioJellyGreen
         amount: -50.0
@@ -201,6 +202,7 @@
         - !type:ReagentThreshold
           min: 10
         newSpecies: Human
+        transferAppearance: true
       - !type:AdjustReagent
         reagent: XenobioHumanToxin
         amount: -50.0
@@ -235,6 +237,7 @@
       metabolismRate: 5 # hello hypospray users!
       effects:
       - !type:RandomSpeciesChange
+        transferAppearance: true
         speciesBlacklist:
         - Skeleton # if he's dead it's GG
         - IPC # do i have to explain this one
@@ -266,6 +269,7 @@
         - !type:ReagentThreshold
           min: 10
         newSpecies: Felinid
+        transferAppearance: true
       - !type:AdjustReagent
         reagent: XenobioFelinidToxin
         amount: -50.0


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Fixes inventory loss on species change / polymorph and adds an option to keep your appearance.

- Inventory now transfers reliably (even while stunned/crit), including items in dependent slots, modsuit-hidden clothing, and permanent implants.
- Adds a transferAppearance option to species changes so you keep your look, filtered to what the destination species allows.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I don't want to have to hunt down lost gear in the void.
Partially fix : https://github.com/Goob-Station/Goob-Station/issues/6230 (Gemini shouldn't even have a bloodstream)
## Technical details
<!-- Summary of code changes for easier review. -->
- PolymorphSystem: inventory transfer uses force: true (works while stunned/crit).
- ServerInventorySystem.TransferEntityInventories: retracts modsuits first (RetractModsuits) so hidden clothing transfers.
- ToggleableClothingSystem.RetractModsuits: retracts ReplaceCurrentClothing toggleables.
- SubdermalImplantSystem.OnPolymorphed: force-removes permanent implants so they transfer too.
- SpeciesChange/RandomSpeciesChange: new transferAppearance field and CloneAppearance(..., keepSpecies: true), which filters markings/skin to the new species. Enabled on xenobio reagents.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before fix
<img width="1309" height="1003" alt="image" src="https://github.com/user-attachments/assets/3a4477e2-429c-4953-96d8-e2dffea11c7d" />
<img width="1263" height="1003" alt="image" src="https://github.com/user-attachments/assets/82da59a8-9076-4b9f-941a-5b8039c53972" />
After fix
<img width="1256" height="999" alt="image" src="https://github.com/user-attachments/assets/8e6f317d-dd87-432c-8e26-30bc756dd87f" />
<img width="1335" height="997" alt="image" src="https://github.com/user-attachments/assets/ba1ed4d9-094b-4610-a910-8ecc4761b028" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Baptr0b0t
- fix: Species changes and transformations now transfer your inventory even while stunned, asleep, or knocked down.
- fix: Clothing hidden under a modsuit is no longer lost when polymoph.
- fix: Modsuit parts no longer detach during inventory transfers.
- fix: Permanent implants (bluespace/redspace lifeline, shadowmind, xeno-compatibility, etc.) now follow you through a polymorph like other implants.
- add: Added a transferAppearance option to species changes, keeping your look (skin, eyes, hair, sex, height) while dropping anything invalid for the new species.
- tweak: Xenobio toxins (slime, human, felinid, banana, advanced mutation) now keep the player's appearance.