### PR TITLE
The ultimate mald generator

### DIFF
--- a/Resources/Prototypes/Body/Parts/human.yml
+++ b/Resources/Prototypes/Body/Parts/human.yml
@@ -93,8 +93,6 @@
   - type: Sprite
     sprite: Mobs/Species/Human/parts.rsi
     state: "l_hand"
-  - type: DoAfterDelayMultiplier # Goobstation
-    multiplier: 0.9
 
 - type: entity
   id: RightHandHuman
@@ -104,8 +102,6 @@
   - type: Sprite
     sprite: Mobs/Species/Human/parts.rsi
     state: "r_hand"
-  - type: DoAfterDelayMultiplier # Goobstation
-    multiplier: 0.9
 
 - type: entity
   id: LeftLegHuman

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -35,9 +35,6 @@
           32:
             sprite: Mobs/Species/Human/displacement.rsi
             state: jumpsuit-female
-  - type: Sprinter # Goob Change: human major
-    staminaDrainRate: 8
-
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/ServerInfo/Guidebook/Mobs/Human.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Human.xml
@@ -11,6 +11,5 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
   Depending on who you ask, humans are either unremarkable or the universal standard to which everything else is compared.
 
-  They interact [color=#ffa500]about 20% faster[/color] compared to other species.
 
 </Document>


### PR DESCRIPTION
## About the PR
Removed innate 20% doafter speed buff and 20% sprint stamina cost from humans.

## Why / Balance
Humans are supposed to be the "default" species with no upsides or downsides. 

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.

**Changelog**
:cl:
- fix: Humans now have no upsides or downsides.
