### PR TITLE
fix up some `EffectConditions`, minor cleanup

### DIFF
--- a/Content.Goobstation.Server/EntityEffects/EffectConditions/TypedDamageThreshold.cs
+++ b/Content.Goobstation.Server/EntityEffects/EffectConditions/TypedDamageThreshold.cs
@@ -49,7 +49,7 @@ public sealed partial class TypedDamageThresholdEntityConditionSystem : EntityCo
 
             if (entity.Comp.Damage.TryGetDamageInGroup(group, out var total) && total > groupDamage)
             {
-                args.Result = !args.Condition.Inverse;
+                args.Result = true;
                 return;
             }
 
@@ -68,7 +68,7 @@ public sealed partial class TypedDamageThresholdEntityConditionSystem : EntityCo
         }
         comparison.ExclusiveAdd(-entity.Comp.Damage);
         comparison = -comparison;
-        args.Result = comparison.AnyPositive() ^ args.Condition.Inverse;
+        args.Result = comparison.AnyPositive();
     }
 }
 
@@ -77,9 +77,6 @@ public sealed partial class TypedDamageThresholdCondition : EntityConditionBase<
 {
     [DataField(required: true)]
     public DamageSpecifier Damage = default!;
-
-    [DataField]
-    public bool Inverse = false;
 
     public override string EntityConditionGuidebookText(IPrototypeManager prototype)
     {
@@ -133,7 +130,7 @@ public sealed partial class TypedDamageThresholdCondition : EntityConditionBase<
         }
 
         return Loc.GetString("reagent-effect-condition-guidebook-typed-damage-threshold",
-                ("inverse", Inverse),
+                ("inverse", Inverted),
                 ("changes", ContentLocalizationManager.FormatList(damages))
                 );
     }

--- a/Content.Goobstation.Shared/EntityEffects/EffectConditions/HasComponentOnEquipmentCondition.cs
+++ b/Content.Goobstation.Shared/EntityEffects/EffectConditions/HasComponentOnEquipmentCondition.cs
@@ -15,7 +15,7 @@ public sealed partial class HasComponentOnEquipmentConditionSystem
     {
         if (args.Condition.Components.Count == 0)
         {
-            args.Result = args.Condition.Invert;
+            args.Result = false;
             return;
         }
 
@@ -27,12 +27,12 @@ public sealed partial class HasComponentOnEquipmentConditionSystem
                 if (!args.Condition.Components.Any(comp =>
                         HasComp(item, comp.Value.Component.GetType())))
                     continue;
-                args.Result = !args.Condition.Invert;
+                args.Result = true;
                 return;
             }
         }
 
-        args.Result = args.Condition.Invert;
+        args.Result = false;
     }
 }
 
@@ -40,9 +40,6 @@ public sealed partial class HasComponentOnEquipmentCondition : EntityConditionBa
 {
     [DataField(required: true)]
     public ComponentRegistry Components = default!;
-
-    [DataField]
-    public bool Invert = false;
 
     public override string EntityConditionGuidebookText(IPrototypeManager prototype)
     {

--- a/Content.Goobstation.Shared/EntityEffects/EffectConditions/TypedDamageThreshold.cs
+++ b/Content.Goobstation.Shared/EntityEffects/EffectConditions/TypedDamageThreshold.cs
@@ -49,7 +49,7 @@ public sealed partial class TypedDamageThresholdEntityConditionSystem : EntityCo
 
             if (entity.Comp.Damage.TryGetDamageInGroup(group, out var total) && total > groupDamage)
             {
-                args.Result = !args.Condition.Inverse;
+                args.Result = true;
                 return;
             }
 
@@ -68,7 +68,7 @@ public sealed partial class TypedDamageThresholdEntityConditionSystem : EntityCo
         }
         comparison.ExclusiveAdd(-entity.Comp.Damage);
         comparison = -comparison;
-        args.Result = comparison.AnyPositive() ^ args.Condition.Inverse;
+        args.Result = comparison.AnyPositive();
     }
 }
 
@@ -77,9 +77,6 @@ public sealed partial class TypedDamageThresholdCondition : EntityConditionBase<
 {
     [DataField(required: true)]
     public DamageSpecifier Damage = default!;
-
-    [DataField]
-    public bool Inverse = false;
 
     public override string EntityConditionGuidebookText(IPrototypeManager prototype)
     {
@@ -133,7 +130,7 @@ public sealed partial class TypedDamageThresholdCondition : EntityConditionBase<
         }
 
         return Loc.GetString("reagent-effect-condition-guidebook-typed-damage-threshold",
-                ("inverse", Inverse),
+                ("inverse", Inverted),
                 ("changes", ContentLocalizationManager.FormatList(damages))
                 );
     }

--- a/Content.Shared/_Shitcode/Wizard/Chemistry/HasComponentCondition.cs
+++ b/Content.Shared/_Shitcode/Wizard/Chemistry/HasComponentCondition.cs
@@ -31,7 +31,7 @@ public sealed partial class HasComponentConditionSystem : EntityConditionSystem<
 
         var hasComp = entHasComp || mindEntHasComp;
 
-        args.Result = hasComp ^ args.Condition.Inverted;
+        args.Result = hasComp;
     }
 }
 

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -114,7 +114,7 @@
         - !type:HasComponentOnEquipmentCondition # goob edit - make suits protect slimes from water damage
           components:
           - type: PressureProtection
-          invert: true
+          inverted: true
       - !type:PopupMessage
         type: Local
         visualType: Large
@@ -124,7 +124,7 @@
         - !type:HasComponentOnEquipmentCondition # goob edit - make suits protect slimes from water damage
           components:
           - type: PressureProtection
-          invert: true
+          inverted: true
   - type: Butcherable
     butcheringType: Spike
     spawned:

--- a/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
@@ -662,7 +662,7 @@
             groups:
               Brute: 1
               Burn: 1
-          inverse: true
+          inverted: true
 
 # Low-effect meds
 - type: reagent
@@ -788,7 +788,7 @@
         - !type:HasComponentOnEquipmentCondition
           components:
           - type: PressureProtection # can't get through this to reach the bodyparts!
-          invert: true
+          inverted: true
   metabolisms:
     Medicine:
       metabolismRate: 3
@@ -850,14 +850,14 @@
         - !type:HasComponentOnEquipmentCondition
           components:
           - type: PressureProtection # can't get through this to reach the bodyparts!
-          invert: true
+          inverted: true
       - !type:ModifyBleed
         amount: -2
         conditions:
         - !type:HasComponentOnEquipmentCondition
           components:
           - type: PressureProtection
-          invert: true
+          inverted: true
   metabolisms:
     Medicine:
       metabolismRate: 3
@@ -907,14 +907,14 @@
         - !type:HasComponentOnEquipmentCondition
           components:
           - type: PressureProtection # can't get through this to reach the bodyparts! (copy pasted comment)
-          invert: true
+          inverted: true
       - !type:ModifyBleed
         amount: -2
         conditions:
         - !type:HasComponentOnEquipmentCondition
           components:
           - type: PressureProtection
-          invert: true
+          inverted: true
 
 - type: reagent
   id: Synthcells
@@ -945,7 +945,7 @@
         - !type:HasComponentOnEquipmentCondition
           components:
           - type: PressureProtection # can't get through this to reach the bodyparts!
-          invert: true
+          inverted: true
   metabolisms:
     Medicine:
       effects:
@@ -997,7 +997,7 @@
           damage:
             groups:
               Brute: 25
-          inverse: true
+          inverted: true
         - !type:ReagentCondition
           reagent: SalicylicAcid
           max: 25
@@ -1051,7 +1051,7 @@
           damage:
             groups:
               Burn: 25
-          inverse: true
+          inverted: true
         - !type:ReagentCondition
           reagent: Oxandrolone
           max: 25

--- a/Resources/Prototypes/_Goobstation/Reagents/toxins.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/toxins.yml
@@ -271,7 +271,7 @@
         - !type:HasComponentOnEquipmentCondition
           components:
           - type: PressureProtection # can't get through this to reach the bodyparts!
-          invert: true
+          inverted: true
 
 - type: reagent
   id: Tirizene


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
this pr solves the issue of certain effectconditions being all wonky with inversion.
**this _doesn't_ solve the issue of some reagents with these conditions cleaning themselves out of the bloodstream.**

closes #6958
## Technical details
<!-- Summary of code changes for easier review. -->
basically, some EffectConditions were handling inversion manually while upstream added `EffectConditionBase.Inverted`, which either resulted in
* the condition being insanely fucked (see: `HasComponentCondition`), or
* the condition having a seperate Invert field different from the Inverted, which was made obsolete.

along with cancelling out the `Inverted` from their conditions, i took the time to make them a bit more consistent by replacing their own Invert/Inverse with `EffectConditionBase.Inverted`. Bleh.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="208" height="285" alt="image" src="https://github.com/user-attachments/assets/bea5e773-d124-49f1-ba75-e15a136a414c" />

i fed mr urist here the airport jungle juice (heretic eldritch essence) and he started convulsing and such so all's well!
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: shoebill
- fix: Fixed certain reagents (eldritch essence, mugwort tea, anti-entropy) turning against their own kind.
