### PR TITLE
Explosion Delimb and Limb Dmg fix

### DIFF
--- a/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
+++ b/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
@@ -591,7 +591,7 @@ public sealed partial class GoobCVars
     /// Applies to Brute and Burn damage
     /// </summary>
     public static readonly CVarDef<float> ExplosionWoundMultiplier =
-        CVarDef.Create("explosion.wounding_multiplier", 4f, CVar.SERVERONLY);
+        CVarDef.Create("explosion.wounding_multiplier", 2.5f, CVar.SERVERONLY);
 
     #endregion
 


### PR DESCRIPTION

## About the PR
Explosions are less Scary now

## Why / Balance
Due to Explosion dmg to Limbs getting Multiplied by 4x, probally reduce its fucking Wounding Multiplier guys..

TLDR a lot of Explosion interactions are much less lethal (pizza box and Burner dont Instantly Delimb you)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [x] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.


**Changelog**

:cl:
- tweak: Explosion Delimbing, Bone Breaking, and Bleeding have been toned down to compensate for Explosion damage being higher overall

