### PR TITLE
Fix BSO Combat Injector 3u/5u Dynamic/Inject-Only Modes

### DIFF
--- a/Resources/Prototypes/Chemistry/injector_modes.yml
+++ b/Resources/Prototypes/Chemistry/injector_modes.yml
@@ -152,3 +152,23 @@
 - type: injectorMode
   parent: [ BaseAdvancedJetInjectorMode, BaseDynamicMode ]
   id: AdvancedJetInjectorDynamicMode
+
+  # Goob start
+  # BSO combat injector's modes
+- type: injectorMode
+  abstract: true
+  id: BaseCombatInjectorMode
+  mobTime: 1 # Attempt to match the previous injector speed
+  transferAmounts:
+  - 3
+  - 5
+
+- type: injectorMode
+  parent: [BaseCombatInjectorMode, BaseDynamicMode]
+  id: CombatInjectorDynamicMode
+
+- type: injectorMode
+  parent: [BaseCombatInjectorMode, BaseInjectMode]
+  id: CombatInjectorInjectMode
+
+  # Goob end

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/blueshield.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/blueshield.yml
@@ -92,10 +92,10 @@
       injector:
         maxVol: 5
   - type: Injector
-    activeModeProtoId: SyringeDrawMode #Goob start
+    activeModeProtoId: CombatInjectorDynamicMode # SyringeDrawMode #Goob start
     allowedModes:
-    - SyringeDrawMode
-    - SyringeInjectMode #Goob end
+    - CombatInjectorDynamicMode # SyringeDrawMode
+    - CombatInjectorInjectMode # SyringeInjectMode #Goob end
   - type: MeleeChemicalInjector
     transferAmount: 5
     solution: injector


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
fixed BSO's combat injector using syringe 5u/10u/15u draw/inject instead of a 3u/5u dynamic/inject like before

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
BSOs can't use undiluted T4 chems without a 3u draw option
it was like this before and it was broken by upstreaming

i based the normal inject time (1s default) off of testimony from other BSO players and also the knowledge that somewhere in some code the minimum injection delay is 1s, and besides as long as it's not a hypospray injection, the BSO will more than likely be stabbing to inject

## Technical details
<!-- Summary of code changes for easier review. -->
added combat injector modes in `Resources\Prototypes\Chemistry\injector_modes.yml`
changed corresponding `activeModeProtoId` and `allowedModes` from syringe to my new modes in `Resources\Prototypes\_Goobstation\Entities\Objects\Weapons\Melee\blueshield.yml` (i commented things out instead of outright deleting to reduce the likelihood of downstreams having a heart attack)

as a sidenote, the video shows a funny bug that i believe is caused by someone forgetting to FIND the locale string instead of directly printing out the name of the string. i'd fix it but i'm lazy and it's out of scope for what i need to do anyhow. here's the buggered line: https://github.com/Goob-Station/Goob-Station/blob/a131686f2854800d7e99932951590d1aa0cbd73c/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs#L557

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://youtu.be/6LriIoWJV0k

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: Duuckie
- fix: Blueshield Officers' combat injectors should work how they used to, with fast (1-second normal inject) 3u/5u transfer amounts and dynamic/inject-only modes.