### PR TITLE
[FIX] supermatter console errors when used

### DIFF
--- a/Content.Goobstation.Client/Supermatter/Consoles/SupermatterEntryContainer.xaml.cs
+++ b/Content.Goobstation.Client/Supermatter/Consoles/SupermatterEntryContainer.xaml.cs
@@ -148,12 +148,12 @@ public sealed partial class SupermatterEntryContainer : BoxContainer
 
     private float GetStoredGas(GasPrototype gas, SupermatterFocusData? focusData)
     {
-        var id = int.Parse(gas.ID);
-
-        if (focusData == null)
+        if (focusData is null)
             return 0;
 
-        return focusData.Value.GasStorage[(Gas)id];
+        Gas id = (Gas) Enum.Parse(typeof(Gas), gas.ID);
+
+        return focusData.Value.GasStorage[id];
     }
 
     private void UpdateEngineBar(ProgressBar bar, PanelContainer border, float value, float leftSize, float rightSize, Color leftColor, Color middleColor, Color rightColor)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
fixes a bug where gas IDs were changed by upstream to be their gas names instead of index, causing SM console to error clientside when trying to convert it to an int to reference it in the gas storage

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: rivermyth
- fix: Fixed the supermatter monitoring console UI erroring when used.