### PR TITLE
Makes mindshields less expensive

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
@@ -116,7 +116,7 @@
     sprite: Objects/Specific/Medical/implanter.rsi
     state: implanter0
   product: CrateMindShieldImplants
-  cost: 2000
+  cost: 1500
   category: cargoproduct-category-name-medical
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
@@ -116,7 +116,7 @@
     sprite: Objects/Specific/Medical/implanter.rsi
     state: implanter0
   product: CrateMindShieldImplants
-  cost: 3000
+  cost: 2000
   category: cargoproduct-category-name-medical
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
@@ -116,7 +116,7 @@
     sprite: Objects/Specific/Medical/implanter.rsi
     state: implanter0
   product: CrateMindShieldImplants
-  cost: 1500
+  cost: 1500 # Goobstation - half cost, revslop
   category: cargoproduct-category-name-medical
   group: market
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

Makes mindshield crates cost 1500 spesos instead of 3000 spesos.

Overall, instead of 1000 spesos per mindshield, instead 500 spesos per mindshield, as there are 3 per crate.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Every rev shift I've seen has been a complete and utter nightmare and bloodbath.

Cargo struggles really hard to make money in a revolution. Bounties are rather difficult when the station is aflame, and other methods are unreliable, such as relying on miners or so.

All I've seen is cargo being entirely unable to afford mindshields, which considering each one costs 1000 credits is not unreasonable. Which makes trying to mindshield crew instead of slaughtering as many as you can pretty much impossible.

I've never seen a revolution be really aided against by mindshields, except when ERT spawns in and admins spawn 21 mindshield implanters on it.

Now that "The Book" lets people convert anyone, even people with flash protection, and has literally infinite uses, it makes revolutions absurdly prolific. The only solution is bloodbathing on the heads side, as deconverting people takes a full 1000 spesos per person, and cargo will never have that kind of money to spend. 

Cutting the price of mindshields in half would be a good start to increasing the importance of cargo to revolutions, allowing heads to create a larger basis of mindshielded crew to aid them against the revolutionaries, which is necessary as converting is easier than ever, and eye protection is not a guarantee of protection against a revolution.

If the revs don't get to cargo first, and waste the entire cargo's budget on plushies, of course.

## Technical details
<!-- Summary of code changes for easier review. -->

No breaking changes.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Mindshield Implants Crate cost decreased from 3000 spesos to 1500 spesos.


