### PR TITLE
undergarments will now always be worn underneath garments instead of being worn as overgarments

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
@@ -88,8 +88,8 @@
       - map: [ "enum.HumanoidVisualLayers.LArm" ]
       - map: [ "enum.HumanoidVisualLayers.RLeg" ]
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
-      - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
-      - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ] # Goobstation
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ] # Goobstation
       - map: [ "jumpsuit" ]
       - map: [ "enum.HumanoidVisualLayers.LHand" ]
       - map: [ "enum.HumanoidVisualLayers.RHand" ]

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
@@ -88,6 +88,8 @@
       - map: [ "enum.HumanoidVisualLayers.LArm" ]
       - map: [ "enum.HumanoidVisualLayers.RLeg" ]
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
       - map: [ "jumpsuit" ]
       - map: [ "enum.HumanoidVisualLayers.LHand" ]
       - map: [ "enum.HumanoidVisualLayers.RHand" ]

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
@@ -217,8 +217,8 @@
       - map: [ "enum.HumanoidVisualLayers.LArm" ]
       - map: [ "enum.HumanoidVisualLayers.RLeg" ]
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
-      - map: [ "underpants" ]
-      - map: [ "undershirt" ]
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ] # goobstation
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ] # goobstation
       - map: [ "socks" ]
       - map: [ "jumpsuit" ]
       - map: ["enum.HumanoidVisualLayers.LFoot"]

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
@@ -58,6 +58,8 @@
       - map: [ "enum.HumanoidVisualLayers.LArm" ]
       - map: [ "enum.HumanoidVisualLayers.RLeg" ]
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ] # Goobstation
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ] # Goobstation
       - map: [ "jumpsuit" ]
       - map: [ "enum.HumanoidVisualLayers.LHand" ]
       - map: [ "enum.HumanoidVisualLayers.RHand" ]

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
@@ -43,6 +43,8 @@
       - map: [ "enum.HumanoidVisualLayers.LArm" ]
       - map: [ "enum.HumanoidVisualLayers.RLeg" ]
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom"]  # Goobstation
+      - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ] # Goobstation
       - shader: StencilClear
         sprite: Mobs/Species/Human/parts.rsi #PJB on stencil clear being on the left leg: "...this is 'fine'" -https://github.com/space-wizards/space-station-14/pull/12217#issuecomment-1291677115
         # its fine, but its still very stupid that it has to be done like this instead of allowing sprites to just directly insert a stencil clear.

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Species/shadowkin.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Species/shadowkin.yml
@@ -259,8 +259,8 @@
         - map: ["enum.HumanoidVisualLayers.LFoot"]
         - map: ["enum.HumanoidVisualLayers.RFoot"]
         - map: ["socks"]
-        - map: ["underpants"]
-        - map: ["undershirt"]
+        - map: ["enum.HumanoidVisualLayers.UndergarmentBottom"] # goobstation
+        - map: ["enum.HumanoidVisualLayers.UndergarmentTop"] # goobstation
         - map: ["jumpsuit"]
         - map: ["enum.HumanoidVisualLayers.LHand"]
         - map: ["enum.HumanoidVisualLayers.RHand"]

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Species/shadowkin.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Species/shadowkin.yml
@@ -155,8 +155,8 @@
       - map: ["enum.HumanoidVisualLayers.LFoot"]
       - map: ["enum.HumanoidVisualLayers.RFoot"]
       - map: ["socks"]
-      - map: ["underpants"]
-      - map: ["undershirt"]
+      - map: ["enum.HumanoidVisualLayers.UndergarmentBottom"] # goobstation
+      - map: ["enum.HumanoidVisualLayers.UndergarmentTop"] # goobstation
       - map: ["jumpsuit"]
       - map: ["enum.HumanoidVisualLayers.LHand"]
       - map: ["enum.HumanoidVisualLayers.RHand"]


### PR DESCRIPTION
Resolves #7166 ~~was less complicated than anticipated~~

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

<img width="498" height="459" alt="ezgif-6f4614d30c9579ec" src="https://github.com/user-attachments/assets/7d366a0f-73f1-4b4d-85d5-064a308262a0" />


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
* the default undergarments added by the 'censor character nudity' accessibility option were worn as overgarments by vulps, chitinids, rodentia, harpies, and shadowkin
* this PR fixes that problem and ensures that their undergarments will be worn as undergarments instead of overgarments
* adding undergarment customization options to the species which didn't have those options is beyond the scope of this PR (all it does is ensure they can't wear undergarments as overgarments)
  * but it does mean that harpies will no longer have their undergarments appear as overgarments in the character customization menu if one has decided to use the undergarment marking options for a harpy character

## Technical details
<!-- Summary of code changes for easier review. -->
* gave vulps, chitinids, rodentia, harpies, and shadowkin SpriteLayers for `"enum.HumanoidVisualLayers.UndergarmentBottom"` and `"enum.HumanoidVisualLayers.UndergarmentTop"` in appropriate positions so that they will now wear their underwear underneath their clothes

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="307" height="228" alt="image" src="https://github.com/user-attachments/assets/ceb62ff0-d4d3-4177-a08f-923566076592" />
<img width="1235" height="428" alt="image" src="https://github.com/user-attachments/assets/53136512-6ccd-421c-872f-8478d0ad0199" />



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

* references to 'underpants' and 'undershirt' visual layers have been replaced with references to `enum.HumanoidVisualLayers.UndergarmentBottom` and `enum.HumanoidVisualLayers.UndergarmentTop`.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: undergarments will no longer be worn as overgarments by rodentia, vulps, chitinids, harpies, and shadowkin