### PR TITLE
[FIX] Stop ore processor vaporizing mats

### DIFF
--- a/Content.Client/Lathe/UI/LatheMenu.xaml
+++ b/Content.Client/Lathe/UI/LatheMenu.xaml
@@ -155,6 +155,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             VerticalExpand="True"
             HorizontalExpand="True"
             Orientation="Vertical">
+            <!-- Begin DeltaV Additions: Mining points -->
+            <BoxContainer Orientation="Vertical" Name="MiningPointsContainer" Visible="False">
+                <BoxContainer Orientation="Horizontal">
+                    <Label Name="MiningPointsLabel" HorizontalExpand="True"/>
+                    <Button Name="MiningPointsClaimButton" Text="{Loc 'lathe-menu-mining-points-claim-button'}"/>
+                </BoxContainer>
+                <RichTextLabel Name="MiningPointsNoConnectionWarning"></RichTextLabel>
+            </BoxContainer>
+            <!-- End DeltaV Additions: Mining points -->
             <Label Text="{Loc 'lathe-menu-materials-title'}" Margin="5 5 5 5" HorizontalAlignment="Center"/>
             <PanelContainer VerticalExpand="True">
                 <PanelContainer.PanelOverride>
@@ -166,15 +175,6 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                     HorizontalExpand="True">
                     <ui:MaterialStorageControl Name="MaterialsList" SizeFlagsStretchRatio="8"/>
                 </BoxContainer>
-                <!-- Begin DeltaV Additions: Mining points -->
-                <BoxContainer Orientation="Vertical" Name="MiningPointsContainer" Visible="False">
-                    <BoxContainer Orientation="Horizontal">
-                        <Label Name="MiningPointsLabel" HorizontalExpand="True"/>
-                        <Button Name="MiningPointsClaimButton" Text="{Loc 'lathe-menu-mining-points-claim-button'}"/>
-                    </BoxContainer>
-                    <RichTextLabel Name="MiningPointsNoConnectionWarning"></RichTextLabel>
-                </BoxContainer>
-                <!-- End DeltaV Additions: Mining points -->
             </PanelContainer>
         </BoxContainer>
         </BoxContainer>

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -28,7 +28,6 @@ using Content.Shared.Power;
 using Content.Shared.ReagentSpeed;
 using Content.Shared.Research.Components;
 using Content.Shared.Research.Prototypes;
-using Content.Goobstation.Shared.Lathe; // Goobstation
 using JetBrains.Annotations;
 using Robust.Server.Containers;
 using Robust.Server.GameObjects;
@@ -248,18 +247,18 @@ namespace Content.Server.Lathe
                 var currentRecipe = _proto.Index(comp.CurrentRecipe.Value);
                 if (currentRecipe.Result is { } resultProto)
                 {
-                    // Goobstation, output to material storage instead of spawning
+                    // Goobstation, output to material storage instead of spawning, if preferred & possible
                     var prototype = _proto.Index(resultProto);
-                    if (comp.OutputToStorage && prototype.TryGetComponent<PhysicalCompositionComponent>(out var composition, _factory))
-                    {
-                        _materialStorage.TryChangeMaterialAmount(uid, composition.MaterialComposition);
-                    }
-                    else
+                    if (!comp.OutputToStorage || !prototype.TryGetComponent<PhysicalCompositionComponent>(out var composition, _factory)
+                        || _materialStorage.TryChangeMaterialAmount(uid, composition.MaterialComposition))
                     {
                         var result = Spawn(resultProto, Transform(uid).Coordinates);
                         _stack.TryMergeToContacts(result);
-                        if (TryComp<ScannableForPointsComponent>(result, out var scannable)) // Goobstation
-                            scannable.Points = 0; // Goobstation, this thing is to prevent ntr duping points via an emagged lathe
+
+                        // <Goobstation> No NTR factorio
+                        if (TryComp<ScannableForPointsComponent>(result, out var scannable))
+                            scannable.Points = 0;
+                        // </Goobstation>
                     }
                 }
 

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -17,11 +17,9 @@ using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.UserInterface;
 using Content.Shared.Database;
-using Content.Shared.Emag.Components;
 using Content.Shared.Emag.Systems;
-using Content.Shared.Examine;
-using Content.Shared.Lathe;
 using Content.Shared.Lathe.Prototypes;
+using Content.Shared.Lathe;
 using Content.Shared.Localizations;
 using Content.Shared.Materials;
 using Content.Shared.Power;
@@ -34,15 +32,12 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
-using Content.Server.Chat.Systems;
 using Content.Goobstation.Common.NTR.Scan; // Goobstation
-using Content.Shared.Chat;
-using Content.Shared.Prototypes;
 
 namespace Content.Server.Lathe
 {
     [UsedImplicitly]
-    public sealed partial class LatheSystem : SharedLatheSystem // Goobstation edit - made partial
+    public sealed partial class LatheSystem : SharedLatheSystem
     {
         [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] private readonly IPrototypeManager _proto = default!;

--- a/Content.Shared/Materials/MaterialStorageComponent.cs
+++ b/Content.Shared/Materials/MaterialStorageComponent.cs
@@ -70,7 +70,7 @@ public sealed partial class MaterialStorageComponent : Component
     [DataField]
     public bool CanEjectStoredMaterials = true;
 
-    // Goobstation Change Start
+    // <Goobstation>
     [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
     public bool ConnectToSilo;
 
@@ -84,7 +84,7 @@ public sealed partial class MaterialStorageComponent : Component
     // ANOTHER BASED ON RECIPES. ON TWO FUCKING COMPONENTS THAT ARE ALMOST ALWAYS USED TOGETHER, AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
     [DataField, AutoNetworkedField]
     public bool IgnoreMaterialWhiteList;
-    // Goobstation Change End
+    // </Goobstation>
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Materials/SharedMaterialStorageSystem.cs
+++ b/Content.Shared/Materials/SharedMaterialStorageSystem.cs
@@ -145,6 +145,11 @@ public abstract class SharedMaterialStorageSystem : EntitySystem
         if (ent.Comp.MaterialWhiteList == null)
             return true;
 
+        /// <Goobstation> this is STUPID STUPID STUPID. needed for ore silo self injection...
+        if (ent.Comp.IgnoreMaterialWhiteList)
+            return true;
+        /// </Goobstation>
+
         return ent.Comp.MaterialWhiteList.Contains(material);
     }
 

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -757,7 +757,6 @@
         - Sheet
         - RawMaterial
         - Ingot
-        - SheetMetalBase
         # </Goobstation>
     - type: Lathe
       idleState: icon

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -135,10 +135,12 @@
         - Sheet
         - RawMaterial
         - Ingot
-        - Metal # Goobstation Start
+        # <Goobstation>
+        - Metal
         - Wooden
         - SheetPlasma
-        - Plastic # Goobstation End
+        - Plastic
+        # </Goobstation
   - type: Lathe
     idleState: icon
     runningState: building
@@ -741,17 +743,22 @@
     - type: Machine
       board: OreProcessorMachineCircuitboard
     - type: MaterialStorage
-      ignoreMaterialWhiteList: true # Goob edit
-      connectToSilo: true # Goob edit
-      disconnectSiloOffMap: true # Goob edit
-      disallowOreEjection: false # Goob edit
       ignoreColor: true
+      # <Goobstation>
+      ignoreMaterialWhiteList: true
+      connectToSilo: true
+      disconnectSiloOffMap: true
+      disallowOreEjection: false
+      # </Goobstation>
       whitelist:
         tags:
-          - Ore
-          - Sheet
-          - RawMaterial
-          - Ingot
+        - Ore
+        # <Goobstation>
+        - Sheet
+        - RawMaterial
+        - Ingot
+        - SheetMetalBase
+        # </Goobstation>
     - type: Lathe
       idleState: icon
       runningState: building


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
fixes the ore processor vaporizing mats due to the whitelist check failing, because the `MaterialStorageComponent.IgnoreMaterialWhiteList` that marty added wasn't actually implemented. also fixes the mining points button overlapping with the materials list

making the processor work reveals another bug where for some reason the amount multiplier doesn't actually work on the produced mats and only works on the consumed ore but lazy to find the issue for and fix that rn, this more important cuz no mats at all bad. set the materials produced amount to "1" for it to produce the correct amounts for now, i believe (evil)

ALSO as a failsafe this makes it so if it fails to directly add materials to the storage it just produces it like normal rather than vaporizing them

will close #6791

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: rivermyth
- fix: Ore Processor no longer vaporizes mats.
- fix: Fixed Ore Processor "Claim points" button overlapping with materials list.