### PR TITLE
Lavaland ruins rework

### DIFF
--- a/Content.Server/_Lavaland/Procedural/Systems/LavalandSystem.Ruins.cs
+++ b/Content.Server/_Lavaland/Procedural/Systems/LavalandSystem.Ruins.cs
@@ -28,33 +28,19 @@ public sealed partial class LavalandSystem
         var random = new Random(lavaland.Comp.Seed);
 
         var usedSpace = GetOutpostBoundary(lavaland);
-        var coords = GetCoordinates(pool.RuinDistance, pool.MaxDistance);
+        var coords = GetCoordinates(pool.RuinDistance, pool.MaxDistance, pool.MinDistance);
 
         random.Shuffle(coords);
 
         SetupGridRuins(pool.GridRuins, lavaland, preloader, ref coords, ref usedSpace);
 
         // Create a new list that excludes all already used spaces that intersect with big ruins.
-        var newCoords = coords.ToHashSet();
-        foreach (var usedBox in usedSpace)
-        {
-            var list = coords.Where(coord => !usedBox.Contains(coord)).ToHashSet();
-            newCoords = newCoords.Concat(list).ToHashSet();
-        }
-
-        coords = newCoords.ToList();
+        coords = coords.Where(coord => !usedSpace.Any(usedBox => usedBox.Contains(coord))).ToList();
 
         SetupDungeonRuins(pool.DungeonRuins, lavaland, preloader, random, ref coords, ref usedSpace);
 
         // Do that again
-        newCoords = coords.ToHashSet();
-        foreach (var usedBox in usedSpace)
-        {
-            var list = coords.Where(coord => !usedBox.Contains(coord)).ToHashSet();
-            newCoords = newCoords.Concat(list).ToHashSet();
-        }
-
-        coords = newCoords.ToList();
+        coords = coords.Where(coord => !usedSpace.Any(usedBox => usedBox.Contains(coord))).ToList();
 
         SetupMarkerRuins(pool.MarkerRuins, lavaland, ref coords, ref usedSpace);
     }
@@ -164,14 +150,14 @@ public sealed partial class LavalandSystem
         var spawned = spawnedBoundedGrid.Value;
         var ruinBox = spawned.Comp.LocalAABB;
 
-        if (!TryPlaceRuin(ruinBox, ruin.SpawnAttempts, coords, usedSpace, out var coord))
+        if (!TryPlaceRuin(ruinBox, ruin.SpawnAttempts, ruin.MinDistance, ruin.MaxDistance, coords, usedSpace, out var coord))
         {
             Log.Warning($"Failed to load ruin {ruin.ID} on {ToPrettyString(lavaland)} planet's surface: all attempts have failed and no eligible spot was found!");
             Del(spawnedBoundedGrid);
             return;
         }
 
-        usedSpace.Add(ruinBox);
+        usedSpace.Add(ruinBox.Translated(coord.Value));
         coords.Remove(coord.Value);
 
         // Teleport it into place on preloader map
@@ -227,7 +213,7 @@ public sealed partial class LavalandSystem
 
         var ruinBox = Box2.CentredAroundZero(ruin.Boundary);
 
-        if (!TryPlaceRuin(ruinBox, ruin.SpawnAttempts, coords, usedSpace, out var coord))
+        if (!TryPlaceRuin(ruinBox, ruin.SpawnAttempts, null, null, coords, usedSpace, out var coord))
         {
             Log.Warning($"Failed to load ruin {ruin.ID} on {ToPrettyString(lavaland)} planet's surface: all attempts have failed and no eligible spot was found!");
             return;
@@ -235,7 +221,7 @@ public sealed partial class LavalandSystem
 
         Spawn(ruin.SpawnedMarker, new EntityCoordinates(lavaland, coord.Value));
 
-        usedSpace.Add(ruinBox);
+        usedSpace.Add(ruinBox.Translated(coord.Value));
         coords.Remove(coord.Value);
     }
 
@@ -244,6 +230,8 @@ public sealed partial class LavalandSystem
     /// </summary>
     /// <param name="ruinBox">Boundaries of a ruin, confined inside a box</param>
     /// <param name="spawnAttempts">The maximum amount of spawn attempts we make before giving up on generating that ruin.</param>
+    /// <param name="minDistance">Optional override of the pool's min distance from the map center, for this specific ruin.</param>
+    /// <param name="maxDistance">Optional override of the pool's max distance from the map center, for this specific ruin.</param>
     /// <param name="coords">A list of all eligible planet coordinates. Has to be shuffled to be as efficient as possible.</param>
     /// <param name="usedSpace">A list of bounding boxes of already placed ruins, translated relative to their position.</param>
     /// <param name="pickedCoord">Picked coordinates that we can safely put a ruin at.</param>
@@ -251,6 +239,8 @@ public sealed partial class LavalandSystem
     private bool TryPlaceRuin(
         Box2 ruinBox,
         int spawnAttempts,
+        int? minDistance,
+        int? maxDistance,
         List<Vector2i> coords,
         List<Box2> usedSpace,
         [NotNullWhen(true)] out Vector2i? pickedCoord)
@@ -259,6 +249,12 @@ public sealed partial class LavalandSystem
         for (var i = 0; i < coords.Count && i < spawnAttempts; i++)
         {
             var pos = coords[i];
+
+            // Ruin can override the pool's distance band from the map center.
+            var distance = MathF.Sqrt(pos.X * pos.X + pos.Y * pos.Y);
+            if (distance < minDistance || distance > maxDistance)
+                continue;
+
             bool intersects = false;
             var translated = ruinBox.Translated(pos);
             foreach (var used in usedSpace)
@@ -280,33 +276,21 @@ public sealed partial class LavalandSystem
         return false;
     }
 
-    private List<Vector2i> GetCoordinates(int distance, int maxDistance)
+    /// <summary>
+    /// Builds a regular grid of positions, keeping only the points inside the [minDistance, maxDistance].
+    /// </summary>
+    private List<Vector2i> GetCoordinates(int distance, int maxDistance, int minDistance = 0)
     {
         var coords = new List<Vector2i>();
-        var moveVector = new Vector2i(maxDistance, maxDistance);
 
-        while (moveVector.Y >= -maxDistance)
+        for (var y = -maxDistance; y <= maxDistance; y += distance)
         {
-            // i love writing shitcode
-            // Moving like a snake through the entire map placing all dots onto its places.
-
-            while (moveVector.X > -maxDistance)
+            for (var x = -maxDistance; x <= maxDistance; x += distance)
             {
-                coords.Add(moveVector);
-                moveVector += new Vector2i(-distance, 0);
+                var length = MathF.Sqrt(x * x + y * y);
+                if (length >= minDistance && length <= maxDistance)
+                    coords.Add(new Vector2i(x, y));
             }
-
-            coords.Add(moveVector);
-            moveVector += new Vector2i(0, -distance);
-
-            while (moveVector.X < maxDistance)
-            {
-                coords.Add(moveVector);
-                moveVector += new Vector2i(distance, 0);
-            }
-
-            coords.Add(moveVector);
-            moveVector += new Vector2i(0, -distance);
         }
 
         return coords;

--- a/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
@@ -106,6 +106,14 @@ public sealed partial class SSDIndicatorComponent : Component
     public ProtoId<SsdIconPrototype> Icon = "SSDIcon";
 
     /// <summary>
+    /// Goobstation: Whether a player has ever controlled this entity.
+    /// Entities that never had a player are exempt from SSD sleep.
+    /// </summary>
+    [AutoNetworkedField]
+    [DataField]
+    public bool HadPlayer;
+
+    /// <summary>
     /// The time at which the entity will fall asleep, if <see cref="CCVars.ICSSDSleep"/> is true.
     /// </summary>
     [AutoNetworkedField, AutoPausedField]

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -41,6 +41,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
     private void OnPlayerAttached(EntityUid uid, SSDIndicatorComponent component, PlayerAttachedEvent args)
     {
         component.IsSSD = false;
+        component.HadPlayer = true; // Goobstation
 
         // Removes force sleep and resets the time to zero
         if (_icSsdSleep)
@@ -90,6 +91,7 @@ public sealed class SSDIndicatorSystem : EntitySystem
         {
             // Forces the entity to sleep when the time has come
             if (!ssd.IsSSD
+                || !ssd.HadPlayer // Goobstation
                 || ssd.NextUpdate > curTime
                 || ssd.FallAsleepTime > curTime
                 || TerminatingOrDeleted(uid))

--- a/Content.Shared/_Lavaland/Procedural/Prototypes/LavalandGridRuinPrototype.cs
+++ b/Content.Shared/_Lavaland/Procedural/Prototypes/LavalandGridRuinPrototype.cs
@@ -42,6 +42,18 @@ public sealed partial class LavalandGridRuinPrototype : IPrototype
     [DataField]
     public int SpawnAttempts = 8;
 
+    /// <summary>
+    /// Overrides the pool's MinDistance for this specific ruin.
+    /// </summary>
+    [DataField]
+    public int? MinDistance;
+
+    /// <summary>
+    /// Overrides the pool's MaxDistance for this specific ruin.
+    /// </summary>
+    [DataField]
+    public int? MaxDistance;
+
     [DataField]
     public bool PatchToPlanet = true;
 

--- a/Content.Shared/_Lavaland/Procedural/Prototypes/LavalandRuinPoolPrototype.cs
+++ b/Content.Shared/_Lavaland/Procedural/Prototypes/LavalandRuinPoolPrototype.cs
@@ -43,6 +43,12 @@ public sealed partial class LavalandRuinPoolPrototype : IPrototype
     public int MaxDistance = 256;
 
     /// <summary>
+    /// Min distance that Ruins can generate.
+    /// </summary>
+    [DataField]
+    public int MinDistance;
+
+    /// <summary>
     /// List of all grid ruins and their count.
     /// Used for ruins that are loaded as proper grids.
     /// </summary>

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -156,6 +156,8 @@
     back: ClothingBackpack
     shoes: ClothingShoesBootsCombat
     id: SyndiPDA
+  inhand:
+  - WeaponPistolViper # Goobstation - no fistfighting
   storage:
     back:
     - BoxSurvivalSlots # Goobstation - Slots Based Survival Boxes

--- a/Resources/Prototypes/_Lavaland/Procedural/lavaland_grid_ruins.yml
+++ b/Resources/Prototypes/_Lavaland/Procedural/lavaland_grid_ruins.yml
@@ -12,6 +12,8 @@
   name: lavaland-ruin-hierophant
   path: /Maps/_Lavaland/Lavaland/ruin_hierophant_arena.yml
   priority: -1 # highest priority
+  minDistance: 180
+  spawnAttempts: 20
   patchToPlanet: false
   componentsToGrant:
   - type: HierophantBeat
@@ -21,6 +23,8 @@
   name: lavaland-ruin-syndicate
   path: /Maps/_Lavaland/Lavaland/ruin_syndicate_base.yml
   priority: -1 # highest priority
+  minDistance: 180
+  spawnAttempts: 20
   patchToPlanet: false
 
 - type: lavalandGridRuin

--- a/Resources/Prototypes/_Lavaland/Procedural/lavaland_ruin_pools.yml
+++ b/Resources/Prototypes/_Lavaland/Procedural/lavaland_ruin_pools.yml
@@ -27,7 +27,8 @@
 - type: lavalandRuinPool
   id: LavalandRuins
   ruinDistance: 14
-  maxDistance: 172
+  minDistance: 60
+  maxDistance: 256
   gridRuins:
     SyndicateBase: 1
     HierophantArena: 1


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Reworked Ruins generation
Fix sleepy NPC 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Staff-discussion - (Remove Lavaland Syndie Base or Nerf it)
fix https://github.com/Goob-Station/Goob-Station/issues/3366

## Technical details
<!-- Summary of code changes for easier review. -->

Added a HadPlayer flag to SSDIndicatorComponent, set on PlayerAttachedEvent. The forced SSD sleep in SSDIndicatorSystem.Update now skips entities that were never player-controlled, so mapped NPCs no longer fall asleep.

Fixed two bugs in LavalandSystem.Ruins: used-space boxes are now translated to the ruin's actual position rather than being stored and the coordinate exclusion filter between generation phases now actually removes occupied spots.
Ruin candidate coordinates are now generated in a radial band (minDistance/maxDistance on the pool) instead of a small square, spreading ruins across the playable disc. 
Grid ruins can override the pool's band per-prototype (nullable minDistance/maxDistance, checked in TryPlaceRuin), used to push SyndicateBase and HierophantArena away from the outpost.
YAML - Gave the SyndicateFootsoldierGearRuin starting gear.


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1503" height="942" alt="image" src="https://github.com/user-attachments/assets/4769e9df-b9b7-44ae-a1ad-e686f263806f" />
No more collision

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: Baptr0b0t
- fix: Hostile NPCs (xenomorphs, syndicate footsoldiers, shuttle pilots...) no longer fall asleep permanently after 10 minutes. Only entities that were actually player-controlled are affected by SSD sleep.
- tweak: Syndicate footsoldiers and shuttle pilots now spawn with a pistol.
- tweak: Lavaland ruins now spread across a much larger portion of the planet.
- tweak: The Syndicate Base and the Hierophant Arena now always generate far away from the mining outpost.
- fix: Lavaland ruins can no longer overlap each other or spawn inside one another due to a broken placement collision check.