### PR TITLE
Fix xenobio slime extract giving a lot of entities upon injected

### DIFF
--- a/Content.Shared/EntityEffects/Effects/EntitySpawning/BaseSpawnEntityEntityEffect.cs
+++ b/Content.Shared/EntityEffects/Effects/EntitySpawning/BaseSpawnEntityEntityEffect.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Prototypes;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.EntityEffects.Effects.EntitySpawning;
 
@@ -27,6 +27,12 @@ public abstract partial class BaseSpawnEntityEntityEffect<T> : EntityEffectBase<
     /// </summary>
     [DataField]
     public bool Predicted = true;
+
+    /// <summary>
+    /// Goobstation - Whether or not this effect should scale
+    /// </summary>
+    [DataField]
+    public bool ShouldScale = true;
 
     public override string EntityEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
         => Loc.GetString("entity-effect-guidebook-spawn-entity",

--- a/Content.Shared/EntityEffects/Effects/EntitySpawning/SpawnEntityEntityEffectSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/EntitySpawning/SpawnEntityEntityEffectSystem.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Network;
+using Robust.Shared.Network;
 
 namespace Content.Shared.EntityEffects.Effects.EntitySpawning;
 
@@ -13,7 +13,7 @@ public sealed partial class SpawnEntityEntityEffectSystem : EntityEffectSystem<T
 
     protected override void Effect(Entity<TransformComponent> entity, ref EntityEffectEvent<SpawnEntity> args)
     {
-        var quantity = args.Effect.Number * (int)Math.Floor(args.Scale);
+        var quantity = args.Effect.ShouldScale ? args.Effect.Number * (int) Math.Floor(args.Scale) : args.Effect.Number; // Goobstation - Added ShouldSCale
         var proto = args.Effect.Entity;
 
         if (args.Effect.Predicted)

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t0/grey.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t0/grey.yml
@@ -38,6 +38,7 @@
       - !type:SpawnEntity
         entity: MobSlimeXenobioBabyGrey
         number: 3
+        shouldScale: false
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:
@@ -50,6 +51,7 @@
       - !type:SpawnEntity
         entity: MonkeyCube
         number: 3
+        shouldScale: false
   - type: Tag
     tags:
     - XenobiologyGreyExtract

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t1/metal.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t1/metal.yml
@@ -24,9 +24,11 @@
       - !type:SpawnEntity
         entity: SheetGlass1
         number: 15
+        shouldScale: false
       - !type:SpawnEntity
         entity: SheetRGlass1
         number: 5
+        shouldScale: false
     - reagents: [ Plasma ]
       methods: [ Touch, Injection ]
       effects:
@@ -42,6 +44,7 @@
       - !type:SpawnEntity
         entity: SheetPlasteel1
         number: 5
+        shouldScale: false
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t2/dark_purple.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t2/dark_purple.yml
@@ -23,6 +23,7 @@
       - !type:SpawnEntity
         entity: SheetPlastic10
         number: 3
+        shouldScale: false
     - reagents: [ Plasma ]
       methods: [ Touch, Injection ]
       effects:
@@ -35,6 +36,7 @@
       - !type:SpawnEntity
         entity: SheetPlasma1
         number: 3
+        shouldScale: false
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t2/silver.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t2/silver.yml
@@ -41,6 +41,7 @@
       - !type:SpawnEntity
         entity: IngotSilver1
         number: 2
+        shouldScale: false
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:
@@ -53,6 +54,7 @@
       - !type:SpawnEntity
         entity: XenobioGoopBall
         number: 3
+        shouldScale: false
   - type: Tag
     tags:
     - XenobiologySilverExtract

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t2/yellow.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t2/yellow.yml
@@ -32,6 +32,7 @@
       - !type:SpawnEntity
         entity: XenobioVolatileOrgan
         number: 1
+        shouldScale: false
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/bluespace.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/bluespace.yml
@@ -24,6 +24,7 @@
       - !type:SpawnEntity
         entity: FloorTileItemBluespace
         number: 30
+        shouldScale: false
     - reagents: [ Plasma ]
       methods: [ Touch, Injection ]
       effects:
@@ -36,6 +37,7 @@
       - !type:SpawnEntity
         entity: MaterialBSCrystal1
         number: 5
+        shouldScale: false
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/gold.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/gold.yml
@@ -27,6 +27,7 @@
       - !type:SpawnEntity
         entity: RPassiveMobSpawner
         number: 5
+        shouldScale: false
     - reagents: [ Plasma ]
       methods: [ Touch, Injection ]
       effects:
@@ -42,6 +43,7 @@
       - !type:SpawnEntity
         entity: RHostileMobSpawner
         number: 5
+        shouldScale: false
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:
@@ -57,6 +59,7 @@
       - !type:SpawnEntity
         entity: RNeutralMobSpawner
         number: 5
+        shouldScale: false
   - type: Tag
     tags:
     - XenobiologyGoldExtract

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/red.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/red.yml
@@ -23,6 +23,7 @@
       - !type:SpawnEntity
         entity: XenobioVolatileRedExtractJelly
         number: 1
+        shouldScale: false
     - reagents: [ Plasma ]
       methods: [ Touch, Injection ]
       effects:

--- a/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/sepia.yml
+++ b/Resources/Prototypes/_Goobstation/Xenobiology/Entities/Objects/Specific/Xenobiology/Extracts/t3/sepia.yml
@@ -39,6 +39,7 @@
       - !type:SpawnEntity
         entity: XenoExtractChronofield
         number: 1
+        shouldScale: false
     - reagents: [ Blood ]
       methods: [ Touch, Injection ]
       effects:
@@ -51,6 +52,7 @@
       - !type:SpawnEntity
         entity: FloorTileItemSepia
         number: 30
+        shouldScale: false
   - type: Tag
     tags:
     - XenobiologySepiaExtract


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Fix xenobio slime extract giving a lot of entities upon injected

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
You can lag the whole room with gold extract or even grey slime. It used to scale with the amount of reagent with the number of spawned entities.
<img width="147" height="27" alt="image" src="https://github.com/user-attachments/assets/07102224-eafa-4ef8-a31b-50b4de2dc6ba" />
Like here if you inject the extract with 5u of  blood, it will spawn 15 grey instead of 3

## Technical details
<!-- Summary of code changes for easier review. -->
give shouldScale and if false cap it with given number

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
5u of water
<img width="268" height="92" alt="image" src="https://github.com/user-attachments/assets/417f9d98-c8f0-464e-b766-d02f6f204fd2" />

result
<img width="554" height="291" alt="image" src="https://github.com/user-attachments/assets/15aaf78e-47ab-42d7-947c-168ef328f9fa" />

No more 4000 entities with a single extract

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed xenobio extract giving a lot of things after injection
