### PR TITLE
Adds zombie infection resistance to thematically fitting suits

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -176,6 +176,8 @@
   - type: IngestionBlocker
   - type: ExplosionResistance
     damageCoefficient: 0.9
+  - type: ZombificationResistance # Goobstation - Zombies
+    zombificationResistanceCoefficient: 0.9
   - type: Armor
     coverage:
     - Head
@@ -346,6 +348,8 @@
     coolingCoefficient: 0.8
   - type: FireProtection
     reduction: 0.15 # not fully sealed so less protection
+  - type: ZombificationResistance # Goobstation - Zombies
+    zombificationResistanceCoefficient: 0.9
   - type: IdentityBlocker
   - type: Tag
     tags:
@@ -388,6 +392,8 @@
     coolingCoefficient: 0.8
   - type: FireProtection
     reduction: 0.2
+  - type: ZombificationResistance # Goobstation - Zombies
+    zombificationResistanceCoefficient: 0.9
   - type: PressureProtection
     highPressureMultiplier: 0.25
     lowPressureMultiplier: 1000

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -35,6 +35,8 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.8
+  - type: ZombificationResistance # Goobstation - Zombies
+    zombificationResistanceCoefficient: 0.45 # Thick suit
   - type: ExplosionResistance
     damageCoefficient: 0.15
   - type: GroupExamine
@@ -77,6 +79,8 @@
     coolingCoefficient: 0.05
   - type: FireProtection
     reduction: 0.65 # doesnt have a full seal so not as good
+  - type: ZombificationResistance # Goobstation - Zombies
+    zombificationResistanceCoefficient: 0.50
   - type: Armor
     coverage:
     - Chest
@@ -127,6 +131,8 @@
     coolingCoefficient: 0.05
   - type: FireProtection
     reduction: 0.8 # atmos firesuit offers best protection, hardsuits are a little vulnerable
+  - type: ZombificationResistance # Goobstation - Zombies
+    zombificationResistanceCoefficient: 0.50
   - type: Armor
     coverage:
     - Chest
@@ -189,6 +195,8 @@
         Radiation: 0.01
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/rad.rsi
+  - type: ZombificationResistance # Goobstation - Zombies
+    zombificationResistanceCoefficient: 0.50
   - type: GroupExamine
   - type: ToggleableClothing # Goobstation - Modsuits change
     clothingPrototypes:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

Adds zombie infection resistance to fire suits, atmos fire suits, rad suits and bomb suits, and associated headwear.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This fits extremely well with the genre, as any project zomboid player would know, with thick clothing capable of absorbing scractching blows to maybe save you from being infected.

They have slightly more resistance to zombification than a winter coat, but less than a proper biosuit, and still inflict significant slowdown without much in the way of actual armor. So still an inferior choice, but its fun anyways.

Go, go out there and put a fire suit on and beat up zombies with a baseball bat.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [x] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Adds zombie infection resistance to fire suits, atmos fire suits, bomb suits, and rad suits, alongside associated headwear.

