### PR TITLE
[MALD PR] FUCK THE CONTRACTOR BATON TAKE THIS SHIT OUTTA HERE

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/contractor_baton.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/contractor_baton.yml
@@ -15,8 +15,8 @@
     sprite: _Goobstation/Objects/Weapons/Melee/contractor_baton.rsi
   - type: Clothing
     sprite: _Goobstation/Objects/Weapons/Melee/contractor_baton.rsi
-  - type: TelescopicBaton
-    alwaysDropItems: true
+  #- type: TelescopicBaton #FUCK OFF
+  #  alwaysDropItems: true #FUCK THE FUCK OFF
   - type: UseDelay
     delays:
       default:


### PR DESCRIPTION
## About the PR
removes the instant knockdown + guaranteed disarm from this shit.

it already deals 80 fucking 5 stamina damage, this shit would stun ANYONE in two hits, security officers in 3 at most if using vests, IT DOES NOT NEED MORE.

## Why / Balance
<img width="499" height="492" alt="HAVE FUN" src="https://github.com/user-attachments/assets/9ca288f7-bc64-4ae3-8ad0-efbc5d8213ba" />

## Technical details
two fucking yaml line change

## Media


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Anui-elxx
- tweak: Takes the contractor baton out back and curbstomps it to death. NO MORE INSTANT DISARM AND KNOCKDOWN
