### PR TITLE
Minor northstar tweaks (BOUNTY)

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -148,7 +148,7 @@
   description: uplink-gloves-north-star-desc
   productEntity: ClothingHandsGlovesNorthStar
   cost:
-    Telecrystal: 40 # goob
+    Telecrystal: 30 # goob
   categories:
   - UplinkWeaponry
   #Goobstation

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -422,18 +422,17 @@
   - type: Clothing
     sprite: Clothing/Hands/Gloves/northstar.rsi
   - type: MeleeWeapon
-    altDisarm: true
-    attackRate: 10
+    autoAttack: true
+    attackRate: 5
     damage:
       types:
-       Blunt: 3
-       Slash: 3
+       Blunt: 4
+       Slash: 4
     soundHit:
       collection: Punch
     animation: WeaponArcFist
     #mustBeEquippedToUse: true # goob edit
-    heavyStaminaCost: 0 # goob edit
-    canWideSwing: false # goob edit
+    heavyStaminaCost: 3 # goob edit
   - type: Fiber
     fiberMaterial: fibers-leather
     fiberColor: fibers-blue


### PR DESCRIPTION
## About the PR
Minorly alters gloves of the north star damage and price, adds autoattack for people who don't have an undetectable autoclicker.

## Why / Balance
Northstars are super underutilized rn, and not really practical since you can't aim your punches and break your mouse spamming at the same time. 

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

**Changelog**

:cl:
- tweak: Rebalanced damage and price for gloves of the north star.