### PR TITLE
Give "cannot be flatpacked" text to machine board

### DIFF
--- a/Content.Shared/Construction/MachinePartSystem.cs
+++ b/Content.Shared/Construction/MachinePartSystem.cs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-using System.Linq;
 using Content.Shared.Construction.Components;
 using Content.Shared.Examine;
 using Content.Shared.Lathe;
 using Content.Shared.Materials;
+using Content.Shared.Stacks;
 using Robust.Shared.Prototypes;
+using System.Collections;
+using System.Linq;
 
 namespace Content.Shared.Construction
 {
@@ -56,6 +58,11 @@ namespace Content.Shared.Construction
                     args.PushMarkup(Loc.GetString("machine-board-component-required-element-entry-text",
                         ("amount", info.Amount),
                         ("requiredElement", examineName)));
+                }
+
+                if (!CanGetMachineBoardCost((uid, component))) // Goobstation
+                {
+                    args.PushMarkup(Loc.GetString("machine-board-cannot-be-flatpacked"));
                 }
             }
         }
@@ -133,6 +140,57 @@ namespace Content.Shared.Construction
             }
 
             // We were able to construct all elements of the recipe.
+            return true;
+        }
+
+        /// <summary>
+        /// Goobstation - Check whether if entity has recipe lathe or physical composition for all of it's material
+        /// </summary>
+        /// <param name="ent">The entity</param>
+        /// <returns></returns>
+        public bool CanGetMachineBoardCost(Entity<MachineBoardComponent> ent)
+        {
+            foreach (var (stackId, _) in ent.Comp.StackRequirements)
+            {
+                var stackProto = _prototype.Index(stackId);
+                var defaultProto = _prototype.Index(stackProto.Spawn);
+
+                if (defaultProto.TryGetComponent<PhysicalCompositionComponent>(out var physComp, EntityManager.ComponentFactory))
+                {
+                    continue;
+                }
+                else if (_lathe.CanGetRecipesFromEntity(stackProto.Spawn))
+                {
+                    continue;
+                }
+                else
+                {
+                    // The item has no material cost, so we cannot get the full cost.
+                    return false;
+                }
+            }
+
+            var genericPartInfo = ent.Comp.ComponentRequirements.Values.Concat(ent.Comp.TagRequirements.Values);
+            foreach (var info in genericPartInfo)
+            {
+                var defaultProtoId = info.DefaultPrototype;
+
+                if (_lathe.CanGetRecipesFromEntity(defaultProtoId))
+                {
+                    continue;
+                }
+                else if (_prototype.Resolve(defaultProtoId, out var defaultProto) &&
+                         defaultProto.TryGetComponent<PhysicalCompositionComponent>(out var physComp, EntityManager.ComponentFactory))
+                {
+                    continue;
+                }
+                else
+                {
+                    // The item has no material cost, so we cannot get the full cost.
+                    return false;
+                }
+            }
+
             return true;
         }
     }

--- a/Content.Shared/Construction/MachinePartSystem.cs
+++ b/Content.Shared/Construction/MachinePartSystem.cs
@@ -4,9 +4,7 @@ using Content.Shared.Construction.Components;
 using Content.Shared.Examine;
 using Content.Shared.Lathe;
 using Content.Shared.Materials;
-using Content.Shared.Stacks;
 using Robust.Shared.Prototypes;
-using System.Collections;
 using System.Linq;
 
 namespace Content.Shared.Construction

--- a/Content.Shared/Lathe/SharedLatheSystem.cs
+++ b/Content.Shared/Lathe/SharedLatheSystem.cs
@@ -145,6 +145,16 @@ public abstract class SharedLatheSystem : EntitySystem
         return recipes.Count != 0;
     }
 
+    /// <summary>
+    /// Goobstation - Check if proto has a lathe recipe
+    /// </summary>
+    /// <param name="prototype">The proto id</param>
+    /// <returns></returns>
+    public bool CanGetRecipesFromEntity(string prototype)
+    {
+        return InverseRecipes.ContainsKey(prototype);
+    }
+
     public string GetRecipeName(ProtoId<LatheRecipePrototype> proto)
     {
         return GetRecipeName(_proto.Index(proto));

--- a/Resources/Locale/en-US/_Goobstation/machine/machine.ftl
+++ b/Resources/Locale/en-US/_Goobstation/machine/machine.ftl
@@ -1,0 +1,1 @@
+machine-board-cannot-be-flatpacked = This machine board cannot be flatpacked.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Give "cannot be flatpacked" text to machine board

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Recently wizden has reworked flatpack and patched the exploit. 
The "exploit" come from this
<img width="479" height="328" alt="image" src="https://github.com/user-attachments/assets/33944c80-e2dd-4438-b45f-9bec4a089e69" />
Before, you can flatpack this type of thing where one of the recipe material dont have lathe recipe or physical composition (e.g, like instrument here where you have to buy it and can't craft it or have physical composition to be recycled). Now you can't and it will display error on the flatpack machine itself. 

But it's way too vague and doesn't explain why it give invalid result. Someone reported it as a upstream bug as a result of this  so I put some markup text to the board to indicate that it cannot be flatpacked. 

## Technical details
<!-- Summary of code changes for easier review. -->
Duplicated some method but discarded the param that I don't use for the markup

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="479" height="328" alt="image" src="https://github.com/user-attachments/assets/624a1f94-6387-4583-ac89-d074cd28701c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Examine your machine board to know if it can be flatpacked or not.
