### PR TITLE
fix and Readd Emote Panel

### DIFF
--- a/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml
+++ b/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml
@@ -37,10 +37,14 @@ SPDX-License-Identifier: AGPL-3.0-or-later
             <PanelContainer.PanelOverride>
                 <graphics:StyleBoxFlat BackgroundColor="#2B2C3B" />
             </PanelContainer.PanelOverride>
-
-            <BoxContainer Orientation="Vertical" HorizontalExpand="True" SeparationOverride="10" Margin="10">
-                <menuBar:GameTopMenuBar Name="TopBar" HorizontalExpand="True" Access="Public" />
-                <chat:ChatBox StyleClasses="ChatOutput" VerticalExpand="True" HorizontalExpand="True" Name="Chat" Access="Protected" MinSize="0 0"/>
+            <BoxContainer Orientation="Horizontal" HorizontalExpand="True"> <!-- Goobstation Emotes panel and the other stuff  start-->
+                <BoxContainer Orientation="Vertical" HorizontalExpand="True" SeparationOverride="10" Margin="10">
+                    <menuBar:GameTopMenuBar Name="TopBar" HorizontalExpand="True" Access="Protected" />
+                    <SplitContainer State="Auto" VerticalExpand="True" Orientation="Vertical">
+                        <us:UserActionsPanel Name="UserActionsPanel" Access="Public"></us:UserActionsPanel>
+                        <chat:ChatBox VerticalExpand="True" HorizontalExpand="True" Name="Chat" Access="Protected" MinSize="0 0"/>
+                    </SplitContainer>
+                </BoxContainer> <!-- Goobstation Emotes panel and the other stuff end -->
             </BoxContainer>
         </PanelContainer>
     </SplitContainer>


### PR DESCRIPTION
## About the PR
Emote panel got removed during upstream.

Code is all physically there this just readds this to the xaml

rouge watched me fix this on stream so should work.

## Why / Balance

## Technical details

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- fix: Emote panel in separated layout is back.