### PR TITLE
Port Omu Eye Damage Fix

### DIFF
--- a/Content.Server/_Shitmed/Body/Systems/EyesSystem.cs
+++ b/Content.Server/_Shitmed/Body/Systems/EyesSystem.cs
@@ -56,8 +56,12 @@ namespace Content.Server._Shitmed.Body.Systems
                 || organ.IntegrityCap <= 0)
                 return;
 
-            var lost = 1f - (float) (organ.OrganIntegrity / organ.IntegrityCap);
-            _blindableSystem.SetEyeDamage((organ.Body.Value, blindable), (int) (blindable.MaxDamage * lost));
+            
+            // Omu: The expected input is scaled as a number between 12 and 3,
+            // such that "blindness" occurs at 25% eye integrity.
+            
+            var blindnessSeverity = (int) ((organ.IntegrityCap - organ.OrganIntegrity) / (organ.IntegrityCap / 12)); // Omu
+            _blindableSystem.SetEyeDamage((organ.Body.Value, blindable), blindnessSeverity); // Omu
         }
 
         private void OnOrganEnabled(EntityUid uid, EyesComponent component, OrganEnabledEvent args)

--- a/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/BlindableSystem.cs
@@ -98,8 +98,12 @@ public sealed class BlindableSystem : EntitySystem
         // for now
         foreach (var eye in eyes)
         {
-            if (!_trauma.TryChangeOrganDamageModifier(eye.Owner, amount, blindable.Owner, "BlindableDamage", eye.Comp2))
-                _trauma.TryCreateOrganDamageModifier(eye.Owner, amount, blindable.Owner, "BlindableDamage", eye.Comp2);
+            // Omu start
+            // Scale the damage done to eye organs proportional to what the cap used to be.
+            var scaledDamage = amount * (eye.Comp2.IntegrityCap / 12);
+            if (!_trauma.TryChangeOrganDamageModifier(eye.Owner, scaledDamage, blindable.Owner, "BlindableDamage", eye.Comp2))
+                _trauma.TryCreateOrganDamageModifier(eye.Owner, scaledDamage, blindable.Owner, "BlindableDamage", eye.Comp2);
+            // Omu end
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
ports omustation's https://github.com/ProjectOmu/OmuStation/pull/1615

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
welders no longer explode your eyes
eye damage now works similarly to how it did pre-upstream

as of right now, there's a very annoying bug that causes the organ damage noise to play multiple times in quick succession when blinding yourself with a welder. this isn't great, but mechanically it's fine
this seems to be a pre-existing issue due to upstream and not caused by this PR

## Technical details
<!-- Summary of code changes for easier review. -->
see original implementation

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="787" height="873" alt="image" src="https://github.com/user-attachments/assets/a3f1b633-932d-4908-9301-f5eefd05a93b" />
<img width="888" height="1011" alt="image" src="https://github.com/user-attachments/assets/b661483c-3be3-4b86-9a1e-1637138fd08e" />
<img width="883" height="992" alt="image" src="https://github.com/user-attachments/assets/27bc73b8-364d-4e03-a3ac-18f6bd7123e6" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Jerulean, Duuckie
- fix: Burning your eyes with a welder now works as expected.