### PR TITLE
Disable NTR Tasks

### DIFF
--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
@@ -5,14 +5,15 @@
   table: !type:AllSelector
     children:
     - id: BoxFolderCentCom
-    # - id: BriefcaseBrownFilled
+    - id: BriefcaseBrownFilled
     - id: WeaponDisablerAdvanced
     - id: BedsheetCentcom
     - id: CaneSheathFilledNanotrasen
     - id: HandheldFaxOfficial
     - id: RubberStampNanorep
-    - id: ExecutiveBriefcaseEmpty # nanorep update
-    - id: ComputerNTRTasksFlatpack # nanorep update
+    #- id: ExecutiveBriefcaseEmpty # nanorep update # No gamer loot.
+    #- id: ComputerNTRTasksFlatpack # nanorep update
+    - id: ClothingEyesGlassesCentCommNoThermal # kinda gamer loot but med/sci and other inspections make it make sense
     - id: Paper
       amount: !type:ConstantNumberSelector
         value: 5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
NTR Tasks actively encourages role abandonment from NTR to pester command with papers that don't ACTUALLY MATTER and are just for the NTR to get gamer loot. even worse when NTR ends up gamering the bar

with the upcoming SOP rework there is just absolutely no place for these. this PR only disables it incase anybody should think of a way to integrate it/the executive briefcase with the NTR's actual role as a reward rather than just Tide Tasks.

this does also place the gamer shades that they normally get from ntr tasks in their locker roundstart because i believe it's appropriate for their role of inspection. (eg. inspecting security for proper prisoner treatment, inspecting med/science, etc)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: rivermyth
- tweak: No more NTR gamer loot
