### PR TITLE
Fix cleanade regression at 842b03bd2e950e5cd5aaa2c516e0ee189145afd8

### DIFF
--- a/Content.Server/Trigger/Systems/SmokeOnTriggerSystem.cs
+++ b/Content.Server/Trigger/Systems/SmokeOnTriggerSystem.cs
@@ -41,7 +41,7 @@ public sealed class SmokeOnTriggerSystem : EntitySystem
 
         // TODO: move all of this into an API function in SmokeSystem
 
-        args.Handled = true;
+        args.Handled = SpawnSmoke(target.Value, ent.Comp.SmokePrototype, ent.Comp.Solution, ent.Comp.Duration, ent.Comp.SpreadAmount); // goobstation, actually call the damn helperfunc pls
     }
 
     /// Trauma - Moved it to helper function


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
This PR fixes cleanades, which at present do not produce space cleaner smoke/foam.

## Why / Balance
The janitors everywhere are weeping.

## Technical details
The xenobio fix at 842b03bd2e950e5cd5aaa2c516e0ee189145afd8 extracted the principal functionality of `Content.Server.Trigger.System.SmokeOnTriggerSystem.OnTrigger` into a helper function, `SmokeOnTriggerSystem.SpawnSmoke`, but then never called it in `SmokeOnTriggerSystem.OnTrigger`. This prevented anything that relied on `SmokeOnTriggerComponent` or `SmokeOnTriggerSystem` from spawning smoke when activated/triggered.

## Media
<img width="554" height="421" alt="image" src="https://github.com/user-attachments/assets/3feceb6c-a682-4326-9161-f9fa6f01a795" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [x] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.
## Breaking changes
Unbreaks `SmokeOnTriggerSystem.OnTrigger`.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Cleanades (and other smoke-spawning things) work again
