### PR TITLE
Increases xeno organ health to insane levels

### DIFF
--- a/Resources/Prototypes/_White/Body/Organs/Animal/xenomorph.yml
+++ b/Resources/Prototypes/_White/Body/Organs/Animal/xenomorph.yml
@@ -10,7 +10,7 @@
     integrity: 10000
     integrityThresholds:
       Normal: 10000
-      Damaged: 5000
+      Damaged: 1
       Destroyed: 0
   - type: Edible
   - type: Extractable

--- a/Resources/Prototypes/_White/Body/Organs/Animal/xenomorph.yml
+++ b/Resources/Prototypes/_White/Body/Organs/Animal/xenomorph.yml
@@ -6,6 +6,12 @@
   - type: Sprite
     sprite: _White/Mobs/Species/Xenomorph/organs.rsi
   - type: Organ
+    intCap: 10000 # goob - insane health so xenos effectively can't take organ damage
+    integrity: 10000
+    integrityThresholds:
+      Normal: 10000
+      Damaged: 5000
+      Destroyed: 0
   - type: Edible
   - type: Extractable
     grindableSolutionName: organ


### PR DESCRIPTION
## About the PR
Gives xenos insane organ health because organs don't passively heal

## Why / Balance
Xenos get fucked over by organ damage more than anyone else, they're a melee only antag that commonly have to deal with a lot of guns.

Organ damage kills xenos in many ways, being: Dead plasma vessel so you can't lay eggs or build as queen, dead hive node so you can't heal on weeds, dead resin spinner on drones making them effectively useless. The only way for a xeno to heal organ damage is to evolve and in 90% of scenarios that's completely impossible.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.

**Changelog**
:cl:
- fix: Xenomorphs no longer suffer from organ damage as easily.
