### PR TITLE
[FIX] controlling another AI's boris ghosts them

### DIFF
--- a/Content.Server/_CorvaxNext/Silicons/Borgs/AiRemoteControlSystem.cs
+++ b/Content.Server/_CorvaxNext/Silicons/Borgs/AiRemoteControlSystem.cs
@@ -88,6 +88,9 @@ public sealed class AiRemoteControlSystem : SharedAiRemoteControlSystem
         if (!_mind.TryGetMind(ai, out var mindId, out var mind))
             return;
 
+        if (_mind.TryGetMind(entity, out _, out _)) // Don't take control of device with mind already. Would ghost them
+            return;
+
         if (!TryComp<StationAiHeldComponent>(ai, out var stationAiHeldComp))
             return;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
since multiple ai cores are constructible now, if another ai tries to remote control a boris when one is already inside it, it will ghost them because it doesn't seem to check for that. this Fixes that

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: rivermyth
- fix: Fixed a bug where when one AI tried to control another's B.O.R.I.S it would kick them out and ghost them.
