### PR TITLE
[FIX] Restoring Ethanol & Alcohol Metabolisms to Pre-Upstream Properties

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -230,7 +230,7 @@
           type: [ Oni ]
         damage:
           types:
-            Poison: 0.2
+            Poison: 0.02 # Goob edit from 0.2 to 0.02 due to upstream making the metabolism rate 1/10 of what it was
       # End DeltaV Additons
       - !type:Vomit
         probability: 0.04

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -174,6 +174,7 @@
           - Dwarf
           - Yowie  # Goobstation - Yowie
           - Cybernetic # Shitmed - Cybernetic Organs
+          - Oni # Goobstation, upstream fix for Oni (DeltaV) taking too much ethanol poisoning
           inverted: true
         damage:
           types:
@@ -230,7 +231,7 @@
           type: [ Oni ]
         damage:
           types:
-            Poison: 0.02 # Goob edit from 0.2 to 0.02 due to upstream making the metabolism rate 1/10 of what it was
+            Poison: 0.05 # Goob edit from 0.2 to 0.05 due to upstream; it's not 0.02 because that will have no effect
       # End DeltaV Additons
       - !type:Vomit
         probability: 0.04

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -174,11 +174,11 @@
           - Dwarf
           - Yowie  # Goobstation - Yowie
           - Cybernetic # Shitmed - Cybernetic Organs
-          - Oni # Goobstation, upstream fix for Oni (DeltaV) taking too much ethanol poisoning
+          - Oni # Goobstation, upstream fix for Oni taking too much ethanol poisoning
           inverted: true
         damage:
           types:
-            Poison: 0.1
+            Poison: 1 # 0.1 # Goob; pre-upstream life-threatening ethanol poisoning damage
             # dwarves take less toxin damage and heal a marginal amount of brute
 # Goobstation Start
 #      - !type:HealthChange
@@ -231,7 +231,7 @@
           type: [ Oni ]
         damage:
           types:
-            Poison: 0.05 # Goob edit from 0.2 to 0.05 due to upstream; it's not 0.02 because that will have no effect
+            Poison: 0.2
       # End DeltaV Additons
       - !type:Vomit
         probability: 0.04

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -174,7 +174,7 @@
           - Dwarf
           - Yowie  # Goobstation - Yowie
           - Cybernetic # Shitmed - Cybernetic Organs
-          - Oni # Goobstation, upstream fix for Oni taking too much ethanol poisoning
+          - Oni # Goobstation, fixes Oni taking base ethanol poisoning on top of their specific ethanol poisoning
           inverted: true
         damage:
           types:

--- a/Resources/Prototypes/_DV/Body/Organs/chitinid.yml
+++ b/Resources/Prototypes/_DV/Body/Organs/chitinid.yml
@@ -43,7 +43,7 @@
     metabolizerTypes: [ Animal ]
     groups:
     - id: Alcohol
-      rateModifier: 0.1
+      # rateModifier: 0.1 # Goobstation; this line causes ethanol to not metabolize at all
   - type: Liver # Shitmed
   - type: Tag # goob edit
     tags:

--- a/Resources/Prototypes/_DV/Body/Organs/chitinid.yml
+++ b/Resources/Prototypes/_DV/Body/Organs/chitinid.yml
@@ -43,7 +43,6 @@
     metabolizerTypes: [ Animal ]
     groups:
     - id: Alcohol
-      # rateModifier: 0.1 # Goobstation; this line causes ethanol to not metabolize at all
   - type: Liver # Shitmed
   - type: Tag # goob edit
     tags:

--- a/Resources/Prototypes/_EinsteinEngines/Body/Organs/shadowkin.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Organs/shadowkin.yml
@@ -131,7 +131,7 @@
     metabolizerTypes: [Shadowkin]
     groups:
     - id: Alcohol
-      rateModifier: 0.1
+      # rateModifier: 0.1 # Goobstation; this line causes ethanol to not metabolize at all
   - type: FoodSequenceElement #Goob
     entries:
       Burger: FSE_OrganShadowkinLiver

--- a/Resources/Prototypes/_EinsteinEngines/Body/Organs/shadowkin.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Organs/shadowkin.yml
@@ -131,7 +131,6 @@
     metabolizerTypes: [Shadowkin]
     groups:
     - id: Alcohol
-      # rateModifier: 0.1 # Goobstation; this line causes ethanol to not metabolize at all
   - type: FoodSequenceElement #Goob
     entries:
       Burger: FSE_OrganShadowkinLiver

--- a/Resources/Prototypes/_Goobstation/Body/Organs/yowie.yml
+++ b/Resources/Prototypes/_Goobstation/Body/Organs/yowie.yml
@@ -38,7 +38,6 @@
     - id: Narcotic
       rateModifier: 1
     - id: Alcohol # Same as parent
-      # rateModifier: 0.1 # This line post-upstream (2026/08/29) causes ethanol to not metabolize at all
     maxPoisonsProcessable: 3 # For proper processing of chems instead of heart
 
 - type: entity

--- a/Resources/Prototypes/_Goobstation/Body/Organs/yowie.yml
+++ b/Resources/Prototypes/_Goobstation/Body/Organs/yowie.yml
@@ -38,7 +38,7 @@
     - id: Narcotic
       rateModifier: 1
     - id: Alcohol # Same as parent
-      rateModifier: 0.1
+      # rateModifier: 0.1 # Goobstation; this line causes ethanol to not metabolize at all
     maxPoisonsProcessable: 3 # For proper processing of chems instead of heart
 
 - type: entity

--- a/Resources/Prototypes/_Goobstation/Body/Organs/yowie.yml
+++ b/Resources/Prototypes/_Goobstation/Body/Organs/yowie.yml
@@ -38,7 +38,7 @@
     - id: Narcotic
       rateModifier: 1
     - id: Alcohol # Same as parent
-      # rateModifier: 0.1 # Goobstation; this line causes ethanol to not metabolize at all
+      # rateModifier: 0.1 # This line post-upstream (2026/08/29) causes ethanol to not metabolize at all
     maxPoisonsProcessable: 3 # For proper processing of chems instead of heart
 
 - type: entity

--- a/Resources/Prototypes/_Mono/Body/Organs/hydra.yml
+++ b/Resources/Prototypes/_Mono/Body/Organs/hydra.yml
@@ -80,7 +80,6 @@
     metabolizerTypes: [Human]
     groups:
     - id: Alcohol
-      # rateModifier: 0.1 # removes alcohol very slowly along with the stomach removing it as a drink # Goob edit; this line causes alcohol to not metabolize at all. Ethanol metabolizes at 0.05u/s anyhow so it's fine
 
 - type: entity
   id: OrganHydrakinHeart

--- a/Resources/Prototypes/_Mono/Body/Organs/hydra.yml
+++ b/Resources/Prototypes/_Mono/Body/Organs/hydra.yml
@@ -80,7 +80,7 @@
     metabolizerTypes: [Human]
     groups:
     - id: Alcohol
-      rateModifier: 0.1 # removes alcohol very slowly along with the stomach removing it as a drink
+      # rateModifier: 0.1 # removes alcohol very slowly along with the stomach removing it as a drink # Goob edit; this line causes alcohol to not metabolize at all. Ethanol metabolizes at 0.05u/s anyhow so it's fine
 
 - type: entity
   id: OrganHydrakinHeart

--- a/Resources/Prototypes/_Shitmed/Body/Organs/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Organs/cybernetic.yml
@@ -191,7 +191,6 @@
     metabolizerTypes: [ Cybernetic ]
     groups:
     - id: Alcohol
-      # rateModifier: 0.1 # Goobstation; this line causes ethanol to not metabolize at all
   - type: Tag
     tags:
     - Organ

--- a/Resources/Prototypes/_Shitmed/Body/Organs/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Organs/cybernetic.yml
@@ -191,7 +191,7 @@
     metabolizerTypes: [ Cybernetic ]
     groups:
     - id: Alcohol
-      rateModifier: 0.1
+      # rateModifier: 0.1 # Goobstation; this line causes ethanol to not metabolize at all
   - type: Tag
     tags:
     - Organ


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
allowed shadowkin, chitinids, yowie, hydrakin, and people with cybernetic livers to metabolize ethanol properly at a 0.05u/s standard rate

on ethanol overdose, oni take 0.18 Poison/s instead of pre-upstream 1.2/s
everyone else (but dwarves/yowie) takes 0.98 Poison/s instead of absolutely minuscule damage
(the numbers are not round because of natural poison regeneration)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
fixes https://github.com/Goob-Station/Goob-Station/issues/6896
expands effects of https://github.com/space-wizards/space-station-14/pull/41192 to non-wizden species
fixes alcohol poisoning not actually killing people

as it turned out, this issue affects four whole-ass species and an organ whose primary purpose is to obliterate ethanol, but APPARENTLY nobody plays the OTHER ones enough to notice (or care enough to make a github issue about it)

## Technical details
<!-- Summary of code changes for easier review. -->
altered the liver prototypes of the respective species' organ YAML files to comment out the offending `rateModifier: 0.1`

changed the damage that ethanol deals to pre-upstream values to reflect how they actually worked pre-upstream

by the by, while doing this PR, bacchus's blessing metabolizes at 0.55u/s because it's a drink and an alcohol. it's kinda weird but it's whatever and i didn't want to touch that
xenobio slimes process ethanol at 0.01u/s (with a rateModifier: 0.2)

diona still get wasted off of (but thankfully don't die to [due to vomiting it out]) 1u absinthe due to the narcotics' 0.01u/s metabolism taking priority (see wizden https://github.com/space-wizards/space-station-14/issues/39659)
slimepeople for some fucking reason process ethanol/bacchus's blessing at 0.12u/s but not any of the other reagent groups faster? probably related to the above

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
i assert that all species shown metabolize at 0.05u/s (the laying down urist has the cybernetic liver)
<img width="898" height="858" alt="Screenshot 2026-08-29 142641" src="https://github.com/user-attachments/assets/49b8cffa-fe56-42c6-9897-a4248f18a100" />


pre-upstream ethanol poisoning behavior has been restored
below are tests taken from 30u ethanol (about 2 glasses of absinthe in a row) --> 15u ethanol
results may vary due to vomiting chances
before:
<img width="1277" height="915" alt="image" src="https://github.com/user-attachments/assets/3e5ce163-4840-457a-9d0d-b313aafd8e2d" />


after:
<img width="524" height="590" alt="image" src="https://github.com/user-attachments/assets/61fe65fd-a7e1-41ce-8314-47f9b6491161" />
fixed oni taking more damage than they're supposed to
<img width="459" height="574" alt="image" src="https://github.com/user-attachments/assets/c8b25e73-c976-4d27-bbab-abb3a3d2678e" />



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Duuckie
- fix: Shadowkin, chitinids, yowie, hydrakin, and people with cybernetic livers now properly metabolize ethanol at the standard metabolism rate (0.05u/s).
- tweak: Ethanol poisoning now deals the damage it did pre-upstream (2 glasses of absinthe have a non-zero chance of putting you into crit).
- fix: Oni actually take reduced damage from ethanol poisoning.