### PR TITLE
Adds crowbars to emergency boxes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -17,6 +17,7 @@
         - id: SpaceMedipen # Goobstation
         - id: FoodSnackNutribrick
         - id: DrinkWaterBottleFull
+        - id: CrowbarRed # Goobstation
   - type: Sprite
     layers:
     - state: internals
@@ -61,6 +62,7 @@
         - id: Flare
         - id: FoodSnackNutribrick
         - id: DrinkWaterBottleFull
+        - id: CrowbarRed # Goobstation
   - type: Sprite
     layers:
     - state: internals
@@ -106,6 +108,7 @@
         - id: Flare
         - id: FoodSnackNutribrick
         - id: DrinkWaterBottleFull
+        - id: CrowbarRed # Goobstation
   - type: Sprite
     layers:
     - state: internals
@@ -134,7 +137,6 @@
     currentLabel: reagent-name-nitrogen
 
 - type: entity
-
   parent: BoxCardboard
   id: BoxSurvivalMedical
   name: survival box
@@ -151,6 +153,7 @@
         - id: Flare
         - id: FoodSnackNutribrick
         - id: DrinkWaterBottleFull
+        - id: CrowbarRed # Goobstation
   - type: Sprite
     layers:
     - state: internals
@@ -201,6 +204,7 @@
         - id: Flare
         - id: FoodSnackNutribrick
         - id: DrinkWaterBottleFull
+        - id: CrowbarRed # Goobstation
   - type: Tag
     tags:
     - BoxCardboard
@@ -294,6 +298,7 @@
         - id: EmergencyMedipen
         - id: Flare
         - id: FoodSnackNutribrick
+        - id: CrowbarRed # Goobstation
   - type: Sprite
     layers:
     - state: internals


### PR DESCRIPTION
## About the PR
Adds crowbars to emergency boxes

## Why / Balance
Latejoins coming into destroyed/unpowered stations need to get through airlocks and firelocks, trying to get through them with hands while dying to depressurized areas sucks ass

## Technical details
YAML YAML YAML

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.

**Changelog**

:cl:
- tweak: Added crowbars to emergency boxes

