### PR TITLE
"Remind secoffs that they are indeed, mortal."

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/cargo.yml
@@ -113,6 +113,8 @@
       weight: 0.01
     - id: WeaponLauncherPirateCannon
       weight: 0.1
+    - id: Throngler
+      weight: 0.001
     - id: WeaponPistolCHIMP
       weight: 0.1
     - id: WeaponSniperMosin


### PR DESCRIPTION
## About the PR
Added the Throngler back to the Grand lottery loot pool.

## Why / Balance
Glory to cargonia.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.

**Changelog**
:cl:
- add: The throngler is back in the cargo lottery pool. Sponsored by the Goob Hugbox & Throngler Citizens' Party!
