### PR TITLE
Chem fix

### DIFF
--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -405,16 +405,35 @@ namespace Content.Shared.Damage
                 // Target a specific body part
                 TargetBodyPart? target;
                 var totalDamage = damage.GetTotal();
+                List<(EntityUid Id, BodyPartComponent Component)>? possibleTargets = null;
 
-                if (totalDamage <= 0 || !canMiss) // Whoops i think i fucked up damage here.
-                    target = _body.GetTargetBodyPart(uid, origin, targetPart);
+                BodyComponent? body = null;
+
+                if (totalDamage < 0 && targetPart == null)
+                {
+                    foreach (var (dmgType, dmgValue) in damage.DamageDict)
+                    {
+                        if (dmgValue >= 0) continue;
+                        var healTargetParts = _body.GetBodyChildren(uid, body).Where((part) => _damageableQuery.TryComp(part.Id, out var partDamageable2) && partDamageable2.Damage.DamageDict.TryGetValue(dmgType, out var oldValue) && oldValue > 0);
+                        if (healTargetParts.Count() > 0)
+                        {
+                            possibleTargets = healTargetParts.ToList();
+                            break;
+                        }
+                    }
+                }
                 else
-                    target = _body.GetRandomBodyPart(uid, origin, targetPart);
+                {
+                    if (!canMiss) // Whoops i think i fucked up damage here.
+                        target = _body.GetTargetBodyPart(uid, origin, targetPart);
+                    else
+                        target = _body.GetRandomBodyPart(uid, origin, targetPart);
 
-                var (partType, symmetry) = _body.ConvertTargetBodyPart(target);
-                var possibleTargets = _body.GetBodyChildrenOfType(uid, partType, symmetry: symmetry).ToList();
+                    var (partType, symmetry) = _body.ConvertTargetBodyPart(target);
+                    possibleTargets = _body.GetBodyChildrenOfType(uid, partType, symmetry: symmetry).ToList();
+                }
 
-                if (possibleTargets.Count == 0)
+                if (possibleTargets == null || possibleTargets.Count == 0)
                 {
                     if (totalDamage <= 0)
                         return null;

--- a/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
@@ -280,6 +280,7 @@
           groups:
             Toxin: -6
       - !type:CleanBloodstream
+        excluded: Musiver
         cleanseRate: 6 # POWERFUL cleansing effect
       - !type:HealthChange
         damage:
@@ -579,6 +580,7 @@
       metabolismRate: 1
       effects:
       - !type:CleanBloodstream
+        excluded: Calomel
         cleanseRate: 4.5 # better than charcoal
       - !type:HealthChange
         damage:
@@ -1085,6 +1087,7 @@
       metabolismRate: 0.25
       effects:
       - !type:CleanBloodstream
+        excluded: PentenicAcid
       - !type:HealthChange
         damage:
           types:


### PR DESCRIPTION
## About the PR
Patches for chem bugs since last upsteam update :(

1. ApplyDamageToBodyParts logic changes for healing chem
2. CleanBloodstream drugs (cleaning itself)

## Why / Balance

## Technical details
1. Additional logic for handling DamageChangedEvent (re-routing healing to limbs) patch only works when have negative totalDamage.

2. Apply excluded tag for CleanBloodstream drugs under ...\Resources\Prototypes\_Goobstation\Reagents


## Media
[![YouTube](http://i.ytimg.com/vi/g3QldEidJ4E/hqdefault.jpg)](https://www.youtube.com/watch?v=g3QldEidJ4E)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
