### PR TITLE
[FIX] remove erroneous silo links

### DIFF
--- a/Resources/Maps/_Goobstation/bagel.yml
+++ b/Resources/Maps/_Goobstation/bagel.yml
@@ -50167,8 +50167,6 @@ entities:
     - type: Transform
       pos: 46.5,5.5
       parent: 2
-    - type: OreSiloClient
-      silo: 16728
 - proto: Carpet
   entities:
   - uid: 7494
@@ -111851,14 +111849,6 @@ entities:
     - type: Transform
       pos: 53.5,6.5
       parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        7493:
-        - - OreSilo
-          - OreSiloClient
-        16853:
-        - - OreSilo
-          - OreSiloClient
 - proto: MaterialWoodPlank
   entities:
   - uid: 16729
@@ -112856,8 +112846,6 @@ entities:
     - type: Transform
       pos: 45.5,4.5
       parent: 2
-    - type: OreSiloClient
-      silo: 16728
     - type: MaterialStorage
       materialWhiteList:
       - Steel

--- a/Resources/Maps/_Goobstation/box.yml
+++ b/Resources/Maps/_Goobstation/box.yml
@@ -16037,8 +16037,6 @@ entities:
       - Arsenal
       - Experimental
       - CivilianServices
-    - type: OreSiloClient
-      silo: 18924
 - proto: BackgammonBoard
   entities:
   - uid: 946
@@ -56732,8 +56730,6 @@ entities:
     - type: Transform
       pos: -28.5,-24.5
       parent: 2
-    - type: OreSiloClient
-      silo: 18924
 - proto: Carpet
   entities:
   - uid: 9024
@@ -124725,17 +124721,6 @@ entities:
     - type: Transform
       pos: -28.5,-22.5
       parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        9023:
-        - - OreSilo
-          - OreSiloClient
-        945:
-        - - OreSilo
-          - OreSiloClient
-        20058:
-        - - OreSilo
-          - OreSiloClient
 - proto: MaterialWoodPlank1
   entities:
   - uid: 18925
@@ -132665,8 +132650,6 @@ entities:
       - Arsenal
       - Experimental
       - CivilianServices
-    - type: OreSiloClient
-      silo: 18924
 - proto: PsychBed
   entities:
   - uid: 20059

--- a/Resources/Maps/_Goobstation/cluster.yml
+++ b/Resources/Maps/_Goobstation/cluster.yml
@@ -23450,8 +23450,6 @@ entities:
     - type: Transform
       pos: 13.5,-20.5
       parent: 2
-    - type: OreSiloClient
-      silo: 504
 - proto: Carpet
   entities:
   - uid: 3347
@@ -58630,14 +58628,6 @@ entities:
     - type: Transform
       pos: 13.5,-24.5
       parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        8695:
-        - - OreSilo
-          - OreSiloClient
-        443:
-        - - OreSilo
-          - OreSiloClient
 - proto: MaterialWoodPlank
   entities:
   - uid: 8618
@@ -59173,8 +59163,6 @@ entities:
     - type: Transform
       pos: 17.5,-23.5
       parent: 2
-    - type: OreSiloClient
-      silo: 504
 - proto: OreProcessorMachineCircuitboard
   entities:
   - uid: 8696

--- a/Resources/Maps/_Goobstation/cog.yml
+++ b/Resources/Maps/_Goobstation/cog.yml
@@ -21135,8 +21135,6 @@ entities:
       - Arsenal
       - Experimental
       - CivilianServices
-    - type: OreSiloClient
-      silo: 22568
 - proto: BananaPhoneInstrument
   entities:
   - uid: 1252
@@ -148382,17 +148380,6 @@ entities:
     - type: Transform
       pos: 56.5,-18.5
       parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        1251:
-        - - OreSilo
-          - OreSiloClient
-        23712:
-        - - OreSilo
-          - OreSiloClient
-        30340:
-        - - OreSilo
-          - OreSiloClient
 - proto: Mattress
   entities:
   - uid: 22569
@@ -155649,8 +155636,6 @@ entities:
       - Arsenal
       - Experimental
       - CivilianServices
-    - type: OreSiloClient
-      silo: 22568
 - proto: ProtolatheMachineCircuitboard
   entities:
   - uid: 23713
@@ -164925,8 +164910,6 @@ entities:
       - Arsenal
       - Experimental
       - CivilianServices
-    - type: OreSiloClient
-      silo: 22568
 - proto: ShardGlass
   entities:
   - uid: 25371

--- a/Resources/Maps/_Goobstation/delta.yml
+++ b/Resources/Maps/_Goobstation/delta.yml
@@ -99018,8 +99018,6 @@ entities:
     - type: Transform
       pos: 7.5,33.5
       parent: 2
-    - type: OreSiloClient
-      silo: 25536
 - proto: Carpet
   entities:
   - uid: 12897
@@ -186691,14 +186689,6 @@ entities:
     - type: Transform
       pos: 16.5,34.5
       parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        12896:
-        - - OreSilo
-          - OreSiloClient
-        15465:
-        - - OreSilo
-          - OreSiloClient
 - proto: MaterialSmileExtract
   entities:
   - uid: 25537
@@ -188200,8 +188190,6 @@ entities:
       - Arsenal
       - Experimental
       - CivilianServices
-    - type: OreSiloClient
-      silo: 25536
 - proto: OrganDionaStomach
   entities:
   - uid: 25726

--- a/Resources/Maps/_Goobstation/kettle.yml
+++ b/Resources/Maps/_Goobstation/kettle.yml
@@ -18138,8 +18138,6 @@ entities:
       - Arsenal
       - Experimental
       - CivilianServices
-    - type: OreSiloClient
-      silo: 26504
 - proto: AutolatheMachineCircuitboard
   entities:
   - uid: 1225
@@ -62509,8 +62507,6 @@ entities:
       - Arsenal
       - Experimental
       - CivilianServices
-    - type: OreSiloClient
-      silo: 26504
 - proto: CircuitImprinterMachineCircuitboard
   entities:
   - uid: 9828
@@ -122715,17 +122711,6 @@ entities:
     - type: Transform
       pos: -12.5,-6.5
       parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        11907:
-        - - OreSilo
-          - OreSiloClient
-        9996:
-        - - OreSilo
-          - OreSiloClient
-        26963:
-        - - OreSilo
-          - OreSiloClient
 - proto: Mattress
   entities:
   - uid: 18198
@@ -129919,8 +129904,6 @@ entities:
       - Arsenal
       - Experimental
       - CivilianServices
-    - type: OreSiloClient
-      silo: 26504
 - proto: ProtolatheMachineCircuitboard
   entities:
   - uid: 19217

--- a/Resources/Maps/_Goobstation/leonid.yml
+++ b/Resources/Maps/_Goobstation/leonid.yml
@@ -99603,8 +99603,6 @@ entities:
     - type: Transform
       pos: -57.5,-49.5
       parent: 2
-    - type: OreSiloClient
-      silo: 24372
 - proto: CleanerDispenser
   entities:
   - uid: 16141
@@ -114923,8 +114921,6 @@ entities:
     - type: Transform
       pos: -67.5,-49.5
       parent: 2
-    - type: OreSiloClient
-      silo: 24372
 - proto: ExtendedEmergencyNitrogenTankFilled
   entities:
   - uid: 21
@@ -160255,23 +160251,6 @@ entities:
     - type: Transform
       pos: -43.5,11.5
       parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        24393:
-        - - OreSilo
-          - OreSiloClient
-        28395:
-        - - OreSilo
-          - OreSiloClient
-        28396:
-        - - OreSilo
-          - OreSiloClient
-        18514:
-        - - OreSilo
-          - OreSiloClient
-        16140:
-        - - OreSilo
-          - OreSiloClient
 - proto: MaterialWoodPlank
   entities:
   - uid: 24373
@@ -160395,8 +160374,6 @@ entities:
     - type: Transform
       pos: -61.5,-23.5
       parent: 2
-    - type: OreSiloClient
-      silo: 24372
 - proto: MedkitAdvancedFilled
   entities:
   - uid: 24394
@@ -183737,8 +183714,6 @@ entities:
       - Arsenal
       - Experimental
       - CivilianServices
-    - type: OreSiloClient
-      silo: 24372
   - uid: 28396
     components:
     - type: Transform
@@ -183750,8 +183725,6 @@ entities:
       - Arsenal
       - Experimental
       - CivilianServices
-    - type: OreSiloClient
-      silo: 24372
 - proto: SeedExtractor
   entities:
   - uid: 28397

--- a/Resources/Maps/_Goobstation/loop.yml
+++ b/Resources/Maps/_Goobstation/loop.yml
@@ -34826,8 +34826,6 @@ entities:
     - type: Transform
       pos: 5.5,62.5
       parent: 2
-    - type: OreSiloClient
-      silo: 15199
 - proto: Carpet
   entities:
   - uid: 5387
@@ -78984,14 +78982,6 @@ entities:
     - type: Transform
       pos: 7.5,67.5
       parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        11908:
-        - - OreSilo
-          - OreSiloClient
-        5386:
-        - - OreSilo
-          - OreSiloClient
 - proto: MaterialWoodPlank
   entities:
   - uid: 11810
@@ -79577,8 +79567,6 @@ entities:
     - type: Transform
       pos: 8.5,66.5
       parent: 2
-    - type: OreSiloClient
-      silo: 15199
 - proto: OxygenCanister
   entities:
   - uid: 2765

--- a/Resources/Maps/_Goobstation/meta.yml
+++ b/Resources/Maps/_Goobstation/meta.yml
@@ -16527,8 +16527,6 @@ entities:
     - type: Transform
       pos: -17.5,17.5
       parent: 2
-    - type: OreSiloClient
-      silo: 1079
     - type: TechnologyDatabase
       supportedDisciplines:
       - Industrial
@@ -54409,8 +54407,6 @@ entities:
     - type: Transform
       pos: -33.5,18.5
       parent: 2
-    - type: OreSiloClient
-      silo: 1079
 - proto: Carpet
   entities:
   - uid: 8258
@@ -61228,7 +61224,6 @@ entities:
     - type: Transform
       pos: 1.5,-37.5
       parent: 2
-    - type: OreSiloClient
       silo: 1079
     - type: MaterialStorage
       materialWhiteList:
@@ -76641,8 +76636,6 @@ entities:
     - type: Transform
       pos: 52.5,14.5
       parent: 2
-    - type: OreSiloClient
-      silo: 1079
 - proto: ExosuitFabricator
   entities:
   - uid: 11912
@@ -76650,15 +76643,11 @@ entities:
     - type: Transform
       pos: 0.5,-41.5
       parent: 2
-    - type: OreSiloClient
-      silo: 1079
   - uid: 11913
     components:
     - type: Transform
       pos: 0.5,-39.5
       parent: 2
-    - type: OreSiloClient
-      silo: 1079
 - proto: ExplosivesSignMed
   entities:
   - uid: 11914
@@ -126614,47 +126603,6 @@ entities:
     - type: Transform
       pos: -7.5,17.5
       parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        25431:
-        - - OreSilo
-          - OreSiloClient
-        25430:
-        - - OreSilo
-          - OreSiloClient
-        8257:
-        - - OreSilo
-          - OreSiloClient
-        19036:
-        - - OreSilo
-          - OreSiloClient
-        18906:
-        - - OreSilo
-          - OreSiloClient
-        11912:
-        - - OreSilo
-          - OreSiloClient
-        11913:
-        - - OreSilo
-          - OreSiloClient
-        9588:
-        - - OreSilo
-          - OreSiloClient
-        21222:
-        - - OreSilo
-          - OreSiloClient
-        21262:
-        - - OreSilo
-          - OreSiloClient
-        11911:
-        - - OreSilo
-          - OreSiloClient
-        21255:
-        - - OreSilo
-          - OreSiloClient
-        21256:
-        - - OreSilo
-          - OreSiloClient
 - proto: MaterialWoodPlank1
   entities:
   - uid: 18900
@@ -126718,8 +126666,6 @@ entities:
     - type: Transform
       pos: -34.5,-30.5
       parent: 2
-    - type: OreSiloClient
-      silo: 1079
     - type: MaterialStorage
       materialWhiteList:
       - Glass
@@ -128041,8 +127987,6 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-    - type: OreSiloClient
-      silo: 1079
     - type: Conveyed
 - proto: OxygenCanister
   entities:
@@ -135246,8 +135190,6 @@ entities:
     - type: Transform
       pos: -17.5,16.5
       parent: 2
-    - type: OreSiloClient
-      silo: 1079
     - type: TechnologyDatabase
       supportedDisciplines:
       - Industrial
@@ -141186,8 +141128,6 @@ entities:
     - type: Transform
       pos: 14.5,-30.5
       parent: 2
-    - type: OreSiloClient
-      silo: 1079
     - type: TechnologyDatabase
       supportedDisciplines:
       - Industrial
@@ -141456,8 +141396,6 @@ entities:
     - type: Transform
       pos: -3.5,42.5
       parent: 2
-    - type: OreSiloClient
-      silo: 1079
     - type: TechnologyDatabase
       supportedDisciplines:
       - Industrial
@@ -141469,8 +141407,6 @@ entities:
     - type: Transform
       pos: -1.5,36.5
       parent: 2
-    - type: OreSiloClient
-      silo: 1079
     - type: TechnologyDatabase
       supportedDisciplines:
       - Industrial
@@ -141516,8 +141452,6 @@ entities:
     - type: Transform
       pos: 19.5,6.5
       parent: 2
-    - type: OreSiloClient
-      silo: 1079
     - type: TechnologyDatabase
       supportedDisciplines:
       - Industrial

--- a/Resources/Maps/_Goobstation/saltern.yml
+++ b/Resources/Maps/_Goobstation/saltern.yml
@@ -23544,8 +23544,6 @@ entities:
     - type: Transform
       pos: 12.5,9.5
       parent: 2
-    - type: OreSiloClient
-      silo: 1977
 - proto: Carpet
   entities:
   - uid: 3634
@@ -52807,14 +52805,6 @@ entities:
     - type: Transform
       pos: 23.5,9.5
       parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        8182:
-        - - OreSilo
-          - OreSiloClient
-        3633:
-        - - OreSilo
-          - OreSiloClient
 - proto: MaterialWoodPlank1
   entities:
   - uid: 8126
@@ -53264,8 +53254,6 @@ entities:
     - type: Transform
       pos: 18.5,13.5
       parent: 2
-    - type: OreSiloClient
-      silo: 1977
 - proto: OxygenCanister
   entities:
   - uid: 8183


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
removes all the prelinked silo clients links in map prototypes, many of them were done in a weird way that bugs out due to changes (imagining ghost silos, etc, which i've had to go and keep disassembling and reassembling lathes just to fix it), and ur supposed to just link from the silo roundstart anyways. pretty sure it's just not normally meant to be serialized when mapmaking, just a side effect of upstream merges i believe, it's not even in any upstream map files.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: rivermyth
- fix: Fixed some lathes being connected to imaginary silos.