### PR TITLE
Bandaid Fix For Insane Bleeding Values

### DIFF
--- a/Content.Shared/_Shitmed/CCVar/SurgeryCVars.cs
+++ b/Content.Shared/_Shitmed/CCVar/SurgeryCVars.cs
@@ -94,7 +94,7 @@ public sealed class SurgeryCVars : CVars
     /// The rate at which severity (wound) points get exchanged into bleeding; e.g., 50 severity would be 3.5 bleeding points.
     /// </summary>
     public static readonly CVarDef<float> BleedingSeverityTrade =
-        CVarDef.Create("bleeds.wound_severity_trade", 0.07f, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("bleeds.wound_severity_trade", 0.03f, CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
     /// How quick by default do bleeds grow to their full form?

--- a/Content.Shared/_Shitmed/CCVar/SurgeryCVars.cs
+++ b/Content.Shared/_Shitmed/CCVar/SurgeryCVars.cs
@@ -94,7 +94,7 @@ public sealed class SurgeryCVars : CVars
     /// The rate at which severity (wound) points get exchanged into bleeding; e.g., 50 severity would be 3.5 bleeding points.
     /// </summary>
     public static readonly CVarDef<float> BleedingSeverityTrade =
-        CVarDef.Create("bleeds.wound_severity_trade", 0.03f, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("bleeds.wound_severity_trade", 0.03f, CVar.SERVER | CVar.REPLICATED); // Originally 0.07f
 
     /// <summary>
     /// How quick by default do bleeds grow to their full form?

--- a/Content.Shared/_Shitmed/CCVar/SurgeryCVars.cs
+++ b/Content.Shared/_Shitmed/CCVar/SurgeryCVars.cs
@@ -94,7 +94,7 @@ public sealed class SurgeryCVars : CVars
     /// The rate at which severity (wound) points get exchanged into bleeding; e.g., 50 severity would be 3.5 bleeding points.
     /// </summary>
     public static readonly CVarDef<float> BleedingSeverityTrade =
-        CVarDef.Create("bleeds.wound_severity_trade", 0.03f, CVar.SERVER | CVar.REPLICATED); // Originally 0.07f
+        CVarDef.Create("bleeds.wound_severity_trade", 0.035f, CVar.SERVER | CVar.REPLICATED); // Originally 0.07f
 
     /// <summary>
     /// How quick by default do bleeds grow to their full form?


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
reduced the severity of bleeding to rates that seem more or less comparable to pre-upstream

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bandaid-ass fix of https://github.com/Goob-Station/Goob-Station/issues/7073
i don't precisely know the root cause behind bleeding being so severe, but this was an easy change for a mildly debilitating issue that's gone unresolved for a solid week or so (i've known it's been a problem since before this issue was raised), and it seems to work out fine

## Technical details
<!-- Summary of code changes for easier review. -->
changed `BleedingSeverityTrade` cvar in `SurgeryCVars` from 0.07f to 0.035f

i'm suspecting that https://github.com/Goob-Station/Goob-Station/pull/6961 might've had something to do with this? this is speculation on my part, but i'm thinking that the scaling up of bleeding to 1.4x after 1s might be related
either way, pre-upstream bleeding being almost exactly half what it is now is really suspicious. my other guess is that bleeding due to wounds is being applied twice somewhere, but i don't know exactly where and this will do fine until the root cause can be fixed

this seems to work fine for gunshots and ODing on puncturase

should the root cause be identified, this should be reverted

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

comparison of bleed from getting magdumped by a MK58

0.07f
<img width="1892" height="890" alt="Screenshot 2026-09-02 202854" src="https://github.com/user-attachments/assets/cecaeb88-6d08-4c45-893c-04f3683ecb08" />
0.035f
<img width="1914" height="711" alt="image" src="https://github.com/user-attachments/assets/c1dd019f-ba9e-48bf-bb4f-18ee7dc5f2ae" />


byrd (non-upstreamed) (though i have to note that on byrd, the MK58 actually kills, whereas on goob it does not)
<img width="1913" height="1003" alt="image" src="https://github.com/user-attachments/assets/cb29fbdd-4422-4079-9ca5-4737a4dd00a8" />



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Duuckie
- fix: Bleeding should be comparable to pre-upstream levels of bleeding.