### PR TITLE
Fixes stamina resistance applying twice

### DIFF
--- a/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
@@ -312,7 +312,7 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
         if (comp.StrainedMusclesActive)
         {
             var stamina = EnsureComp<StaminaComponent>(uid);
-            _stamina.TakeStaminaDamage(uid, 7.5f, visual: false, immediate: false);
+            _stamina.TakeStaminaDamage(uid, 7.5f, visual: false, immediate: false, ignoreResist: true);
             if (stamina.StaminaDamage >= stamina.CritThreshold || _gravity.IsWeightless(uid))
                 ToggleStrainedMuscles(uid, comp);
         }

--- a/Content.Goobstation.Shared/Dash/DashActionSystem.cs
+++ b/Content.Goobstation.Shared/Dash/DashActionSystem.cs
@@ -50,7 +50,7 @@ public sealed class DashActionSystem : EntitySystem
         _throwing.TryThrow(args.Performer, vec, speed, animated: false);
 
         if (args.StaminaDrain != null)
-            _stamina.TakeStaminaDamage(args.Performer, args.StaminaDrain.Value, visual: false, immediate: false);
+            _stamina.TakeStaminaDamage(args.Performer, args.StaminaDrain.Value, visual: false, immediate: false, ignoreResist: true);
 
         if (args.Emote != null && TryComp<AnimatedEmotesComponent>(args.Performer, out var emotes))
         {

--- a/Content.Goobstation.Shared/Projectiles/ProjectileImmunitySystem.cs
+++ b/Content.Goobstation.Shared/Projectiles/ProjectileImmunitySystem.cs
@@ -96,7 +96,7 @@ public sealed class ProjectileImmunitySystem : EntitySystem
         args.Reflected = true;
 
         if (ent.Comp.StaminaCostPerDodge > 0)
-            _stamina.TakeStaminaDamage(ent, ent.Comp.StaminaCostPerDodge, logDamage: false);
+            _stamina.TakeStaminaDamage(ent, ent.Comp.StaminaCostPerDodge, logDamage: false, ignoreResist: true);
 
         if (ent.Comp.DodgeEffect != null)
             SpawnAttachedTo(ent.Comp.DodgeEffect.Value, new EntityCoordinates(ent, Vector2.Zero));
@@ -111,7 +111,7 @@ public sealed class ProjectileImmunitySystem : EntitySystem
             return;
 
         if (ent.Comp.StaminaCostPerDodge > 0)
-            _stamina.TakeStaminaDamage(ent, ent.Comp.StaminaCostPerDodge, logDamage: false);
+            _stamina.TakeStaminaDamage(ent, ent.Comp.StaminaCostPerDodge, logDamage: false, ignoreResist: true);
 
         if (ent.Comp.DodgeEffect != null)
             SpawnAttachedTo(ent.Comp.DodgeEffect.Value, new EntityCoordinates(ent, Vector2.Zero));

--- a/Content.Goobstation.Shared/Stunnable/OvertimeStaminaDamageSystem.cs
+++ b/Content.Goobstation.Shared/Stunnable/OvertimeStaminaDamageSystem.cs
@@ -51,7 +51,7 @@ public sealed partial class OvertimeStaminaDamageSystem : EntitySystem
     {
         var damage = ent.Comp.Amount / ent.Comp.Delta;
 
-        _stamina.TakeStaminaDamage(ent, damage, immediate: false, visual: false);
+        _stamina.TakeStaminaDamage(ent, damage, immediate: false, visual: false, ignoreResist: true); // Ignore resists, we calculated in resists already
 
         ent.Comp.Damage -= damage;
 

--- a/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
@@ -226,7 +226,7 @@ public abstract partial class SharedStaminaSystem : EntitySystem
                 damageOvertime *= component.LightAttackOvertimeDamageMultiplier;
             }
 
-            TakeStaminaDamage(ent, damageImmediate / toHit.Count, comp, source: args.User, with: args.Weapon, sound: component.Sound, immediate: true);
+            TakeStaminaDamage(ent, damageImmediate / toHit.Count, comp, source: args.User, with: args.Weapon, sound: component.Sound, immediate: true, ignoreResist: true); // Goob: IgnoreResist: true, we already calculated resists
             TakeOvertimeStaminaDamage(ent, damageOvertime);
         }
     }
@@ -271,7 +271,7 @@ public abstract partial class SharedStaminaSystem : EntitySystem
         damage *= hitEvent.Value;
         overtime *= hitEvent.Value;
 
-        TakeStaminaDamage(target, damage, source: uid, sound: component.Sound);
+        TakeStaminaDamage(target, damage, source: uid, sound: component.Sound, ignoreResist: true); // Goob: Ignore resists, we calculated this already.
         TakeOvertimeStaminaDamage(target, overtime); // Goobstation
     }
 
@@ -333,9 +333,6 @@ public abstract partial class SharedStaminaSystem : EntitySystem
     {
         if (!Resolve(uid, ref component, false)
         || value == 0) // no damage???
-            return;
-
-        if (!Timing.IsFirstTimePredicted)
             return;
 
         var ev = new BeforeStaminaDamageEvent(value, source); // Goob change: Added source param.

--- a/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
@@ -335,6 +335,9 @@ public abstract partial class SharedStaminaSystem : EntitySystem
         || value == 0) // no damage???
             return;
 
+        if (!Timing.IsFirstTimePredicted)
+            return;
+
         var ev = new BeforeStaminaDamageEvent(value, source); // Goob change: Added source param.
         RaiseLocalEvent(uid, ref ev);
         if (ev.Cancelled)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

Looks like a upstream merge oopsies

In TakeStaminaDamage resists get applied from WizCode, but Goobcode had resists apply on-hit or on-collide. See line 331 in SharedStaminaSystem.

So the end result was all stamina resistant armor doing double the resisting as expected. Being applied twice.

So overall, if the resists are already precalculated from On-Hit/Collide/etc, I just made sure it is set to ignore resists.


This also meant that martial arts, which typically before the wizcode change a year ago directly applied stamina damage without checking for resists before since they weren't designed around it, are already affected by resists now due to the WizCode.

I dunno if that's a bug or not but its not hard to fix if you want me to. I know in ss13 typically martial arts bypassed resists like that.

Also makes a few things that shouldn't respect stam resist (self inflicted stamina damage) not respect it


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixes https://github.com/Goob-Station/Goob-Station/issues/7033

I hate bugs

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

After: (One disabler hit, 30% stamina resistance)
<img width="982" height="492" alt="Screenshot 2026-08-22 014209" src="https://github.com/user-attachments/assets/d7f222fd-fd89-4e80-9b50-b94a8749c260" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Stamina resist on armor no longer applies twice to incoming stamina damage.
- fix: A few sources of self inflicted stamina damage that shouldn't respect stamina resistance now don't.