### PR TITLE
fix biomass reclaimer not grinding souled bodies and cloning costing less

### DIFF
--- a/Resources/ConfigPresets/_Goobstation/goobCore.toml
+++ b/Resources/ConfigPresets/_Goobstation/goobCore.toml
@@ -89,3 +89,6 @@ enabled = true
 
 [voice]
 barks_enabled = true
+
+[biomass]
+easy_mode = false


### PR DESCRIPTION
I don't know why its true default.

see cvar:
<img width="1053" height="117" alt="image" src="https://github.com/user-attachments/assets/62926ed0-f035-43d9-861a-dc3c88ae3265" />

:cl:
- tweak: Enabled biomass reclaimer being unusable on souled bodies