### PR TITLE
Fixing drone battery alert system (you can now see how much power you have left)

### DIFF
--- a/Content.Client/Silicons/Borgs/BorgSystem.Battery.cs
+++ b/Content.Client/Silicons/Borgs/BorgSystem.Battery.cs
@@ -45,6 +45,7 @@ public sealed partial class BorgSystem
         if (!_powerCell.TryGetBatteryFromSlot((ent.Owner, ent.Comp2), out var battery))
         {
             _alerts.ShowAlert(ent.Owner, ent.Comp1.NoBatteryAlert);
+            _alerts.ClearAlert(ent.Owner, ent.Comp1.BatteryAlert);
             return;
         }
 
@@ -58,6 +59,7 @@ public sealed partial class BorgSystem
             chargeLevel = 1;
         }
 
+        _alerts.ClearAlert(ent.Owner, ent.Comp1.NoBatteryAlert); // this line might be redundant...
         _alerts.ShowAlert(ent.Owner, ent.Comp1.BatteryAlert, chargeLevel);
     }
 

--- a/Content.Client/_Imp/Drone/ClientDroneSystem.cs
+++ b/Content.Client/_Imp/Drone/ClientDroneSystem.cs
@@ -1,0 +1,134 @@
+using Content.Client.Popups;
+using Content.Shared._Imp.Drone;
+using Content.Shared.Alert;
+using Content.Shared.Popups;
+using Content.Shared.Power.EntitySystems;
+using Content.Shared.PowerCell;
+using Content.Shared.PowerCell.Components;
+using Robust.Client.Player;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+
+namespace Content.Client._Imp.Drone;
+
+/// <summary>
+/// Clientside part of the SharedDroneSystem.
+/// Mainly handles updating the battery alert.
+/// Heavily based on <see cref="Content.Client.Silicons.Borgs.BorgSystem">BorgSystem.Battery.cs</see>.
+/// </summary>
+public sealed class ClientDroneSystem : SharedDroneSystem
+{
+    [Dependency] private readonly PowerCellSystem _powerCell = default!;
+    [Dependency] private readonly SharedBatterySystem _battery = default!;
+    [Dependency] private readonly AlertsSystem _alerts = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly PopupSystem _popupSystem = default!;
+    
+    // How often to update the battery alert.
+    // Also gets updated instantly when switching bodies or a battery is inserted or removed.
+    private static readonly TimeSpan AlertUpdateDelay = TimeSpan.FromSeconds(0.5f);
+
+    // Don't put this on the component because we only need to track the time for a single entity
+    // and we don't want to TryComp it every single tick.
+    private TimeSpan _nextAlertUpdate = TimeSpan.Zero;
+    private EntityQuery<DroneComponent> _chassisQuery;
+    private EntityQuery<PowerCellSlotComponent> _slotQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        InitializeBattery();
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        UpdateBattery();
+    }
+
+    private void InitializeBattery()
+    {
+        SubscribeLocalEvent<DroneComponent, LocalPlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeLocalEvent<DroneComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
+
+        _chassisQuery = GetEntityQuery<DroneComponent>();
+        _slotQuery = GetEntityQuery<PowerCellSlotComponent>();
+    }
+
+    private void OnPlayerAttached(Entity<DroneComponent> ent, ref LocalPlayerAttachedEvent args)
+    {
+        UpdateBatteryAlert((ent.Owner, ent.Comp, null));
+    }
+
+    private void OnPlayerDetached(Entity<DroneComponent> ent, ref LocalPlayerDetachedEvent args)
+    {
+        // Remove all batteru related alerts.
+        _alerts.ClearAlert(ent.Owner, ent.Comp.BatteryAlert);
+        _alerts.ClearAlert(ent.Owner, ent.Comp.NoBatteryAlert);
+    }
+
+    private void UpdateBatteryAlert(Entity<DroneComponent, PowerCellSlotComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp2))
+            return;
+
+        if (!_powerCell.TryGetBatteryFromSlot((ent.Owner, ent.Comp2), out var battery))
+        {
+            _alerts.ShowAlert(ent.Owner, ent.Comp1.NoBatteryAlert);
+            return;
+        }
+
+        // Alert levels from 0 to 10.
+        var chargePercent = (short)MathF.Round(_battery.GetChargeLevel(battery.Value.AsNullable()) * 10f);
+
+        if (chargePercent == 5 && chargePercent < ent.Comp1.LastChargePercent)
+        {
+            if (_gameTiming.CurTime >= ent.Comp1.NextProximityAlert)
+            {
+                _popupSystem.PopupEntity(Loc.GetString("drone-med-battery"), ent.Owner, ent.Owner, PopupType.MediumCaution);
+                ent.Comp1.NextProximityAlert = _gameTiming.CurTime + ent.Comp1.ProximityDelay;
+            }
+        }
+
+        if (chargePercent == 2 && chargePercent < ent.Comp1.LastChargePercent)
+        {
+            if (_gameTiming.CurTime >= ent.Comp1.NextProximityAlert)
+            {
+                _popupSystem.PopupEntity(Loc.GetString("drone-low-battery"), ent.Owner, ent.Owner, PopupType.LargeCaution);
+                ent.Comp1.NextProximityAlert = _gameTiming.CurTime + ent.Comp1.ProximityDelay;
+            }
+        }
+
+        // we make sure 0 only shows if they have absolutely no battery.
+        // also account for floating point imprecision
+        if (chargePercent == 0 && _powerCell.HasDrawCharge(ent.Owner))
+            chargePercent = 1;
+
+        ent.Comp1.LastChargePercent = chargePercent;
+
+        _alerts.ClearAlert(ent.Owner, ent.Comp1.NoBatteryAlert);
+        _alerts.ShowAlert(ent.Owner, ent.Comp1.BatteryAlert, chargePercent);
+    }
+
+    // Periodically update the charge indicator.
+    // We do this with a client-side alert so that we don't have to network the charge level.
+    private void UpdateBattery()
+    {
+        if (_player.LocalEntity is not { } localPlayer)
+            return;
+
+        var curTime = _gameTiming.CurTime;
+
+        if (curTime < _nextAlertUpdate)
+            return;
+
+        _nextAlertUpdate = curTime + AlertUpdateDelay;
+
+        if (!_chassisQuery.TryComp(localPlayer, out var chassis) || !_slotQuery.TryComp(localPlayer, out var slot))
+            return;
+
+        UpdateBatteryAlert((localPlayer, chassis, slot));
+    }
+}

--- a/Content.Server/_Imp/Drone/DroneSystem.cs
+++ b/Content.Server/_Imp/Drone/DroneSystem.cs
@@ -62,7 +62,7 @@ namespace Content.Server._Imp.Drone
 
         private void OnMapInit(Entity<DroneComponent> ent, ref MapInitEvent args)
         {
-            UpdateBatteryAlert(ent);
+            //UpdateBatteryAlert(ent);
 
             if (!TryComp<MindContainerComponent>(ent.Owner, out var mind) || !mind.HasMind)
                 _powerCell.SetDrawEnabled(ent.Owner, false);
@@ -128,8 +128,6 @@ namespace Content.Server._Imp.Drone
         	if (TerminatingOrDeleted(uid))
         		return;
 
-            UpdateBatteryAlert((uid, component));
-
             // if we run out of charge & the drone isn't being deleted, kill the drone
             if (!_powerCell.HasDrawCharge(uid))
                 _mobStateSystem.ChangeMobState(uid, MobState.Dead);
@@ -191,51 +189,6 @@ namespace Content.Server._Imp.Drone
 
             var state = new DroneBuiState(chargePercent, hasBattery);
             _ui.SetUiState(uid, DroneUiKey.Key, state);
-        }
-
-        private void UpdateBatteryAlert(Entity<DroneComponent> ent)
-        {
-            if (!TryComp<PowerCellSlotComponent>(ent, out var slotComponent))
-                return;
-
-            if (!_powerCell.TryGetBatteryFromSlot(ent.Owner,out var battery ))
-            {
-                _alerts.ClearAlert(ent.Owner, ent.Comp.BatteryAlert);
-                _alerts.ShowAlert(ent.Owner, ent.Comp.NoBatteryAlert);
-                return;
-            }
-
-            var chargePercent = new short();
-            if (_battery.TryGetBatteryComponent(ent.Owner, out var batteryComponent, out var _))
-                chargePercent = (short) MathF.Round(batteryComponent.LastCharge / batteryComponent.MaxCharge * 10f);
-
-            if (chargePercent == 5 && chargePercent < ent.Comp.LastChargePercent)
-            {
-                if (_gameTiming.CurTime >= ent.Comp.NextProximityAlert)
-                {
-                    _popupSystem.PopupEntity(Loc.GetString("drone-med-battery"), ent.Owner, ent.Owner, PopupType.MediumCaution);
-                    ent.Comp.NextProximityAlert = _gameTiming.CurTime + ent.Comp.ProximityDelay;
-                }
-            }
-
-            if (chargePercent == 2 && chargePercent < ent.Comp.LastChargePercent)
-            {
-                if (_gameTiming.CurTime >= ent.Comp.NextProximityAlert)
-                {
-                    _popupSystem.PopupEntity(Loc.GetString("drone-low-battery"), ent.Owner, ent.Owner, PopupType.LargeCaution);
-                    ent.Comp.NextProximityAlert = _gameTiming.CurTime + ent.Comp.ProximityDelay;
-                }
-            }
-
-            // we make sure 0 only shows if they have absolutely no battery.
-            // also account for floating point imprecision
-            if (chargePercent == 0 && _powerCell.HasDrawCharge(ent.Owner))
-                chargePercent = 1;
-
-            ent.Comp.LastChargePercent = chargePercent;
-
-            _alerts.ClearAlert(ent.Owner, ent.Comp.NoBatteryAlert);
-            _alerts.ShowAlert(ent.Owner, ent.Comp.BatteryAlert, chargePercent);
         }
 
         private bool NonDronesInRange(EntityUid uid, DroneComponent component)

--- a/Content.Server/_Imp/Drone/DroneSystem.cs
+++ b/Content.Server/_Imp/Drone/DroneSystem.cs
@@ -62,8 +62,6 @@ namespace Content.Server._Imp.Drone
 
         private void OnMapInit(Entity<DroneComponent> ent, ref MapInitEvent args)
         {
-            //UpdateBatteryAlert(ent);
-
             if (!TryComp<MindContainerComponent>(ent.Owner, out var mind) || !mind.HasMind)
                 _powerCell.SetDrawEnabled(ent.Owner, false);
         }

--- a/Resources/Prototypes/_Imp/_Drone/drone_alert.yml
+++ b/Resources/Prototypes/_Imp/_Drone/drone_alert.yml
@@ -28,3 +28,4 @@
   description: alerts-drone-battery-desc
   minSeverity: 0
   maxSeverity: 10
+  clientHandled: true # Goobstation (the power cell battery is read on the client so that we don't have to periodically network the charge)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
* The power level alert for maintenance drones is currently broken (always shows 100%). This PR fixes that problem.
* it now shows current power levels as intended (and sends warning messages when at ~50% and ~20% charge, as intended.)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
* I decided to try the maintenance drone ghost role a couple of days ago and was very confused as to why i kept spontaneously disintegrating into a puddle of oil - someone mentioned in ooc chat that they self-destruct when out of power but the power indicator is broken so you need to inspect yourself to see the power
  * figured i may as well do something about it
  * more chudproof now i guess 🤷‍
* also as it's now more clientside i suppose that's one less thing to worry about serverside

## Technical details
<!-- Summary of code changes for easier review. -->
* Drone battery alert code has been moved from `Content.Server/_Imp/Drone/DroneSystem.cs` to brand new `Content.Client/_Imp/Drone/ClientDroneSystem.cs`.
  * New implementation is based on how borg battery alerts (which do work) are handled by `Content.Client/Silicons/Borgs/BorgSystem.Battery.cs` instead of `Content.Server/Silicons/Borgs/BorgSystem.cs`
  * drone battery alerts are no longer networked (handled 100% clientside - just like borg batteries)
* Also simplified the implementation of the (now-clientside) `ClientDroneSystem.UpdateBatteryAlert` function (it still does everything it's meant to do, just with a bit less boilerplate).

## testing
1. spawn drone
2. become the drone
3. observe the inexorable decay of the drone's power level in real time
4. ponder as to whether or not this a metaphor

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

check out this drone with a battery level alert which actually reflects its current power level (and has been given the "please charge you're at ~50% power" warning message)

<img width="1776" height="1151" alt="image" src="https://github.com/user-attachments/assets/3e6424a2-631f-49ae-abf4-70e7c56c7a14" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
* new class/namespace
  * `Content.Client._Imp.Drone.ClientDroneSystem.cs`
  * drone battery alerts are now handled in there, rather than in `Content.Server._Imp.Drone.DroneSystem.cs`
* drone battery alerts are no longer networked
  * just like borg battery alerts

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Maintenance drones can now see how much power they have left in real time (so now there is no excuse for running out of power)