### PR TITLE
FIX: Wrong prototype mapped in Oasis

### DIFF
--- a/Resources/Maps/.oasis.yml
+++ b/Resources/Maps/.oasis.yml
@@ -129078,7 +129078,7 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF1212FF'
-- proto: Gauze10Lingering
+- proto: Gauze
   entities:
   - uid: 17923
     components:


### PR DESCRIPTION
Gauze10Lingering was erased by upstream but not removed from Oasis.