### PR TITLE
Fix cloning dictionary not clearing and causing infinite cloning

### DIFF
--- a/Content.Server/Cloning/CloningPodSystem.cs
+++ b/Content.Server/Cloning/CloningPodSystem.cs
@@ -60,7 +60,8 @@ public sealed class CloningPodSystem : EntitySystem
     [Dependency] private readonly CloningSystem _cloning = default!;
     [Dependency] private readonly EmagSystem _emag = default!;
 
-    public readonly Dictionary<MindComponent, EntityUid> ClonesWaitingForMind = new();
+    // Goobstation - killed
+    //public readonly Dictionary<MindComponent, EntityUid> ClonesWaitingForMind = new();
     public readonly ProtoId<CloningSettingsPrototype> SettingsId = "CloningPod";
     public const float EasyModeCloningCost = 0.7f;
     private static readonly ProtoId<ReagentPrototype> BloodId = "Blood";
@@ -84,17 +85,38 @@ public sealed class CloningPodSystem : EntitySystem
         _signalSystem.EnsureSinkPorts(ent.Owner, ent.Comp.PodPort);
     }
 
-    internal void TransferMindToClone(EntityUid mindId, MindComponent mind)
+    // <GoobStation> rewrite so it uses BeingClonedComponent instead of a dictionary
+    // Most other edits in this commit are ported from f4f4e258929bdf61177a4fb61467d527dd9d103b
+    // Upstreamer note. Using this because of a few edge cases with cloning and honestly it just handles better
+     internal void TransferMindToClone(EntityUid mindId, MindComponent mind)
     {
-        if (!ClonesWaitingForMind.TryGetValue(mind, out var entity) ||
+        // Goobstation start
+        /*if (!ClonesWaitingForMind.TryGetValue(mind, out var entity) ||
             !EntityManager.EntityExists(entity) ||
             !TryComp<MindContainerComponent>(entity, out var mindComp) ||
             mindComp.Mind != null)
+            return;*/
+
+        // find first mob this player is meant to use and doesn't already have a mind via alternate means
+        var query = EntityQueryEnumerator<BeingClonedComponent, MindContainerComponent>();
+        var found = false;
+        EntityUid entity;
+        while (query.MoveNext(out entity, out var cloned, out var mc))
+        {
+            if (cloned.Mind == mind && mc.Mind == null)
+            {
+                found = true;
+                break;
+            }
+        }
+
+        if (!found)
             return;
+        // Goobstation end
 
         _mindSystem.TransferTo(mindId, entity, ghostCheckOverride: true, mind: mind);
         _mindSystem.UnVisit(mindId, mind);
-        ClonesWaitingForMind.Remove(mind);
+        // ClonesWaitingForMind.Remove(mind); // Goob
     }
 
     private void HandleMindAdded(EntityUid uid, BeingClonedComponent clonedComponent, MindAddedMessage message)
@@ -230,7 +252,7 @@ public sealed class CloningPodSystem : EntitySystem
         cloneMindReturn.Parent = uid;
         cloneMindReturn.Original = bodyToClone; // Goobstation
         _containerSystem.Insert(mob.Value, clonePod.BodyContainer);
-        ClonesWaitingForMind.Add(mind, mob.Value);
+        // ClonesWaitingForMind.Add(mind, mob.Value); // Goobstation, if you want to use old dictionary. Make this a TryAdd else you get infiniclones
         _euiManager.OpenEui(new AcceptCloningEui(mindEnt, mind, this), client);
 
         UpdateStatus(uid, CloningPodStatus.NoMind, clonePod);
@@ -340,6 +362,6 @@ public sealed class CloningPodSystem : EntitySystem
 
     public void Reset(RoundRestartCleanupEvent ev)
     {
-        ClonesWaitingForMind.Clear();
+        // ClonesWaitingForMind.Clear(); //Goobstation
     }
 }


### PR DESCRIPTION
## About the PR
During upstream i nuked whatever system goob had for cloning. "Why the fuck do we have an eqe just use a dictionary we keep wizden parity this way" i said to myself

This results in this dictionary being updated with an `Add` and not being removed properly when people do not transfer. Attempting to add an already existing entry throws, and in the cases where a clone should be cancelled, it is isnt because we threw early.

Why the fuck are there no validation checks here, its all fucking done in the wrong order. I dont  care. Im not doing them. Im reverting the old system. If thats too much to read change the add to a TryAdd instead.

## Why / Balance


## Technical details


## Media

fixes this shit:

<img width="541" height="427" alt="image" src="https://github.com/user-attachments/assets/0f05b814-008e-48c4-b472-41801f3dc3dc" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**

:cl:
- fix: You can no longer clone instantly and at no cost by keeping your soul tied down.
