### PR TITLE
[FIX] Changelings and Zombies Have Normal Max Blood Volume

### DIFF
--- a/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
+++ b/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
@@ -682,20 +682,20 @@ public abstract partial class SharedBloodstreamSystem : EntitySystem
         }
 
         // ent.Comp.BloodReferenceSolution = reagents.Clone(); // Goob, scaling max according to original volume; see below
-        // DirtyField(ent, ent.Comp, nameof(BloodstreamComponent.BloodReferenceSolution)); // Goob
 
         // Goob start: appropriately scale the target's BloodReferenceSolution according to their previous max volume
         var referenceSolution = reagents.Clone();
         referenceSolution.ScaleSolution(ent.Comp.BloodReferenceSolution.MaxVolume / referenceSolution.Volume); // Using the old max to scale the reference solution up/down
         referenceSolution.MaxVolume = ent.Comp.BloodReferenceSolution.MaxVolume; // This doesn't actually affect blood regeneration, but it'd be slopcode if I didn't set this
         ent.Comp.BloodReferenceSolution = referenceSolution;
-        DirtyField(ent, ent.Comp, nameof(BloodstreamComponent.BloodReferenceSolution));
         // Goob end
+        DirtyField(ent, ent.Comp, nameof(BloodstreamComponent.BloodReferenceSolution));
+
 
         if (currentVolume == FixedPoint2.Zero)
             return;
 
-        var solution = reagents.Clone(); // ent.Comp.BloodReferenceSolution.Clone(); // Goob, adjusted due to above fixes; this acts the same otherwise
+        var solution = reagents.Clone(); // Goob, adjusted due to above fixes; this acts the same otherwise
         solution.ScaleSolution(currentVolume / solution.Volume);
         SolutionContainer.AddSolution(ent.Comp.BloodSolution.Value, solution);
     }

--- a/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
+++ b/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
@@ -659,6 +659,7 @@ public abstract partial class SharedBloodstreamSystem : EntitySystem
 
     /// <summary>
     /// Change what someone's blood is made of, on the fly.
+    /// Goob: this will set their max blood level according to their current species's BloodReferenceSolution.
     /// </summary>
     public void ChangeBloodReagents(Entity<BloodstreamComponent?> ent, Solution reagents)
     {
@@ -680,13 +681,21 @@ public abstract partial class SharedBloodstreamSystem : EntitySystem
             currentVolume += bloodSolution.RemoveReagent(reagent.Reagent, quantity: bloodSolution.Volume, ignoreReagentData: true);
         }
 
-        ent.Comp.BloodReferenceSolution = reagents.Clone();
+        // ent.Comp.BloodReferenceSolution = reagents.Clone(); // Goob, scaling max according to original volume; see below
+        // DirtyField(ent, ent.Comp, nameof(BloodstreamComponent.BloodReferenceSolution)); // Goob
+
+        // Goob start: appropriately scale the target's BloodReferenceSolution according to their previous max volume
+        var referenceSolution = reagents.Clone();
+        referenceSolution.ScaleSolution(ent.Comp.BloodReferenceSolution.MaxVolume / referenceSolution.Volume); // Using the old max to scale the reference solution up/down
+        referenceSolution.MaxVolume = ent.Comp.BloodReferenceSolution.MaxVolume; // This doesn't actually affect blood regeneration, but it'd be slopcode if I didn't set this
+        ent.Comp.BloodReferenceSolution = referenceSolution;
         DirtyField(ent, ent.Comp, nameof(BloodstreamComponent.BloodReferenceSolution));
+        // Goob end
 
         if (currentVolume == FixedPoint2.Zero)
             return;
 
-        var solution = ent.Comp.BloodReferenceSolution.Clone();
+        var solution = reagents.Clone(); // ent.Comp.BloodReferenceSolution.Clone(); // Goob, adjusted due to above fixes; this acts the same otherwise
         solution.ScaleSolution(currentVolume / solution.Volume);
         SolutionContainer.AddSolution(ent.Comp.BloodSolution.Value, solution);
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
this gives zombies and changelings a normal amount of blood
this supersedes https://github.com/Goob-Station/Goob-Station/pull/7109 (thank you feisty for starting the work)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
fixes https://github.com/Goob-Station/Goob-Station/issues/7110
you can now bloodpack zombies to get meaningfully large amounts of blood out of them once again
changelings don't get outed by having No Blood

## Technical details
<!-- Summary of code changes for easier review. -->
`ChangeBloodReagents` uses the species-specific max blood volume to scale the `BloodReferenceSolution` and its max volume

copied off the homework in `Content.Shared/Body/Systems/SharedBloodstreamSystem.cs` that changes the current solution so i could build a second block beforehand to change the `BloodReferenceSolution`

for some reason, the original implementation set `ent.Comp.BloodReferenceSolution` directly to the input reagents with no scaling or anything, but it set the current volume to a scaled version of the reagents. i don't know why it did this but i made the new `BloodReferenceSolution` actually set the appropriate max volume according to the previous max volume

i did not touch the failsafe for if it can't resolve the solution because i don't know how to trigger that and frankly i don't think i want to

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->


even works if your zombies bleed milk
<img width="1255" height="846" alt="Screenshot 2026-09-01 223010" src="https://github.com/user-attachments/assets/4332d71b-2fa3-4a89-b377-e529a52624fc" />
<img width="1136" height="615" alt="image" src="https://github.com/user-attachments/assets/a4849a1f-6176-4f8d-9ada-4e042b087fe4" />


the rest below is just showing that it works on zombies and changelings, the two things that change your blood
<img width="929" height="450" alt="Screenshot 2026-09-01 222405" src="https://github.com/user-attachments/assets/3eff1fdd-115d-4bf2-beff-f01b43855cce" />
<img width="1430" height="878" alt="Screenshot 2026-09-01 222326" src="https://github.com/user-attachments/assets/8a6ab79b-011b-423e-9fc5-812a2034940e" />
<img width="1601" height="941" alt="Screenshot 2026-09-01 222154" src="https://github.com/user-attachments/assets/9ae93351-d413-4a45-88be-2ce313ef82d2" />
<img width="1286" height="687" alt="Screenshot 2026-09-01 222105" src="https://github.com/user-attachments/assets/9905d7ad-e410-4a7d-9d09-bd52138df261" />

i genuinely don't know how this works but changing DNA works fine as a changeling (was a shadowling w/200 blood)
<img width="1088" height="801" alt="image" src="https://github.com/user-attachments/assets/0972022f-ee4a-40bb-9042-42b9622192c1" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Duuckie, feistyfedora
- fix: Zombies and changelings have the appropriate amount of max blood for their species.