### PR TITLE
Armor Tweaks ( mostly missing Coverage and Trauma deductions )

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -555,6 +555,12 @@
     sprite: Clothing/OuterClothing/Armor/magusblue.rsi
   - type: Armor
     # Goob start
+    traumaDeductions: # Wizard Also Probally should have this
+      Dismemberment: 0.5
+      OrganDamage: 0.5
+      BoneDamage: 0.5
+      VeinsDamage: 0
+      NerveDamage: 0
     modifiers:
       coefficients:
         Blunt: 0.4

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -84,10 +84,12 @@
     - Chest
     - Groin
     - Tail
-    traumaDeductions:
-      Dismemberment: 0.1
-      OrganDamage: 0.1
-      BoneDamage: 0.1
+    - Arm
+    - Leg
+    traumaDeductions: # Parity with Riot suit, Delimb merge kinda forces this.
+      Dismemberment: 0.4
+      OrganDamage: 0.4
+      BoneDamage: 0.4
       VeinsDamage: 0
       NerveDamage: 0
     modifiers:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -543,7 +543,7 @@
     - Chest
     - Groin
     - Tail
-    traumaDeductions:
+    traumaDeductions: # Goobstation
       Dismemberment: 0.2
       OrganDamage: 0.2
       BoneDamage: 0.2

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -82,12 +82,18 @@
   id: ClothingOuterArmorHoS
   components:
   - type: Armor
-    coverage:
+    coverage: # Goobstation
     - Chest
     - Groin
     - Tail
     - Arm
     - Leg
+    traumaDeductions: # Goobstation - 
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
     modifiers:
       coefficients:
         Blunt: 0.6
@@ -109,12 +115,18 @@
   id: ClothingOuterArmorWarden
   components:
   - type: Armor
-    coverage:
+    coverage: # Goobstation
     - Chest
     - Groin
     - Tail
     - Arm
     - Leg
+    traumaDeductions: # Goobstation.
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
     modifiers:
       coefficients:
         Blunt: 0.6
@@ -309,6 +321,12 @@
     - Tail
     - Arm
     - Leg
+    traumaDeductions: # Goobstation
+      Dismemberment: 0.1
+      OrganDamage: 0.1
+      BoneDamage: 0.1
+      VeinsDamage: 0
+      NerveDamage: 0
     modifiers:
       coefficients:
         Slash: 0.9
@@ -460,6 +478,12 @@
     - Tail
     - Arm
     - Leg
+    traumaDeductions: # Goobstation
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
     modifiers:
       coefficients:
         Blunt: 0.65
@@ -519,6 +543,12 @@
     - Chest
     - Groin
     - Tail
+    traumaDeductions:
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
     modifiers:
       coefficients:
         Blunt: 0.7

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -142,6 +142,12 @@
     - Foot
     - Tail
     - Other
+    traumaDeductions:
+      Dismemberment: 0.1
+      OrganDamage: 0.1
+      BoneDamage: 0.1
+      VeinsDamage: 0
+      NerveDamage: 0
     modifiers:
       coefficients:
         Heat: 0.9

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -226,6 +226,12 @@
     - Foot
     - Tail
     - Other
+    traumaDeductions: # Goobstation - Ninja Shoudnt be Getting too many permanent injuries.
+      Dismemberment: 0.4
+      OrganDamage: 0.4
+      BoneDamage: 0.4
+      VeinsDamage: 0
+      NerveDamage: 0
     modifiers:
       coefficients:
         Blunt: 0.8

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -23,7 +23,7 @@
     - Foot
     - Tail
     - Other
-    traumaDeductions: # Bomb Suit is getting you Delimbed and all broken bones, this should fix it forever
+    traumaDeductions: # Goobstation - Bomb Suit is getting you Delimbed and all broken bones, this should fix it forever
       Dismemberment: 1
       OrganDamage: 1
       BoneDamage: 1

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -23,6 +23,12 @@
     - Foot
     - Tail
     - Other
+    traumaDeductions: # Bomb Suit is getting you Delimbed and all broken bones, this should fix it forever
+      Dismemberment: 1
+      OrganDamage: 1
+      BoneDamage: 1
+      VeinsDamage: 0
+      NerveDamage: 0
     modifiers:
       coefficients:
         Blunt: 0.9

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/helmets.yml
@@ -47,6 +47,12 @@
   - type: Clothing
     sprite: _Goobstation/Clothing/Head/Helmets/hev.rsi
   - type: Armor
+    traumaDeductions:
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
     modifiers:
       coefficients:
         Blunt: 0.75
@@ -158,6 +164,12 @@
   - type: Armor
     coverage:
     - Head
+    traumaDeductions:
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.2
+      VeinsDamage: 0
+      NerveDamage: 0
     modifiers:
       coefficients:
         Blunt: 0.5

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/voidsuit-helmet.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/voidsuit-helmet.yml
@@ -312,7 +312,7 @@
         Slash: 0.85
         Piercing: 0.75
         Heat: 0.7
-        Radiation: 0.9
+        Radiation: 0.0 # Smartest Goobstation Contrib - Antag with singulo objective is not immune to singulo.
         Caustic: 0.9
   - type: FireProtection
     reduction: 0.4

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/armour.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/armour.yml
@@ -262,6 +262,12 @@
     - Leg
     - Foot
     - Tail
+    traumaDeductions:
+      Dismemberment: 0.5
+      OrganDamage: 0.5
+      BoneDamage: 0.5 # Solo Ontag
+      VeinsDamage: 0
+      NerveDamage: 0
     modifiers:
       coefficients:
         Blunt: 0.5

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/specific.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/specific.yml
@@ -13,6 +13,12 @@
   - type: ExplosionResistance
     damageCoefficient: 0.7
   - type: Armor
+    traumaDeductions: # Highly Trained Professional.
+      Dismemberment: 0.2
+      OrganDamage: 0.2
+      BoneDamage: 0.4
+      VeinsDamage: 0
+      NerveDamage: 0
     modifiers:
       coefficients:
         Blunt: 0.7

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/specific.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/specific.yml
@@ -166,6 +166,12 @@
   - type: ExplosionResistance
     damageCoefficient: 0.7
   - type: Armor
+    traumaDeductions: # Honestly i'll do something different here
+      Dismemberment: 0.7
+      OrganDamage: 0.2
+      BoneDamage: -0.6
+      VeinsDamage: 0
+      NerveDamage: 0
     modifiers:
       coefficients:
         Blunt: 0.8


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR ##
Small Tweaks to most Crew armor

## Why / Balance
Delimbing increase, so crew needs some tools to Deal with that

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: Bulletproof vest now has limb coverage
- tweak: Added Would Resistances ( Delimbing, Bone Breaking... ) to most armors

