### PR TITLE
[FIX] Zombies have blood now

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -44,6 +44,7 @@ using Robust.Shared.Prototypes;
 using Content.Shared.NPC.Prototypes;
 using Content.Shared.Roles;
 using Content.Shared.Temperature.Components;
+using Content.Shared.Chemistry.Reagent;
 
 // Goobstation
 using Content.Server.Polymorph.Systems;
@@ -95,6 +96,7 @@ public sealed partial class ZombieSystem
     private static readonly ProtoId<NpcFactionPrototype> ZombieFaction = "Zombie";
     private static readonly string MindRoleZombie = "MindRoleZombie";
     private static readonly List<ProtoId<AntagPrototype>> BannableZombiePrototypes = ["Zombie"];
+    private static readonly ProtoId<ReagentPrototype> ZombieBloodProto = "ZombieBlood"; // Goob - Zombie blood update
 
     /// <summary>
     /// Handles an entity turning into a zombie when they die or go into crit
@@ -292,7 +294,15 @@ public sealed partial class ZombieSystem
         //NOTE: they are supposed to bleed, just not take damage
         _bloodstream.SetBloodLossThreshold(target, 0f);
         //Give them zombie blood
-        _bloodstream.ChangeBloodReagents(target, zombiecomp.NewBloodReagents);
+        // Goob Start - Zombie blood update
+        if (TryComp<BloodstreamComponent>(target, out var targStream))
+        {
+            // Grab current bloodstream volume to replace
+            var oldVolume = targStream.BloodReferenceSolution.Volume;
+            // Give them new blood
+            _bloodstream.ChangeBloodReagents(target, new([new(ZombieBloodProto, oldVolume)]));
+        }
+        // Goob end
 
         //This is specifically here to combat insuls, because frying zombies on grilles is funny as shit.
         _inventory.TryUnequip(target, "gloves", true, true);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Gave zombies the amount of blood their species usually starts with. 

fixes #7110 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Zombies only had 1 unit of blood which breaks most med systems.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a TryComp and updated ChangeBloodReagents call.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
None.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [x] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Zombie blood works normally now.