### PR TITLE
Bugfix being unable to recall some of nullrod 

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/nullrod.yml
@@ -61,6 +61,7 @@
       types:
         Slash: 20
     UntrainedUseString: nullrod-holyclaymore-untrained-usage-popup
+    recallType: Normal
   - type: Gun
     soundGunshot: /Audio/Effects/radpulse7.ogg
     fireRate: 0.5
@@ -153,6 +154,7 @@
       types:
         Blunt: 20
     UntrainedUseString: nullrod-rosary-untrained-usage-popup
+    recallType: Normal
   - type: AlternatePrayable
     repeatPrayer: true
   - type: HealNearOnPray # These numbers look high but WoundMed...
@@ -232,6 +234,7 @@
       types:
         Slash: 20
     UntrainedUseString: nullrod-arrythmicknife-untrained-usage-popup
+    recallType: Normal
   - type: Item
     size: Huge
     sprite: _ShitChap/Objects/Weapons/Nullrod/arrythmic.rsi
@@ -274,6 +277,7 @@
       types:
         Blunt: 20
     UntrainedUseString: nullrod-monkstaff-untrained-usage-popup
+    recallType: Normal
   - type: Item
     size: Huge
     sprite: _ShitChap/Objects/Weapons/Nullrod/monkstaff.rsi
@@ -357,6 +361,7 @@
       types:
         Stamina: 200
     UntrainedUseString: nullrod-bulwark-untrained-usage-popup
+    recallType: Normal
   - type: MeleeWeapon
     attackRate: 0.5
     damage:
@@ -428,6 +433,7 @@
       types:
         Radiation: 20
     UntrainedUseString: nullrod-honkmother-untrained-usage-popup
+    recallType: Normal
   - type: MeleeWeapon
     attackRate: 0.8
     damage:
@@ -814,6 +820,7 @@
       types:
         Heat: 20
     UntrainedUseString: nullrod-dragontail-untrained-usage-popup
+    recallType: Normal
   - type: Sprite
     sprite: _ShitChap/Objects/Weapons/Nullrod/dragontail.rsi
     state: icon
@@ -845,6 +852,7 @@
       types:
         Slash: 25
     UntrainedUseString: nullrod-chainsword-untrained-usage-popup
+    recallType: Normal
   - type: Sprite
     sprite: _ShitChap/Objects/Weapons/Nullrod/chainsword.rsi
     layers:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
bugfix, people are mad 👍 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
c#
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed being unable to recall some of the nullrod
