### PR TITLE
ZED's infection fix and nerf

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -339,7 +339,7 @@ namespace Content.Server.Zombies
 
                     // If we cannot infect the living target, the zed will just heal itself.
                     if (HasComp<ZombieImmuneComponent>(uid) || cannotSpread ||
-                        _random.Prob(GetZombieInfectionChance(uid, entity.Comp)))
+                        !_random.Prob(GetZombieInfectionChance(uid, entity.Comp)))
                         continue;
 
 

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -35,14 +35,14 @@ public sealed partial class ZombieComponent : Component
     /// The baseline infection chance you have if you have no protective gear
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float BaseZombieInfectionChance = 1.00f; ///Goobchange
+    public float BaseZombieInfectionChance = 0.9f; ///Goobchange
 
     /// <summary>
     /// The minimum infection chance possible. This is simply to prevent
     /// being overly protected by bundling up.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float MinZombieInfectionChance = 0.05f;
+    public float MinZombieInfectionChance = 0.01f;
 
     /// <summary>
     /// How effective each resistance type on a piece of armor is. Using a damage specifier for this seems illegal.
@@ -51,9 +51,9 @@ public sealed partial class ZombieComponent : Component
     {
         DamageDict = new ()
         {
-            {"Slash", 0.5},
-            {"Piercing", 0.3},
-            {"Blunt", 0.1},
+            {"Slash", 1}, // Goobstation change
+            {"Piercing", 0.5}, // Goobstation change
+            {"Blunt", 0.2}, // Goobstation change
         }
     };
 

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -51,7 +51,7 @@ public sealed partial class ZombieComponent : Component
     {
         DamageDict = new ()
         {
-            {"Slash", 1}, // Goobstation change
+            {"Slash", 1.0}, // Goobstation change
             {"Piercing", 0.5}, // Goobstation change
             {"Blunt", 0.2}, // Goobstation change
         }

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -302,6 +302,8 @@
     sprite: Clothing/OuterClothing/Coats/labcoat_cmo.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Coats/labcoat_cmo.rsi
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.35 # Goobstation - Same as Biosuits
   - type: Armor
     coverage:
     - Chest

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -132,6 +132,8 @@
   - type: TemperatureProtection
     heatingCoefficient: 0.1
     coolingCoefficient: 0.1
+  - type: ZombificationResistance # Goobstation - Same as Biosuits
+    zombificationResistanceCoefficient: 0.35 
   - type: Armor
     coverage:
     - Chest


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR ##
Zed Infection now Actually cares About your armor 

## Why / Balance
Armor Coefficiency was so Low that armor preety much didnt matter in zed rounds
upstream also made infections 100% guarranteed
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I'm a fat fucking Chud
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: Zed Infection Chance Rebalance (Lower base chance and minimal chance, armor is more effective vs Zed infection)
- fix: Fixed Inverted Zed Infection Chance

