### PR TITLE
BSO's Flippo .rsi state errors

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/lighters.yml
@@ -26,8 +26,6 @@
       map: ["flame"]
       visible: false
       shader: unshaded
-  - type: Item
-    size: Tiny
   - type: SolutionContainerManager
     solutions:
       Welder:
@@ -40,7 +38,3 @@
     netsync: false
     radius: 3 # Bigger since blue makes it hard to see. Worth it for the drip.
     color: blue
-  - type: ItemTogglePointLight
-  - type: UseDelay
-  - type: IgnitionSource
-    ignited: false

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Tools/lighters.yml
@@ -7,12 +7,12 @@
 
 - type: entity
   name: blue flippo
-  parent: [BaseItem, BaseCentcommContraband]
+  parent: [FlippoLighter, BaseCentcommContraband]
   id: FlippoLighterBlueshield
   description: "A specialized blue lighter given only to specific officers. Great for a smoke after a long day."
   components:
   - type: Sprite
-    sprite: /Textures/_Goobstation/Objects/Tools/lighters.rsi
+    sprite: _Goobstation/Objects/Tools/lighters.rsi
     layers:
     - state: icon
       map: ["base"]
@@ -26,43 +26,8 @@
       map: ["flame"]
       visible: false
       shader: unshaded
-  - type: ItemToggle
-    predictable: false
-    soundActivate:
-      path: /Audio/Items/Lighters/zippo_open.ogg
-      params:
-        volume: -5
-    soundDeactivate:
-      path: /Audio/Items/Lighters/zippo_close.ogg
-      params:
-        volume: -5
-  - type: ItemToggleMeleeWeapon
-    activatedDamage:
-      types:
-        Heat: 1
-  - type: ItemToggleSize
-    activatedSize: Small
-  - type: ItemToggleHot
   - type: Item
     size: Tiny
-    sprite: Objects/Tools/lighters.rsi
-    heldPrefix: zippo
-  - type: Appearance
-  - type: GenericVisualizer
-    visuals:
-      enum.ToggleableVisuals.Enabled:
-        flame:
-          True: { visible: true }
-          False: { visible: false }
-        open:
-          True: { visible: true }
-          False: { visible: false }
-        top:
-          True: { visible: true }
-          False: { visible: false }
-        base:
-          True: { visible: false }
-          False: { visible: true }
   - type: SolutionContainerManager
     solutions:
       Welder:
@@ -70,24 +35,6 @@
         - ReagentId: WeldingFuel
           Quantity: 20
         maxVol: 20
-  - type: Welder
-    fuelConsumption: 0.01
-    fuelLitCost: 0.1
-    tankSafe: true
-  - type: ToggleableVisuals
-    spriteLayer: lighter_flame
-    inhandVisuals:
-      left:
-      - state: zippo-inhand-left-flame
-        shader: unshaded
-      right:
-      - state: zippo-inhand-right-flame
-        shader: unshaded
-  - type: MeleeWeapon
-    wideAnimationRotation: 180
-    damage:
-      types:
-        Blunt: 1
   - type: PointLight
     enabled: false
     netsync: false
@@ -97,6 +44,3 @@
   - type: UseDelay
   - type: IgnitionSource
     ignited: false
-  - type: Tag
-    tags:
-      - Lighter #Goobstation - whitelisted cig pack strorage (added tag)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
parents the BSO lighter off of the regular flippo and fixes console error spam from missing .rsi states.

errors were caused by the Item component's heldPrefix field, which from what i checked doesnt do anything? if its doing something and im being dumb shoot me ig.

## Why / Balance
console error spam.
proper parenting.

## Technical details
yamlslop

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
not gameplay facing, shouldn't need a changelog