### PR TITLE
FIX 3/11 of explosion damage

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -589,7 +589,7 @@ public sealed partial class ExplosionSystem
 
                 // TODO EXPLOSIONS turn explosions into entities, and pass the the entity in as the damage origin.
                 if (!WouldTriggerDestructibleThreshold(entity, damage, cause))
-                    _damageableSystem.TryChangeDamage(entity, damage, ignoreResistances: true, targetPart: TargetBodyPart.All, splitDamage: SplitDamageBehavior.Split); // Shitmed Change
+                    _damageableSystem.TryChangeDamage(entity, damage, ignoreResistances: true, targetPart: TargetBodyPart.All, splitDamage: SplitDamageBehavior.SplitExplosion); // Shitmed Change
             }
         }
 

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -725,6 +725,12 @@ namespace Content.Shared.Damage
                     return newDamage;
                 case SplitDamageBehavior.Split:
                     return newDamage / parts.Count;
+                case SplitDamageBehavior.SplitExplosion:
+                    var vitalParts = parts.Where(part =>
+                    TryComp<ConsciousnessRequiredComponent>(part.Id, out var consciousness)
+                    && consciousness.CausesDeath == true).ToList();
+
+                    return newDamage / vitalParts.Count;
                 case SplitDamageBehavior.SplitEnsureAllDamaged:
                     var damagedParts = parts.Where(part =>
                         part.Damageable.TotalDamage > FixedPoint2.Zero).ToList();

--- a/Content.Shared/_Shitmed/Damage/DamageBehaviors.cs
+++ b/Content.Shared/_Shitmed/Damage/DamageBehaviors.cs
@@ -9,6 +9,7 @@ public enum SplitDamageBehavior
 {
     None,
     Split,
+    SplitExplosion,
     SplitEnsureAllOrganic,
     SplitEnsureAllDamaged,
     SplitEnsureAllDamagedAndOrganic,


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
The issue where explosions were defacto dealing only 3/11 damage has been resolved. 
Woundmed ever since limb damage stopped killing, has broken all explosives by dividing their damage across ALL body parts. This PR brings back the old damage for all explosions to bodies with woundmed.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The explosive's stats were not designed to deal 3/11 lethal damage

## Technical details
<!-- Summary of code changes for easier review. -->
Added a new type of damage split, in which the damage is divided by the count of vital parts

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Explosions again deal full lethal damage, instead of 3/11 due to woundmed
-->
- fix: Explosions again deal full lethal damage, instead of 3/11 due to woundmed