### PR TITLE
Fix access messages being added when you examine any species

### DIFF
--- a/Content.Goobstation.Common/BlockMarkup/BlockMarkupMessageComponent.cs
+++ b/Content.Goobstation.Common/BlockMarkup/BlockMarkupMessageComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Goobstation.Common.BlockMarkup;
+
+/// <summary>
+/// Markup component to block markup message from being seen by examiner.
+/// </summary>
+[RegisterComponent]
+public sealed partial class BlockMarkupMessageComponent : Component;

--- a/Content.Goobstation.Common/BlockMarkup/BlockMarkupMessageComponent.cs
+++ b/Content.Goobstation.Common/BlockMarkup/BlockMarkupMessageComponent.cs
@@ -1,7 +1,0 @@
-namespace Content.Goobstation.Common.BlockMarkup;
-
-/// <summary>
-/// Markup component to block markup message from being seen by examiner.
-/// </summary>
-[RegisterComponent]
-public sealed partial class BlockMarkupMessageComponent : Component;

--- a/Content.Shared/Access/Components/AccessReaderComponent.cs
+++ b/Content.Shared/Access/Components/AccessReaderComponent.cs
@@ -97,6 +97,12 @@ public sealed partial class AccessReaderComponent : Component
     /// </remarks>
     [DataField]
     public LocId ExaminationText = "access-reader-examination";
+
+    /// <summary>
+    /// Goobstation - Whether or not the examination text should be shown.
+    /// </summary>
+    [DataField]
+    public bool ShouldShowExaminationText = true;
 }
 
 [DataDefinition, Serializable, NetSerializable]

--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -22,6 +22,7 @@ using Robust.Shared.Collections;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using Content.Goobstation.Common.BlockMarkup; // Goobstation
 
 namespace Content.Shared.Access.Systems;
 
@@ -56,6 +57,9 @@ public sealed class AccessReaderSystem : EntitySystem
 
     private void OnExamined(Entity<AccessReaderComponent> ent, ref ExaminedEvent args)
     {
+        if (HasComp<BlockMarkupMessageComponent>(ent.Owner)) // Goobstation - here because Wanted Menu apply AccessReaderComponent to base species
+            return;
+
         if (!GetMainAccessReader(ent, out var mainAccessReader))
             return;
 

--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -22,7 +22,6 @@ using Robust.Shared.Collections;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
-using Content.Goobstation.Common.BlockMarkup; // Goobstation
 
 namespace Content.Shared.Access.Systems;
 
@@ -57,7 +56,7 @@ public sealed class AccessReaderSystem : EntitySystem
 
     private void OnExamined(Entity<AccessReaderComponent> ent, ref ExaminedEvent args)
     {
-        if (HasComp<BlockMarkupMessageComponent>(ent.Owner)) // Goobstation - here because Wanted Menu apply AccessReaderComponent to base species
+        if (!ent.Comp.ShouldShowExaminationText) // Goobstation - Wanted Menu
             return;
 
         if (!GetMainAccessReader(ent, out var mainAccessReader))

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -193,6 +193,7 @@
   - type: Stripping
   - type: AccessReader # Goobstation-WantedMenu
     access: [["Security"]]
+  - type: BlockMarkupMessage # Goobstation - Block markup message from access reader
   - type: UserInterface
     interfaces:
       enum.HumanoidMarkingModifierKey.Key:

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -193,7 +193,7 @@
   - type: Stripping
   - type: AccessReader # Goobstation-WantedMenu
     access: [["Security"]]
-  - type: BlockMarkupMessage # Goobstation - Block markup message from access reader
+    shouldShowExaminationText: false
   - type: UserInterface
     interfaces:
       enum.HumanoidMarkingModifierKey.Key:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Removed the markup message from base species

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bug
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
before 
<img width="462" height="311" alt="image" src="https://github.com/user-attachments/assets/aaf77f49-de2d-4972-b522-90cf5969493a" />

after
<img width="452" height="247" alt="image" src="https://github.com/user-attachments/assets/91cab0ef-c1dd-444a-a1c9-0c72f2c168bc" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Remove the access text from species examine
