### PR TITLE
[FIX] InvalidOperationException in zed cure

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -430,26 +430,30 @@ namespace Content.Server.Zombies
         /// Tries to cure the entity of zombification by reverting its polymorph
         /// </summary>
         /// <param name="ent">Entity to cure.</param>
-        /// <param name="currentEnt">Entity to use now, differs if succeeded.</param>
+        /// <param name="currentUid">Entity to use now, differs if succeeded.</param>
         /// <returns></returns>
-        private bool TryCureZombie(Entity<ZombieComponent> ent, out EntityUid currentEnt)
+        private bool TryCureZombie(Entity<ZombieComponent> ent, out EntityUid currentUid)
         {
-            currentEnt = TryComp(ent, out PolymorphedEntityComponent? comp) ? _polymorph.Revert((ent, comp))!.Value : ent;
-            return currentEnt != ent.Owner;
+            if (TryComp(ent, out PolymorphedEntityComponent? comp)
+                && _polymorph.Revert((ent, comp)) is { } uid)
+                currentUid = uid;
+            else
+                currentUid = ent.Owner;
+            return currentUid != ent.Owner;
         }
 
         private void OnUnZombifyEvent(Entity<ZombieComponent> ent, ref EntityUnZombifiedEvent args)
         {
-            bool success = TryCureZombie(ent, out EntityUid currentEnt);
+            bool success = TryCureZombie(ent, out EntityUid currentUid);
             _popup.PopupEntity(
                 Loc.GetString($"zombie-cure-{(success ? "success" : "failed")}"),
-                currentEnt,
+                currentUid,
                 PopupType.Medium
             );
 
             // we want to make sure this is added to the reverted ent
             if (args.Inoculate)
-                EnsureComp<ZombieImmuneComponent>(currentEnt);
+                EnsureComp<ZombieImmuneComponent>(currentUid);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
fixes nullable object with no value in zombie cure, would result in constant erroring if polymorph's revert target was deleted rather than user-facing `The cure fails to take hold!`

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="357" height="252" alt="Screenshot 2026-07-15 100100" src="https://github.com/user-attachments/assets/4c533b99-d4f4-4164-ab8e-cb7086f8d2c6" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: rivermyth
- fix: Fix zombie cure not properly handling errors.
