### PR TITLE
Make Plasma Tanks wearable on back (for plasmen)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/gas_tanks.yml
@@ -271,3 +271,4 @@
     slots:
     - Belt
     - suitStorage
+    - Back # Goobstation For plasmamen. Square tank, round attachment tho?


### PR DESCRIPTION
## About the PR
"Medium" Preiority bug by the way.

## Why / Balance


## Technical details


## Media

These ones, from engi tank dispensers.
<img width="177" height="104" alt="image" src="https://github.com/user-attachments/assets/afc6c996-9e28-4142-9115-5e50f7c33958" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**

:cl:
- tweak: Square plasma tanks now fit in your back slot. 
