### PR TITLE
[Fix] Stack atmos devices in different configs, Issue #6851

### DIFF
--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -28,6 +28,7 @@ using Content.Goobstation.Maths.FixedPoint;
 using Content.Shared.Hands.Components;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
+using Content.Shared.Atmos.Components;
 using Content.Shared.Doors.Systems;
 using Content.Shared.Doors.Components; // Goob - Check for Door Bolt
 
@@ -504,6 +505,13 @@ public sealed class RCDSystem : EntitySystem
                 {
                     var entDirection = Transform(ent).LocalRotation.GetCardinalDir();
                     if (entDirection != direction)
+                        isIdentical = false;
+                }
+
+                if (HasComp<AtmosPipeLayersComponent>(ent))
+                {
+                    var entPipeLayer = Comp<AtmosPipeLayersComponent>(ent).CurrentPipeLayer;
+                    if (entPipeLayer != AtmosPipeLayer.Primary)
                         isIdentical = false;
                 }
 

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -28,7 +28,7 @@ using Content.Goobstation.Maths.FixedPoint;
 using Content.Shared.Hands.Components;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
-using Content.Shared.Atmos.Components;
+using Content.Shared.Atmos.Components; // Goob - Check for pipe layer
 using Content.Shared.Doors.Systems;
 using Content.Shared.Doors.Components; // Goob - Check for Door Bolt
 
@@ -508,7 +508,7 @@ public sealed class RCDSystem : EntitySystem
                         isIdentical = false;
                 }
 
-                if (HasComp<AtmosPipeLayersComponent>(ent))
+                if (HasComp<AtmosPipeLayersComponent>(ent))     //Goob - check for pipe layers
                 {
                     var entPipeLayer = Comp<AtmosPipeLayersComponent>(ent).CurrentPipeLayer;
                     if (entPipeLayer != AtmosPipeLayer.Primary)

--- a/Resources/Prototypes/RPD/rpd.yml
+++ b/Resources/Prototypes/RPD/rpd.yml
@@ -58,6 +58,7 @@
   collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
+  allowMultiDirection: true
 
 - type: rcd
   id: VolumetricPump
@@ -70,6 +71,7 @@
   collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
+  allowMultiDirection: true
 
 - type: rcd
   id: ManualValve
@@ -82,6 +84,7 @@
   collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
+  allowMultiDirection: true
 
 - type: rcd
   id: SignalValve
@@ -94,6 +97,7 @@
   collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
+  allowMultiDirection: true
 
 - type: rcd
   id: PressureValve
@@ -119,6 +123,7 @@
   collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
+  allowMultiDirection: true
 
 - type: rcd
   id: VentScrubber
@@ -131,6 +136,7 @@
   collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
+  allowMultiDirection: true
 
 - type: rcd
   id: VentGas
@@ -143,6 +149,7 @@
   collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
+  allowMultiDirection: true
 
 - type: rcd
   id: DualPortVent
@@ -155,6 +162,7 @@
   collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
+  allowMultiDirection: true
 
 - type: rcd
   id: VentPassive
@@ -167,6 +175,7 @@
   collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
+  allowMultiDirection: true
 
 - type: rcd
   id: Radiator
@@ -179,6 +188,7 @@
   collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
+  allowMultiDirection: true
 
 - type: rcd
   id: RadiatorBend
@@ -191,6 +201,7 @@
   collisionMask: Impassable
   rotation: User
   fx: EffectRCDConstruct0
+  allowMultiDirection: true
 
 - type: rcd
   id: MixerGas


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Added a check so the RPD can build over devices in different configs. Also added multidirection to most RPD builds.

## Why / Balance
Fixing a bug from upstream, listed in [https://github.com/Goob-Station/Goob-Station/issues/6851]

## Technical details
Added a check to rcdsystem.cs so atmos devices could be built on top of eachother if they were in different configs
Updated rpd.yml to add multidirection to most items

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: Atmos devices can be stacked in different configs now
- fix: Atmos devices can be stacked in different rotations now