### PR TITLE
Nuke rat is now evil...

### DIFF
--- a/Resources/Prototypes/_Trauma/Entities/Mobs/NPCs/syndicate.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Mobs/NPCs/syndicate.yml
@@ -54,6 +54,19 @@
     - FootstepSound
   - type: Damageable
     damageModifierSet: NukieSpider
+  #goobstation start
+  - type: GrantDisease
+    baseDisease: DiseaseBaseMouse
+    complexity: 50 #evil...
+    possibleTypes:
+    - Bacterial
+    - Viral
+  - type: DiseaseOnHit
+    spreadParams:
+      chance: 0.2 # plague rat chance
+      power: 1
+      spreadType: Blood
+  #goobstation end
 
 - type: entity
   parent: MobGiantSpiderAngry


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Nukie reinforcement rat spreads diseases
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.

**Changelog**

:cl:
- tweak: Nukie Rat Reinforcement Now spread Diseases