### PR TITLE
fix: paper preview and open in hand

### DIFF
--- a/Content.Client/Paper/UI/PaperSheetlet.cs
+++ b/Content.Client/Paper/UI/PaperSheetlet.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Content.Client.Resources;
 using Content.Client.Stylesheets;
 using Content.Client.Stylesheets.SheetletConfigs;
@@ -38,6 +39,10 @@ public sealed class PaperSheetlet : Sheetlet<NanotrasenStylesheet>
             E<PanelContainer>()
                 .Identifier("PaperEditBackground")
                 .Prop(PanelContainer.StylePropertyPanel, borderedTransparentBackground),
+            E<TextEdit>()
+                .Class("PaperLineEdit")
+                .Prop(LineEdit.StylePropertyStyleBox, new StyleBoxEmpty())
+                .Prop("font-color", new Color(25, 25, 25)),
         ];
     }
 }

--- a/Content.Client/Paper/UI/PaperSheetlet.cs
+++ b/Content.Client/Paper/UI/PaperSheetlet.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using Content.Client.Resources;
 using Content.Client.Stylesheets;
 using Content.Client.Stylesheets.SheetletConfigs;

--- a/Content.Shared/Paper/PaperSystem.cs
+++ b/Content.Shared/Paper/PaperSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.UserInterface;
 using Content.Shared.Database;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
+using Content.Shared.Interaction.Events;
 using Content.Shared.Popups;
 using Content.Shared.Tag;
 using Robust.Shared.Player;
@@ -49,6 +50,7 @@ public sealed class PaperSystem : EntitySystem
         SubscribeLocalEvent<PaperComponent, PaperSignatureRequestMessage>(OnSignatureRequest); // Starlight-edit
 
         SubscribeLocalEvent<ActivateOnPaperOpenedComponent, PaperWriteEvent>(OnPaperWrite);
+        SubscribeLocalEvent<PaperComponent, UseInHandEvent>(OnUseInHand);
     }
 
     private void OnMapInit(Entity<PaperComponent> entity, ref MapInitEvent args)
@@ -291,6 +293,17 @@ public sealed class PaperSystem : EntitySystem
     public void UpdateUserInterface(Entity<PaperComponent> entity)
     {
         _uiSystem.SetUiState(entity.Owner, PaperUiKey.Key, new PaperBoundUserInterfaceState(entity.Comp.Content, entity.Comp.StampedBy, entity.Comp.Mode));
+    }
+
+    private void OnUseInHand(Entity<PaperComponent> entity, ref UseInHandEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        entity.Comp.Mode = PaperAction.Read;
+        UpdateUserInterface(entity);
+        _uiSystem.TryToggleUi(entity.Owner, PaperUiKey.Key, args.User);
+        args.Handled = true;
     }
 
     # region Starlight


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

Added an event handler in `PaperSystem.cs` (paper open in hand) and added a small Text Edit section in `PaperSheelet.cs` (preview writing). Took me forever to root out `PaperSheetlet.cs`.
Closes #6810
Closes #6794 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fix paper from upstream merge

## Technical details
<!-- Summary of code changes for easier review. -->

Added an event handler called `OnUseInHand.cs` in `PaperSystem.cs` (paper open in hand). Still works when on the ground because of `ActivateInWorldEvent`.
The actual active stylesheet (`NanotrasenStylesheet`) did not have a `PaperLineEdit` rule for `TextEdit`, only a deprecated one in `StyleNano.cs` had a rule (I assume from the merge. There was a comment in `StyleNano.cs` that indicated it (`// TODO: REMOVE (obsolete)`), so the default color was still white (color of paper).

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="744" height="783" alt="image" src="https://github.com/user-attachments/assets/23564ecd-af94-4bd7-834f-fe3eee773a34" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- fix: paper preview while writing! yippee!
- fix: z, e, and left click work to open paper when in hand