### PR TITLE
Visually impaired (and blind) characters not seeing signs (and whispers) fix

### DIFF
--- a/Content.Goobstation.Server/Chat/DeafnessBlindnessSystem.cs
+++ b/Content.Goobstation.Server/Chat/DeafnessBlindnessSystem.cs
@@ -52,8 +52,11 @@ public sealed class DeafnessBlindnessSystem : EntitySystem
     }
     private void OnBlindnessOverrideInRange(Entity<PermanentBlindnessComponent> ent, ref ChatMessageOverrideInRange args)
     {
+        // Goob edit start
         if (!args.RequiresSight)
             return;
-        args.Cancel();
+        if (ent.Comp.Blindness <= 0)
+            args.Cancel();
+        // Goob edit end
     }
 }

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -711,10 +711,9 @@ public sealed partial class ChatSystem : SharedChatSystem
                 continue; // Won't get logged to chat, and ghosts are too far away to see the pop-up, so we just won't send it to them.
 
             // Goob edit start
-            if (TryComp<DeafComponent>(listener, out var modifier) && language.SpeechOverride.RequireSpeech)
-                continue; // blocks anyone with the deaf component from hearing.
-            if (HasComp<PermanentBlindnessComponent>(listener) || HasComp<TemporaryBlindnessComponent>(listener))
-                continue; // block blind people from seeing subtle sign language gestures
+            var evSight = new ChatMessageOverrideInRange(language.SpeechOverride.RequireSpeech, language.SpeechOverride.RequireSight);
+            RaiseLocalEvent(listener, ref evSight);
+            if (evSight.Cancelled) continue;
             // Goob edit end
 
             // Einstein Engines - Language begin


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Altered a part of the chat system to fix with how characters with impaired visions would view whispers and messages in sign language.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Before this, characters that had vision impairment would be unable to hear any whispers and any characters that doesn't have the 'Blind' trait but had the 'PermanentBlindnessComponent' (mantle beasts or short-sighteds) couldn't see sign language even though it would make sense for them.

## Technical details
<!-- Summary of code changes for easier review. -->
DeafnessBlindnessSystem.cs in Content.Goobstation.Server/Chat has the 'PermanentBlindnessComponent' hooked on OnBlindnessOverrideInRange method altered, checks for 'RequiresSight' then checks if the entity in question is completely blind, if true then it cancels the message on client.

ChatSystem.cs's SendEntityWhispers on listeners check has been altered to use RaiseLocalEvent with ChatMessageOverrideInRange instead of checking for component, due to the difficulty of getting the 'blindness' variable from the PermanentBlindnessComponent.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Blind/visually impaired characters can now hear whispers.
- fix: Visually impaired (not totally blind) characters can see sign language.