### PR TITLE
Fix Gemini Removed Components

### DIFF
--- a/Content.Goobstation.Shared/CloneProjector/CloneProjectorComponent.cs
+++ b/Content.Goobstation.Shared/CloneProjector/CloneProjectorComponent.cs
@@ -58,10 +58,10 @@ public sealed partial class CloneProjectorComponent : Component
     [DataField]
     public bool RestrictRangedWeapons = true;
 
-    [DataField]
+    [DataField, AlwaysPushInheritance]
     public ComponentRegistry? AddedComponents;
 
-    [DataField]
+    [DataField, AlwaysPushInheritance]
     public ComponentRegistry? RemovedComponents;
 
     /// <summary>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Fixed Gemini comp.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because I don't want to have to deal with a Gemini's Polymorph. (cf. https://github.com/Goob-Station/Goob-Station/pull/6736)
Fix https://github.com/Goob-Station/Goob-Station/issues/6230
## Technical details
<!-- Summary of code changes for easier review. -->
Added [AlwaysPushInheritance] to AddedComponents/RemovedComponents on CloneProjectorComponent. This makes child overrides merge by component type instead of replacing, which is the standard Robust idiom for ComponentRegistry fields.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- No, I didn't added media to this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Baptr0b0t

- fix: Fixed gemini having bloodstream, injectable solution, surgery, polymorph, destructible, temperature, respirator, internals, dna, fingerprint...
