### PR TITLE
[FIX] fix station ai being set to crewsimov after experimental law board finishes

### DIFF
--- a/Content.Shared/Silicons/Laws/Components/SiliconLawUpdaterComponent.cs
+++ b/Content.Shared/Silicons/Laws/Components/SiliconLawUpdaterComponent.cs
@@ -21,5 +21,5 @@ public sealed partial class SiliconLawUpdaterComponent : Component
     /// Goob edit: the last lawset that was loaded with this updater.
     /// </summary>
     [ViewVariables]
-    public ProtoId<SiliconLawsetPrototype> LastLawset = "Crewsimov";
+    public ProtoId<SiliconLawsetPrototype> LastLawset = "NTDefault";
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
`LastLawset` supposed to be `NTDefault`. it not.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
wa

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix:  Fix the Station AI being set to Crewsimov instead of NTDefault after the experimental law board time runs out.