### PR TITLE
Fix stupid shit causing smoke trigger and sleeping to break

### DIFF
--- a/Content.Goobstation.Server/EntityEffects/DoSmokeEffectSystem.cs
+++ b/Content.Goobstation.Server/EntityEffects/DoSmokeEffectSystem.cs
@@ -6,11 +6,11 @@ namespace Content.Goobstation.Server.EntityEffects;
 
 public sealed partial class DoSmokeEffectSystem : EntityEffectSystem<TransformComponent, DoSmokeEffect>
 {
-    [Dependency] private SmokeOnTriggerSystem _smoke = default!;
+    [Dependency] private SmokeOnTriggerSystem _smokeOnTrigger = default!;
 
     protected override void Effect(Entity<TransformComponent> ent, ref EntityEffectEvent<DoSmokeEffect> args)
     {
         var e = args.Effect;
-        _smoke.SpawnSmoke(ent, e.SmokePrototype, e.Solution, e.Duration, e.SpreadAmount);
+        _smokeOnTrigger.GoidaFuckingFixThisSpawnSmoke(ent, e.SmokePrototype, e.Solution, e.Duration, e.SpreadAmount);
     }
 }

--- a/Content.Goobstation.Shared/Xenobiology/Systems/SlimeLatchSystem.cs
+++ b/Content.Goobstation.Shared/Xenobiology/Systems/SlimeLatchSystem.cs
@@ -5,9 +5,9 @@ using Content.Goobstation.Maths.FixedPoint;
 using Content.Goobstation.Shared.Xenobiology;
 using Content.Goobstation.Shared.Xenobiology.Components;
 using Content.Goobstation.Shared.Xenobiology.Components.Equipment;
-using Content.Shared._Goobstation.Sleep;
 using Content.Shared._Shitmed.Targeting;
 using Content.Shared.ActionBlocker;
+using Content.Shared.Bed.Sleep;
 using Content.Shared.Body.Components;
 using Content.Shared.Body.Systems;
 using Content.Shared.Chemistry.EntitySystems;
@@ -74,7 +74,7 @@ public sealed partial class SlimeLatchSystem : EntitySystem
         SubscribeLocalEvent<SlimeComponent, SelfBeforeClimbEvent>(OnSelfBeforeClimb);
         SubscribeLocalEvent<SlimeComponent, UpdateCanMoveEvent>(OnUpdateCanMove);
         SubscribeLocalEvent<SlimeDamageOvertimeComponent, WakeDamageOverrideEvent>(OnWakeOverride);
-        SubscribeLocalEvent<SlimeDamageOvertimeComponent, SleepOverrideEvent>(OnSleepOverride);
+        SubscribeLocalEvent<SlimeDamageOvertimeComponent, TryingToSleepEvent>(OnSleepOverride);
 
         _bloodstreamQuery = GetEntityQuery<BloodstreamComponent>();
         _hungerQuery = GetEntityQuery<HungerComponent>();
@@ -163,12 +163,12 @@ public sealed partial class SlimeLatchSystem : EntitySystem
         args.IgnoreDamage = true;
     }
 
-    private void OnSleepOverride(Entity<SlimeDamageOvertimeComponent> ent, ref SleepOverrideEvent args)
+    private void OnSleepOverride(Entity<SlimeDamageOvertimeComponent> ent, ref TryingToSleepEvent args)
     {
         if (!TryComp<MobStateComponent>(ent.Owner, out var mobState))
             return;
 
-        args.MobState = mobState.CurrentState;
+        args.Cancelled = mobState.CurrentState != MobState.Alive;
     }
 
     private void OnMobStateChangedSOD(Entity<SlimeDamageOvertimeComponent> ent, ref MobStateChangedEvent args)

--- a/Content.Server/Trigger/Systems/SmokeOnTriggerSystem.cs
+++ b/Content.Server/Trigger/Systems/SmokeOnTriggerSystem.cs
@@ -41,7 +41,9 @@ public sealed class SmokeOnTriggerSystem : EntitySystem
 
         // TODO: move all of this into an API function in SmokeSystem
 
-        args.Handled = true;
+        // Goobstation - call SpawnSmoke helper
+        // TODO: fuck YOU trauma. why the FUCK. TODO: make a wizden PR fixing this fucking nonsense
+        args.Handled = GoidaFuckingFixThisSpawnSmoke(target.Value, ent.Comp.SmokePrototype, ent.Comp.Solution, ent.Comp.Duration, ent.Comp.SpreadAmount);
     }
 
     /// Trauma - Moved it to helper function
@@ -50,7 +52,7 @@ public sealed class SmokeOnTriggerSystem : EntitySystem
     /// TODO This should have moved to <see cref="SmokeSystem"/>
     /// </summary>
     /// <returns></returns>
-    public bool SpawnSmoke(EntityUid target, string prototype, Solution solution, TimeSpan duration, int spreadAmount)
+    public bool GoidaFuckingFixThisSpawnSmoke(EntityUid target, string prototype, Solution solution, TimeSpan duration, int spreadAmount)
     {
         var xform = Transform(target);
         var mapCoords = _transform.GetMapCoordinates(target, xform);

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Goobstation - start
-using Content.Goobstation.Common.Sleeping; 
-using Content.Shared._Goobstation.Sleep;
-// Goobstation - end
+using Content.Goobstation.Common.Sleeping;
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
 using Content.Shared.Buckle.Components;
@@ -158,11 +155,7 @@ public sealed partial class SleepingSystem : EntitySystem
 
     private void OnComponentRemoved(Entity<SleepingComponent> ent, ref ComponentRemove args)
     {
-        if (!TryComp<ActionComponent>(ent.Comp.WakeAction, out var action)) // Goobstation - Xenobio
-            return;
-
-        if (action != null) // Goobstation - Xenobio.
-            _actionsSystem.RemoveAction(ent.Owner, ent.Comp.WakeAction);
+        _actionsSystem.RemoveAction(ent.Owner, ent.Comp.WakeAction);
 
         var ev = new SleepStateChangedEvent(false);
         RaiseLocalEvent(ent, ref ev);
@@ -259,20 +252,19 @@ public sealed partial class SleepingSystem : EntitySystem
         if (!args.DamageIncreased || args.DamageDelta == null)
             return;
 
-        /* Shitmed Change Start - Surgery needs this, sorry! If the nocturine gamers get too feisty
-        I'll probably just increase the threshold */
-
+        // Shitmed start - Surgery needs this, sorry! If the nocturine gamers get too feisty
+        // TODO: i dont know what the fuck that above comment means.
+        // anyways this is currently used for xenobiology. replace this with ForcedSleepingStatusEffect later
         var ev = new WakeDamageOverrideEvent();
         RaiseLocalEvent(ent.Owner, ref ev);
 
         if (ev.Cancelled || ev.IgnoreDamage)
             return;
+        // Shitmed end
 
         if (args.DamageDelta.GetTotal() >= ent.Comp.WakeThreshold
-            && !_statusEffect.HasEffectComp<ForcedSleepingStatusEffectComponent>(ent))
+            && !_statusEffect.HasEffectComp<ForcedSleepingStatusEffectComponent>(ent)) // Shitmed
             TryWaking((ent, ent.Comp));
-
-        // Shitmed Change End
     }
 
     /// <summary>
@@ -321,15 +313,6 @@ public sealed partial class SleepingSystem : EntitySystem
         RaiseLocalEvent(ent, ref tryingToSleepEvent);
         if (tryingToSleepEvent.Cancelled)
             return false;
-
-        // Goobstation - start
-        var ev = new SleepOverrideEvent();
-        RaiseLocalEvent(ent.Owner, ref ev);
-
-        if (ev.MobState != MobState.Alive)
-            return false;
-
-        // Goobstation - end
 
         EnsureComp<SleepingComponent>(ent);
         return true;

--- a/Content.Shared/_Goobstation/Sleep/SleepOverrideEvent.cs
+++ b/Content.Shared/_Goobstation/Sleep/SleepOverrideEvent.cs
@@ -1,9 +1,0 @@
-using Content.Shared.Mobs;
-
-namespace Content.Shared._Goobstation.Sleep;
-
-/// <summary>
-/// Raised whenever entity almost went to sleep
-/// </summary>
-[ByRefEvent]
-public record struct SleepOverrideEvent(MobState MobState = MobState.Alive);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About 

- fixed nonsense changes to sleeping system including the addition of an event that literally does the same thing as the upstream event that goes right before it...
- fixed smoke helper function not being actually called by `SmokeOnTriggerSystem`. renamed function appropriately

credit to ishkab for showing both issue locations in their PR

Will close #7146
Will close #7151

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: ishkab, Jerulean, rivermyth
- fix: Fixed the mass insomnia that's gripped the station. Falling asleep and the many ways to snooze work again.
- fix: Cleanades (and other smoke-spawning things) work again
