### PR TITLE
Kills hardlight bow explosive mode damage

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Bow/hardlight_arrows.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Bow/hardlight_arrows.yml
@@ -137,7 +137,7 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
-    totalIntensity: 18
+    totalIntensity: 6
     intensitySlope: 0.6
     maxIntensity: 6
     canCreateVacuum: false


### PR DESCRIPTION
## About the PR
Divides explosion intensity by 2/3rds on the hardlight bow.

## Why / Balance
I heard horror stories of the infamous john hardlight bow terrorizing goobians

## Technical details
1 number yaml change

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.

**Changelog**
:cl:
- tweak: killed hardlight bow explosion damage, goob is saved
