### PR TITLE
Add 25 minute workflow timeout to Content.IntegrationTests

### DIFF
--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -54,6 +54,7 @@ jobs:
       run: dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0
 
     - name: Run Content.IntegrationTests
+      timeout-minutes: 30
       shell: pwsh
       run: |
         $env:DOTNET_gcServer=1


### PR DESCRIPTION
tests should never last this long. afaik they ALWAYS fail anyways when this happens, they are literally hardcoded to stop at 20 minutes, to hard crash at 21 minutes, but it seems to sometimes get so low on memory and freezes so that it just keeps going for no reason. i think.

also the default workflow timeout is fucking 6 hours long, i've literally seen it reach this before too

https://github.com/Goob-Station/Goob-Station/blob/25ddc0283fce5210ce89ceff9150905eaab6ba0d/Content.IntegrationTests/PoolManagerTestEventHandler.cs#L12-L30
https://github.com/Goob-Station/Goob-Station/blob/25ddc0283fce5210ce89ceff9150905eaab6ba0d/Content.IntegrationTests/PoolManagerTestEventHandler.cs#L9-L10
<img width="1524" height="248" alt="Image" src="https://github.com/user-attachments/assets/6105cbce-9ab3-4eab-b512-52ce31d87926" />