### PR TITLE
delete bullshit from DamageableSystem.cs

### DIFF
--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -348,23 +348,14 @@ namespace Content.Shared.Damage
                 }
 
                 // Goob edit start
-                List<float>? multipliers = null;
                 var damagePerPart = adjustedDamage;
-                if (targetedBodyParts.Count > 0 && adjustedDamage.PartDamageVariation != 0f)
-                {
-                    multipliers =
-                        GetDamageVariationMultipliers(adjustedDamage.PartDamageVariation, targetedBodyParts.Count);
-                }
-                else
-                    damagePerPart = ApplySplitDamageBehaviors(splitDamageBehavior, adjustedDamage, targetedBodyParts);
+                damagePerPart = ApplySplitDamageBehaviors(splitDamageBehavior, adjustedDamage, targetedBodyParts);
                 var appliedDamage = new DamageSpecifier();
                 var surplusHealing = new DamageSpecifier();
                 for (var i = 0; i < targetedBodyParts.Count; i++)
                 {
                     var (partId, _, partDamageable) = targetedBodyParts[i];
                     var modifiedDamage = damagePerPart;
-                    if (multipliers != null && multipliers.Count == targetedBodyParts.Count)
-                        modifiedDamage *= multipliers[i];
                     modifiedDamage += surplusHealing;
                     // Goob edit end
 
@@ -639,30 +630,6 @@ namespace Content.Shared.Damage
                 ignoreBlockers: ignoreBlockers);
 
             return true;
-        }
-
-        public List<float> GetDamageVariationMultipliers(float variation, int count)
-        {
-            DebugTools.AssertNotEqual(count, 0);
-            var list = new List<float>(count);
-            var weights = new List<float>(count);
-            var totalWeight = 0f;
-            var random = new System.Random((int) _timing.CurTick.Value);
-            for (var i = 0; i < count; i++)
-            {
-                var weight = random.NextFloat() * MathF.Abs(variation) + 1f;
-                weights.Add(weight);
-                totalWeight += weight;
-            }
-
-            DebugTools.AssertNotEqual(totalWeight, 0f);
-
-            foreach (var weight in weights)
-            {
-                list.Add(weight / totalWeight);
-            }
-
-            return list;
         }
 
         public DamageSpecifier ApplySplitDamageBehaviors(SplitDamageBehavior splitDamageBehavior,


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
In follow-up to #6827, I'm cutting out a duplicate piece of code that prevents the fix.

## Technical details
<!-- Summary of code changes for easier review. -->
This stupid piece of crap duplicated the functionality of the 'else' block, but with a shittier implementation. The main function of this idiotic random generator - dividing damage between body parts - is processed perfectly by 'SplitDamageBehavior.Split' ||except for randomization, obviously||. But it blocks more advanced cases of SplitDamageBehavior

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

:cl:
- tweak: Damage distribution across the entire body is no longer randomized.
