### PR TITLE
Nuke abomination of a method in  lathesystem and fix bulk lathe printing

### DIFF
--- a/Content.Server/Lathe/LatheSystem.Goob.cs
+++ b/Content.Server/Lathe/LatheSystem.Goob.cs
@@ -18,80 +18,27 @@ public sealed partial class LatheSystem
     /// Produces 0-time items that output into the storage automatically.
     /// Used in order to prevent stack overflows (of the server) caused by printing a lot of materials at once.
     /// TODO It's still not great and in the future should be replaced with something even more optimized.
+    ///
+    /// update i don't know why its needed this fucking way and i don't care. Im removing the dupe code method.
+    /// tl;dr this just gets the next recipe and sets the current recipe again until there isnt any.
     /// </summary>
-    private void FinishProducingManyStorage(Entity<LatheComponent, LatheProducingComponent> ent)
+    private bool TryStartNextBulkRecipe(EntityUid uid, LatheComponent comp)
     {
-        var (uid, comp, prodComp) = ent;
+        if (comp.Queue.First is not { } node) // break here, when queue empty it stop. wow.
+            return false;
 
-        if (comp.CurrentRecipe != null)
-        {
-            var count = comp.Queue.Count;
-            while (comp.CurrentRecipe != null)
-            {
-                var batch = comp.Queue.First();
-                batch.ItemsPrinted++;
-                if (batch.ItemsPrinted >= batch.ItemsRequested || batch.ItemsPrinted < 0)
-                    comp.Queue.RemoveFirst();
+        var batch = node.Value;
+        var recipe = _proto.Index(batch.Recipe);
+        var time = _reagentSpeed.ApplySpeed(uid, recipe.CompleteTime) * comp.TimeMultiplier;
 
-                // Modified FinishProducing method
-                var currentRecipe = _proto.Index(comp.CurrentRecipe.Value);
-                if (currentRecipe.Result is { } resultProto)
-                {
-                    var prototype = _proto.Index(resultProto);
-                    // Storage output is already true if we are in this method
-                    if (prototype.TryGetComponent<PhysicalCompositionComponent>(out var composition, _factory))
-                    {
-                        _materialStorage.TryChangeMaterialAmount(uid, composition.MaterialComposition);
-                    }
-                    else
-                    {
-                        // This case should ideally never happen? But whatever
-                        var result = Spawn(resultProto, Transform(uid).Coordinates);
-                        _stack.TryMergeToContacts(result);
-                        if (TryComp<ScannableForPointsComponent>(result, out var scannable)) // Goobstation
-                            scannable.Points = 0; // Goobstation, this thing is to prevent ntr duping points via an emagged lathe
-                    }
-                }
+        if (time != TimeSpan.Zero)
+            return false;
 
-                if (currentRecipe.ResultReagents is { } resultReagents &&
-                    comp.ReagentOutputSlotId is { } slotId)
-                {
-                    var toAdd = new Solution(
-                        resultReagents.Select(p => new ReagentQuantity(p.Key.Id, p.Value)));
+        batch.ItemsPrinted++;
+        if (batch.ItemsPrinted >= batch.ItemsRequested || batch.ItemsPrinted < 0)
+            comp.Queue.RemoveFirst();
 
-                    // dispense it in the container if we have it and dump it if we don't
-                    if (_container.TryGetContainer(uid, slotId, out var container) &&
-                        container.ContainedEntities.Count == 1 &&
-                        _solution.TryGetFitsInDispenser(container.ContainedEntities.First(), out var solution, out _))
-                    {
-                        _solution.AddSolution(solution.Value, toAdd);
-                    }
-                    else
-                    {
-                        // No popup because this is a mass-produced case and we don't want 10000 popups
-                        //_popup.PopupEntity(Loc.GetString("lathe-reagent-dispense-no-container", ("name", uid)), uid);
-                        _puddle.TrySpillAt(uid, toAdd, out _);
-                    }
-                }
-
-                var recipeProto = comp.Queue.First().Recipe;
-                var recipe = _proto.Index(batch.Recipe);
-                var time = _reagentSpeed.ApplySpeed(uid, recipe.CompleteTime) * comp.TimeMultiplier;
-                if (time != TimeSpan.Zero)
-                    break;
-
-                comp.CurrentRecipe = recipe;
-            }
-        }
-
-        comp.CurrentRecipe = null;
-        prodComp.StartTime = _timing.CurTime;
-
-        if (!TryStartProducing(uid, comp))
-        {
-            RemCompDeferred(uid, prodComp);
-            UpdateUserInterfaceState(uid, comp);
-            UpdateRunningAppearance(uid, false);
-        }
+        comp.CurrentRecipe = recipe;
+        return true;
     }
 }

--- a/Content.Server/Lathe/LatheSystem.Goob.cs
+++ b/Content.Server/Lathe/LatheSystem.Goob.cs
@@ -1,12 +1,4 @@
-﻿using System.Linq;
-using Content.Goobstation.Common.NTR.Scan;
-using Content.Goobstation.Shared.Lathe;
-using Content.Server.Chat.Systems;
-using Content.Server.Lathe.Components;
-using Content.Shared.Chemistry.Components;
-using Content.Shared.Chemistry.Reagent;
-using Content.Shared.Lathe;
-using Content.Shared.Materials;
+﻿using Content.Shared.Lathe;
 
 namespace Content.Server.Lathe;
 

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -222,12 +222,8 @@ namespace Content.Server.Lathe
 
             if (time == TimeSpan.Zero)
             {
-                // Goobstation edit start: handle special case with lots of 0-time recipes that insert into storage
-                if (component.OutputToStorage)
-                    FinishProducing(uid, component, lathe, true);
-                // Goobstation edit end
-
-                FinishProducing(uid, component, lathe);
+                FinishProducing(uid, component, lathe,
+                    component.OutputToStorage); // Goobstation edit start: handle special case with lots of 0-time recipes that insert into storage
             }
             return true;
         }

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -224,7 +224,7 @@ namespace Content.Server.Lathe
             {
                 // Goobstation edit start: handle special case with lots of 0-time recipes that insert into storage
                 if (component.OutputToStorage)
-                    FinishProducingManyStorage((uid, component, lathe));
+                    FinishProducing(uid, component, lathe, true);
                 // Goobstation edit end
 
                 FinishProducing(uid, component, lathe);
@@ -232,12 +232,13 @@ namespace Content.Server.Lathe
             return true;
         }
 
-        public void FinishProducing(EntityUid uid, LatheComponent? comp = null, LatheProducingComponent? prodComp = null)
+       public void FinishProducing(EntityUid uid, LatheComponent? comp = null, LatheProducingComponent? prodComp = null,
+           bool bulk = false) // Goobstation
         {
             if (!Resolve(uid, ref comp, ref prodComp, false))
                 return;
 
-            if (comp.CurrentRecipe != null)
+            while (comp.CurrentRecipe != null) // Goob, if to while for bulk recipes
             {
                 var currentRecipe = _proto.Index(comp.CurrentRecipe.Value);
                 if (currentRecipe.Result is { } resultProto)
@@ -276,10 +277,15 @@ namespace Content.Server.Lathe
                         _puddle.TrySpillAt(uid, toAdd, out _);
                     }
                 }
-            }
 
-            comp.CurrentRecipe = null;
-            prodComp.StartTime = _timing.CurTime;
+                comp.CurrentRecipe = null;
+                prodComp.StartTime = _timing.CurTime;
+
+                // Goobstation edit start, see method comment
+                if (!bulk || !TryStartNextBulkRecipe(uid, comp))
+                    break;
+                // Goobstation edit end
+            }
 
             if (!TryStartProducing(uid, comp))
             {


### PR DESCRIPTION
## About the PR

You guys do not know what the fuck you are merging. I understand shit breaks in upstream but double check the fixes at least. If the PR gives NO MEDIA. NO EXPLANATION. NO ANYTHING. Fucking close it instead.

Changes in https://github.com/Goob-Station/Goob-Station/pull/6878 make it so that this abomination of a method trows at lines that do not fucking do anyhting. making this a while method makes this not check count, and you're never checking it, means it runs on empty fucking recipes and throws, not doing bulk recipes properly.

I don't know why the fuck rouden was duplicating code to write in a few bulk stuff. Changes this mess to a helper that works as a bool

You can now print stuff.

## Why / Balance


## Technical details
How to test:

Open ore processor menu. Input raw material like quartz. Request many (like 10) of it to be made. Watch it be made in the correct amount.

## Media
<img width="913" height="618" alt="image" src="https://github.com/user-attachments/assets/27ac3b0c-8c03-45d8-9e30-e3cb6561cbe2" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

Nukes abominabale method that is `FinishProducingManyStorage` and replaces it with a `bool` of `bulk = true.`, which will run a helper method to advance the current recipe and reset the next recipe so we continue iterating over this. If there is no recipe in the queue, it breaks and moves onto updating ui code.

`bulk` is tied to `OutputToStorage` datafield in comp which is what it was used for in the first place.

**Changelog**

:cl:
- fix: Ore lathes now print raw materials properly into storage in bulk instead of having to print one by one.
