### PR TITLE
Adds proximity sensors to Vendomats

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/vendomat.yml
@@ -3,6 +3,7 @@
 - type: vendingMachineInventory
   id: VendomatInventory
   startingInventory:
+    ProximitySensor: 2
     RemoteSignaller: 1
     Igniter: 2
     Wirecutter: 2


### PR DESCRIPTION
## About the PR
Adds proximity sensors to Vendomats

## Why / Balance
Big enough change to let engies make weldbots without invading science or waiting for the xenobio player to leave his cave, small enough that you still have to find and fight for a Vendomat roundstart

## Technical details
Whatever, go my yaml ninjas,,.

## Media
<img width="430" height="353" alt="image" src="https://github.com/user-attachments/assets/09acaf5a-0fcc-4333-aa5f-2773d738c190" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Proximity Senors are now for sale inside of the Vendomats!
